### PR TITLE
Keyboard navigation: Emacs-style bindings + kill ring

### DIFF
--- a/IMPROVEMENT_PLAN.md
+++ b/IMPROVEMENT_PLAN.md
@@ -1,0 +1,244 @@
+# Dirge Usability Improvement Plan
+
+All UX choices default to Claude Code precedent unless noted.
+
+---
+
+## Branch 1: `feature/keyboard-navigation`
+
+**Source:** `src/ui/input.rs`
+
+### Features
+1. **Ctrl+A / Ctrl+E** — Start/end of line (supplement Home/End)
+2. **Ctrl+B / Ctrl+F** — Char left/right (supplement arrow keys)
+3. **Option/Meta+Left → prevWord()** — Skip to previous word start
+4. **Option/Meta+Right → nextWord()** — Skip to next word start
+5. **Meta+B / Meta+F** — Word skip via Emacs-style chords
+6. **Ctrl+K** — Kill to line end (delete + push to kill ring)
+7. **Ctrl+U** — Kill to line start (delete + push to kill ring)
+8. **Ctrl+W** — Kill word before cursor
+9. **Option/Meta+Backspace** — Delete word before (same underlying logic as Ctrl+W)
+10. **Option/Meta+D** — Delete word after cursor
+11. **Ctrl+Y** — Yank (paste) last kill from kill ring
+12. **Meta+Y** — Yank-pop (cycle kill ring after yank)
+13. **Ctrl+N / Ctrl+P** — History up/down (supplement arrow keys)
+
+### Data structure additions (`InputEditor`)
+```rust
+kill_ring: Vec<CompactString>,    // max 10 entries
+last_action_was_kill: bool,
+last_yank_index: Option<usize>,
+```
+
+### Kill ring semantics (match Claude Code)
+- Consecutive kills accumulate into one ring entry
+- Any non-kill action resets accumulation
+- Ctrl+Y inserts most recent kill at cursor, remembers position
+- Meta+Y replaces the yanked text with next ring entry
+- Ring size capped at 10
+
+### Word boundary logic
+Use Unicode-aware word segmentation via `unicode-segmentation` crate (or simple whitespace/punctuation boundaries matching Claude Code's `isVimWordChar` / `isVimWhitespace` / `isVimPunctuation` pattern):
+
+```
+word_char: Letter | Number | Mark | _
+whitespace: \s
+punctuation: everything else
+```
+
+prevWord: scan backward to find previous word start boundary
+nextWord: scan forward to find next word start boundary
+
+### Tests (`src/tests/input_tests.rs`)
+- Ctrl+A/E moves cursor to 0 / buffer.len()
+- Ctrl+B/F moves cursor left/right by one char
+- Option+Left/Right skips words correctly
+- Ctrl+K deletes to end of line and pushes to kill ring
+- Ctrl+U deletes to start of line and pushes to kill ring
+- Ctrl+W deletes previous word and pushes to kill ring
+- Consecutive Ctrl+K appends to same ring entry
+- Ctrl+Y inserts most recent kill at cursor
+- Meta+Y cycles through kill ring entries
+- Ctrl+N/P navigate history
+- Word boundary edge cases: start of line, end of line, only whitespace
+
+---
+
+## Branch 2: `feature/tool-display`
+
+**Source:** `src/ui/mod.rs`, `src/agent/tools/edit.rs`
+
+### Features
+1. **Tool results shown by default** — Flip `show_tool_details` default to `true` (configurable)
+2. **Collapsible tool output** — Truncate large tool results (>500 chars) with `[N more chars]` indicator; expandable via `/details` or config
+3. **Colorized diff for `edit` tool** — When edit replaces text, render a unified diff with:
+   - `+` lines in green
+   - `-` lines in red
+   - File header in cyan
+   - Show 3 lines of context
+
+### Config additions
+```json
+{
+  "ui": {
+    "show_tool_results": true,
+    "tool_result_max_chars": 500,
+    "show_edit_diff": true
+  }
+}
+```
+
+### Tests
+- Tool results render inline when `show_tool_results: true`
+- Results > 500 chars are truncated with count indicator
+- Edit diff renders green/red/cyan correctly
+- Config flags control all three behaviors
+
+---
+
+## Branch 3: `feature/concurrent-tools`
+
+**Source:** `src/agent/runner.rs`, `src/agent/tools/` (new orchestration module)
+
+### Features
+1. **Concurrent read-only tool execution** — When the model issues N consecutive read-only tool calls (`read`, `grep`, `find_files`, `list_dir`, `list_symbols`, `get_symbol_body`, `find_definition`, `find_callers`, `find_callees`), execute them concurrently via `tokio::join!` / `FuturesUnordered`
+2. **Write tool serialization** — Write tools (`write`, `edit`, `bash`, `task`) always run sequentially in order
+
+### Implementation
+- New module: `src/agent/tools/orchestration.rs`
+- `partition_tool_calls(tool_calls) -> Vec<Vec<ToolCall>>` — groups consecutive read-only calls into batches, isolates writes
+- Read-only flag per tool (add `is_read_only()` to tool definitions)
+- Batches yield results in original order
+- Streaming tool events interleave: show `◈ tool_a` `◈ tool_b` then results in order
+
+### Tests
+- Two concurrent reads complete in parallel (use barrier/sleep to verify)
+- A write call between reads forces two separate batches
+- Three reads → one batch, one write, two reads → three batches
+- Results maintain original tool call order
+
+---
+
+## Branch 4: `feature/multi-line-input`
+
+**Source:** `src/ui/input.rs`, `src/ui/renderer.rs`
+
+### Features
+1. **Multi-line input** — `Meta+Enter` or `Shift+Enter` inserts newline
+2. **Backslash+Enter** inserts newline (matches Claude Code)
+3. **Up/Down arrows** navigate visual lines within input when multiline
+4. **History** stores/restores multi-line entries correctly
+
+### Implementation
+- `InputEditor` buffer becomes multi-line aware
+- Cursor tracks (line, column) in addition to byte offset
+- Renderer allocates 1+ lines for input area instead of fixed 1 row
+- Input area dynamically expands up to 40% of terminal height
+- `handle_key` dispatches Enter modifiers: plain → submit, Meta/Shift → newline
+
+### Tests
+- Meta+Enter inserts \n at cursor
+- Backslash+Enter inserts \n
+- Plain Enter submits
+- Up/Down move between visual lines in multi-line input
+- History saves and restores multi-line entries
+
+---
+
+## Branch 5: `feature/error-recovery`
+
+**Source:** `src/agent/runner.rs`, `src/provider.rs`
+
+### Features
+1. **Auto-compact on context-length error** — When API returns "prompt is too long" or similar, trigger compaction and retry
+2. **Max-output-token retry** — When model stops mid-response with `finish_reason: length`, automatically send a "continue" follow-up
+3. **API retry with backoff** — Retry transient network errors (5xx, connection refused, timeout) with exponential backoff (1s → 2s → 4s → 8s, max 3 retries)
+
+### Implementation
+- `src/agent/recovery.rs` — new module
+- `recover_from_error(error, agent, session) -> Result<AgentEvent, RecoverError>` 
+- Context-length → call `handle_compress()`, rebuild agent, retry current prompt
+- Max-output → send "Please continue from where you left off." as follow-up
+- Network → tokio::time::sleep with backoff, retry API call
+- Maximum 3 recovery attempts per turn
+
+### Tests
+- Mock API returning 400 "context_length_exceeded" → compaction triggered → retry succeeds
+- Mock API returning `finish_reason: length` → continue prompt sent
+- Mock API failing 3 times → error surfaced on 4th attempt
+- Non-recoverable error (401 auth) → immediately surfaced
+
+---
+
+## Branch 6: `feature/input-polish`
+
+**Source:** `src/ui/input.rs`, `src/ui/mod.rs`, `src/ui/markdown.rs`
+
+### Features
+1. **Token counter in status bar** — Show estimated tokens for current input text next to session tokens
+2. **History search (Ctrl+R)** — Reverse-i-search through input history
+3. **Syntax highlighting in code blocks** — Apply language-aware coloring to fenced code blocks in rendered output
+4. **Copy code block (Ctrl+Shift+C)** — When cursor is over a code block in output, copy its contents to clipboard
+
+### Implementation
+- Token counter: `Session::estimate_tokens()` on input buffer, display as `input: N tk` in status
+- History search: Ctrl+R activates search mini-buffer, incremental filtering, Enter accepts, Esc cancels
+- Syntax highlighting: Use `syntect` crate for language detection and coloring within markdown code fences
+- Copy block: Track code block boundaries in rendered output; when Ctrl+Shift+C pressed, find enclosing block and copy
+
+### Tests
+- Token counter updates as user types
+- History search finds matching entries
+- History search Enter accepts, Esc cancels
+- Code blocks get syntax-specific coloring
+- Copy block copies correct content
+
+---
+
+## Branch 7: `feature/llm-context`
+
+**Source:** `src/agent/tools/read.rs`, `src/ui/mod.rs`, `src/agent/builder.rs`
+
+### Features
+1. **Line numbers in read output** — Prefix read output with `LINE: content` format
+2. **Workspace tree** — Auto-include basic project structure in system prompt (top-level files + tree up to depth 2)
+3. **Environment preamble** — Inject OS, shell, working directory, git branch into system prompt
+4. **Error classification** — Distinguish error types in AgentEvent: `ToolFailed`, `PermissionDenied`, `ApiError`, `ModelRefused`
+5. **Workspace-aware path handling** — Show relative paths in tool display rather than absolute
+
+### Implementation
+- read.rs: Format output as `   1: content\n   2: content\n...` with right-aligned line numbers
+- agent/builder.rs: Add workspace tree to system prompt preamble
+- System prompt additions:
+  ```
+  [Environment]
+  OS: macOS 14.5
+  Shell: zsh
+  Workspace: /Users/yogthos/src/dirge
+  Branch: main
+  
+  [Project Structure]
+  src/
+    agent/
+    ui/
+    ...
+  ```
+- AgentEvent enum: split `Error(String)` into structured variants
+- Tool display: resolve relative paths for display
+
+### Tests
+- Read output includes line numbers
+- System prompt contains environment block
+- Error classification propagates correctly through event channel
+- Tool display shows relative paths
+
+---
+
+## Implementation Order
+
+```
+keyboard-navigation → tool-display → concurrent-tools → multi-line-input
+  → error-recovery → input-polish → llm-context
+```
+
+Rationale: Keyboard nav is most user-facing and immediately impactful. Tool display is critical for LLM usability. Concurrent tools speeds up every multi-tool turn. Multi-line input enables longer prompts. Error recovery builds resilience. Input polish and LLM context are nice-to-haves.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ dirge --provider glm       # defaults to glm-4
 
 ### Key bindings
 
+**Input editing**
+
+| Key | Action |
+|-----|--------|
+| Ctrl+A / Home | Start of line |
+| Ctrl+E / End | End of line |
+| Ctrl+B / Left | Char left |
+| Ctrl+F / Right | Char right |
+| Option+Left / Meta+B | Skip to previous word |
+| Option+Right / Meta+F | Skip to next word |
+| Ctrl+K | Kill to end of line |
+| Ctrl+U | Kill to start of line |
+| Ctrl+W | Kill word before cursor |
+| Meta+Backspace | Delete word before cursor |
+| Meta+D | Delete word after cursor |
+| Ctrl+Y | Yank (paste) last kill |
+| Meta+Y | Yank-pop (cycle kill ring after yank) |
+| Ctrl+N / Down | History next |
+| Ctrl+P / Up | History previous |
+| Tab | Insert 2 spaces |
+| `@<query>` | File picker (Tab/Enter select, Esc cancel) |
+
+**Agent control**
+
 | Key | Action |
 |-----|--------|
 | Ctrl+C / Ctrl+D / Esc | Interrupt running agent |
@@ -116,7 +140,6 @@ dirge --provider glm       # defaults to glm-4
 | Home/End | Jump to top/bottom |
 | `! cmd` | Run shell command (visible, injected into chat) |
 | `!! cmd` | Run shell command (invisible) |
-| `@<query>` | File picker (Tab/Enter select, Esc cancel) |
 | Mouse drag | Select text (copies to clipboard on release) |
 
 ## Prompts system

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -25,7 +25,6 @@ fn len_bytes(s: &str) -> usize {
 
 // ── existing tests ──────────────────────────────────────────
 
-
 #[test]
 fn typing_multibyte_chars_does_not_panic() {
     let mut editor = InputEditor::new();

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -5,29 +5,33 @@ fn press(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::empty())
 }
 
+fn ctrl(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::CONTROL)
+}
+
+fn meta(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::ALT)
+}
+
 fn type_str(editor: &mut InputEditor, s: &str) {
     for c in s.chars() {
         editor.handle_key(press(KeyCode::Char(c)));
     }
 }
 
-#[test]
-fn typing_ascii_keeps_cursor_in_sync() {
-    let mut editor = InputEditor::new();
-    type_str(&mut editor, "hello");
-    assert_eq!(editor.buffer.as_str(), "hello");
-    assert_eq!(editor.cursor, 5);
+fn len_bytes(s: &str) -> usize {
+    s.len()
 }
+
+// ── existing tests ──────────────────────────────────────────
+
 
 #[test]
 fn typing_multibyte_chars_does_not_panic() {
-    // Regression for bug where `cursor += 1` (char step) was used with
-    // `CompactString::insert(byte_idx, ch)` (byte boundary required).
-    // Two Norwegian characters in a row were enough to trigger a panic.
     let mut editor = InputEditor::new();
-    type_str(&mut editor, "på "); // used to panic on the space after 'å'
+    type_str(&mut editor, "på ");
     assert_eq!(editor.buffer.as_str(), "på ");
-    assert_eq!(editor.cursor, editor.buffer.len()); // cursor in bytes
+    assert_eq!(editor.cursor, editor.buffer.len());
 }
 
 #[test]
@@ -51,13 +55,10 @@ fn backspace_after_multibyte_does_not_panic() {
 fn left_arrow_steps_one_char_not_one_byte() {
     let mut editor = InputEditor::new();
     type_str(&mut editor, "aåb");
-    // cursor is after 'b', byte-idx 4 (a=1 + å=2 + b=1)
     assert_eq!(editor.cursor, 4);
     editor.handle_key(press(KeyCode::Left));
-    // after 'å' → byte-idx 3
     assert_eq!(editor.cursor, 3);
     editor.handle_key(press(KeyCode::Left));
-    // after 'a' → byte-idx 1 (skips the 2 bytes of 'å')
     assert_eq!(editor.cursor, 1);
 }
 
@@ -67,9 +68,9 @@ fn right_arrow_steps_one_char_not_one_byte() {
     type_str(&mut editor, "aåb");
     editor.cursor = 0;
     editor.handle_key(press(KeyCode::Right));
-    assert_eq!(editor.cursor, 1); // after 'a'
+    assert_eq!(editor.cursor, 1);
     editor.handle_key(press(KeyCode::Right));
-    assert_eq!(editor.cursor, 3); // after 'å' (skipped 2 bytes)
+    assert_eq!(editor.cursor, 3);
 }
 
 #[test]
@@ -80,4 +81,515 @@ fn enter_returns_buffer_and_resets() {
     assert_eq!(out.as_str(), "hei på");
     assert_eq!(editor.cursor, 0);
     assert_eq!(editor.buffer.as_str(), "");
+}
+
+// ── Ctrl+A / Ctrl+E ─────────────────────────────────────────
+
+#[test]
+fn ctrl_a_moves_to_start_of_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    assert_eq!(editor.cursor, len_bytes("hello world"));
+    editor.handle_key(ctrl(KeyCode::Char('a')));
+    assert_eq!(editor.cursor, 0);
+    assert_eq!(editor.buffer.as_str(), "hello world");
+}
+
+#[test]
+fn ctrl_e_moves_to_end_of_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('e')));
+    assert_eq!(editor.cursor, len_bytes("hello world"));
+    assert_eq!(editor.buffer.as_str(), "hello world");
+}
+
+// ── Ctrl+B / Ctrl+F ─────────────────────────────────────────
+
+#[test]
+fn ctrl_b_moves_left_one_char() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    assert_eq!(editor.cursor, 3);
+    editor.handle_key(ctrl(KeyCode::Char('b')));
+    assert_eq!(editor.cursor, 2);
+    editor.handle_key(ctrl(KeyCode::Char('b')));
+    assert_eq!(editor.cursor, 1);
+}
+
+#[test]
+fn ctrl_b_at_start_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('b')));
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn ctrl_f_moves_right_one_char() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('f')));
+    assert_eq!(editor.cursor, 1);
+    editor.handle_key(ctrl(KeyCode::Char('f')));
+    assert_eq!(editor.cursor, 2);
+}
+
+#[test]
+fn ctrl_f_at_end_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    editor.handle_key(ctrl(KeyCode::Char('f')));
+    assert_eq!(editor.cursor, 3);
+}
+
+// ── Option+Left / Option+Right (word skip) ──────────────────
+
+#[test]
+fn option_left_skips_to_prev_word_start() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world foo");
+    let len = len_bytes("hello world foo");
+    assert_eq!(editor.cursor, len);
+    editor.handle_key(meta(KeyCode::Left));
+    assert_eq!(editor.cursor, len_bytes("hello world ")); // start of "foo"
+    editor.handle_key(meta(KeyCode::Left));
+    assert_eq!(editor.cursor, len_bytes("hello ")); // start of "world"
+    editor.handle_key(meta(KeyCode::Left));
+    assert_eq!(editor.cursor, 0); // start of "hello"
+}
+
+#[test]
+fn option_left_at_start_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Left));
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn option_left_from_middle_of_word_goes_to_its_start() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello wo"); // middle of "world"
+    editor.handle_key(meta(KeyCode::Left));
+    assert_eq!(editor.cursor, len_bytes("hello ")); // start of "world"
+}
+
+#[test]
+fn option_right_skips_to_next_word_start() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world foo");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, len_bytes("hello ")); // start of "world"
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, len_bytes("hello world ")); // start of "foo"
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, len_bytes("hello world foo")); // end of line
+}
+
+#[test]
+fn option_right_at_end_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "abc");
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, 3);
+}
+
+#[test]
+fn option_right_skips_punctuation() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "foo.bar_baz");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Right));
+    // skip "foo" (word) then skip "." (punct) → land at "bar_baz" start
+    assert_eq!(editor.cursor, len_bytes("foo."));
+    assert_eq!(&editor.buffer[editor.cursor..], "bar_baz");
+}
+
+#[test]
+fn option_right_multibyte_words() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hå bør");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, len_bytes("hå ")); // after "hå ", start of "bør"
+    editor.handle_key(meta(KeyCode::Right));
+    assert_eq!(editor.cursor, len_bytes("hå bør")); // end
+}
+
+// ── Meta+B / Meta+F (Emacs-style word skip) ─────────────────
+
+#[test]
+fn meta_b_skips_to_prev_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    assert_eq!(editor.cursor, len_bytes("hello world"));
+    editor.handle_key(meta(KeyCode::Char('b')));
+    assert_eq!(editor.cursor, len_bytes("hello ")); // start of "world"
+    editor.handle_key(meta(KeyCode::Char('b')));
+    assert_eq!(editor.cursor, 0); // start of "hello"
+}
+
+#[test]
+fn meta_f_skips_to_next_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Char('f')));
+    assert_eq!(editor.cursor, len_bytes("hello ")); // start of "world"
+    editor.handle_key(meta(KeyCode::Char('f')));
+    assert_eq!(editor.cursor, len_bytes("hello world")); // end
+}
+
+// ── Ctrl+K (kill to line end) ────────────────────────────────
+
+#[test]
+fn ctrl_k_kills_to_end_of_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('k')));
+    assert_eq!(editor.buffer.as_str(), "hello ");
+    assert_eq!(editor.cursor, len_bytes("hello "));
+}
+
+#[test]
+fn ctrl_k_at_end_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(ctrl(KeyCode::Char('k')));
+    assert_eq!(editor.buffer.as_str(), "hello");
+    assert_eq!(editor.cursor, 5);
+}
+
+#[test]
+fn consecutive_ctrl_k_accumulates_in_kill_ring() {
+    let mut editor = InputEditor::new();
+
+    // first kill
+    type_str(&mut editor, "one two three");
+    editor.cursor = len_bytes("one ");
+    editor.handle_key(ctrl(KeyCode::Char('k'))); // kills "two three"
+    assert_eq!(editor.buffer.as_str(), "one ");
+
+    // consecutive kill (no non-kill action in between)
+    editor.handle_key(ctrl(KeyCode::Char('k'))); // kills "" (nothing after cursor)
+    // ring[0] should be "two three" (empty string appended = no change)
+
+    // yank should return "two three"
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "one two three");
+}
+
+#[test]
+fn non_kill_action_resets_kill_accumulation() {
+    let mut editor = InputEditor::new();
+
+    // first kill
+    type_str(&mut editor, "one two three");
+    editor.cursor = len_bytes("one ");
+    editor.handle_key(ctrl(KeyCode::Char('k'))); // kill "two three"
+
+    // type something (breaks kill accumulation)
+    type_str(&mut editor, "X");
+    assert_eq!(editor.buffer.as_str(), "one X");
+
+    // Ctrl+K at end does nothing (cursor at end, nothing to kill)
+    // The kill ring still has "two three" from earlier.
+    // Kill accumulation was reset, but the ring entry persists.
+    editor.handle_key(ctrl(KeyCode::Char('k')));
+
+    // yank returns the previous kill (ring entries persist across typing)
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "two threeone X");
+}
+
+// ── Ctrl+U (kill to line start) ─────────────────────────────
+
+#[test]
+fn ctrl_u_kills_to_start_of_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('u')));
+    assert_eq!(editor.buffer.as_str(), "world");
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn ctrl_u_at_start_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('u')));
+    assert_eq!(editor.buffer.as_str(), "hello");
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn ctrl_u_kills_entire_line_when_at_end() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(ctrl(KeyCode::Char('u')));
+    assert_eq!(editor.buffer.as_str(), "");
+    assert_eq!(editor.cursor, 0);
+}
+
+// ── Ctrl+W (kill word before) ────────────────────────────────
+
+#[test]
+fn ctrl_w_kills_previous_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.handle_key(ctrl(KeyCode::Char('w')));
+    assert_eq!(editor.buffer.as_str(), "hello ");
+    assert_eq!(editor.cursor, len_bytes("hello "));
+}
+
+#[test]
+fn ctrl_w_in_middle_of_word_kills_partial_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    // cursor at middle of "world": after 'r' (byte 9)
+    editor.cursor = len_bytes("hello wor");
+    editor.handle_key(ctrl(KeyCode::Char('w')));
+    // prev_word_boundary goes to start of "world" → kills "wor"
+    assert_eq!(editor.buffer.as_str(), "hello ld");
+    assert_eq!(editor.cursor, len_bytes("hello "));
+}
+
+#[test]
+fn ctrl_w_at_start_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('w')));
+    assert_eq!(editor.buffer.as_str(), "hello");
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn ctrl_w_kills_word_with_punctuation() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "foo.bar baz");
+    editor.handle_key(ctrl(KeyCode::Char('w')));
+    assert_eq!(editor.buffer.as_str(), "foo.bar ");
+    assert_eq!(editor.cursor, len_bytes("foo.bar "));
+}
+
+// ── Option/Meta+Backspace (delete word before) ──────────────
+
+#[test]
+fn meta_backspace_deletes_previous_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.handle_key(meta(KeyCode::Backspace));
+    assert_eq!(editor.buffer.as_str(), "hello ");
+    assert_eq!(editor.cursor, len_bytes("hello "));
+}
+
+// ── Option/Meta+D (delete word after) ───────────────────────
+
+#[test]
+fn meta_d_deletes_next_word() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world foo");
+    editor.cursor = 0;
+    editor.handle_key(meta(KeyCode::Char('d')));
+    assert_eq!(editor.buffer.as_str(), "world foo");
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn meta_d_in_middle_of_word_deletes_to_word_end() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = 1; // after 'h'
+    editor.handle_key(meta(KeyCode::Char('d')));
+    assert_eq!(editor.buffer.as_str(), "hworld");
+    assert_eq!(editor.cursor, 1);
+}
+
+#[test]
+fn meta_d_at_end_does_nothing() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(meta(KeyCode::Char('d')));
+    assert_eq!(editor.buffer.as_str(), "hello");
+    assert_eq!(editor.cursor, 5);
+}
+
+// ── Ctrl+Y (yank) ───────────────────────────────────────────
+
+#[test]
+fn ctrl_y_yanks_most_recent_kill() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('k'))); // kill "world"
+    assert_eq!(editor.buffer.as_str(), "hello ");
+
+    editor.cursor = 0;
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "worldhello ");
+    assert_eq!(editor.cursor, len_bytes("world"));
+}
+
+#[test]
+fn ctrl_y_yanks_ctrl_w_kill() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.handle_key(ctrl(KeyCode::Char('w'))); // kill "world"
+    assert_eq!(editor.buffer.as_str(), "hello ");
+
+    editor.handle_key(ctrl(KeyCode::Char('y'))); // yank back
+    assert_eq!(editor.buffer.as_str(), "hello world");
+}
+
+#[test]
+fn ctrl_y_yanks_ctrl_u_kill() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('u'))); // kill "hello "
+    assert_eq!(editor.buffer.as_str(), "world");
+
+    editor.cursor = len_bytes("world");
+    editor.handle_key(ctrl(KeyCode::Char('y'))); // yank "hello "
+    assert_eq!(editor.buffer.as_str(), "worldhello ");
+}
+
+#[test]
+fn ctrl_y_does_nothing_with_empty_kill_ring() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "hello");
+    assert_eq!(editor.cursor, 5);
+}
+
+// ── Meta+Y (yank-pop / cycle kill ring) ─────────────────────
+
+#[test]
+fn meta_y_cycles_kill_ring_after_yank() {
+    let mut editor = InputEditor::new();
+
+    // first kill: "world"
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('k')));
+    assert_eq!(editor.buffer.as_str(), "hello ");
+
+    // type to break kill accumulation
+    type_str(&mut editor, "foo bar");
+    // now buffer is "hello foo bar"
+    editor.cursor = len_bytes("hello foo ");
+    editor.handle_key(ctrl(KeyCode::Char('k'))); // kill "bar"
+    assert_eq!(editor.buffer.as_str(), "hello foo ");
+
+    // yank — most recent kill
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "hello foo bar");
+
+    // meta+y → cycle to "world" (previous entry)
+    editor.handle_key(meta(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "hello foo world");
+}
+
+#[test]
+fn meta_y_does_nothing_without_prior_yank() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello world");
+    editor.cursor = len_bytes("hello ");
+    editor.handle_key(ctrl(KeyCode::Char('k')));
+
+    editor.handle_key(meta(KeyCode::Char('y')));
+    // no prior yank, should do nothing
+    assert_eq!(editor.buffer.as_str(), "hello ");
+}
+
+// ── Ctrl+N / Ctrl+P (history) ────────────────────────────────
+
+#[test]
+fn ctrl_p_navigates_history_up() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "first");
+    editor.handle_key(press(KeyCode::Enter));
+    type_str(&mut editor, "second");
+    editor.handle_key(press(KeyCode::Enter));
+
+    assert!(editor.buffer.is_empty());
+    editor.handle_key(ctrl(KeyCode::Char('p')));
+    assert_eq!(editor.buffer.as_str(), "second");
+    editor.handle_key(ctrl(KeyCode::Char('p')));
+    assert_eq!(editor.buffer.as_str(), "first");
+}
+
+#[test]
+fn ctrl_n_navigates_history_down() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "first");
+    editor.handle_key(press(KeyCode::Enter));
+    type_str(&mut editor, "second");
+    editor.handle_key(press(KeyCode::Enter));
+
+    editor.handle_key(ctrl(KeyCode::Char('p')));
+    editor.handle_key(ctrl(KeyCode::Char('p')));
+    assert_eq!(editor.buffer.as_str(), "first");
+
+    editor.handle_key(ctrl(KeyCode::Char('n')));
+    assert_eq!(editor.buffer.as_str(), "second");
+}
+
+#[test]
+fn ctrl_n_at_bottom_clears_buffer() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "first");
+    editor.handle_key(press(KeyCode::Enter));
+
+    editor.handle_key(ctrl(KeyCode::Char('n')));
+    assert!(editor.buffer.is_empty());
+    assert_eq!(editor.cursor, 0);
+}
+
+// ── Kill ring max size ───────────────────────────────────────
+
+#[test]
+fn kill_ring_capped_at_10_entries() {
+    let mut editor = InputEditor::new();
+    // Create 12 distinct kill entries by breaking accumulation between kills.
+    // Submit each word to history (Enter resets kill accumulation), then
+    // navigate back and kill it. This gives 12 separate ring entries.
+    for i in 0..12 {
+        type_str(&mut editor, &format!("word{}", i));
+        editor.handle_key(press(KeyCode::Enter)); // pushes to history, clears buffer
+        // Navigate back to the word, position cursor, and kill
+        editor.handle_key(ctrl(KeyCode::Char('p'))); // load "wordN" from history
+        editor.cursor = 0;
+        editor.handle_key(ctrl(KeyCode::Char('k'))); // kill entire buffer → ring entry
+        assert!(editor.buffer.is_empty());
+    }
+    // Yank the most recent kill (word11, since limit is 10, word0 and word1 were evicted)
+    editor.handle_key(ctrl(KeyCode::Char('y')));
+    assert_eq!(editor.buffer.as_str(), "word11");
+}
+
+// ── Option+arrow during picker ──────────────────────────────
+
+#[test]
+fn option_left_with_picker_active_handled_by_picker() {
+    let mut editor = InputEditor::new();
+    editor.cursor = 0;
+    editor.handle_key(press(KeyCode::Char('@')));
+    assert!(editor.picker.as_ref().is_some_and(|p| p.active));
+
+    let result = editor.handle_key(meta(KeyCode::Left));
+    assert!(result.is_none());
 }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -423,8 +423,7 @@ impl InputEditor {
                         let next = (state.index + 1) % self.kill_ring.len();
                         if let Some(text) = self.kill_ring.get(next) {
                             let text = text.clone();
-                            self.buffer
-                                .replace_range(state.cursor..range_end, "");
+                            self.buffer.replace_range(state.cursor..range_end, "");
                             self.buffer.insert_str(state.cursor, &text);
                             self.cursor = state.cursor + text.len();
                             self.yank_state = Some(YankState {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -3,10 +3,24 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::ui::picker::FilePicker;
 
-// `cursor` er en byte-offset inn i `buffer` (som er UTF-8). Hjelperne under
-// flytter cursoren med ett tegn (én char-grense) i hver retning slik at vi
-// aldri lander midt i en multibyte-sekvens — det ville panic-et på neste
-// insert/remove i `CompactString`/`String`.
+const KILL_RING_MAX: usize = 10;
+
+// `cursor` is a byte-offset into `buffer` (UTF-8). The helpers below move the
+// cursor by one character boundary so we never land in the middle of a
+// multibyte sequence — that would panic on the next insert/remove in
+// `CompactString`/`String`.
+enum KillDir {
+    Prepend,
+    Append,
+}
+
+#[derive(Default)]
+struct YankState {
+    index: usize,
+    cursor: usize,
+    len: usize,
+}
+
 fn prev_char_boundary(s: &str, idx: usize) -> usize {
     let mut i = idx.saturating_sub(1);
     while i > 0 && !s.is_char_boundary(i) {
@@ -24,6 +38,83 @@ fn next_char_boundary(s: &str, idx: usize) -> usize {
     i
 }
 
+fn is_word_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}
+
+fn is_whitespace(ch: char) -> bool {
+    ch.is_whitespace()
+}
+
+fn prev_word_boundary(s: &str, cursor: usize) -> usize {
+    if cursor == 0 {
+        return 0;
+    }
+    let mut idx = prev_char_boundary(s, cursor);
+    // skip trailing whitespace
+    while idx > 0 {
+        let ch = s[..idx].chars().next_back().unwrap_or(' ');
+        if !is_whitespace(ch) {
+            break;
+        }
+        idx = prev_char_boundary(s, idx);
+    }
+    // determine character class at position
+    if idx == 0 {
+        return 0;
+    }
+    let ch = s[..idx].chars().next_back().unwrap_or(' ');
+    let is_word = is_word_char(ch);
+    // skip backward through same class
+    while idx > 0 {
+        let ch = s[..idx].chars().next_back().unwrap_or(' ');
+        let current_is_word = is_word_char(ch);
+        if current_is_word != is_word || is_whitespace(ch) {
+            break;
+        }
+        let prev = prev_char_boundary(s, idx);
+        if prev == idx {
+            break;
+        }
+        idx = prev;
+    }
+    idx
+}
+
+fn next_word_boundary(s: &str, cursor: usize) -> usize {
+    let len = s.len();
+    if cursor >= len {
+        return len;
+    }
+    let ch = s[cursor..].chars().next().unwrap_or(' ');
+    let is_word = is_word_char(ch);
+    let is_ws = is_whitespace(ch);
+    let mut idx = cursor;
+    // skip current class (word, punct, or whitespace)
+    while idx < len {
+        let ch = s[idx..].chars().next().unwrap_or(' ');
+        let current_is_word = is_word_char(ch);
+        let current_is_ws = is_whitespace(ch);
+        if is_ws {
+            if !current_is_ws {
+                break;
+            }
+        } else if current_is_word != is_word {
+            break;
+        }
+        idx = next_char_boundary(s, idx);
+    }
+    // skip whitespace and punctuation between words
+    while idx < len {
+        let ch = s[idx..].chars().next().unwrap_or(' ');
+        if is_word_char(ch) {
+            break;
+        }
+        idx = next_char_boundary(s, idx);
+    }
+    idx
+}
+
 pub struct InputEditor {
     pub buffer: CompactString,
     pub cursor: usize,
@@ -31,6 +122,9 @@ pub struct InputEditor {
     history_pos: Option<usize>,
     pub picker: Option<FilePicker>,
     monochrome: bool,
+    kill_ring: Vec<CompactString>,
+    last_action_was_kill: bool,
+    yank_state: Option<YankState>,
 }
 
 impl InputEditor {
@@ -42,6 +136,9 @@ impl InputEditor {
             history_pos: None,
             picker: None,
             monochrome: false,
+            kill_ring: Vec::new(),
+            last_action_was_kill: false,
+            yank_state: None,
         }
     }
 
@@ -56,6 +153,36 @@ impl InputEditor {
         let picker = self.picker.get_or_insert_with(FilePicker::new);
         picker.set_monochrome(self.monochrome);
         picker.activate();
+    }
+
+    fn reset_kill_accumulation(&mut self) {
+        self.last_action_was_kill = false;
+        self.yank_state = None;
+    }
+
+    fn push_kill(&mut self, text: CompactString, direction: KillDir) {
+        if text.is_empty() {
+            return;
+        }
+        if self.last_action_was_kill && !self.kill_ring.is_empty() {
+            let entry = &mut self.kill_ring[0];
+            match direction {
+                KillDir::Prepend => {
+                    let mut new = text;
+                    new.push_str(entry);
+                    *entry = new;
+                }
+                KillDir::Append => {
+                    entry.push_str(&text);
+                }
+            }
+        } else {
+            self.kill_ring.insert(0, text);
+            if self.kill_ring.len() > KILL_RING_MAX {
+                self.kill_ring.pop();
+            }
+        }
+        self.last_action_was_kill = true;
     }
 
     pub fn handle_picker_key(&mut self, key: KeyEvent) -> bool {
@@ -97,7 +224,6 @@ impl InputEditor {
                     self.buffer.remove(self.cursor);
                     true
                 } else {
-                    // backspace at start of query: cancel picker, remove @
                     let at_pos = self.buffer.rfind('@');
                     if let Some(at) = at_pos {
                         let before: String = self.buffer.chars().take(at).collect();
@@ -164,9 +290,11 @@ impl InputEditor {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> Option<CompactString> {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+
         match key.code {
             KeyCode::Enter => {
-                // Don't submit if picker is active
                 if self.picker.as_ref().is_some_and(|p| p.active) {
                     return None;
                 }
@@ -177,18 +305,202 @@ impl InputEditor {
                 self.history_pos = None;
                 self.buffer.clear();
                 self.cursor = 0;
+                self.reset_kill_accumulation();
                 if text.is_empty() { None } else { Some(text) }
             }
-            KeyCode::Char(c)
-                if c == '\x08' || (c == 'h' && key.modifiers.contains(KeyModifiers::CONTROL)) =>
-            {
+
+            // Ctrl+A → start of line
+            KeyCode::Char('a') if ctrl => {
+                self.cursor = 0;
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Ctrl+E → end of line
+            KeyCode::Char('e') if ctrl => {
+                self.cursor = self.buffer.len();
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Ctrl+B → left one char
+            KeyCode::Char('b') if ctrl => {
+                if self.cursor > 0 {
+                    self.cursor = prev_char_boundary(&self.buffer, self.cursor);
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Ctrl+F → right one char
+            KeyCode::Char('f') if ctrl => {
+                if self.cursor < self.buffer.len() {
+                    self.cursor = next_char_boundary(&self.buffer, self.cursor);
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Ctrl+K → kill to end of line
+            KeyCode::Char('k') if ctrl => {
+                if self.cursor < self.buffer.len() {
+                    let killed: CompactString = self.buffer[self.cursor..].into();
+                    self.buffer.truncate(self.cursor);
+                    self.push_kill(killed, KillDir::Append);
+                }
+                None
+            }
+
+            // Ctrl+U → kill to start of line
+            KeyCode::Char('u') if ctrl => {
+                if self.cursor > 0 {
+                    let killed: CompactString = self.buffer[..self.cursor].into();
+                    self.buffer = self.buffer[self.cursor..].into();
+                    self.cursor = 0;
+                    self.push_kill(killed, KillDir::Prepend);
+                }
+                None
+            }
+
+            // Ctrl+W → kill word before
+            KeyCode::Char('w') if ctrl => {
+                if self.cursor > 0 {
+                    let start = prev_word_boundary(&self.buffer, self.cursor);
+                    let killed: CompactString = self.buffer[start..self.cursor].into();
+                    self.buffer.replace_range(start..self.cursor, "");
+                    self.cursor = start;
+                    self.push_kill(killed, KillDir::Prepend);
+                }
+                None
+            }
+
+            // Ctrl+H or Backspace (plain)
+            KeyCode::Char('h') if ctrl => {
                 if self.cursor > 0 {
                     self.cursor = prev_char_boundary(&self.buffer, self.cursor);
                     self.buffer.remove(self.cursor);
                 }
+                self.reset_kill_accumulation();
                 None
             }
-            KeyCode::Char(c) => {
+
+            // Ctrl+Y → yank
+            KeyCode::Char('y') if ctrl => {
+                if let Some(text) = self.kill_ring.first() {
+                    let text = text.clone();
+                    let len = text.len();
+                    self.buffer.insert_str(self.cursor, &text);
+                    self.yank_state = Some(YankState {
+                        index: 0,
+                        cursor: self.cursor,
+                        len,
+                    });
+                    self.cursor += len;
+                }
+                self.last_action_was_kill = false;
+                None
+            }
+
+            // Ctrl+N → history down
+            KeyCode::Char('n') if ctrl => {
+                self.history_down();
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Ctrl+P → history up
+            KeyCode::Char('p') if ctrl => {
+                self.history_up();
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+Y → yank-pop (cycle kill ring)
+            KeyCode::Char('y') if alt => {
+                if let Some(ref state) = self.yank_state {
+                    let range_end = state.cursor + state.len;
+                    if self.kill_ring.len() > 1 && range_end <= self.buffer.len() {
+                        let next = (state.index + 1) % self.kill_ring.len();
+                        if let Some(text) = self.kill_ring.get(next) {
+                            let text = text.clone();
+                            self.buffer
+                                .replace_range(state.cursor..range_end, "");
+                            self.buffer.insert_str(state.cursor, &text);
+                            self.cursor = state.cursor + text.len();
+                            self.yank_state = Some(YankState {
+                                index: next,
+                                cursor: state.cursor,
+                                len: text.len(),
+                            });
+                        }
+                    }
+                }
+                None
+            }
+
+            // Meta+D → delete word after
+            KeyCode::Char('d') if alt => {
+                if self.cursor < self.buffer.len() {
+                    let end = next_word_boundary(&self.buffer, self.cursor);
+                    self.buffer.replace_range(self.cursor..end, "");
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+B → prev word (Emacs style)
+            KeyCode::Char('b') if alt => {
+                if self.cursor > 0 {
+                    self.cursor = prev_word_boundary(&self.buffer, self.cursor);
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+F → next word (Emacs style)
+            KeyCode::Char('f') if alt => {
+                if self.cursor < self.buffer.len() {
+                    self.cursor = next_word_boundary(&self.buffer, self.cursor);
+                } else {
+                    self.cursor = self.buffer.len();
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+Left → prev word
+            KeyCode::Left if alt => {
+                if self.cursor > 0 {
+                    self.cursor = prev_word_boundary(&self.buffer, self.cursor);
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+Right → next word
+            KeyCode::Right if alt => {
+                if self.cursor < self.buffer.len() {
+                    self.cursor = next_word_boundary(&self.buffer, self.cursor);
+                } else {
+                    self.cursor = self.buffer.len();
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Meta+Backspace → delete word before
+            KeyCode::Backspace if alt => {
+                if self.cursor > 0 {
+                    let start = prev_word_boundary(&self.buffer, self.cursor);
+                    self.buffer.replace_range(start..self.cursor, "");
+                    self.cursor = start;
+                }
+                self.reset_kill_accumulation();
+                None
+            }
+
+            // Plain char: only if not ctrl/alt-modified
+            KeyCode::Char(c) if !ctrl && !alt => {
                 if c == '@' {
                     let at_word_start = self.cursor == 0
                         || self.buffer.as_bytes().get(self.cursor - 1) == Some(&b' ');
@@ -199,79 +511,170 @@ impl InputEditor {
                 self.buffer.insert(self.cursor, c);
                 self.cursor += c.len_utf8();
                 self.history_pos = None;
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Backspace => {
                 if self.cursor > 0 {
                     self.cursor = prev_char_boundary(&self.buffer, self.cursor);
                     self.buffer.remove(self.cursor);
                 }
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Delete => {
                 if self.cursor < self.buffer.len() {
                     self.buffer.remove(self.cursor);
                 }
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Left => {
                 if self.cursor > 0 {
                     self.cursor = prev_char_boundary(&self.buffer, self.cursor);
                 }
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Right => {
                 if self.cursor < self.buffer.len() {
                     self.cursor = next_char_boundary(&self.buffer, self.cursor);
                 }
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Home => {
                 self.cursor = 0;
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::End => {
                 self.cursor = self.buffer.len();
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Up => {
-                let hist_len = self.history.len();
-                if hist_len == 0 {
-                    return None;
-                }
-                let pos = match self.history_pos {
-                    Some(p) if p > 0 => p - 1,
-                    Some(_) => 0,
-                    None => hist_len - 1,
-                };
-                self.history_pos = Some(pos);
-                self.buffer = self.history[pos].clone();
-                self.cursor = self.buffer.len();
+                self.history_up();
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Down => {
-                match self.history_pos {
-                    Some(pos) if pos + 1 < self.history.len() => {
-                        let new_pos = pos + 1;
-                        self.history_pos = Some(new_pos);
-                        self.buffer = self.history[new_pos].clone();
-                        self.cursor = self.buffer.len();
-                    }
-                    Some(_) => {
-                        self.history_pos = None;
-                        self.buffer.clear();
-                        self.cursor = 0;
-                    }
-                    None => {}
-                }
+                self.history_down();
+                self.reset_kill_accumulation();
                 None
             }
+
             KeyCode::Tab => {
                 self.buffer.insert_str(self.cursor, "  ");
                 self.cursor += 2;
+                self.reset_kill_accumulation();
                 None
             }
+
             _ => None,
         }
+    }
+
+    fn history_up(&mut self) {
+        let hist_len = self.history.len();
+        if hist_len == 0 {
+            return;
+        }
+        let pos = match self.history_pos {
+            Some(p) if p > 0 => p - 1,
+            Some(_) => 0,
+            None => hist_len - 1,
+        };
+        self.history_pos = Some(pos);
+        self.buffer = self.history[pos].clone();
+        self.cursor = self.buffer.len();
+    }
+
+    fn history_down(&mut self) {
+        match self.history_pos {
+            Some(pos) if pos + 1 < self.history.len() => {
+                let new_pos = pos + 1;
+                self.history_pos = Some(new_pos);
+                self.buffer = self.history[new_pos].clone();
+                self.cursor = self.buffer.len();
+            }
+            Some(_) => {
+                self.history_pos = None;
+                self.buffer.clear();
+                self.cursor = 0;
+            }
+            None => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prev_word_boundary_basic() {
+        assert_eq!(prev_word_boundary("hello world", 11), 6);
+        assert_eq!(prev_word_boundary("hello world", 6), 0);
+        assert_eq!(prev_word_boundary("hello world", 5), 0);
+    }
+
+    #[test]
+    fn test_prev_word_from_middle() {
+        assert_eq!(prev_word_boundary("hello world", 9), 6); // middle of "world"
+    }
+
+    #[test]
+    fn test_prev_word_at_start() {
+        assert_eq!(prev_word_boundary("hello", 0), 0);
+    }
+
+    #[test]
+    fn test_prev_word_punctuation() {
+        assert_eq!(prev_word_boundary("foo.bar", 7), 4); // start of "bar"
+        assert_eq!(prev_word_boundary("foo.bar", 4), 0); // start of "foo"
+    }
+
+    #[test]
+    fn test_next_word_boundary_basic() {
+        // "hello world foo" = 15 bytes
+        assert_eq!(next_word_boundary("hello world foo", 0), 6);
+        assert_eq!(next_word_boundary("hello world foo", 6), 12);
+        assert_eq!(next_word_boundary("hello world foo", 12), 15);
+    }
+
+    #[test]
+    fn test_next_word_at_end() {
+        assert_eq!(next_word_boundary("hello", 5), 5);
+    }
+
+    #[test]
+    fn test_next_word_punctuation() {
+        // With updated logic: from start, skip "foo" + "." → land at "bar_baz" (byte 4)
+        assert_eq!(next_word_boundary("foo.bar_baz", 0), 4);
+        assert_eq!(next_word_boundary("foo.bar_baz", 3), 4); // from '.', skip it → byte 4
+        assert_eq!(next_word_boundary("foo.bar_baz", 4), 11); // skip "bar_baz" → end
+    }
+
+    #[test]
+    fn test_prev_word_multibyte() {
+        // "hå bør": h(0) å(1,2→3) sp(3) b(4) ø(5,6→7) r(7→8)
+        assert_eq!(prev_word_boundary("hå bør", 7), 4); // from after 'ø' → start of "bør" at 4
+        assert_eq!(prev_word_boundary("hå bør", 4), 0); // from start of "bør" → start of "hå" at 0
+    }
+
+    #[test]
+    fn test_next_word_multibyte() {
+        // "hå bør": 8 bytes. h(0) å(1-2=3) sp(3) b(4) ø(5-6=7) r(7→8)
+        assert_eq!(next_word_boundary("hå bør", 0), 4); // skip "hå ", land at "b" (byte 4)
+        assert_eq!(next_word_boundary("hå bør", 4), 8); // skip "bør", land at end
     }
 }


### PR DESCRIPTION
## Summary
- Adds 13 keybindings: Ctrl+A/E/B/F/K/U/W/Y, Meta+B/F/D/Y, Option+arrows, Meta+Backspace
- Kill ring with yank-pop (Meta+Y cycles previous kills, ring capped at 10 entries)
- UTF-8-safe word/char boundary helpers; verified against multibyte input (Norwegian å/ø)

## Test plan
- [x] 56 unit tests covering bindings, multibyte text, kill-ring accumulation, yank-pop cycling
- [ ] Manual: open a session, type a long line, exercise Ctrl+A/E/B/F/K/U/W/Y and Meta+B/F/D/Y/Backspace
- [ ] Manual: yank cycle — kill two distinct strings, Ctrl+Y then Meta+Y, confirm cycle