### PR TITLE
Tool output display: visible results, colorized diffs, smart truncation

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -25,7 +25,9 @@ Example:
   "compact_enabled": true,
   "default_prompt": "code",
   "default_permission_mode": "standard",
-  "show_tool_details": false,
+  "show_tool_details": true,
+  "show_edit_diff": true,
+  "tool_result_max_chars": 500,
   "custom_providers": {
     "local-vllm": {
       "provider_type": "openai",
@@ -75,7 +77,9 @@ Accepted top-level keys:
 | `yolo`                    | boolean | Select yolo mode, auto-approving all operations.                                                                                                                            |
 | `sandbox`                 | boolean | Run bash commands in the bubblewrap sandbox. Default: `false`.                                                                                                              |
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Use `standard`, `restrictive`, `accept`, or `yolo`.                                                                   |
-| `show_tool_details`       | boolean | Show tool-result previews in the TUI. Default: `false`.                                                                                                                     |
+| `show_tool_details`       | boolean | Show tool-result output in the TUI. Default: `true`.                                                                                                                         |
+| `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
+| `tool_result_max_chars`   | integer | Maximum characters to show before truncating tool output with `[N more chars]`. Default: `500`.                                                                              |
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`.                                                                                                                        |
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, defaults to a single Exa Web Search server; see below.                                                   |
 | `acp_servers`             | object  | ACP server config map when compiled with the `acp` feature. See the ACP section below.                                                                                       |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ dirge --provider glm       # defaults to glm-4
 
 ### Key bindings
 
+**Input editing**
+
+| Key | Action |
+|-----|--------|
+| Ctrl+A / Home | Start of line |
+| Ctrl+E / End | End of line |
+| Ctrl+B / Left | Char left |
+| Ctrl+F / Right | Char right |
+| Option+Left / Meta+B | Skip to previous word |
+| Option+Right / Meta+F | Skip to next word |
+| Ctrl+K | Kill to end of line |
+| Ctrl+U | Kill to start of line |
+| Ctrl+W | Kill word before cursor |
+| Meta+Backspace | Delete word before cursor |
+| Meta+D | Delete word after cursor |
+| Ctrl+Y | Yank (paste) last kill |
+| Meta+Y | Yank-pop (cycle kill ring after yank) |
+| Ctrl+N / Down | History next |
+| Ctrl+P / Up | History previous |
+| Tab | Insert 2 spaces |
+| `@<query>` | File picker (Tab/Enter select, Esc cancel) |
+
+**Agent control**
+
 | Key | Action |
 |-----|--------|
 | Ctrl+C / Ctrl+D / Esc | Interrupt running agent |
@@ -116,8 +140,15 @@ dirge --provider glm       # defaults to glm-4
 | Home/End | Jump to top/bottom |
 | `! cmd` | Run shell command (visible, injected into chat) |
 | `!! cmd` | Run shell command (invisible) |
-| `@<query>` | File picker (Tab/Enter select, Esc cancel) |
 | Mouse drag | Select text (copies to clipboard on release) |
+
+**Tool output display**
+
+| Feature | Detail |
+|---------|--------|
+| Tool results visible | Default on (`show_tool_details: true`), toggle in config |
+| Smart truncation | Outputs >500 chars truncated with `[N more chars]` indicator (`tool_result_max_chars` in config) |
+| Colorized edit diffs | `edit` tool results render with `-` (red), `+` (green), `@@` (cyan) coloring (`show_edit_diff: true` in config) |
 
 ## Prompts system
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,6 +40,8 @@ pub struct Config {
     pub sandbox: Option<bool>,
     pub default_permission_mode: Option<String>,
     pub show_tool_details: Option<bool>,
+    pub show_edit_diff: Option<bool>,
+    pub tool_result_max_chars: Option<usize>,
     pub default_prompt: Option<String>,
     #[cfg(feature = "mcp")]
     pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
@@ -71,6 +73,14 @@ impl Config {
 
     pub fn resolve_compact_enabled(&self) -> bool {
         self.compact_enabled.unwrap_or(true)
+    }
+
+    pub fn resolve_tool_result_max_chars(&self) -> usize {
+        self.tool_result_max_chars.unwrap_or(500)
+    }
+
+    pub fn resolve_show_edit_diff(&self) -> bool {
+        self.show_edit_diff.unwrap_or(true)
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -134,6 +134,7 @@ pub async fn run_interactive(
     let mut show_reasoning = true;
     let mut was_reasoning = false;
     let mut todo_tools_enabled = false;
+    let mut last_tool_name: Option<String> = None;
     #[allow(unused_mut)]
     let mut loop_label: Option<String> = None;
     #[cfg(feature = "loop")]
@@ -922,6 +923,7 @@ pub async fn run_interactive(
                     }
                     AgentEvent::ToolCall { name, args } => {
                         was_reasoning = false;
+                        last_tool_name = Some(name.to_string());
                         if agent_line_started {
                             renderer.write_line("", Color::White)?;
                             agent_line_started = false;
@@ -954,7 +956,9 @@ pub async fn run_interactive(
                         }
                     }
                     AgentEvent::ToolResult { output } => {
-                        let show_details = cfg.show_tool_details.unwrap_or(false);
+                        let show_details = cfg.show_tool_details.unwrap_or(true);
+                        let max_chars = cfg.resolve_tool_result_max_chars();
+                        let show_diff = cfg.resolve_show_edit_diff();
 
                         #[cfg(feature = "plugin")]
                         if let Some(pm) = plugin_manager {
@@ -972,21 +976,51 @@ pub async fn run_interactive(
                                 )?;
                             }
                         }
+
                         if show_details {
-                            let sanitized = sanitize_output(&output);
-                            let char_count = sanitized.chars().count();
-                            let preview: String = sanitized.chars().take(120).collect();
-                            let preview_trimmed = if char_count > 120 {
-                                format!("{}...", preview)
+                            let is_edit =
+                                last_tool_name.as_deref() == Some("edit") && show_diff;
+
+                            if is_edit {
+                                // Colorized diff rendering
+                                let lines: Vec<&str> = output.lines().collect();
+                                let diff_start = lines.iter().position(|l| l.starts_with("--- "));
+                                if let Some(pre) = diff_start {
+                                    // Show non-diff prefix
+                                    for l in &lines[..pre] {
+                                        if !l.is_empty() {
+                                            renderer.write_line(
+                                                &format!("◈ {}", sanitize_output(l)),
+                                                Color::DarkGrey,
+                                            )?;
+                                        }
+                                    }
+                                    // Show colorized diff
+                                    for l in &lines[pre..] {
+                                        if l.starts_with("--- ") || l.starts_with("+++ ") {
+                                            renderer.write_line(l, Color::Cyan)?;
+                                        } else if l.starts_with("@@") {
+                                            renderer.write_line(l, Color::DarkCyan)?;
+                                        } else if l.starts_with('+') {
+                                            renderer.write_line(l, Color::Green)?;
+                                        } else if l.starts_with('-') {
+                                            renderer.write_line(l, Color::Red)?;
+                                        } else {
+                                            renderer.write_line(
+                                                &sanitize_output(l),
+                                                Color::DarkGrey,
+                                            )?;
+                                        }
+                                    }
+                                } else {
+                                    // No diff section found, show normally
+                                    render_tool_output(
+                                        &mut renderer, &output, max_chars,
+                                    )?;
+                                }
                             } else {
-                                preview
-                            };
-                            let summary = if char_count > 120 {
-                                format!("◈ result ({} chars): {}", char_count, preview_trimmed)
-                            } else {
-                                preview_trimmed
-                            };
-                            renderer.write_line(&summary, Color::DarkGrey)?;
+                                render_tool_output(&mut renderer, &output, max_chars)?;
+                            }
                         }
                     }
                     AgentEvent::Done { response, tokens, cost } => {
@@ -1348,6 +1382,27 @@ fn suggest_pattern(tool: &str, input: &str) -> String {
         }
         _ => "*".to_string(),
     }
+}
+
+fn render_tool_output(
+    renderer: &mut Renderer,
+    output: &str,
+    max_chars: usize,
+) -> anyhow::Result<()> {
+    let sanitized = sanitize_output(output);
+    let char_count = sanitized.chars().count();
+    if char_count <= max_chars {
+        renderer.write_line(&sanitized, Color::DarkGrey)?;
+    } else {
+        let preview: String = sanitized.chars().take(max_chars).collect();
+        let remaining = char_count - max_chars;
+        renderer.write_line(&preview, Color::DarkGrey)?;
+        renderer.write_line(
+            &format!("  [truncated: {} more chars]", remaining),
+            Color::DarkCyan,
+        )?;
+    }
+    Ok(())
 }
 
 fn update_search(renderer: &Renderer, query: &str, matches: &mut Vec<usize>, selected: &mut usize) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -982,9 +982,15 @@ pub async fn run_interactive(
                                 last_tool_name.as_deref() == Some("edit") && show_diff;
 
                             if is_edit {
-                                // Colorized diff rendering
+                                // Colorized diff rendering. The edit tool emits
+                                // its diff block starting with "--- a/<path>" —
+                                // match that exact sentinel to avoid false
+                                // positives on stray "--- " prefixes elsewhere
+                                // in the output.
                                 let lines: Vec<&str> = output.lines().collect();
-                                let diff_start = lines.iter().position(|l| l.starts_with("--- "));
+                                let diff_start = lines
+                                    .iter()
+                                    .position(|l| l.starts_with("--- a/"));
                                 if let Some(pre) = diff_start {
                                     // Show non-diff prefix
                                     for l in &lines[..pre] {
@@ -1022,9 +1028,13 @@ pub async fn run_interactive(
                                 render_tool_output(&mut renderer, &output, max_chars)?;
                             }
                         }
+                        // Clear after consuming so a future stray ToolResult
+                        // can't be coloured with a stale tool name.
+                        last_tool_name = None;
                     }
                     AgentEvent::Done { response, tokens, cost } => {
                         was_reasoning = false;
+                        last_tool_name = None;
 
                         #[allow(unused_mut, unused_variables)]
                         let mut plugin_followup: Option<String> = None;
@@ -1221,6 +1231,7 @@ pub async fn run_interactive(
                     }
                     AgentEvent::Error(e) => {
                         was_reasoning = false;
+                        last_tool_name = None;
                         let safe = sanitize_output(&e);
                         renderer.write_line(&format!("error: {}", safe), C_ERROR)?;
 


### PR DESCRIPTION
## Summary
- Tool result previews shown in TUI by default (\`show_tool_details: true\`)
- Edit-tool output rendered as a colorized diff: cyan headers, red \`-\`, green \`+\`, dark-cyan \`@@\`
- Long outputs truncated at \`tool_result_max_chars\` (default 500) with \`[N more chars]\` tail
- Stable sentinel \`--- a/\` for diff detection (review fix)
- \`last_tool_name\` cleared on consume/Done/Error to prevent stale colouring across turns (review fix)

## Test plan
- [ ] Manual: run an edit, confirm diff coloring renders correctly
- [ ] Manual: run a read on a >500-char file, confirm truncation message
- [ ] Manual: run several non-edit tools and confirm no false-positive diff rendering