### PR TITLE
Per-turn read/grep/list cache with mutation invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ _dirge_ is one of the smallest and most performant coding agents on the market.
 - Binary size: 12MB
 - RAM footprint: ~8MB on an empty session, ~12MB when working (vs ~300MB for opencode or other JS-based coding agents)
 
+### Tool result caching
+
+Read-only tool calls (`read`, `grep`, `find_files`, `list_dir`) are cached per agent turn. Repeated calls with identical arguments within the same turn return cached results, avoiding redundant filesystem I/O. The cache clears automatically before each new prompt.
+
 ## Installation
 
 ```bash

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -95,20 +95,23 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 cache.clone(),
             )),
-            Box::new(tools::WriteTool::new(
+            Box::new(tools::WriteTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),
                 plan_file.clone(),
+                cache.clone(),
             )),
-            Box::new(tools::EditTool::new(
+            Box::new(tools::EditTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),
                 plan_file.clone(),
+                cache.clone(),
             )),
-            Box::new(tools::BashTool::new(
+            Box::new(tools::BashTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),
                 sandbox.clone(),
+                cache.clone(),
             )),
             Box::new(tools::GrepTool::with_cache(
                 permission.clone(),

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use crate::agent::prompt::{SYSTEM_PROMPT, TODO_TOOLS_PROMPT};
 use crate::agent::tools;
+use crate::agent::tools::ToolCache;
 use crate::cli::Cli;
 use crate::config::Config;
 use crate::context::ContextFiles;
@@ -34,7 +35,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     parent_model: Option<AnyModel>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
-) -> Agent<M> {
+) -> (Agent<M>, ToolCache) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let skills: Arc<[Skill]> = Arc::from(
         tokio::task::spawn_blocking(move || skill::discover_skills(&cwd))
@@ -84,10 +85,16 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     }
 
     if cli.resolve_no_tools(cfg) {
-        builder.build()
+        (builder.build(), ToolCache::new())
     } else {
+        let cache = ToolCache::new();
+
         let base_tools: Vec<Box<dyn rig::tool::ToolDyn>> = vec![
-            Box::new(tools::ReadTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(tools::ReadTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+            )),
             Box::new(tools::WriteTool::new(
                 permission.clone(),
                 ask_tx.clone(),
@@ -103,12 +110,21 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 sandbox.clone(),
             )),
-            Box::new(tools::GrepTool::new(permission.clone(), ask_tx.clone())),
-            Box::new(tools::FindFilesTool::new(
+            Box::new(tools::GrepTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),
+                cache.clone(),
             )),
-            Box::new(tools::ListDirTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(tools::FindFilesTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+            )),
+            Box::new(tools::ListDirTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+            )),
             Box::new(tools::WriteTodoList::new(
                 permission.clone(),
                 ask_tx.clone(),
@@ -151,7 +167,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             }
         }
 
-        builder.build()
+        (builder.build(), cache)
     }
 }
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -6,9 +6,9 @@ use rig::message::ToolResultContent;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingChat};
 use tokio::sync::mpsc;
 
+use crate::agent::tools::ToolCache;
 use crate::event::AgentEvent;
 use crate::session::{MessageRole, Session};
-use crate::agent::tools::ToolCache;
 
 pub struct AgentRunner {
     pub event_rx: mpsc::Receiver<AgentEvent>,

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -8,6 +8,7 @@ use tokio::sync::mpsc;
 
 use crate::event::AgentEvent;
 use crate::session::{MessageRole, Session};
+use crate::agent::tools::ToolCache;
 
 pub struct AgentRunner {
     pub event_rx: mpsc::Receiver<AgentEvent>,
@@ -35,12 +36,18 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
     messages
 }
 
-pub fn spawn_agent<M, P>(agent: Agent<M, P>, prompt: String, history: Vec<Message>) -> AgentRunner
+pub fn spawn_agent<M, P>(
+    agent: Agent<M, P>,
+    prompt: String,
+    history: Vec<Message>,
+    cache: ToolCache,
+) -> AgentRunner
 where
     M: CompletionModel + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
     P: rig::agent::PromptHook<M> + 'static,
 {
+    cache.clear();
     let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(256);
 
     tokio::spawn(async move {

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -2,6 +2,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use tokio::time::{Duration, timeout};
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, check_perm};
 
 use crate::sandbox::Sandbox;
@@ -12,14 +13,31 @@ pub struct BashTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub sandbox: Sandbox,
+    cache: Option<ToolCache>,
 }
 
 impl BashTool {
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>, sandbox: Sandbox) -> Self {
         BashTool {
             permission,
             ask_tx,
             sandbox,
+            cache: None,
+        }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        sandbox: Sandbox,
+        cache: ToolCache,
+    ) -> Self {
+        BashTool {
+            permission,
+            ask_tx,
+            sandbox,
+            cache: Some(cache),
         }
     }
 }
@@ -84,6 +102,11 @@ impl Tool for BashTool {
         }
         if exit_code != 0 {
             result.push_str(&format!("\nExit code: {}", exit_code));
+        }
+        // Bash may have mutated the filesystem; conservatively invalidate the
+        // per-turn read/grep/list cache.
+        if let Some(ref cache) = self.cache {
+            cache.clear();
         }
         Ok(result)
     }

--- a/src/agent/tools/cache.rs
+++ b/src/agent/tools/cache.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+struct CacheEntry {
+    value: String,
+    generation: u64,
+}
+
+#[derive(Clone)]
+pub struct ToolCache {
+    entries: Arc<Mutex<HashMap<String, CacheEntry>>>,
+    generation: Arc<AtomicU64>,
+}
+
+impl Default for ToolCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToolCache {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(HashMap::new())),
+            generation: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<String> {
+        let current_gen = self.generation.load(Ordering::Relaxed);
+        let guard = self.entries.lock().unwrap();
+        match guard.get(key) {
+            Some(e) if e.generation == current_gen => Some(e.value.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn set(&self, key: &str, value: String) {
+        let current_gen = self.generation.load(Ordering::Relaxed);
+        self.entries.lock().unwrap().insert(
+            key.to_string(),
+            CacheEntry {
+                value,
+                generation: current_gen,
+            },
+        );
+    }
+
+    pub fn clear(&self) {
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        self.entries.lock().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_hit_and_miss() {
+        let cache = ToolCache::new();
+        assert!(cache.get("key1").is_none());
+        cache.set("key1", "value1".to_string());
+        assert_eq!(cache.get("key1"), Some("value1".to_string()));
+    }
+
+    #[test]
+    fn test_cache_clear_invalidates_entries() {
+        let cache = ToolCache::new();
+        cache.set("key1", "value1".to_string());
+        cache.clear();
+        assert!(cache.get("key1").is_none());
+    }
+
+    #[test]
+    fn test_cache_clone_shares_state() {
+        let cache1 = ToolCache::new();
+        let cache2 = cache1.clone();
+        cache1.set("shared", "data".to_string());
+        assert_eq!(cache2.get("shared"), Some("data".to_string()));
+    }
+
+    #[test]
+    fn test_clear_in_one_clone_affects_other() {
+        let cache1 = ToolCache::new();
+        let cache2 = cache1.clone();
+        cache1.set("x", "y".to_string());
+        cache2.clear();
+        assert!(cache1.get("x").is_none());
+    }
+}

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -3,15 +3,18 @@ use std::path::PathBuf;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, EditArgs, PermCheck, ToolError, check_perm_path};
 
 pub struct EditTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     plan_file: Option<PathBuf>,
+    cache: Option<ToolCache>,
 }
 
 impl EditTool {
+    #[allow(dead_code)]
     pub fn new(
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
@@ -21,6 +24,21 @@ impl EditTool {
             permission,
             ask_tx,
             plan_file,
+            cache: None,
+        }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        plan_file: Option<PathBuf>,
+        cache: ToolCache,
+    ) -> Self {
+        EditTool {
+            permission,
+            ask_tx,
+            plan_file,
+            cache: Some(cache),
         }
     }
 
@@ -186,6 +204,10 @@ impl Tool for EditTool {
         };
 
         tokio::fs::write(&args.path, &output).await?;
+        // File mutated → invalidate cached reads/greps/listings for this turn.
+        if let Some(ref cache) = self.cache {
+            cache.clear();
+        }
 
         let mut result = format!("Applied edit to {}", args.path);
         if do_replace_all {

--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -3,10 +3,10 @@ use regex::Regex;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
     AskSender, FindFilesArgs, MAX_FIND_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
 };
-use crate::agent::tools::cache::ToolCache;
 
 pub struct FindFilesTool {
     pub permission: Option<PermCheck>,
@@ -17,7 +17,11 @@ pub struct FindFilesTool {
 impl FindFilesTool {
     #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        FindFilesTool { permission, ask_tx, cache: None }
+        FindFilesTool {
+            permission,
+            ask_tx,
+            cache: None,
+        }
     }
 
     pub fn with_cache(
@@ -25,7 +29,11 @@ impl FindFilesTool {
         ask_tx: Option<AskSender>,
         cache: ToolCache,
     ) -> Self {
-        FindFilesTool { permission, ask_tx, cache: Some(cache) }
+        FindFilesTool {
+            permission,
+            ask_tx,
+            cache: Some(cache),
+        }
     }
 }
 

--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -6,15 +6,26 @@ use rig::tool::Tool;
 use crate::agent::tools::{
     AskSender, FindFilesArgs, MAX_FIND_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
 };
+use crate::agent::tools::cache::ToolCache;
 
 pub struct FindFilesTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub cache: Option<ToolCache>,
 }
 
 impl FindFilesTool {
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        FindFilesTool { permission, ask_tx }
+        FindFilesTool { permission, ask_tx, cache: None }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        cache: ToolCache,
+    ) -> Self {
+        FindFilesTool { permission, ask_tx, cache: Some(cache) }
     }
 }
 
@@ -48,6 +59,18 @@ impl Tool for FindFilesTool {
 
     async fn call(&self, args: FindFilesArgs) -> Result<String, ToolError> {
         check_perm(&self.permission, &self.ask_tx, "find_files", &args.pattern).await?;
+
+        let cache_key = format!(
+            "find_files:{}:{}",
+            args.pattern,
+            args.path.as_deref().unwrap_or("."),
+        );
+
+        if let Some(ref cache) = self.cache {
+            if let Some(cached) = cache.get(&cache_key) {
+                return Ok(cached);
+            }
+        }
 
         let re = Regex::new(&args.pattern)
             .map_err(|e| ToolError::Msg(format!("Invalid regex: {}", e)))?;
@@ -84,23 +107,28 @@ impl Tool for FindFilesTool {
             }
         }
 
-        if results.is_empty() {
-            return Ok("No files found matching the pattern.".to_string());
-        }
-
-        results.sort();
-
-        let total = results.len();
-        if total >= MAX_FIND_RESULTS {
-            Ok(format!(
-                "{} files found (showing first {}):\n{}\n\n... and {} more",
-                total,
-                MAX_FIND_RESULTS,
-                results[..MAX_FIND_RESULTS].join("\n"),
-                total - MAX_FIND_RESULTS
-            ))
+        let result = if results.is_empty() {
+            "No files found matching the pattern.".to_string()
         } else {
-            Ok(format!("{} files found:\n{}", total, results.join("\n")))
+            results.sort();
+            let total = results.len();
+            if total >= MAX_FIND_RESULTS {
+                format!(
+                    "{} files found (showing first {}):\n{}\n\n... and {} more",
+                    total,
+                    MAX_FIND_RESULTS,
+                    results[..MAX_FIND_RESULTS].join("\n"),
+                    total - MAX_FIND_RESULTS
+                )
+            } else {
+                format!("{} files found:\n{}", total, results.join("\n"))
+            }
+        };
+
+        if let Some(ref cache) = self.cache {
+            cache.set(&cache_key, result.clone());
         }
+
+        Ok(result)
     }
 }

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -6,15 +6,26 @@ use rig::tool::Tool;
 use crate::agent::tools::{
     AskSender, GrepArgs, MAX_GREP_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
 };
+use crate::agent::tools::cache::ToolCache;
 
 pub struct GrepTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub cache: Option<ToolCache>,
 }
 
 impl GrepTool {
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        GrepTool { permission, ask_tx }
+        GrepTool { permission, ask_tx, cache: None }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        cache: ToolCache,
+    ) -> Self {
+        GrepTool { permission, ask_tx, cache: Some(cache) }
     }
 
     fn glob_to_regex(glob: &str) -> String {
@@ -76,6 +87,20 @@ impl Tool for GrepTool {
 
     async fn call(&self, args: GrepArgs) -> Result<String, ToolError> {
         check_perm(&self.permission, &self.ask_tx, "grep", &args.pattern).await?;
+
+        let cache_key = format!(
+            "grep:{}:{}:{}:{}",
+            args.pattern,
+            args.path.as_deref().unwrap_or("."),
+            args.include.as_deref().unwrap_or(""),
+            args.context_lines.unwrap_or(0),
+        );
+
+        if let Some(ref cache) = self.cache {
+            if let Some(cached) = cache.get(&cache_key) {
+                return Ok(cached);
+            }
+        }
 
         let re = Regex::new(&args.pattern)
             .map_err(|e| ToolError::Msg(format!("Invalid regex pattern: {}", e)))?;
@@ -197,27 +222,33 @@ impl Tool for GrepTool {
             }
         }
 
-        if all_results.is_empty() {
-            return Ok("No matches found.".to_string());
+        let result = if all_results.is_empty() {
+            "No matches found.".to_string()
+        } else {
+            let total = all_results.len();
+            if total >= MAX_GREP_RESULTS {
+                format!(
+                    "{} results (showing first {}, searched {} files):\n{}\n\n... and {} more matches",
+                    total,
+                    MAX_GREP_RESULTS,
+                    file_count,
+                    all_results.join("\n"),
+                    total - MAX_GREP_RESULTS
+                )
+            } else {
+                format!(
+                    "{} results (searched {} files):\n{}",
+                    total,
+                    file_count,
+                    all_results.join("\n")
+                )
+            }
+        };
+
+        if let Some(ref cache) = self.cache {
+            cache.set(&cache_key, result.clone());
         }
 
-        let total = all_results.len();
-        if total >= MAX_GREP_RESULTS {
-            Ok(format!(
-                "{} results (showing first {}, searched {} files):\n{}\n\n... and {} more matches",
-                total,
-                MAX_GREP_RESULTS,
-                file_count,
-                all_results.join("\n"),
-                total - MAX_GREP_RESULTS
-            ))
-        } else {
-            Ok(format!(
-                "{} results (searched {} files):\n{}",
-                total,
-                file_count,
-                all_results.join("\n")
-            ))
-        }
+        Ok(result)
     }
 }

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -3,10 +3,10 @@ use regex::Regex;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
     AskSender, GrepArgs, MAX_GREP_RESULTS, PermCheck, ToolError, check_perm, is_skip_dir,
 };
-use crate::agent::tools::cache::ToolCache;
 
 pub struct GrepTool {
     pub permission: Option<PermCheck>,
@@ -17,7 +17,11 @@ pub struct GrepTool {
 impl GrepTool {
     #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        GrepTool { permission, ask_tx, cache: None }
+        GrepTool {
+            permission,
+            ask_tx,
+            cache: None,
+        }
     }
 
     pub fn with_cache(
@@ -25,7 +29,11 @@ impl GrepTool {
         ask_tx: Option<AskSender>,
         cache: ToolCache,
     ) -> Self {
-        GrepTool { permission, ask_tx, cache: Some(cache) }
+        GrepTool {
+            permission,
+            ask_tx,
+            cache: Some(cache),
+        }
     }
 
     fn glob_to_regex(glob: &str) -> String {

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -4,10 +4,10 @@ use ignore::WalkBuilder;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
     AskSender, ListDirArgs, PermCheck, ToolError, check_perm_path, is_skip_dir,
 };
-use crate::agent::tools::cache::ToolCache;
 
 fn format_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB"];
@@ -39,7 +39,11 @@ pub struct ListDirTool {
 impl ListDirTool {
     #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        ListDirTool { permission, ask_tx, cache: None }
+        ListDirTool {
+            permission,
+            ask_tx,
+            cache: None,
+        }
     }
 
     pub fn with_cache(
@@ -47,7 +51,11 @@ impl ListDirTool {
         ask_tx: Option<AskSender>,
         cache: ToolCache,
     ) -> Self {
-        ListDirTool { permission, ask_tx, cache: Some(cache) }
+        ListDirTool {
+            permission,
+            ask_tx,
+            cache: Some(cache),
+        }
     }
 }
 

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -7,6 +7,7 @@ use rig::tool::Tool;
 use crate::agent::tools::{
     AskSender, ListDirArgs, PermCheck, ToolError, check_perm_path, is_skip_dir,
 };
+use crate::agent::tools::cache::ToolCache;
 
 fn format_size(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB"];
@@ -32,11 +33,21 @@ fn count_dir_entries(path: &Path) -> u64 {
 pub struct ListDirTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub cache: Option<ToolCache>,
 }
 
 impl ListDirTool {
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        ListDirTool { permission, ask_tx }
+        ListDirTool { permission, ask_tx, cache: None }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        cache: ToolCache,
+    ) -> Self {
+        ListDirTool { permission, ask_tx, cache: Some(cache) }
     }
 }
 
@@ -67,6 +78,14 @@ impl Tool for ListDirTool {
     async fn call(&self, args: ListDirArgs) -> Result<String, ToolError> {
         let path = args.path.as_deref().unwrap_or(".");
         check_perm_path(&self.permission, &self.ask_tx, "list_dir", path).await?;
+
+        let cache_key = format!("list_dir:{}", path);
+
+        if let Some(ref cache) = self.cache {
+            if let Some(cached) = cache.get(&cache_key) {
+                return Ok(cached);
+            }
+        }
 
         let walker = WalkBuilder::new(path)
             .git_ignore(true)
@@ -146,6 +165,11 @@ impl Tool for ListDirTool {
             };
             result.push_str(&format!("  [{}]  {}{}\n", kind, padded, size_str));
         }
+
+        if let Some(ref cache) = self.cache {
+            cache.set(&cache_key, result.clone());
+        }
+
         Ok(result)
     }
 }

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -1,4 +1,5 @@
 mod bash;
+pub(crate) mod cache;
 pub(crate) mod edit;
 mod find_files;
 mod grep;
@@ -13,6 +14,7 @@ mod todo;
 mod write;
 
 pub use bash::BashTool;
+pub use cache::ToolCache;
 pub use edit::EditTool;
 pub use find_files::FindFilesTool;
 pub use grep::GrepTool;

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -1,8 +1,8 @@
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
-use crate::agent::tools::{AskSender, PermCheck, ReadArgs, ToolError, check_perm_path};
 use crate::agent::tools::cache::ToolCache;
+use crate::agent::tools::{AskSender, PermCheck, ReadArgs, ToolError, check_perm_path};
 
 pub struct ReadTool {
     pub permission: Option<PermCheck>,
@@ -13,7 +13,11 @@ pub struct ReadTool {
 impl ReadTool {
     #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        ReadTool { permission, ask_tx, cache: None }
+        ReadTool {
+            permission,
+            ask_tx,
+            cache: None,
+        }
     }
 
     pub fn with_cache(
@@ -21,7 +25,11 @@ impl ReadTool {
         ask_tx: Option<AskSender>,
         cache: ToolCache,
     ) -> Self {
-        ReadTool { permission, ask_tx, cache: Some(cache) }
+        ReadTool {
+            permission,
+            ask_tx,
+            cache: Some(cache),
+        }
     }
 }
 

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -2,15 +2,26 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use crate::agent::tools::{AskSender, PermCheck, ReadArgs, ToolError, check_perm_path};
+use crate::agent::tools::cache::ToolCache;
 
 pub struct ReadTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub cache: Option<ToolCache>,
 }
 
 impl ReadTool {
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        ReadTool { permission, ask_tx }
+        ReadTool { permission, ask_tx, cache: None }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        cache: ToolCache,
+    ) -> Self {
+        ReadTool { permission, ask_tx, cache: Some(cache) }
     }
 }
 
@@ -39,6 +50,19 @@ impl Tool for ReadTool {
 
     async fn call(&self, args: ReadArgs) -> Result<String, ToolError> {
         check_perm_path(&self.permission, &self.ask_tx, "read", &args.path).await?;
+
+        let cache_key = format!(
+            "read:{}:{}:{}",
+            args.path,
+            args.offset.unwrap_or(1),
+            args.limit.unwrap_or(2000),
+        );
+
+        if let Some(ref cache) = self.cache {
+            if let Some(cached) = cache.get(&cache_key) {
+                return Ok(cached);
+            }
+        }
 
         let metadata = tokio::fs::metadata(&args.path).await?;
         let file_size = metadata.len();
@@ -69,6 +93,11 @@ impl Tool for ReadTool {
             end,
             excerpt
         );
+
+        if let Some(ref cache) = self.cache {
+            cache.set(&cache_key, info.clone());
+        }
+
         Ok(info)
     }
 }

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -3,15 +3,18 @@ use std::path::{Path, PathBuf};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ToolError, WriteArgs, check_perm_path};
 
 pub struct WriteTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     plan_file: Option<PathBuf>,
+    cache: Option<ToolCache>,
 }
 
 impl WriteTool {
+    #[allow(dead_code)]
     pub fn new(
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
@@ -21,6 +24,21 @@ impl WriteTool {
             permission,
             ask_tx,
             plan_file,
+            cache: None,
+        }
+    }
+
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        plan_file: Option<PathBuf>,
+        cache: ToolCache,
+    ) -> Self {
+        WriteTool {
+            permission,
+            ask_tx,
+            plan_file,
+            cache: Some(cache),
         }
     }
 }
@@ -73,6 +91,10 @@ impl Tool for WriteTool {
         }
         let bytes = args.content.len();
         tokio::fs::write(path, &args.content).await?;
+        // File mutated → invalidate cached reads/greps/listings for this turn.
+        if let Some(ref cache) = self.cache {
+            cache.clear();
+        }
         Ok(format!("Written {} bytes to {}", bytes, args.path))
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -9,6 +9,7 @@ use rig::streaming::StreamingChat;
 use crate::agent::builder;
 use crate::agent::prompt;
 use crate::agent::runner::{self, AgentRunner};
+use crate::agent::tools::ToolCache;
 use crate::cli::Cli;
 use crate::config::{Config, CustomProviderConfig};
 use crate::context::ContextFiles;
@@ -282,7 +283,13 @@ impl AnyModel {
 }
 
 #[derive(Clone)]
-pub enum AnyAgent {
+pub struct AnyAgent {
+    inner: AnyAgentInner,
+    cache: ToolCache,
+}
+
+#[derive(Clone)]
+pub(crate) enum AnyAgentInner {
     OpenRouter(Agent<openrouter::completion::CompletionModel>),
     OpenAI(Agent<openai::completion::CompletionModel>),
     Anthropic(Agent<anthropic::completion::CompletionModel>),
@@ -294,29 +301,34 @@ pub enum AnyAgent {
 }
 
 impl AnyAgent {
+    pub fn new(inner: AnyAgentInner, cache: ToolCache) -> Self {
+        AnyAgent { inner, cache }
+    }
+
     pub async fn run_print(&self, prompt: &str, max_turns: usize) -> anyhow::Result<String> {
-        match self {
-            AnyAgent::OpenRouter(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::OpenAI(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::Anthropic(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::Gemini(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::DeepSeek(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::Glm(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::Ollama(a) => runner::run_print(a, prompt, max_turns).await,
-            AnyAgent::Custom(a) => runner::run_print(a, prompt, max_turns).await,
+        match &self.inner {
+            AnyAgentInner::OpenRouter(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::OpenAI(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::Anthropic(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::Gemini(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::DeepSeek(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::Glm(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::Ollama(a) => runner::run_print(a, prompt, max_turns).await,
+            AnyAgentInner::Custom(a) => runner::run_print(a, prompt, max_turns).await,
         }
     }
 
     pub fn spawn_runner(self, prompt: String, history: Vec<Message>) -> AgentRunner {
-        match self {
-            AnyAgent::OpenRouter(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::OpenAI(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::Anthropic(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::Gemini(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::DeepSeek(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::Glm(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::Ollama(a) => runner::spawn_agent(a, prompt, history),
-            AnyAgent::Custom(a) => runner::spawn_agent(a, prompt, history),
+        self.cache.clear();
+        match self.inner {
+            AnyAgentInner::OpenRouter(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::OpenAI(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::Anthropic(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::Gemini(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::DeepSeek(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::Glm(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::Ollama(a) => runner::spawn_agent(a, prompt, history, self.cache),
+            AnyAgentInner::Custom(a) => runner::spawn_agent(a, prompt, history, self.cache),
         }
     }
 }
@@ -428,142 +440,35 @@ pub async fn build_agent(
 ) -> AnyAgent {
     let parent_model = model.clone();
 
+    macro_rules! build_inner {
+        ($m:expr, $variant:ident) => {{
+            let (agent, cache) = builder::build_agent_inner(
+                $m,
+                cli,
+                cfg,
+                context,
+                permission,
+                ask_tx,
+                sandbox.clone(),
+                Some(parent_model.clone()),
+                #[cfg(feature = "mcp")]
+                mcp_manager,
+                #[cfg(feature = "semantic")]
+                semantic_manager,
+            )
+            .await;
+            AnyAgent::new(AnyAgentInner::$variant(agent), cache)
+        }};
+    }
+
     match model {
-        AnyModel::OpenRouter(m) => AnyAgent::OpenRouter(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::OpenAI(m) => AnyAgent::OpenAI(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::Anthropic(m) => AnyAgent::Anthropic(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::Gemini(m) => AnyAgent::Gemini(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::DeepSeek(m) => AnyAgent::DeepSeek(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::Glm(m) => AnyAgent::Glm(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::Ollama(m) => AnyAgent::Ollama(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox,
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
-        AnyModel::Custom(m) => AnyAgent::Custom(
-            builder::build_agent_inner(
-                m,
-                cli,
-                cfg,
-                context,
-                permission,
-                ask_tx,
-                sandbox.clone(),
-                Some(parent_model.clone()),
-                #[cfg(feature = "mcp")]
-                mcp_manager,
-                #[cfg(feature = "semantic")]
-                semantic_manager,
-            )
-            .await,
-        ),
+        AnyModel::OpenRouter(m) => build_inner!(m, OpenRouter),
+        AnyModel::OpenAI(m) => build_inner!(m, OpenAI),
+        AnyModel::Anthropic(m) => build_inner!(m, Anthropic),
+        AnyModel::Gemini(m) => build_inner!(m, Gemini),
+        AnyModel::DeepSeek(m) => build_inner!(m, DeepSeek),
+        AnyModel::Glm(m) => build_inner!(m, Glm),
+        AnyModel::Ollama(m) => build_inner!(m, Ollama),
+        AnyModel::Custom(m) => build_inner!(m, Custom),
     }
 }


### PR DESCRIPTION
## Summary
- New \`ToolCache\` (Arc<Mutex<HashMap>> + atomic generation counter), cleared at the start of every agent turn
- Read-only tools (read/grep/find_files/list_dir) check the cache before doing filesystem work
- Write/edit/bash clear the cache on success so a re-read after mutation returns fresh content (review fix)
- Provider builder refactored: macro-ized variant construction in \`AnyAgent::build\`

## Test plan
- [x] Unit tests for cache hit/miss, clear, clone-sharing, generation invalidation
- [ ] Manual: model that does read → edit → read same file in one turn returns updated content on the second read
- [ ] Manual: repeated identical read in one turn returns instantly (cache hit)