### PR TITLE
Multi-line input: Shift/Meta+Enter, line navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ dirge --provider glm       # defaults to glm-4
 | Meta+D | Delete word after cursor |
 | Ctrl+Y | Yank (paste) last kill |
 | Meta+Y | Yank-pop (cycle kill ring after yank) |
-| Ctrl+N / Down | History next |
-| Ctrl+P / Up | History previous |
+| Ctrl+N / Down | History next (multi-line: next logical line, history at boundary) |
+| Ctrl+P / Up | History previous (multi-line: previous logical line, history at boundary) |
+| Shift+Enter / Meta+Enter | Insert newline (multi-line input) |
 | Tab | Insert 2 spaces |
 | `@<query>` | File picker (Tab/Enter select, Esc cancel) |
 

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -13,6 +13,14 @@ fn meta(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::ALT)
 }
 
+fn shift_enter() -> KeyEvent {
+    KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)
+}
+
+fn meta_enter() -> KeyEvent {
+    KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)
+}
+
 fn type_str(editor: &mut InputEditor, s: &str) {
     for c in s.chars() {
         editor.handle_key(press(KeyCode::Char(c)));
@@ -590,5 +598,136 @@ fn option_left_with_picker_active_handled_by_picker() {
     assert!(editor.picker.as_ref().is_some_and(|p| p.active));
 
     let result = editor.handle_key(meta(KeyCode::Left));
+    assert!(result.is_none());
+}
+
+// ── Multi-line input ────────────────────────────────────────
+
+#[test]
+fn shift_enter_inserts_newline() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "world");
+    assert_eq!(editor.buffer.as_str(), "hello\nworld");
+}
+
+#[test]
+fn meta_enter_inserts_newline() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(meta_enter());
+    type_str(&mut editor, "world");
+    assert_eq!(editor.buffer.as_str(), "hello\nworld");
+}
+
+#[test]
+fn plain_enter_submits_multiline_text() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "line1");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "line2");
+    let submitted = editor.handle_key(press(KeyCode::Enter)).unwrap();
+    assert_eq!(submitted.as_str(), "line1\nline2");
+    assert!(editor.buffer.is_empty());
+}
+
+#[test]
+fn multiline_history_saves_and_restores() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "first");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "second");
+    editor.handle_key(press(KeyCode::Enter)); // submit
+
+    // Navigate up in history
+    editor.handle_key(press(KeyCode::Up));
+    assert_eq!(editor.buffer.as_str(), "first\nsecond");
+}
+
+#[test]
+fn multiline_cursor_up_moves_to_previous_logical_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "line1");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "line2");
+    // cursor is at end: after "line2"
+    let end_pos = editor.cursor;
+    editor.handle_key(press(KeyCode::Up));
+    // cursor should now be on line1
+    assert!(editor.cursor < end_pos);
+    // verify it's on line1
+    let line1_end = "line1".len();
+    assert!(editor.cursor <= line1_end);
+}
+
+#[test]
+fn multiline_cursor_down_moves_to_next_logical_line() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "line1");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "line2");
+    // Move to start of line1
+    editor.cursor = 0;
+    editor.handle_key(press(KeyCode::Down));
+    // cursor should now be on line2
+    let line1_len = "line1\n".len();
+    assert!(editor.cursor >= line1_len);
+}
+
+#[test]
+fn multiline_up_at_top_goes_to_history() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "prev");
+    editor.handle_key(press(KeyCode::Enter)); // submit to history
+
+    type_str(&mut editor, "line1");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "line2");
+    editor.cursor = 0; // at top of multi-line buffer
+
+    // Up at top should go to history
+    editor.handle_key(press(KeyCode::Up));
+    assert_eq!(editor.buffer.as_str(), "prev");
+}
+
+#[test]
+fn multiline_down_at_bottom_goes_to_history() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "prev");
+    editor.handle_key(press(KeyCode::Enter));
+
+    type_str(&mut editor, "next");
+    editor.handle_key(press(KeyCode::Enter));
+
+    // Load "next" from history
+    editor.handle_key(press(KeyCode::Up));
+    assert_eq!(editor.buffer.as_str(), "next");
+
+    // Down from bottom of single line should clear
+    editor.handle_key(press(KeyCode::Down));
+    assert!(editor.buffer.is_empty());
+}
+
+#[test]
+fn enter_with_picker_active_does_not_submit() {
+    let mut editor = InputEditor::new();
+    editor.cursor = 0;
+    editor.handle_key(press(KeyCode::Char('@')));
+    assert!(editor.picker.as_ref().is_some_and(|p| p.active));
+
+    let result = editor.handle_key(press(KeyCode::Enter));
+    assert!(result.is_none());
+    assert!(editor.picker.as_ref().is_some_and(|p| p.active));
+}
+
+#[test]
+fn meta_enter_with_picker_active_inserts_newline() {
+    let mut editor = InputEditor::new();
+    editor.cursor = 0;
+    editor.handle_key(press(KeyCode::Char('@')));
+    // Even with picker active, Meta+Enter should insert newline
+    // (the handle_picker_key returns false for Meta+Enter, so it falls through)
+    let result = editor.handle_key(meta_enter());
     assert!(result.is_none());
 }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -115,6 +115,30 @@ fn next_word_boundary(s: &str, cursor: usize) -> usize {
     idx
 }
 
+fn cursor_line_start(s: &str, cursor: usize) -> usize {
+    if cursor == 0 {
+        return 0;
+    }
+    let haystack = &s[..cursor];
+    match haystack.rfind('\n') {
+        Some(pos) => pos + 1,
+        None => 0,
+    }
+}
+
+fn prev_line_start(s: &str, cursor: usize) -> Option<usize> {
+    let line_start = cursor_line_start(s, cursor);
+    if line_start == 0 {
+        return None;
+    }
+    Some(cursor_line_start(s, line_start.saturating_sub(1)))
+}
+
+fn next_line_start(s: &str, cursor: usize) -> Option<usize> {
+    let after = &s[cursor..];
+    after.find('\n').map(|p| cursor + p + 1)
+}
+
 pub struct InputEditor {
     pub buffer: CompactString,
     pub cursor: usize,
@@ -292,12 +316,21 @@ impl InputEditor {
     pub fn handle_key(&mut self, key: KeyEvent) -> Option<CompactString> {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let has_shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
         match key.code {
             KeyCode::Enter => {
                 if self.picker.as_ref().is_some_and(|p| p.active) {
                     return None;
                 }
+                // Meta+Enter or Shift+Enter inserts newline
+                if has_shift || alt {
+                    self.buffer.insert(self.cursor, '\n');
+                    self.cursor += 1;
+                    self.history_pos = None;
+                    return None;
+                }
+                // Plain Enter → submit
                 let text = self.buffer.clone();
                 if !text.is_empty() {
                     self.history.push(text.clone());
@@ -560,14 +593,48 @@ impl InputEditor {
             }
 
             KeyCode::Up => {
-                self.history_up();
                 self.reset_kill_accumulation();
+                // If already navigating history, continue.
+                if self.history_pos.is_some() {
+                    self.history_up();
+                    return None;
+                }
+                // Try moving up within the multiline buffer first.
+                if let Some(pos) = prev_line_start(&self.buffer, self.cursor) {
+                    let line_start = cursor_line_start(&self.buffer, self.cursor);
+                    let col = self.cursor - line_start;
+                    let target_line_end = self.buffer[pos..]
+                        .find('\n')
+                        .map(|p| pos + p)
+                        .unwrap_or(self.buffer.len());
+                    self.cursor = (pos + col).min(target_line_end);
+                    return None;
+                }
+                // At top of buffer → fall through to history.
+                self.history_up();
                 None
             }
 
             KeyCode::Down => {
-                self.history_down();
                 self.reset_kill_accumulation();
+                // If already navigating history, continue.
+                if self.history_pos.is_some() {
+                    self.history_down();
+                    return None;
+                }
+                // Try moving down within the multiline buffer first.
+                if let Some(pos) = next_line_start(&self.buffer, self.cursor) {
+                    let line_start = cursor_line_start(&self.buffer, self.cursor);
+                    let col = self.cursor - line_start;
+                    let target_line_end = self.buffer[pos..]
+                        .find('\n')
+                        .map(|p| pos + p)
+                        .unwrap_or(self.buffer.len());
+                    self.cursor = (pos + col).min(target_line_end);
+                    return None;
+                }
+                // At bottom of buffer → fall through to history.
+                self.history_down();
                 None
             }
 
@@ -675,5 +742,24 @@ mod tests {
         // "hå bør": 8 bytes. h(0) å(1-2=3) sp(3) b(4) ø(5-6=7) r(7→8)
         assert_eq!(next_word_boundary("hå bør", 0), 4); // skip "hå ", land at "b" (byte 4)
         assert_eq!(next_word_boundary("hå bør", 4), 8); // skip "bør", land at end
+    }
+
+    #[test]
+    fn test_cursor_line_start() {
+        assert_eq!(cursor_line_start("hello\nworld", 10), 6);
+        assert_eq!(cursor_line_start("hello\nworld", 3), 0);
+        assert_eq!(cursor_line_start("single", 6), 0);
+    }
+
+    #[test]
+    fn test_prev_line_start() {
+        assert_eq!(prev_line_start("hello\nworld", 10), Some(0));
+        assert_eq!(prev_line_start("hello\nworld", 3), None);
+    }
+
+    #[test]
+    fn test_next_line_start() {
+        assert_eq!(next_line_start("hello\nworld", 0), Some(6));
+        assert_eq!(next_line_start("hello\nworld", 10), None);
     }
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -456,8 +456,8 @@ impl Renderer {
 
     pub fn draw_bottom(
         &mut self,
-        input_line: &str,
-        cursor_pos: usize,
+        full_input: &str,
+        full_cursor: usize,
         status: &str,
         is_running: bool,
     ) -> io::Result<()> {
@@ -473,6 +473,25 @@ impl Renderer {
             "> "
         };
 
+        // Extract the current logical line for display
+        let line_start = full_input[..full_cursor]
+            .rfind('\n')
+            .map(|p| p + 1)
+            .unwrap_or(0);
+        let line_end = full_input[full_cursor..]
+            .find('\n')
+            .map(|p| full_cursor + p)
+            .unwrap_or(full_input.len());
+        let visible_line = &full_input[line_start..line_end];
+        let col_in_line = full_cursor - line_start;
+
+        // Count lines for status display
+        let line_count = if full_input.is_empty() {
+            1
+        } else {
+            full_input.chars().filter(|&c| c == '\n').count() + 1
+        };
+
         stdout.execute(MoveTo(0, input_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
         stdout.execute(MoveTo(0, input_row))?;
@@ -480,17 +499,17 @@ impl Renderer {
         write!(stdout, "{}", prompt)?;
         write!(stdout, "{}", ResetColor)?;
         let visible_width = cols.saturating_sub(2) as usize;
-        let input_len = input_line.len();
+        let input_len = visible_line.len();
 
-        if cursor_pos < self.input_scroll_offset {
-            self.input_scroll_offset = cursor_pos;
-        } else if cursor_pos >= self.input_scroll_offset + visible_width {
-            self.input_scroll_offset = cursor_pos - visible_width + 1;
+        if col_in_line < self.input_scroll_offset {
+            self.input_scroll_offset = col_in_line;
+        } else if col_in_line >= self.input_scroll_offset + visible_width {
+            self.input_scroll_offset = col_in_line - visible_width + 1;
         }
         let max_scroll = input_len.saturating_sub(visible_width);
         self.input_scroll_offset = self.input_scroll_offset.min(max_scroll);
 
-        let visible: String = input_line
+        let visible: String = visible_line
             .chars()
             .skip(self.input_scroll_offset)
             .take(visible_width)
@@ -505,16 +524,19 @@ impl Renderer {
             "{}",
             SetForegroundColor(self.color(Color::DarkGrey))
         )?;
-        let status_display = if self.scroll_offset > 0 {
+        let mut status_display = if self.scroll_offset > 0 {
             format!("-- SCROLL -- {}", status)
         } else {
             status.to_string()
         };
+        if line_count > 1 {
+            status_display.push_str(&format!(" [{} lines]", line_count));
+        }
         let truncated: String = status_display.chars().take(cols as usize).collect();
         write!(stdout, "{}", truncated)?;
         write!(stdout, "{}", ResetColor)?;
 
-        let cursor_x = (2 + cursor_pos.saturating_sub(self.input_scroll_offset)) as u16;
+        let cursor_x = (2 + col_in_line.saturating_sub(self.input_scroll_offset)) as u16;
         stdout.execute(MoveTo(cursor_x, input_row))?;
         stdout.flush()?;
         Ok(())


### PR DESCRIPTION
## Summary
- Shift+Enter / Meta+Enter inserts a literal newline; plain Enter still submits
- Up/Down navigates between logical lines inside a multi-line buffer; falls through to history at boundaries
- Status bar shows \`[N lines]\` when buffer is multi-line; input row displays the current logical line
- Renderer scrolls the visible line based on cursor column within that line

## Test plan
- [x] Unit tests: Shift/Meta+Enter inserts newline; plain Enter submits; Up/Down moves between lines; history loads multi-line text
- [ ] Manual: type a multi-line message, navigate with Up/Down, submit with plain Enter
- [ ] Manual: Up at line 0 falls through to history; Down at last line continues to history