### PR TITLE
Live token counter in input bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ dirge --provider glm       # defaults to glm-4
 | `!! cmd` | Run shell command (invisible) |
 | `@<query>` | File picker (Tab/Enter select, Esc cancel) |
 | Mouse drag | Select text (copies to clipboard on release) |
+| (input) | Live token count shown next to input bar (`N tk`) |
 
 ## Prompts system
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -497,6 +497,17 @@ impl Renderer {
             .collect();
         write!(stdout, "{}", visible)?;
 
+        let token_est = input_line.len() as u64 / 4;
+        if token_est > 0 {
+            write!(
+                stdout,
+                "{}",
+                SetForegroundColor(self.color(Color::DarkGrey))
+            )?;
+            write!(stdout, "  ({} tk)", token_est)?;
+            write!(stdout, "{}", ResetColor)?;
+        }
+
         stdout.execute(MoveTo(0, status_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
         stdout.execute(MoveTo(0, status_row))?;


### PR DESCRIPTION
## Summary
- Shows approximate token count (\`bytes/4\`) next to the input prompt
- Uses full buffer length (not just visible line) so multi-line drafts get accurate counts

## Test plan
- [ ] Manual: type a short prompt, confirm \`(N tk)\` appears next to input
- [ ] Manual: type a multi-line prompt with Shift+Enter, confirm count reflects total buffer