### PR TITLE
Line-numbered read output + environment preamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 
 - **Multi-provider**: OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, GLM, Ollama, plus custom providers
 - **Standard tools**: read, write, edit, bash, grep, find_files, list_dir, write_todo_list
+- **Line-numbered read output**: `read` tool prefixes each line with right-aligned line numbers (`123: content`)
+- **Environment-aware**: system prompt includes OS, shell, working directory, and git branch for context
 - **Semantic code tools** (tree-sitter): list_symbols, get_symbol_body, find_definition, find_callers, find_callees — supports TypeScript/TSX and Python
 - **Claude-compatible skills**: discover skills from `.claude/skills/`, `.maki/skills/`, `.opencode/skills/`, `.dirge/skills/` directories. Agent can call the `skill` tool to load instructions on demand
 - **Bash permissions** (tree-sitter): parses shell commands to split `&&`/`;`/`|` into individual segments, detects command substitution and complex constructs

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -84,7 +84,11 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             .and_then(|output| {
                 if output.status.success() {
                     let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    if !branch.is_empty() { Some(branch) } else { None }
+                    if !branch.is_empty() {
+                        Some(branch)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -70,6 +70,33 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         preamble.push_str(&format!("\n\nCurrent working directory: {}", cwd_str));
     }
 
+    preamble.push_str(&format!("\nOS: {}", std::env::consts::OS));
+
+    if let Ok(shell) = std::env::var("SHELL") {
+        preamble.push_str(&format!("\nShell: {}", shell));
+    }
+
+    let git_branch = tokio::task::spawn_blocking(|| {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|output| {
+                if output.status.success() {
+                    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                    if !branch.is_empty() { Some(branch) } else { None }
+                } else {
+                    None
+                }
+            })
+    })
+    .await
+    .unwrap_or(None);
+
+    if let Some(branch) = git_branch {
+        preamble.push_str(&format!("\nGit branch: {}", branch));
+    }
+
     let mut builder = AgentBuilder::new(model).preamble(&preamble);
 
     let max_tokens = cli.resolve_max_tokens(cfg);

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -11,7 +11,7 @@ Formatting rules:
 - For file contents show the path and relevant lines
 
 Available tools:
-- read: Read file contents (supports offset/limit for large files, max 10MB)
+- read: Read file contents (supports offset/limit for large files, max 10MB). Lines are prefixed with right-aligned numbers for reference (e.g. \"   1: content\"). When passing text from read to edit, strip the \"NNN: \" prefix — use only the actual file content.
 - write: Create or overwrite files (creates parent dirs automatically)
 - edit: Edit files by exact text match. If old_text appears multiple times, shows all match locations with line numbers. Use replaceAll: true for bulk replace. Handles both LF and CRLF. Shows unified diff.
 - bash: Execute bash commands (supports timeout param)

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -55,10 +55,13 @@ impl Tool for ReadTool {
         let limit = args.limit.unwrap_or(2000);
         let end = (offset + limit).min(total_lines);
 
+        let width = (total_lines.to_string().len()).max(1);
         let excerpt: String = content
             .lines()
             .skip(offset)
             .take(end - offset)
+            .enumerate()
+            .map(|(i, line)| format!("{:>width$}: {}", offset + i + 1, line))
             .collect::<Vec<_>>()
             .join("\n");
         let info = format!(
@@ -70,5 +73,28 @@ impl Tool for ReadTool {
             excerpt
         );
         Ok(info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Verifies the line-numbering format used in read output.
+    /// The model sees this format and must strip "NNN: " prefixes when passing text to edit.
+    #[test]
+    fn test_line_number_format() {
+        let content = "line one\nline two\nline three\n";
+        let total_lines = content.lines().count();
+        let excerpt: String = content
+            .lines()
+            .take(3)
+            .enumerate()
+            .map(|(i, line)| {
+                let width = (total_lines.to_string().len()).max(1);
+                format!("{:>width$}: {}", i + 1, line)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(excerpt, "1: line one\n2: line two\n3: line three");
     }
 }


### PR DESCRIPTION
## Summary
- \`read\` tool prefixes each line with a right-aligned line number (\`  42: content\`); width scales with file size
- System prompt updated to instruct the model to strip the \`NNN: \` prefix before passing text to \`edit\`
- Agent preamble now includes OS, shell, current working directory, and current git branch
- Git branch resolution moved to \`tokio::task::spawn_blocking\` so it doesn't block the async runtime

## Test plan
- [x] Unit test: line-number format verified
- [ ] Manual: read a file, check line-number format and width
- [ ] Manual: confirm preamble contains OS, shell, cwd, git branch
- [ ] Manual: read → edit cycle; verify edit succeeds (model strips prefix as instructed)