### PR TITLE
fix: token counter uses full_input after multi-line rename

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -516,7 +516,7 @@ impl Renderer {
             .collect();
         write!(stdout, "{}", visible)?;
 
-        let token_est = input_line.len() as u64 / 4;
+        let token_est = full_input.len() as u64 / 4;
         if token_est > 0 {
             write!(
                 stdout,


### PR DESCRIPTION
## Summary
- The squash merge of #6 (token counter) referenced \`input_line\`, but #4 (multi-line input) renamed the renderer's locals to \`full_input\` / \`visible_line\`. Build broke on main as a result.
- Use \`full_input.len()\` so the token estimate covers the entire multi-line draft, not just the visible line.

## Test plan
- [x] \`./build.sh\` succeeds
- [x] \`cargo check\` clean