### PR TITLE
fix: stream agent events live, don't buffer until completion

### DIFF
--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -37,66 +37,61 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
     messages
 }
 
+/// Outcome of a streaming pass — used by the retry loop to decide whether
+/// it's safe to re-issue the request. We never buffer events themselves;
+/// they're sent to the UI as they arrive so the user sees progress in real
+/// time.
 #[derive(Default)]
-struct StreamBuffer {
-    events: Vec<AgentEvent>,
+struct StreamOutcome {
     had_tool_calls: bool,
-}
-
-impl StreamBuffer {
-    fn push(&mut self, event: AgentEvent) {
-        if matches!(
-            event,
-            AgentEvent::ToolCall { .. } | AgentEvent::ToolResult { .. }
-        ) {
-            self.had_tool_calls = true;
-        }
-        self.events.push(event);
-    }
-
-    fn flush(&self, tx: &mpsc::Sender<AgentEvent>) {
-        for event in &self.events {
-            let _ = tx.try_send(event.clone());
-        }
-    }
+    error: Option<String>,
 }
 
 async fn run_stream<M, P>(
     agent: &Agent<M, P>,
     prompt: &str,
     history: Vec<Message>,
-) -> (StreamBuffer, Result<(), String>)
+    event_tx: &mpsc::Sender<AgentEvent>,
+) -> StreamOutcome
 where
     M: CompletionModel + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
     P: rig::agent::PromptHook<M> + 'static,
 {
-    let mut buf = StreamBuffer::default();
+    let mut outcome = StreamOutcome::default();
     let mut stream = agent.stream_chat(prompt.to_string(), history).await;
 
     while let Some(item) = stream.next().await {
         match item {
             Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(text))) => {
-                buf.push(AgentEvent::Token(CompactString::from(text.text)));
+                let _ = event_tx
+                    .send(AgentEvent::Token(CompactString::from(text.text)))
+                    .await;
             }
             Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Reasoning(
                 r,
             ))) => {
-                buf.push(AgentEvent::Reasoning(CompactString::new(r.display_text())));
+                let _ = event_tx
+                    .send(AgentEvent::Reasoning(CompactString::new(r.display_text())))
+                    .await;
             }
             Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
                 tool_call,
                 ..
             })) => {
-                buf.push(AgentEvent::ToolCall {
-                    name: CompactString::from(tool_call.function.name),
-                    args: tool_call.function.arguments,
-                });
+                outcome.had_tool_calls = true;
+                let _ = event_tx
+                    .send(AgentEvent::ToolCall {
+                        name: CompactString::from(tool_call.function.name),
+                        args: tool_call.function.arguments,
+                    })
+                    .await;
             }
             Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
                 tool_result,
                 ..
             })) => {
+                outcome.had_tool_calls = true;
                 let mut output = String::new();
                 for c in tool_result.content.iter() {
                     if let ToolResultContent::Text(t) = c {
@@ -106,27 +101,32 @@ where
                         output.push_str(&t.text);
                     }
                 }
-                buf.push(AgentEvent::ToolResult {
-                    output: CompactString::from(output),
-                });
+                let _ = event_tx
+                    .send(AgentEvent::ToolResult {
+                        output: CompactString::from(output),
+                    })
+                    .await;
             }
             Ok(MultiTurnStreamItem::FinalResponse(res)) => {
                 let response_text = res.response();
                 let estimated_tokens = Session::estimate_tokens(response_text);
-                buf.push(AgentEvent::Done {
-                    response: CompactString::from(response_text),
-                    tokens: estimated_tokens,
-                    cost: 0.0,
-                });
-                return (buf, Ok(()));
+                let _ = event_tx
+                    .send(AgentEvent::Done {
+                        response: CompactString::from(response_text),
+                        tokens: estimated_tokens,
+                        cost: 0.0,
+                    })
+                    .await;
+                return outcome;
             }
             Err(e) => {
-                return (buf, Err(e.to_string()));
+                outcome.error = Some(e.to_string());
+                return outcome;
             }
             _ => {}
         }
     }
-    (buf, Ok(()))
+    outcome
 }
 
 pub fn spawn_agent<M, P>(
@@ -148,76 +148,70 @@ where
         let mut attempts = 0;
 
         loop {
-            let (buf, result) = run_stream(&agent, &prompt, history.clone()).await;
+            let outcome = run_stream(&agent, &prompt, history.clone(), &event_tx).await;
 
-            match result {
-                Ok(()) => {
-                    buf.flush(&event_tx);
-                    break;
-                }
-                Err(msg) => {
-                    let kind = recovery::classify_error(&msg);
+            let msg = match outcome.error {
+                None => break,
+                Some(m) => m,
+            };
 
-                    // Auth and unknown errors surface immediately
-                    if kind == ErrorKind::Auth || kind == ErrorKind::Other {
-                        buf.flush(&event_tx);
-                        let _ = event_tx
-                            .send(AgentEvent::Error(CompactString::new(msg)))
-                            .await;
-                        break;
-                    }
+            let kind = recovery::classify_error(&msg);
 
-                    // Context-length errors: not retryable without compaction
-                    // Surface a helpful error hinting at /compress
-                    if kind == ErrorKind::ContextLength {
-                        buf.flush(&event_tx);
-                        let hint = format!(
-                            "{} — try /compress to compact the conversation, then retry",
-                            msg
-                        );
-                        let _ = event_tx
-                            .send(AgentEvent::Error(CompactString::new(hint)))
-                            .await;
-                        break;
-                    }
-
-                    // If any tool calls were dispatched, their side effects already
-                    // executed. Retrying would re-run them. Flush the partial
-                    // buffer and surface the error instead.
-                    if buf.had_tool_calls {
-                        buf.flush(&event_tx);
-                        let err =
-                            format!("{} (tool side effects already applied, not retrying)", msg);
-                        let _ = event_tx
-                            .send(AgentEvent::Error(CompactString::new(err)))
-                            .await;
-                        break;
-                    }
-
-                    if !policy.should_retry(attempts, kind) {
-                        let retry_msg = format!("{} (retries exhausted)", msg);
-                        let _ = event_tx
-                            .send(AgentEvent::Error(CompactString::new(retry_msg)))
-                            .await;
-                        break;
-                    }
-
-                    // Emit retry notification as reasoning
-                    let retry_msg = format!(
-                        "retrying ({kind:?} error, attempt {attempt}/{max})...",
-                        kind = kind,
-                        attempt = attempts + 1,
-                        max = policy.max_retries(),
-                    );
-                    let _ = event_tx
-                        .send(AgentEvent::Reasoning(CompactString::new(retry_msg)))
-                        .await;
-
-                    let delay = policy.backoff_duration(attempts);
-                    tokio::time::sleep(delay).await;
-                    attempts += 1;
-                }
+            // Auth and unknown errors surface immediately
+            if kind == ErrorKind::Auth || kind == ErrorKind::Other {
+                let _ = event_tx
+                    .send(AgentEvent::Error(CompactString::new(msg)))
+                    .await;
+                break;
             }
+
+            // Context-length errors: not retryable without compaction
+            // Surface a helpful error hinting at /compress
+            if kind == ErrorKind::ContextLength {
+                let hint = format!(
+                    "{} — try /compress to compact the conversation, then retry",
+                    msg
+                );
+                let _ = event_tx
+                    .send(AgentEvent::Error(CompactString::new(hint)))
+                    .await;
+                break;
+            }
+
+            // If any tool calls were dispatched, their side effects already
+            // executed. Retrying would re-run them. Surface the error
+            // without retrying — events already streamed live, so the user
+            // sees what got done.
+            if outcome.had_tool_calls {
+                let err = format!("{} (tool side effects already applied, not retrying)", msg);
+                let _ = event_tx
+                    .send(AgentEvent::Error(CompactString::new(err)))
+                    .await;
+                break;
+            }
+
+            if !policy.should_retry(attempts, kind) {
+                let retry_msg = format!("{} (retries exhausted)", msg);
+                let _ = event_tx
+                    .send(AgentEvent::Error(CompactString::new(retry_msg)))
+                    .await;
+                break;
+            }
+
+            // Emit retry notification as reasoning
+            let retry_msg = format!(
+                "retrying ({kind:?} error, attempt {attempt}/{max})...",
+                kind = kind,
+                attempt = attempts + 1,
+                max = policy.max_retries(),
+            );
+            let _ = event_tx
+                .send(AgentEvent::Reasoning(CompactString::new(retry_msg)))
+                .await;
+
+            let delay = policy.backoff_duration(attempts);
+            tokio::time::sleep(delay).await;
+            attempts += 1;
         }
     });
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -5,6 +5,7 @@ use rig::completion::{CompletionModel, Message};
 use rig::message::ToolResultContent;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingChat};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::agent::recovery::{self, ErrorKind, RecoveryPolicy};
 use crate::agent::tools::ToolCache;
@@ -13,6 +14,11 @@ use crate::session::{MessageRole, Session};
 
 pub struct AgentRunner {
     pub event_rx: mpsc::Receiver<AgentEvent>,
+    /// Handle to the spawned tokio task. The UI calls `abort()` on interrupt
+    /// so in-flight LLM calls and tool execution actually stop, rather than
+    /// running to completion in the background and emitting permission
+    /// prompts after the user thought they cancelled.
+    pub task: JoinHandle<()>,
 }
 
 pub fn convert_history(session: &Session) -> Vec<Message> {
@@ -143,7 +149,7 @@ where
     cache.clear();
     let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(256);
 
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let policy = RecoveryPolicy::default();
         let mut attempts = 0;
 
@@ -215,7 +221,7 @@ where
         }
     });
 
-    AgentRunner { event_rx }
+    AgentRunner { event_rx, task }
 }
 
 pub async fn run_print<M, P>(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -128,6 +128,10 @@ pub async fn run_interactive(
     input.set_monochrome(cli.no_color);
     let mut is_running = false;
     let mut agent_rx: Option<mpsc::Receiver<AgentEvent>> = None;
+    // Handle to the background agent task. Held alongside `agent_rx` so the
+    // UI can abort in-flight work on Ctrl+C/D/Esc — otherwise tools keep
+    // running and permission prompts arrive after the user has interrupted.
+    let mut agent_abort: Option<tokio::task::JoinHandle<()>> = None;
     let mut agent_line_started = false;
     let mut response_buf = String::new();
     let mut response_start_line: Option<usize> = None;
@@ -321,6 +325,7 @@ pub async fn run_interactive(
                             }
                             if is_running {
                                 is_running = false;
+                                if let Some(h) = agent_abort.take() { h.abort(); }
                                 agent_rx = None;
                                 #[cfg(feature = "loop")]
                                 if let Some(ref mut ls) = loop_state {
@@ -450,6 +455,7 @@ pub async fn run_interactive(
 
                         if key.code == KeyCode::Esc && is_running {
                             is_running = false;
+                            if let Some(h) = agent_abort.take() { h.abort(); }
                             agent_rx = None;
                             #[cfg(feature = "loop")]
                             if let Some(ref mut ls) = loop_state {
@@ -637,6 +643,7 @@ pub async fn run_interactive(
                                                 session.add_message(MessageRole::User, &msg);
                                                 let runner = agent.clone().spawn_runner(msg, history);
                                                 agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                                 is_running = true;
                                             }
                                             Err(e) => {
@@ -728,6 +735,7 @@ pub async fn run_interactive(
                                             session.add_message(MessageRole::User, &prompt);
                                             let runner = agent.clone().spawn_runner(prompt, history);
                                             agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                             is_running = true;
                                             wt_return_path = Some(main_path);
                                         }
@@ -784,6 +792,7 @@ pub async fn run_interactive(
                                             let prompt = ls.build_prompt();
                                             let runner = agent.clone().spawn_runner(prompt, Vec::new());
                                             agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                             is_running = true;
                                             loop_label = Some(ls.iteration_label());
                                         }
@@ -850,6 +859,7 @@ pub async fn run_interactive(
 
                                 let runner = agent.clone().spawn_runner(prompt, history);
                                 agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                 is_running = true;
 
                                 session.add_message(MessageRole::User, &text);
@@ -1131,6 +1141,7 @@ pub async fn run_interactive(
                             )?;
                         }
                         is_running = false;
+                        if let Some(h) = agent_abort.take() { h.abort(); }
                         agent_rx = None;
 
                         #[cfg(feature = "plugin")]
@@ -1160,6 +1171,7 @@ pub async fn run_interactive(
                                     crate::agent::runner::convert_history(session),
                                 );
                                 agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                 is_running = true;
                             }
                             crate::plugin::PostDoneAction::LoopStop => {
@@ -1185,6 +1197,7 @@ pub async fn run_interactive(
                                     let prompt = ls.build_prompt();
                                     let runner = agent.clone().spawn_runner(prompt, Vec::new());
                                     agent_rx = Some(runner.event_rx);
+                                                agent_abort = Some(runner.task);
                                     is_running = true;
                                     loop_label = Some(ls.iteration_label());
                                     renderer.write_line(
@@ -1253,6 +1266,7 @@ pub async fn run_interactive(
                         }
 
                         is_running = false;
+                        if let Some(h) = agent_abort.take() { h.abort(); }
                         agent_rx = None;
                         agent_line_started = false;
                         response_buf.clear();


### PR DESCRIPTION
## Summary
The error-recovery work introduced a \`StreamBuffer\` that collected every \`Token\`/\`Reasoning\`/\`ToolCall\`/\`ToolResult\` event and only flushed them to the UI on success. Result: the user saw a completely silent agent for the entire turn. They'd type something or hit Ctrl+C out of frustration (printing \"interrupted\") while the background task kept running and asked for permissions.

## What changed
- \`run_stream\` now \`event_tx.send().await\`s each event as it arrives — same path as before the error-recovery PR.
- Retry-safety preserved via a plain \`StreamOutcome { had_tool_calls, error }\` struct: if any tool calls already dispatched, surface the error rather than retry (same correctness as before — side effects don't double-fire).
- For pure-streaming errors before any tool call, we still retry with jittered backoff. The user may see a couple of duplicated tokens, but that's a much friendlier failure mode than total silence.

## Repro user reported
\`\`\`
> let's examine the persistence layer
interrupted                 ← Ctrl+C, but nothing had been visible
> are you there?
interrupted                 ← same again
[permission] find_files: .*\\.edn   ← bg task still alive
\`\`\`

## Test plan
- [x] \`cargo test --bin dirge --features plugin\` — 158 passing
- [ ] Manual: ask any non-trivial question, confirm tokens stream live as the model produces them
- [ ] Manual: kill network mid-stream before any tool call, confirm retry message appears and stream resumes
- [ ] Manual: kill network after a tool call, confirm "(tool side effects already applied, not retrying)" error