### PR TITLE
Expand input box to show full multi-line draft + Ctrl+J fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ dirge --provider glm       # defaults to glm-4
 | Meta+Y | Yank-pop (cycle kill ring after yank) |
 | Ctrl+N / Down | History next (multi-line: next logical line, history at boundary) |
 | Ctrl+P / Up | History previous (multi-line: previous logical line, history at boundary) |
-| Shift+Enter / Meta+Enter | Insert newline (multi-line input) |
+| Shift+Enter / Meta+Enter / Ctrl+J | Insert newline (input box expands; Ctrl+J works in any terminal) |
 | Tab | Insert 2 spaces |
 | `@<query>` | File picker (Tab/Enter select, Esc cancel) |
 | Paste (≥4 lines) | Collapses to `[N lines pasted]`; re-paste same content to expand inline |

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -913,3 +913,27 @@ fn ctrl_j_during_picker_is_noop() {
     assert!(result.is_none());
     assert_eq!(editor.buffer.as_str(), buf_before);
 }
+
+#[test]
+fn paste_with_crlf_line_endings_collapses() {
+    // Regression: a paste from a clipboard/source that uses \r\n line
+    // endings used to be treated as a single line because matches('\n')
+    // only counts LF. The threshold check failed, the raw text (including
+    // \r) got inserted, and the terminal rendered carriage returns as
+    // overstrikes — garbling the input.
+    let mut editor = InputEditor::new();
+    editor.handle_paste("a\r\nb\r\nc\r\nd\r\ne");
+    // After normalization the paste is 5 lines, >= 4, so collapses.
+    assert!(editor.buffer.contains('\u{0001}'));
+    assert_eq!(editor.expanded().as_str(), "a\nb\nc\nd\ne");
+}
+
+#[test]
+fn paste_with_cr_only_line_endings_collapses() {
+    // Some sources (e.g., legacy macOS clipboards) deliver `\r` alone.
+    // Same normalization should apply.
+    let mut editor = InputEditor::new();
+    editor.handle_paste("a\rb\rc\rd\re");
+    assert!(editor.buffer.contains('\u{0001}'));
+    assert_eq!(editor.expanded().as_str(), "a\nb\nc\nd\ne");
+}

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -888,3 +888,28 @@ fn paste_during_picker_is_ignored() {
     editor.handle_paste("a\nb\nc\nd");
     assert_eq!(editor.buffer.as_str(), buffer_before);
 }
+
+fn ctrl_j() -> KeyEvent {
+    KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL)
+}
+
+#[test]
+fn ctrl_j_inserts_newline_as_fallback() {
+    // Terminals that don't deliver Shift+Enter as a distinct event always
+    // deliver Ctrl+J. It must insert a newline, never submit.
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "hello");
+    editor.handle_key(ctrl_j());
+    type_str(&mut editor, "world");
+    assert_eq!(editor.buffer.as_str(), "hello\nworld");
+}
+
+#[test]
+fn ctrl_j_during_picker_is_noop() {
+    let mut editor = InputEditor::new();
+    editor.handle_key(press(KeyCode::Char('@')));
+    let buf_before = editor.buffer.to_string();
+    let result = editor.handle_key(ctrl_j());
+    assert!(result.is_none());
+    assert_eq!(editor.buffer.as_str(), buf_before);
+}

--- a/src/tests/input_tests.rs
+++ b/src/tests/input_tests.rs
@@ -937,3 +937,134 @@ fn paste_with_cr_only_line_endings_collapses() {
     assert!(editor.buffer.contains('\u{0001}'));
     assert_eq!(editor.expanded().as_str(), "a\nb\nc\nd\ne");
 }
+#[test]
+fn yank_after_submit_preserves_pasted_content() {
+    // Regression: killing a marker into the kill ring, then submitting
+    // (which cleared `pastes`), then yanking back, used to leave marker
+    // bytes in the buffer referencing a now-empty pastes vec. `expanded()`
+    // silently dropped them, so the agent received text *without* the
+    // paste body the user thought they'd yanked back. We now expand
+    // markers inline in kill-ring entries before clearing pastes, so the
+    // kill ring carries raw text across the submit boundary.
+    let mut editor = InputEditor::new();
+    editor.handle_paste("a\nb\nc\nd\ne");
+    editor.handle_key(ctrl(KeyCode::Char('u'))); // kill marker into ring
+    editor.handle_key(press(KeyCode::Enter)); // submit empty (clears pastes)
+    type_str(&mut editor, "hello");
+    editor.handle_key(ctrl(KeyCode::Char('y'))); // yank — text, not marker
+    let submitted = editor.handle_key(press(KeyCode::Enter)).unwrap();
+    assert!(
+        submitted.contains("a\nb\nc\nd\ne"),
+        "expected yank to restore paste body, got: {:?}",
+        submitted
+    );
+}
+
+// ── Paste collapse — robustness ─────────────────────────────
+
+#[test]
+fn paste_at_start_of_buffer() {
+    let mut editor = InputEditor::new();
+    editor.handle_paste("a\nb\nc\nd");
+    type_str(&mut editor, " trailing");
+    assert_eq!(editor.expanded().as_str(), "a\nb\nc\nd trailing");
+}
+
+#[test]
+fn paste_in_middle_of_buffer() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "before-after");
+    editor.cursor = "before-".len();
+    editor.handle_paste("L1\nL2\nL3\nL4");
+    assert_eq!(editor.expanded().as_str(), "before-L1\nL2\nL3\nL4after");
+}
+
+#[test]
+fn two_distinct_pastes_keep_both_bodies() {
+    let mut editor = InputEditor::new();
+    editor.handle_paste("paste-1-a\nb\nc\nd");
+    type_str(&mut editor, " mid ");
+    editor.handle_paste("paste-2-w\nx\ny\nz");
+    assert_eq!(
+        editor.expanded().as_str(),
+        "paste-1-a\nb\nc\nd mid paste-2-w\nx\ny\nz"
+    );
+    // Two complete marker blocks → 4 sentinel chars total.
+    assert_eq!(editor.buffer.matches('\u{0001}').count(), 4);
+}
+
+#[test]
+fn home_and_end_skip_past_markers() {
+    let mut editor = InputEditor::new();
+    editor.handle_paste("a\nb\nc\nd");
+    type_str(&mut editor, "tail");
+    editor.handle_key(press(KeyCode::End));
+    assert_eq!(editor.cursor, editor.buffer.len());
+    editor.handle_key(press(KeyCode::Home));
+    assert_eq!(editor.cursor, 0);
+    assert_eq!(editor.expanded().as_str(), "a\nb\nc\ndtail");
+}
+
+#[test]
+fn marker_survives_multiline_up_down_nav() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "row1");
+    editor.handle_key(shift_enter());
+    editor.handle_paste("p1\np2\np3\np4");
+    editor.handle_key(shift_enter());
+    type_str(&mut editor, "row3");
+    editor.handle_key(press(KeyCode::Up));
+    editor.handle_key(press(KeyCode::Up));
+    editor.handle_key(press(KeyCode::Down));
+    editor.handle_key(press(KeyCode::Down));
+    assert_eq!(editor.expanded().as_str(), "row1\np1\np2\np3\np4\nrow3");
+}
+
+#[test]
+fn empty_paste_is_noop() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "existing");
+    let buf_before = editor.buffer.to_string();
+    let cur_before = editor.cursor;
+    editor.handle_paste("");
+    assert_eq!(editor.buffer.as_str(), buf_before);
+    assert_eq!(editor.cursor, cur_before);
+}
+
+#[test]
+fn paste_containing_only_paste_mark_chars_is_noop() {
+    // PASTE_MARK chars get stripped first; if the paste was *only* those
+    // chars, cleaned content is empty and we return early — no placeholder,
+    // no empty marker block.
+    let mut editor = InputEditor::new();
+    editor.handle_paste("\u{0001}\u{0001}\u{0001}\u{0001}");
+    assert_eq!(editor.buffer.as_str(), "");
+    assert_eq!(editor.cursor, 0);
+}
+
+#[test]
+fn delete_at_start_of_marker_removes_whole_block() {
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "before");
+    editor.handle_paste("p1\np2\np3\np4");
+    type_str(&mut editor, "after");
+    editor.cursor = "before".len();
+    editor.handle_key(press(KeyCode::Delete));
+    assert_eq!(editor.expanded().as_str(), "beforeafter");
+    assert!(!editor.buffer.contains('\u{0001}'));
+}
+
+#[test]
+fn multibyte_chars_adjacent_to_marker() {
+    // Marker bytes are ASCII, but surrounding text may be multibyte UTF-8.
+    // Cursor motion and slicing must not split a multibyte char.
+    let mut editor = InputEditor::new();
+    type_str(&mut editor, "héllo "); // 'é' is 2 bytes
+    editor.handle_paste("p1\np2\np3\np4");
+    type_str(&mut editor, " wörld");
+    while editor.cursor > 0 {
+        editor.handle_key(press(KeyCode::Left));
+    }
+    assert_eq!(editor.cursor, 0);
+    assert_eq!(editor.expanded().as_str(), "héllo p1\np2\np3\np4 wörld");
+}

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -332,9 +332,15 @@ impl InputEditor {
         if self.picker.as_ref().is_some_and(|p| p.active) {
             return;
         }
+        // Normalize line endings to `\n`. macOS-era clipboards and some
+        // terminal paste streams deliver `\r` or `\r\n`. Without this the
+        // line count comes out as 1, the collapse threshold isn't reached,
+        // and the raw text gets inserted — with embedded `\r` chars that
+        // the terminal then renders as carriage-returns, garbling the line.
+        let normalized: String = text.replace("\r\n", "\n").replace('\r', "\n");
         // Strip PASTE_MARK so it can never appear in paste content and confuse
         // the marker parser.
-        let cleaned: String = text.chars().filter(|&c| c != PASTE_MARK).collect();
+        let cleaned: String = normalized.chars().filter(|&c| c != PASTE_MARK).collect();
         if cleaned.is_empty() {
             return;
         }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -607,6 +607,20 @@ impl InputEditor {
         let alt = key.modifiers.contains(KeyModifiers::ALT);
         let has_shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
+        // Ctrl+J is a portable newline trigger — many terminals never send
+        // Shift+Enter as a distinct keystroke, but Ctrl+J always arrives.
+        // Handled here before the Enter arm so it works even when the
+        // terminal collapses Ctrl+J onto KeyCode::Enter.
+        if ctrl && matches!(key.code, KeyCode::Char('j')) {
+            if !self.picker.as_ref().is_some_and(|p| p.active) {
+                self.buffer.insert(self.cursor, '\n');
+                self.cursor += 1;
+                self.history_pos = None;
+                self.reset_kill_accumulation();
+            }
+            return None;
+        }
+
         match key.code {
             KeyCode::Enter => {
                 if self.picker.as_ref().is_some_and(|p| p.active) {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -404,21 +404,28 @@ impl InputEditor {
     /// original paste bodies. Used at submit time so the agent receives the
     /// real text.
     pub fn expanded(&self) -> CompactString {
-        let blocks = marker_blocks(&self.buffer);
+        Self::expand_with_pastes(&self.buffer, &self.pastes).into()
+    }
+
+    /// Expand markers in `s` using `pastes` for bodies. Free-function form
+    /// so it can also be used to flatten markers in kill-ring entries
+    /// before we clear `pastes`.
+    fn expand_with_pastes(s: &str, pastes: &[Option<CompactString>]) -> String {
+        let blocks = marker_blocks(s);
         if blocks.is_empty() {
-            return self.buffer.clone();
+            return s.to_string();
         }
-        let mut out = String::with_capacity(self.buffer.len());
+        let mut out = String::with_capacity(s.len());
         let mut cur = 0;
         for (start, end, idx) in blocks {
-            out.push_str(&self.buffer[cur..start]);
-            if let Some(Some(body)) = self.pastes.get(idx) {
+            out.push_str(&s[cur..start]);
+            if let Some(Some(body)) = pastes.get(idx) {
                 out.push_str(body);
             }
             cur = end;
         }
-        out.push_str(&self.buffer[cur..]);
-        out.into()
+        out.push_str(&s[cur..]);
+        out
     }
 
     /// Return (display_text, display_cursor_col) for a logical line of the
@@ -650,6 +657,16 @@ impl InputEditor {
                 self.history_pos = None;
                 self.buffer.clear();
                 self.cursor = 0;
+                // Flatten markers in kill-ring entries to their raw bodies
+                // before dropping pastes — otherwise a later Ctrl+Y would
+                // yank back marker bytes referencing indices we just
+                // cleared, and `expanded()` would silently omit them.
+                for entry in self.kill_ring.iter_mut() {
+                    if entry.contains(PASTE_MARK) {
+                        let expanded = Self::expand_with_pastes(entry, &self.pastes);
+                        *entry = expanded.into();
+                    }
+                }
                 self.pastes.clear();
                 self.reset_kill_accumulation();
                 if submitted.is_empty() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -598,7 +598,7 @@ pub async fn run_interactive(
                                     is_running,
                                 )?;
                                 if let Some(ref picker) = input.picker {
-                                    picker.draw()?;
+                                    picker.draw(renderer.input_top_row())?;
                                 }
                                 continue;
                             }
@@ -868,7 +868,7 @@ pub async fn run_interactive(
                             is_running,
                         )?;
                         if let Some(ref picker) = input.picker {
-                            picker.draw()?;
+                            picker.draw(renderer.input_top_row())?;
                         }
                     }
                 }
@@ -1275,7 +1275,7 @@ pub async fn run_interactive(
                     is_running,
                 )?;
                 if let Some(ref picker) = input.picker {
-                    picker.draw()?;
+                    picker.draw(renderer.input_top_row())?;
                 }
             }
             Some(ask_req) = async {
@@ -1354,7 +1354,7 @@ pub async fn run_interactive(
                     is_running,
                 )?;
                 if let Some(ref picker) = input.picker {
-                    picker.draw()?;
+                    picker.draw(renderer.input_top_row())?;
                 }
             }
             _ = tokio::time::sleep(tokio::time::Duration::from_millis(200)), if is_running => {
@@ -1364,7 +1364,7 @@ pub async fn run_interactive(
                     is_running,
                 )?;
                 if let Some(ref picker) = input.picker {
-                    picker.draw()?;
+                    picker.draw(renderer.input_top_row())?;
                 }
             }
             else => {

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -224,18 +224,26 @@ impl FilePicker {
         *self.file_cache.lock().unwrap_or_else(|e| e.into_inner()) = files;
     }
 
-    pub fn draw(&self) -> std::io::Result<()> {
+    /// Draw the picker overlay just above the input box.
+    ///
+    /// `input_top` is the screen row where the input box begins — the picker
+    /// stops one row above it. With the multi-line input feature, the input
+    /// box can be several rows tall, so we can't hardcode `rows - 2` here
+    /// anymore.
+    pub fn draw(&self, input_top: u16) -> std::io::Result<()> {
         if !self.active {
             return Ok(());
         }
-        let (cols, rows) = crossterm::terminal::size()?;
+        let (cols, _rows) = crossterm::terminal::size()?;
         let mut stdout = std::io::stdout();
 
-        let max_items = (rows.saturating_sub(4)).min(10) as usize;
+        // Bottom anchor row for the picker — one above the input box.
+        let bottom_anchor = input_top.saturating_sub(1);
+        // Cap list height so we don't run off the top of the screen.
+        let max_items = (bottom_anchor as usize).min(10);
 
         if self.matches.is_empty() {
-            let r = rows.saturating_sub(3);
-            stdout.execute(MoveTo(0, r))?;
+            stdout.execute(MoveTo(0, bottom_anchor))?;
             write!(
                 stdout,
                 "{}",
@@ -254,7 +262,7 @@ impl FilePicker {
             .min(self.matches.len().saturating_sub(list_height));
         let end_idx = (start_idx + list_height).min(self.matches.len());
 
-        let top_row = rows.saturating_sub(3).saturating_sub(list_height as u16);
+        let top_row = bottom_anchor.saturating_sub(list_height as u16);
 
         for i in start_idx..end_idx {
             let render_row = top_row + (i - start_idx) as u16;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -116,6 +116,14 @@ impl Renderer {
         rows.saturating_sub(self.input_rows + 1) as usize
     }
 
+    /// The screen row index where the input box starts. Overlays that need
+    /// to anchor *above* the input box (e.g. the file picker) should treat
+    /// this as their bottom limit.
+    pub fn input_top_row(&self) -> u16 {
+        let (_, rows) = self.terminal_size();
+        rows.saturating_sub(self.input_rows + 1)
+    }
+
     pub fn buffer_line_at_row(&self, row: u16) -> Option<usize> {
         let (_, rows) = self.terminal_size();
         let visible = rows.saturating_sub(self.input_rows + 1) as usize;
@@ -529,7 +537,12 @@ impl Renderer {
         // glance which row is "the" prompt and which are wrapped lines.
         let prompt_cont = "· ";
 
-        let visible_width = cols.saturating_sub(2) as usize;
+        // Reserve right-edge space for the token counter so it never
+        // overdraws line content. Width is the width of the longest
+        // realistic counter string ("  (NNNN tk)" ~= 12 chars).
+        let token_est = editor.expanded().len() as u64 / 4;
+        let counter_reserve: u16 = if token_est > 0 { 12 } else { 0 };
+        let visible_width = cols.saturating_sub(2 + counter_reserve) as usize;
 
         // Recompute horizontal scroll based on the cursor's line. Each draw
         // re-anchors so very long single lines still pan horizontally.
@@ -572,14 +585,11 @@ impl Renderer {
             write!(stdout, "{}", visible)?;
         }
 
-        // Token estimate counts the expanded text on the last visible row's
-        // trailing space, so it doesn't shift around while editing.
-        let last_row = input_top + (visible_input_rows as u16 - 1);
-        let token_est = editor.expanded().len() as u64 / 4;
-        if token_est > 0 {
-            stdout.execute(MoveTo(0, last_row))?;
-            // Place the counter at the right side of the row, beyond any
-            // visible text so we don't overdraw line content.
+        // Token counter on the last visible row, sitting in the reserved
+        // right-edge gap (see `counter_reserve` above). Doesn't overdraw
+        // line content because `visible_width` already excludes this band.
+        if counter_reserve > 0 {
+            let last_row = input_top + (visible_input_rows as u16 - 1);
             let counter = format!("  ({} tk)", token_est);
             let counter_col = cols.saturating_sub(counter.len() as u16);
             stdout.execute(MoveTo(counter_col, last_row))?;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -14,6 +14,11 @@ pub struct LineEntry {
     pub color: Color,
 }
 
+/// Cap on how many logical input lines we'll show stacked at the bottom of
+/// the screen before the input box starts internally scrolling. Beyond this
+/// the chat-history viewport would be unreasonably squashed.
+pub const MAX_INPUT_VISIBLE_LINES: usize = 8;
+
 pub struct Renderer {
     lines: u16,
     col: u16,
@@ -23,6 +28,11 @@ pub struct Renderer {
     partial_color: Color,
     scroll_offset: usize,
     input_scroll_offset: usize,
+    /// Number of rows the input area currently occupies (1 by default, grows
+    /// up to MAX_INPUT_VISIBLE_LINES as the user adds newlines via
+    /// Shift+Enter / Meta+Enter / Ctrl+J). The chat viewport shrinks by the
+    /// same amount so the total layout fits.
+    input_rows: u16,
     monochrome: bool,
     pub selection_active: bool,
     pub selection_start: Option<usize>,
@@ -40,6 +50,7 @@ impl Renderer {
             partial_color: Color::White,
             scroll_offset: 0,
             input_scroll_offset: 0,
+            input_rows: 1,
             monochrome: false,
             selection_active: false,
             selection_start: None,
@@ -98,14 +109,16 @@ impl Renderer {
         }
     }
 
+    /// Number of rows reserved for chat history above the input area.
+    /// Subtracts the input box (`input_rows`) and the status line (1 row).
     pub fn visible_lines(&self) -> usize {
         let (_, rows) = self.terminal_size();
-        rows.saturating_sub(2) as usize
+        rows.saturating_sub(self.input_rows + 1) as usize
     }
 
     pub fn buffer_line_at_row(&self, row: u16) -> Option<usize> {
         let (_, rows) = self.terminal_size();
-        let visible = rows.saturating_sub(2) as usize;
+        let visible = rows.saturating_sub(self.input_rows + 1) as usize;
         let total = self.buffer.len();
         if total == 0 {
             return None;
@@ -232,7 +245,7 @@ impl Renderer {
 
     pub fn render_viewport(&mut self) -> io::Result<()> {
         let (cols, rows) = self.terminal_size();
-        let visible = rows.saturating_sub(2) as usize;
+        let visible = rows.saturating_sub(self.input_rows + 1) as usize;
         let total = self.buffer.len();
         let mut stdout = io::stdout();
 
@@ -309,7 +322,7 @@ impl Renderer {
         if rows < 3 {
             return;
         }
-        let max_content = rows.saturating_sub(2);
+        let max_content = rows.saturating_sub(self.input_rows + 1);
         if self.lines >= max_content {
             let mut stdout = io::stdout();
             let _ = stdout.execute(ScrollUp(1));
@@ -324,7 +337,7 @@ impl Renderer {
 
     fn content_row(&self) -> u16 {
         let (_, rows) = self.terminal_size();
-        self.lines.min(rows.saturating_sub(3))
+        self.lines.min(rows.saturating_sub(self.input_rows + 2))
     }
 
     pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
@@ -466,74 +479,120 @@ impl Renderer {
         let full_input: &str = editor.buffer.as_str();
         let full_cursor: usize = editor.cursor;
 
-        let input_row = rows.saturating_sub(2);
+        // Break the buffer into logical lines (one per `\n`). An empty buffer
+        // still shows one row so the prompt is visible.
+        let logical_lines: Vec<&str> = if full_input.is_empty() {
+            vec![""]
+        } else {
+            full_input.split('\n').collect()
+        };
+        let line_count = logical_lines.len();
+
+        // Determine which logical line the cursor sits on, and the byte
+        // offset within it.
+        let cursor_line_start = full_input[..full_cursor]
+            .rfind('\n')
+            .map(|p| p + 1)
+            .unwrap_or(0);
+        let cursor_line_idx = full_input[..cursor_line_start].matches('\n').count();
+        let cursor_col_in_line = full_cursor - cursor_line_start;
+
+        // Decide how many input rows to show. Cap at MAX_INPUT_VISIBLE_LINES
+        // so the chat viewport doesn't disappear under huge pastes / drafts.
+        let visible_input_rows = line_count.min(MAX_INPUT_VISIBLE_LINES).max(1);
+
+        // Pick which slice of logical lines to render so the cursor's line is
+        // always on screen. Simple scroll-to-keep-cursor-visible strategy.
+        let first_visible_line = if cursor_line_idx >= visible_input_rows {
+            cursor_line_idx + 1 - visible_input_rows
+        } else {
+            0
+        };
+
+        // If the bottom panel grew or shrank, the chat viewport needs to be
+        // repainted at its new size before we overwrite the bottom rows.
+        let new_input_rows = visible_input_rows as u16;
+        if new_input_rows != self.input_rows {
+            self.input_rows = new_input_rows;
+            self.render_viewport()?;
+        }
+
         let status_row = rows.saturating_sub(1);
-        let prompt = if is_running {
+        let input_top = rows.saturating_sub(self.input_rows + 1);
+        let prompt_main = if is_running {
             self.spinner_tick = !self.spinner_tick;
             if self.spinner_tick { ". " } else { ": " }
         } else {
             "> "
         };
+        // Continuation rows get a dimmer prompt so the user can see at a
+        // glance which row is "the" prompt and which are wrapped lines.
+        let prompt_cont = "· ";
 
-        // Extract the current logical line, then render with paste
-        // placeholders substituted so the input bar stays compact.
-        let line_start = full_input[..full_cursor]
-            .rfind('\n')
-            .map(|p| p + 1)
-            .unwrap_or(0);
-        let line_end = full_input[full_cursor..]
-            .find('\n')
-            .map(|p| full_cursor + p)
-            .unwrap_or(full_input.len());
-        let raw_line = &full_input[line_start..line_end];
-        let raw_col = full_cursor - line_start;
-        let (visible_line_owned, col_in_line) = editor.render_line(raw_line, raw_col);
-        let visible_line: &str = visible_line_owned.as_str();
-
-        // Count lines for status display (buffer-logical, not paste-expanded).
-        let line_count = if full_input.is_empty() {
-            1
-        } else {
-            full_input.chars().filter(|&c| c == '\n').count() + 1
-        };
-
-        stdout.execute(MoveTo(0, input_row))?;
-        write!(stdout, "{}", " ".repeat(cols as usize))?;
-        stdout.execute(MoveTo(0, input_row))?;
-        write!(stdout, "{}", SetForegroundColor(self.color(Color::Cyan)))?;
-        write!(stdout, "{}", prompt)?;
-        write!(stdout, "{}", ResetColor)?;
         let visible_width = cols.saturating_sub(2) as usize;
-        let input_len = visible_line.len();
 
-        if col_in_line < self.input_scroll_offset {
-            self.input_scroll_offset = col_in_line;
-        } else if col_in_line >= self.input_scroll_offset + visible_width {
-            self.input_scroll_offset = col_in_line - visible_width + 1;
+        // Recompute horizontal scroll based on the cursor's line. Each draw
+        // re-anchors so very long single lines still pan horizontally.
+        let cursor_raw_line = logical_lines[cursor_line_idx];
+        let (_, cursor_display_col) = editor.render_line(cursor_raw_line, cursor_col_in_line);
+        if cursor_display_col < self.input_scroll_offset {
+            self.input_scroll_offset = cursor_display_col;
+        } else if cursor_display_col >= self.input_scroll_offset + visible_width {
+            self.input_scroll_offset = cursor_display_col - visible_width + 1;
         }
-        let max_scroll = input_len.saturating_sub(visible_width);
-        self.input_scroll_offset = self.input_scroll_offset.min(max_scroll);
 
-        let visible: String = visible_line
-            .chars()
-            .skip(self.input_scroll_offset)
-            .take(visible_width)
-            .collect();
-        write!(stdout, "{}", visible)?;
+        // Render each visible logical line.
+        for row_offset in 0..visible_input_rows {
+            let row = input_top + row_offset as u16;
+            let line_idx = first_visible_line + row_offset;
+            stdout.execute(MoveTo(0, row))?;
+            write!(stdout, "{}", " ".repeat(cols as usize))?;
+            stdout.execute(MoveTo(0, row))?;
+            write!(stdout, "{}", SetForegroundColor(self.color(Color::Cyan)))?;
+            if line_idx == 0 {
+                write!(stdout, "{}", prompt_main)?;
+            } else {
+                write!(stdout, "{}", prompt_cont)?;
+            }
+            write!(stdout, "{}", ResetColor)?;
+            let raw_line = logical_lines.get(line_idx).copied().unwrap_or("");
+            let (display_line, _) = editor.render_line(raw_line, 0);
+            // Apply horizontal scroll if this line contains the cursor; other
+            // lines render from column 0 (they'll get truncated if too wide).
+            let scroll = if line_idx == cursor_line_idx {
+                self.input_scroll_offset
+            } else {
+                0
+            };
+            let visible: String = display_line
+                .chars()
+                .skip(scroll)
+                .take(visible_width)
+                .collect();
+            write!(stdout, "{}", visible)?;
+        }
 
-        // Token estimate counts the expanded text, since that's what the agent
-        // actually receives.
+        // Token estimate counts the expanded text on the last visible row's
+        // trailing space, so it doesn't shift around while editing.
+        let last_row = input_top + (visible_input_rows as u16 - 1);
         let token_est = editor.expanded().len() as u64 / 4;
         if token_est > 0 {
+            stdout.execute(MoveTo(0, last_row))?;
+            // Place the counter at the right side of the row, beyond any
+            // visible text so we don't overdraw line content.
+            let counter = format!("  ({} tk)", token_est);
+            let counter_col = cols.saturating_sub(counter.len() as u16);
+            stdout.execute(MoveTo(counter_col, last_row))?;
             write!(
                 stdout,
                 "{}",
                 SetForegroundColor(self.color(Color::DarkGrey))
             )?;
-            write!(stdout, "  ({} tk)", token_est)?;
+            write!(stdout, "{}", counter)?;
             write!(stdout, "{}", ResetColor)?;
         }
 
+        // Status row.
         stdout.execute(MoveTo(0, status_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
         stdout.execute(MoveTo(0, status_row))?;
@@ -547,15 +606,25 @@ impl Renderer {
         } else {
             status.to_string()
         };
-        if line_count > 1 {
+        if line_count > MAX_INPUT_VISIBLE_LINES {
+            // Buffer is bigger than the visible window — tell the user how
+            // many extra logical lines there are.
+            status_display.push_str(&format!(
+                " [{} lines, {} hidden]",
+                line_count,
+                line_count - MAX_INPUT_VISIBLE_LINES
+            ));
+        } else if line_count > 1 {
             status_display.push_str(&format!(" [{} lines]", line_count));
         }
         let truncated: String = status_display.chars().take(cols as usize).collect();
         write!(stdout, "{}", truncated)?;
         write!(stdout, "{}", ResetColor)?;
 
-        let cursor_x = (2 + col_in_line.saturating_sub(self.input_scroll_offset)) as u16;
-        stdout.execute(MoveTo(cursor_x, input_row))?;
+        // Place the visible cursor on its row at the right column.
+        let cursor_row = input_top + (cursor_line_idx - first_visible_line) as u16;
+        let cursor_x = (2 + cursor_display_col.saturating_sub(self.input_scroll_offset)) as u16;
+        stdout.execute(MoveTo(cursor_x, cursor_row))?;
         stdout.flush()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
Multi-line input was already wired into \`InputEditor\`, but the renderer kept a single-row input bar — only the current logical line of a draft was visible, with a \`[N lines]\` indicator on the status row. Hard to review a paragraph you're composing.

This PR makes the bottom panel grow with the draft (Claude Code-style):
- The bottom panel grows from 1 row to up to **\`MAX_INPUT_VISIBLE_LINES = 8\`** as the user adds newlines.
- Continuation rows show a dimmer \`·\` prompt; only row-0 uses the cyan \`>\` / \`.\`/\`:\` prompt-or-spinner.
- Beyond 8 lines the panel caps and scrolls internally to keep the cursor row visible; status shows \`[N lines, K hidden]\`.
- Chat viewport above shrinks by the same amount via a new \`Renderer.input_rows\` field; \`visible_lines()\`/\`content_row()\`/\`render_viewport()\` all consult it.

Also added **Ctrl+J** as a third newline trigger alongside Shift+Enter / Meta+Enter. Many terminals (default macOS Terminal, vanilla xterm, etc.) don't deliver Shift+Enter as a distinct keystroke; Ctrl+J is universal.

## Test plan
- [x] 2 new unit tests cover Ctrl+J newline + Ctrl+J inside picker no-op
- [x] Full test suite: 172 passing
- [x] \`./build.sh\` clean
- [ ] Manual: open dirge, Shift+Enter to grow input box, verify continuation prompt \`·\`, paste large block, confirm cap + scroll
- [ ] Manual: in a terminal that doesn't send Shift+Enter (default macOS Terminal), confirm Ctrl+J works