### PR TITLE
Add websearch and webfetch tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -2683,6 +2683,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures",
+ "html2text",
  "http 1.4.0",
  "ignore",
  "image",
@@ -3570,6 +3571,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "html2text"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c97eea9d3e6524d8d2a4643ce0e3135500c4c7ca1d02393a485f871bef69d8"
+dependencies = [
+ "html5ever",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -5133,6 +5156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,7 +5834,37 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5808,6 +5872,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -5926,6 +5999,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -7494,6 +7573,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7786,6 +7889,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -8647,6 +8760,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ image = "0.25"
 base64 = "0.22"
 streaming-iterator = { version = "0.1", optional = true }
 janetrs = { version = "0.8", optional = true }
+html2text = "0.17"
 
 [profile.release]
 opt-level = "z"

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -176,11 +176,41 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         let question_tool = question_tx
             .map(|tx| Box::new(tools::QuestionTool::new(tx)) as Box<dyn rig::tool::ToolDyn>);
 
+        // Web tools: gated on config + env var
+        let websearch_enabled = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.websearch)
+            .unwrap_or(false)
+            || std::env::var("WEBSEARCH_ENABLED")
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false);
+        let webfetch_enabled = cfg
+            .tools
+            .as_ref()
+            .and_then(|t| t.webfetch)
+            .unwrap_or(false);
+
+        let websearch_tool = websearch_enabled
+            .then(|| std::env::var("EXA_API_KEY").ok())
+            .flatten()
+            .map(|key| Box::new(tools::WebSearchTool::new(key)) as Box<dyn rig::tool::ToolDyn>);
+        let webfetch_tool = webfetch_enabled
+            .then(|| Box::new(tools::WebFetchTool::new()) as Box<dyn rig::tool::ToolDyn>);
+
         #[allow(unused_mut)]
         let mut builder = builder.tools(base_tools);
 
         if let Some(qt) = question_tool {
             builder = builder.tools(vec![qt]);
+        }
+
+        if let Some(ws) = websearch_tool {
+            builder = builder.tools(vec![ws]);
+        }
+
+        if let Some(wf) = webfetch_tool {
+            builder = builder.tools(vec![wf]);
         }
 
         if let Some(pm) = parent_model {

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -185,22 +185,22 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             || std::env::var("WEBSEARCH_ENABLED")
                 .map(|v| v == "true" || v == "1")
                 .unwrap_or(false);
-        let webfetch_enabled = cfg
-            .tools
-            .as_ref()
-            .and_then(|t| t.webfetch)
-            .unwrap_or(false);
+        let webfetch_enabled = cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(false);
 
         let websearch_tool = websearch_enabled
             .then(|| std::env::var("EXA_API_KEY").ok())
             .flatten()
-            .map(|key| Box::new(tools::WebSearchTool::new(
-                permission.clone(),
-                ask_tx.clone(),
-                key,
-            )) as Box<dyn rig::tool::ToolDyn>);
-        let webfetch_tool = webfetch_enabled
-            .then(|| Box::new(tools::WebFetchTool::new(permission.clone(), ask_tx.clone())) as Box<dyn rig::tool::ToolDyn>);
+            .map(|key| {
+                Box::new(tools::WebSearchTool::new(
+                    permission.clone(),
+                    ask_tx.clone(),
+                    key,
+                )) as Box<dyn rig::tool::ToolDyn>
+            });
+        let webfetch_tool = webfetch_enabled.then(|| {
+            Box::new(tools::WebFetchTool::new(permission.clone(), ask_tx.clone()))
+                as Box<dyn rig::tool::ToolDyn>
+        });
 
         #[allow(unused_mut)]
         let mut builder = builder.tools(base_tools);

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -194,9 +194,13 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         let websearch_tool = websearch_enabled
             .then(|| std::env::var("EXA_API_KEY").ok())
             .flatten()
-            .map(|key| Box::new(tools::WebSearchTool::new(key)) as Box<dyn rig::tool::ToolDyn>);
+            .map(|key| Box::new(tools::WebSearchTool::new(
+                permission.clone(),
+                ask_tx.clone(),
+                key,
+            )) as Box<dyn rig::tool::ToolDyn>);
         let webfetch_tool = webfetch_enabled
-            .then(|| Box::new(tools::WebFetchTool::new()) as Box<dyn rig::tool::ToolDyn>);
+            .then(|| Box::new(tools::WebFetchTool::new(permission.clone(), ask_tx.clone())) as Box<dyn rig::tool::ToolDyn>);
 
         #[allow(unused_mut)]
         let mut builder = builder.tools(base_tools);

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -12,6 +12,8 @@ pub mod semantic;
 mod skill;
 mod task;
 mod todo;
+mod webfetch;
+mod websearch;
 mod write;
 
 pub use bash::BashTool;
@@ -26,6 +28,8 @@ pub use read::ReadTool;
 pub use skill::SkillTool;
 pub use task::TaskTool;
 pub use todo::WriteTodoList;
+pub use webfetch::WebFetchTool;
+pub use websearch::WebSearchTool;
 pub use write::WriteTool;
 
 use std::io;

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -11,10 +11,7 @@ pub struct WebFetchTool {
 
 impl WebFetchTool {
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        Self {
-            permission,
-            ask_tx,
-        }
+        Self { permission, ask_tx }
     }
 }
 
@@ -31,8 +28,7 @@ fn default_max_chars() -> usize {
 
 fn html_to_markdown(html: &str) -> String {
     // Second arg is line-wrap width (100 cols), not buffer size
-    html2text::from_read(html.as_bytes(), 100)
-        .unwrap_or_else(|_| html.to_string())
+    html2text::from_read(html.as_bytes(), 100).unwrap_or_else(|_| html.to_string())
 }
 
 /// Normalize a URL. Respects explicit http:// (localhost, internal services).
@@ -109,9 +105,7 @@ impl Tool for WebFetchTool {
             return Err(ToolError::Msg("no URLs provided".to_string()));
         }
         if args.urls.len() > 10 {
-            return Err(ToolError::Msg(
-                "maximum 10 URLs per call".to_string(),
-            ));
+            return Err(ToolError::Msg("maximum 10 URLs per call".to_string()));
         }
 
         check_perm(
@@ -165,7 +159,10 @@ mod tests {
 
     #[test]
     fn test_normalize_url_http_preserved() {
-        assert_eq!(normalize_url("http://localhost:3000"), "http://localhost:3000");
+        assert_eq!(
+            normalize_url("http://localhost:3000"),
+            "http://localhost:3000"
+        );
     }
 
     #[test]
@@ -175,7 +172,10 @@ mod tests {
 
     #[test]
     fn test_normalize_url_internal_http() {
-        assert_eq!(normalize_url("http://169.254.169.254"), "http://169.254.169.254");
+        assert_eq!(
+            normalize_url("http://169.254.169.254"),
+            "http://169.254.169.254"
+        );
     }
 
     #[test]

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -1,0 +1,183 @@
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use serde::Deserialize;
+
+use crate::agent::tools::ToolError;
+
+pub struct WebFetchTool;
+
+impl WebFetchTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Deserialize)]
+pub struct WebFetchArgs {
+    pub urls: Vec<String>,
+    #[serde(default = "default_max_chars")]
+    pub max_chars: usize,
+}
+
+fn default_max_chars() -> usize {
+    3000
+}
+
+fn html_to_markdown(html: &str) -> String {
+    html2text::from_read(html.as_bytes(), html.len())
+        .unwrap_or_else(|_| html.to_string())
+}
+
+async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String> {
+    let url = if url.starts_with("http://") {
+        url.replacen("http://", "https://", 1)
+    } else if !url.starts_with("https://") {
+        format!("https://{}", url)
+    } else {
+        url.to_string()
+    };
+
+    let resp = client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                format!("timeout fetching {}", url)
+            } else {
+                format!("fetch error for {}: {}", url, e)
+            }
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("{} returned {}", url, status.as_u16()));
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("read error for {}: {}", url, e))?;
+
+    Ok(html_to_markdown(&body))
+}
+
+impl Tool for WebFetchTool {
+    const NAME: &'static str = "webfetch";
+
+    type Error = ToolError;
+    type Args = WebFetchArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "webfetch".to_string(),
+            description: "Fetch the content of one or more URLs and return it as markdown. HTTP URLs are automatically upgraded to HTTPS. Use for reading documentation pages, API references, or any web content."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "urls": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "URLs to fetch (may be comma-separated)"
+                    },
+                    "max_chars": {
+                        "type": "number",
+                        "description": "Maximum characters to return per URL (default: 3000)"
+                    }
+                },
+                "required": ["urls"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: WebFetchArgs) -> Result<String, ToolError> {
+        if args.urls.is_empty() {
+            return Err(ToolError::Msg("no URLs provided".to_string()));
+        }
+        if args.urls.len() > 10 {
+            return Err(ToolError::Msg(
+                "maximum 10 URLs per call".to_string(),
+            ));
+        }
+
+        let client = reqwest::Client::builder()
+            .user_agent("dirge/1.0")
+            .build()
+            .map_err(|e| ToolError::Msg(format!("client build error: {}", e)))?;
+
+        let mut output = String::new();
+        let max = args.max_chars.min(10000);
+
+        for (i, url) in args.urls.iter().enumerate() {
+            if i > 0 {
+                output.push_str("\n\n---\n\n");
+            }
+            output.push_str(&format!("## {}\n\n", url));
+
+            match fetch_url(&client, url).await {
+                Ok(content) => {
+                    let truncated: String = content.chars().take(max).collect();
+                    output.push_str(&truncated);
+                    if content.chars().count() > max {
+                        output.push_str("\n\n*(truncated)*");
+                    }
+                }
+                Err(e) => {
+                    output.push_str(&format!("Error: {}", e));
+                }
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+impl Default for WebFetchTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_html_to_markdown_basic() {
+        let html = "<h1>Title</h1><p>Paragraph</p>";
+        let md = html_to_markdown(html);
+        assert!(md.contains("Title"));
+        assert!(md.contains("Paragraph"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_links() {
+        let html = r#"<a href="https://example.com">click here</a>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("click here"));
+    }
+
+    #[test]
+    fn test_url_upgrade_http_to_https() {
+        // Test the URL upgrade logic via fetch_url's URL normalization
+        let urls = vec![
+            "http://example.com".to_string(),
+            "example.com/page".to_string(),
+            "https://secure.example".to_string(),
+        ];
+        for url in urls {
+            // Just verify the upgrade logic compiles and runs
+            assert!(!url.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_definition_has_correct_name() {
+        let tool = WebFetchTool::new();
+        let def = tool.definition(String::new()).await;
+        assert_eq!(def.name, "webfetch");
+    }
+}

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -2,13 +2,19 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::Deserialize;
 
-use crate::agent::tools::ToolError;
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
-pub struct WebFetchTool;
+pub struct WebFetchTool {
+    pub permission: Option<PermCheck>,
+    pub ask_tx: Option<AskSender>,
+}
 
 impl WebFetchTool {
-    pub fn new() -> Self {
-        Self
+    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
+        Self {
+            permission,
+            ask_tx,
+        }
     }
 }
 
@@ -24,18 +30,23 @@ fn default_max_chars() -> usize {
 }
 
 fn html_to_markdown(html: &str) -> String {
-    html2text::from_read(html.as_bytes(), html.len())
+    // Second arg is line-wrap width (100 cols), not buffer size
+    html2text::from_read(html.as_bytes(), 100)
         .unwrap_or_else(|_| html.to_string())
 }
 
-async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String> {
-    let url = if url.starts_with("http://") {
-        url.replacen("http://", "https://", 1)
-    } else if !url.starts_with("https://") {
-        format!("https://{}", url)
-    } else {
+/// Normalize a URL. Respects explicit http:// (localhost, internal services).
+/// Only prepends https:// when no scheme is present.
+fn normalize_url(url: &str) -> String {
+    if url.starts_with("http://") || url.starts_with("https://") {
         url.to_string()
-    };
+    } else {
+        format!("https://{}", url)
+    }
+}
+
+async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String> {
+    let url = normalize_url(url);
 
     let resp = client
         .get(&url)
@@ -73,7 +84,7 @@ impl Tool for WebFetchTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "webfetch".to_string(),
-            description: "Fetch the content of one or more URLs and return it as markdown. HTTP URLs are automatically upgraded to HTTPS. Use for reading documentation pages, API references, or any web content."
+            description: "Fetch the content of one or more URLs and return it as markdown. Schemeless URLs get https:// prepended. Explicit http:// URLs (localhost, internal services) are respected. Use for reading documentation pages, API references, or any web content."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -102,6 +113,14 @@ impl Tool for WebFetchTool {
                 "maximum 10 URLs per call".to_string(),
             ));
         }
+
+        check_perm(
+            &self.permission,
+            &self.ask_tx,
+            "webfetch",
+            &format!("fetch {} urls", args.urls.len()),
+        )
+        .await?;
 
         let client = reqwest::Client::builder()
             .user_agent("dirge/1.0")
@@ -135,15 +154,29 @@ impl Tool for WebFetchTool {
     }
 }
 
-impl Default for WebFetchTool {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_normalize_url_https() {
+        assert_eq!(normalize_url("https://example.com"), "https://example.com");
+    }
+
+    #[test]
+    fn test_normalize_url_http_preserved() {
+        assert_eq!(normalize_url("http://localhost:3000"), "http://localhost:3000");
+    }
+
+    #[test]
+    fn test_normalize_url_schemeless_prepends_https() {
+        assert_eq!(normalize_url("example.com"), "https://example.com");
+    }
+
+    #[test]
+    fn test_normalize_url_internal_http() {
+        assert_eq!(normalize_url("http://169.254.169.254"), "http://169.254.169.254");
+    }
 
     #[test]
     fn test_html_to_markdown_basic() {
@@ -160,23 +193,9 @@ mod tests {
         assert!(md.contains("click here"));
     }
 
-    #[test]
-    fn test_url_upgrade_http_to_https() {
-        // Test the URL upgrade logic via fetch_url's URL normalization
-        let urls = vec![
-            "http://example.com".to_string(),
-            "example.com/page".to_string(),
-            "https://secure.example".to_string(),
-        ];
-        for url in urls {
-            // Just verify the upgrade logic compiles and runs
-            assert!(!url.is_empty());
-        }
-    }
-
     #[tokio::test]
     async fn test_definition_has_correct_name() {
-        let tool = WebFetchTool::new();
+        let tool = WebFetchTool::new(None, None);
         let def = tool.definition(String::new()).await;
         assert_eq!(def.name, "webfetch");
     }

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -1,0 +1,211 @@
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+
+use crate::agent::tools::ToolError;
+
+/// Exa search result item.
+#[derive(Debug, Deserialize)]
+struct ExaResult {
+    title: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    published_date: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    author: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExaResponse {
+    results: Vec<ExaResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExaRequest<'a> {
+    query: &'a str,
+    #[serde(rename = "type")]
+    search_type: &'a str,
+    contents: ExaContents,
+    #[serde(rename = "numResults")]
+    num_results: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ExaContents {
+    text: bool,
+}
+
+pub struct WebSearchTool {
+    pub api_key: String,
+}
+
+impl WebSearchTool {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct WebSearchArgs {
+    pub query: String,
+    #[serde(default = "default_num_results")]
+    pub num_results: usize,
+}
+
+fn default_num_results() -> usize {
+    10
+}
+
+fn format_search_results(results: &[ExaResult]) -> String {
+    let mut out = String::new();
+    for (i, r) in results.iter().enumerate() {
+        if i > 0 {
+            out.push_str("\n\n---\n\n");
+        }
+        if let Some(title) = &r.title {
+            out.push_str(&format!("**{}**\n", title));
+        }
+        if let Some(url) = &r.url {
+            out.push_str(&format!("{}\n", url));
+        }
+        if let Some(text) = &r.text {
+            let truncated: String = text.chars().take(500).collect();
+            out.push_str(&format!("\n{}\n", truncated));
+        }
+    }
+    if out.is_empty() {
+        out = "No results found.".to_string();
+    }
+    out
+}
+
+impl Tool for WebSearchTool {
+    const NAME: &'static str = "websearch";
+
+    type Error = ToolError;
+    type Args = WebSearchArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "websearch".to_string(),
+            description: "Search the web using Exa. Returns structured results with titles, URLs, and text snippets. Use for looking up current documentation, API references, or up-to-date information beyond your training cutoff."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query"
+                    },
+                    "num_results": {
+                        "type": "number",
+                        "description": "Maximum number of results (default: 10)"
+                    }
+                },
+                "required": ["query"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: WebSearchArgs) -> Result<String, ToolError> {
+        let client = reqwest::Client::new();
+        let body = ExaRequest {
+            query: &args.query,
+            search_type: "auto",
+            contents: ExaContents { text: true },
+            num_results: args.num_results.min(20),
+        };
+
+        let resp = client
+            .post("https://api.exa.ai/search")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ToolError::Msg(format!("websearch request failed: {}", e)))?;
+
+        let status = resp.status();
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| ToolError::Msg(format!("websearch read failed: {}", e)))?;
+
+        if !status.is_success() {
+            return Err(ToolError::Msg(format!(
+                "websearch returned {}: {}",
+                status.as_u16(),
+                &body_text.chars().take(300).collect::<String>()
+            )));
+        }
+
+        let parsed: ExaResponse =
+            serde_json::from_str(&body_text).map_err(|e| {
+                ToolError::Msg(format!("websearch parse error: {}", e))
+            })?;
+
+        Ok(format_search_results(&parsed.results))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_search_results_single() {
+        let results = vec![ExaResult {
+            title: Some("Test Title".to_string()),
+            url: Some("https://example.com".to_string()),
+            text: Some("Some text content".to_string()),
+            published_date: None,
+            author: None,
+        }];
+        let formatted = format_search_results(&results);
+        assert!(formatted.contains("**Test Title**"));
+        assert!(formatted.contains("https://example.com"));
+        assert!(formatted.contains("Some text content"));
+    }
+
+    #[test]
+    fn test_format_search_results_empty() {
+        let formatted = format_search_results(&[]);
+        assert_eq!(formatted, "No results found.");
+    }
+
+    #[test]
+    fn test_format_search_results_multiple() {
+        let results = vec![
+            ExaResult {
+                title: Some("First".to_string()),
+                url: Some("https://first.example".to_string()),
+                text: Some("First text".to_string()),
+                published_date: None,
+                author: None,
+            },
+            ExaResult {
+                title: Some("Second".to_string()),
+                url: Some("https://second.example".to_string()),
+                text: Some("Second text".to_string()),
+                published_date: None,
+                author: None,
+            },
+        ];
+        let formatted = format_search_results(&results);
+        assert!(formatted.contains("**First**"));
+        assert!(formatted.contains("**Second**"));
+        assert!(formatted.contains("---"));
+    }
+
+    #[tokio::test]
+    async fn test_definition_has_correct_name() {
+        let tool = WebSearchTool::new("test-key".to_string());
+        let def = tool.definition(String::new()).await;
+        assert_eq!(def.name, "websearch");
+    }
+}

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -2,7 +2,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 
-use crate::agent::tools::ToolError;
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
 /// Exa search result item.
 #[derive(Debug, Deserialize)]
@@ -11,12 +11,6 @@ struct ExaResult {
     url: Option<String>,
     #[serde(default)]
     text: Option<String>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    published_date: Option<String>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    author: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -40,12 +34,22 @@ struct ExaContents {
 }
 
 pub struct WebSearchTool {
-    pub api_key: String,
+    pub permission: Option<PermCheck>,
+    pub ask_tx: Option<AskSender>,
+    api_key: String,
 }
 
 impl WebSearchTool {
-    pub fn new(api_key: String) -> Self {
-        Self { api_key }
+    pub fn new(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        api_key: String,
+    ) -> Self {
+        Self {
+            permission,
+            ask_tx,
+            api_key,
+        }
     }
 }
 
@@ -113,6 +117,14 @@ impl Tool for WebSearchTool {
     }
 
     async fn call(&self, args: WebSearchArgs) -> Result<String, ToolError> {
+        check_perm(
+            &self.permission,
+            &self.ask_tx,
+            "websearch",
+            &args.query,
+        )
+        .await?;
+
         let client = reqwest::Client::new();
         let body = ExaRequest {
             query: &args.query,
@@ -163,8 +175,6 @@ mod tests {
             title: Some("Test Title".to_string()),
             url: Some("https://example.com".to_string()),
             text: Some("Some text content".to_string()),
-            published_date: None,
-            author: None,
         }];
         let formatted = format_search_results(&results);
         assert!(formatted.contains("**Test Title**"));
@@ -185,15 +195,11 @@ mod tests {
                 title: Some("First".to_string()),
                 url: Some("https://first.example".to_string()),
                 text: Some("First text".to_string()),
-                published_date: None,
-                author: None,
             },
             ExaResult {
                 title: Some("Second".to_string()),
                 url: Some("https://second.example".to_string()),
                 text: Some("Second text".to_string()),
-                published_date: None,
-                author: None,
             },
         ];
         let formatted = format_search_results(&results);
@@ -204,7 +210,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_definition_has_correct_name() {
-        let tool = WebSearchTool::new("test-key".to_string());
+        let tool = WebSearchTool::new(None, None, "test-key".to_string());
         let def = tool.definition(String::new()).await;
         assert_eq!(def.name, "websearch");
     }

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -40,11 +40,7 @@ pub struct WebSearchTool {
 }
 
 impl WebSearchTool {
-    pub fn new(
-        permission: Option<PermCheck>,
-        ask_tx: Option<AskSender>,
-        api_key: String,
-    ) -> Self {
+    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>, api_key: String) -> Self {
         Self {
             permission,
             ask_tx,
@@ -117,13 +113,7 @@ impl Tool for WebSearchTool {
     }
 
     async fn call(&self, args: WebSearchArgs) -> Result<String, ToolError> {
-        check_perm(
-            &self.permission,
-            &self.ask_tx,
-            "websearch",
-            &args.query,
-        )
-        .await?;
+        check_perm(&self.permission, &self.ask_tx, "websearch", &args.query).await?;
 
         let client = reqwest::Client::new();
         let body = ExaRequest {
@@ -156,10 +146,8 @@ impl Tool for WebSearchTool {
             )));
         }
 
-        let parsed: ExaResponse =
-            serde_json::from_str(&body_text).map_err(|e| {
-                ToolError::Msg(format!("websearch parse error: {}", e))
-            })?;
+        let parsed: ExaResponse = serde_json::from_str(&body_text)
+            .map_err(|e| ToolError::Msg(format!("websearch parse error: {}", e)))?;
 
         Ok(format_search_results(&parsed.results))
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,13 @@ pub struct CustomProviderConfig {
     pub api_key_env: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct ToolsConfig {
+    pub websearch: Option<bool>,
+    pub webfetch: Option<bool>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -43,6 +50,7 @@ pub struct Config {
     pub show_edit_diff: Option<bool>,
     pub tool_result_max_chars: Option<usize>,
     pub default_prompt: Option<String>,
+    pub tools: Option<ToolsConfig>,
     #[cfg(feature = "mcp")]
     pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
 


### PR DESCRIPTION
## Summary
- `webfetch`: fetches one or more URLs, converts HTML → markdown (html2text, 100-col wrap). Schemeless URLs get `https://` prepended; explicit `http://` is respected (localhost, internal services). Max 10 URLs/call, 15s timeout, 10KB cap per URL.
- `websearch`: Exa.ai search via `EXA_API_KEY`. Returns ranked title/url/snippet.
- Both tools are gated by `cfg.tools.{websearch,webfetch}` (also `WEBSEARCH_ENABLED` env), and both route through `check_perm` so the user is prompted on each call.

Stacked on #13.

## Test plan
- [x] `cargo build`
- [x] Tool unit tests (normalize_url cases, html→md, definition names)
- [ ] Manual: enable `webfetch` in config, agent fetches a page, output is wrapped markdown
- [ ] Manual: enable `websearch`, results render with titles + URLs + snippets