### PR TITLE
Add plan_enter and plan_exit tools for agent-initiated mode switching

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -180,10 +180,9 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             .map(|tx| Box::new(tools::QuestionTool::new(tx)) as Box<dyn rig::tool::ToolDyn>);
 
         let plan_tools = plan_tx.map(|tx| {
-            let enter = Box::new(tools::PlanEnterTool::new(tx.clone()))
-                as Box<dyn rig::tool::ToolDyn>;
-            let exit = Box::new(tools::PlanExitTool::new(tx))
-                as Box<dyn rig::tool::ToolDyn>;
+            let enter =
+                Box::new(tools::PlanEnterTool::new(tx.clone())) as Box<dyn rig::tool::ToolDyn>;
+            let exit = Box::new(tools::PlanExitTool::new(tx)) as Box<dyn rig::tool::ToolDyn>;
             vec![enter, exit]
         });
 

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -9,6 +9,7 @@ use crate::agent::prompt::{SYSTEM_PROMPT, TODO_TOOLS_PROMPT};
 use crate::agent::tools;
 use crate::agent::tools::ToolCache;
 use crate::agent::tools::background::BackgroundStore;
+use crate::agent::tools::plan::PlanSwitchSender;
 use crate::agent::tools::question::QuestionSender;
 use crate::cli::Cli;
 use crate::config::Config;
@@ -34,6 +35,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     permission: Option<PermCheck>,
     ask_tx: Option<AskSender>,
     question_tx: Option<QuestionSender>,
+    plan_tx: Option<PlanSwitchSender>,
     sandbox: Sandbox,
     parent_model: Option<AnyModel>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
@@ -177,6 +179,14 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         let question_tool = question_tx
             .map(|tx| Box::new(tools::QuestionTool::new(tx)) as Box<dyn rig::tool::ToolDyn>);
 
+        let plan_tools = plan_tx.map(|tx| {
+            let enter = Box::new(tools::PlanEnterTool::new(tx.clone()))
+                as Box<dyn rig::tool::ToolDyn>;
+            let exit = Box::new(tools::PlanExitTool::new(tx))
+                as Box<dyn rig::tool::ToolDyn>;
+            vec![enter, exit]
+        });
+
         // Web tools: gated on config + env var
         let websearch_enabled = cfg
             .tools
@@ -208,6 +218,10 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
 
         if let Some(qt) = question_tool {
             builder = builder.tools(vec![qt]);
+        }
+
+        if let Some(pt) = plan_tools {
+            builder = builder.tools(pt);
         }
 
         if let Some(ws) = websearch_tool {

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -6,6 +6,7 @@ mod find_files;
 mod grep;
 mod list_dir;
 mod memory;
+pub(crate) mod plan;
 pub(crate) mod question;
 mod read;
 #[cfg(feature = "semantic")]
@@ -25,6 +26,7 @@ pub use find_files::FindFilesTool;
 pub use grep::GrepTool;
 pub use list_dir::ListDirTool;
 pub use memory::MemoryTool;
+pub use plan::{PlanEnterTool, PlanExitTool};
 pub use question::QuestionTool;
 pub use read::ReadTool;
 pub use skill::SkillTool;

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -73,13 +73,13 @@ impl Tool for PlanEnterTool {
             .map_err(|_| ToolError::Msg("plan system unavailable".to_string()))?;
 
         match reply_rx.await {
-            Ok(PlanSwitchResponse::Accepted) => {
-                Ok("plan mode activated".to_string())
-            }
+            Ok(PlanSwitchResponse::Accepted) => Ok("plan mode activated".to_string()),
             Ok(PlanSwitchResponse::Rejected) => {
                 Err(ToolError::Msg("user declined plan mode".to_string()))
             }
-            Err(_) => Err(ToolError::Msg("plan channel closed unexpectedly".to_string())),
+            Err(_) => Err(ToolError::Msg(
+                "plan channel closed unexpectedly".to_string(),
+            )),
         }
     }
 }
@@ -131,13 +131,13 @@ impl Tool for PlanExitTool {
             .map_err(|_| ToolError::Msg("plan system unavailable".to_string()))?;
 
         match reply_rx.await {
-            Ok(PlanSwitchResponse::Accepted) => {
-                Ok("switched to implementation mode".to_string())
-            }
+            Ok(PlanSwitchResponse::Accepted) => Ok("switched to implementation mode".to_string()),
             Ok(PlanSwitchResponse::Rejected) => {
                 Err(ToolError::Msg("user declined mode switch".to_string()))
             }
-            Err(_) => Err(ToolError::Msg("plan channel closed unexpectedly".to_string())),
+            Err(_) => Err(ToolError::Msg(
+                "plan channel closed unexpectedly".to_string(),
+            )),
         }
     }
 }

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -120,17 +120,6 @@ impl Tool for PlanExitTool {
     }
 
     async fn call(&self, _args: PlanExitArgs) -> Result<String, ToolError> {
-        // Write PLAN.md with current plan if it doesn't exist
-        if let Ok(cwd) = std::env::current_dir() {
-            let plan_path = cwd.join("PLAN.md");
-            if !plan_path.exists() {
-                let _ = std::fs::write(
-                    &plan_path,
-                    "# Implementation Plan\n\n*(plan contents will appear here)*\n",
-                );
-            }
-        }
-
         let (reply_tx, reply_rx) = oneshot::channel();
 
         self.plan_tx

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -1,0 +1,231 @@
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use serde::Deserialize;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::agent::tools::ToolError;
+
+pub type PlanSwitchSender = mpsc::Sender<PlanSwitchRequest>;
+pub type PlanSwitchReceiver = mpsc::Receiver<PlanSwitchRequest>;
+
+#[derive(Debug)]
+pub struct PlanSwitchRequest {
+    pub action: PlanAction,
+    pub reply: oneshot::Sender<PlanSwitchResponse>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PlanAction {
+    Enter,
+    Exit,
+}
+
+#[derive(Debug)]
+pub enum PlanSwitchResponse {
+    Accepted,
+    Rejected,
+}
+
+// --- plan_enter ---
+
+pub struct PlanEnterTool {
+    plan_tx: PlanSwitchSender,
+}
+
+impl PlanEnterTool {
+    pub fn new(plan_tx: PlanSwitchSender) -> Self {
+        Self { plan_tx }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct PlanEnterArgs {}
+
+impl Tool for PlanEnterTool {
+    const NAME: &'static str = "plan_enter";
+
+    type Error = ToolError;
+    type Args = PlanEnterArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "plan_enter".to_string(),
+            description: "Suggest switching to plan mode for complex tasks. The user will be asked to confirm. In plan mode, the agent uses a planning prompt that focuses on analysis and creating a detailed implementation plan rather than writing code."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn call(&self, _args: PlanEnterArgs) -> Result<String, ToolError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        self.plan_tx
+            .send(PlanSwitchRequest {
+                action: PlanAction::Enter,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| ToolError::Msg("plan system unavailable".to_string()))?;
+
+        match reply_rx.await {
+            Ok(PlanSwitchResponse::Accepted) => {
+                Ok("plan mode activated".to_string())
+            }
+            Ok(PlanSwitchResponse::Rejected) => {
+                Err(ToolError::Msg("user declined plan mode".to_string()))
+            }
+            Err(_) => Err(ToolError::Msg("plan channel closed unexpectedly".to_string())),
+        }
+    }
+}
+
+// --- plan_exit ---
+
+pub struct PlanExitTool {
+    plan_tx: PlanSwitchSender,
+}
+
+impl PlanExitTool {
+    pub fn new(plan_tx: PlanSwitchSender) -> Self {
+        Self { plan_tx }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct PlanExitArgs {}
+
+impl Tool for PlanExitTool {
+    const NAME: &'static str = "plan_exit";
+
+    type Error = ToolError;
+    type Args = PlanExitArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "plan_exit".to_string(),
+            description: "Suggest switching from plan mode to implementation mode. The user will be asked to confirm. The agent will switch to the code prompt for writing and executing code."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn call(&self, _args: PlanExitArgs) -> Result<String, ToolError> {
+        // Write PLAN.md with current plan if it doesn't exist
+        if let Ok(cwd) = std::env::current_dir() {
+            let plan_path = cwd.join("PLAN.md");
+            if !plan_path.exists() {
+                let _ = std::fs::write(
+                    &plan_path,
+                    "# Implementation Plan\n\n*(plan contents will appear here)*\n",
+                );
+            }
+        }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+
+        self.plan_tx
+            .send(PlanSwitchRequest {
+                action: PlanAction::Exit,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| ToolError::Msg("plan system unavailable".to_string()))?;
+
+        match reply_rx.await {
+            Ok(PlanSwitchResponse::Accepted) => {
+                Ok("switched to implementation mode".to_string())
+            }
+            Ok(PlanSwitchResponse::Rejected) => {
+                Err(ToolError::Msg("user declined mode switch".to_string()))
+            }
+            Err(_) => Err(ToolError::Msg("plan channel closed unexpectedly".to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_plan_enter_accepted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = PlanEnterTool::new(tx);
+
+        let handle = tokio::spawn(async move { tool.call(PlanEnterArgs {}).await });
+
+        let req = rx.recv().await.unwrap();
+        assert!(matches!(req.action, PlanAction::Enter));
+        let _ = req.reply.send(PlanSwitchResponse::Accepted);
+
+        let result = handle.await.unwrap().unwrap();
+        assert_eq!(result, "plan mode activated");
+    }
+
+    #[tokio::test]
+    async fn test_plan_enter_rejected() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = PlanEnterTool::new(tx);
+
+        let handle = tokio::spawn(async move { tool.call(PlanEnterArgs {}).await });
+
+        let req = rx.recv().await.unwrap();
+        let _ = req.reply.send(PlanSwitchResponse::Rejected);
+
+        let result = handle.await.unwrap();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("declined"));
+    }
+
+    #[tokio::test]
+    async fn test_plan_exit_accepted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = PlanExitTool::new(tx);
+
+        let handle = tokio::spawn(async move { tool.call(PlanExitArgs {}).await });
+
+        let req = rx.recv().await.unwrap();
+        assert!(matches!(req.action, PlanAction::Exit));
+        let _ = req.reply.send(PlanSwitchResponse::Accepted);
+
+        let result = handle.await.unwrap().unwrap();
+        assert_eq!(result, "switched to implementation mode");
+    }
+
+    #[tokio::test]
+    async fn test_plan_exit_rejected() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = PlanExitTool::new(tx);
+
+        let handle = tokio::spawn(async move { tool.call(PlanExitArgs {}).await });
+
+        let req = rx.recv().await.unwrap();
+        let _ = req.reply.send(PlanSwitchResponse::Rejected);
+
+        let result = handle.await.unwrap();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("declined"));
+    }
+
+    #[tokio::test]
+    async fn test_both_definitions() {
+        let (tx1, _rx) = mpsc::channel(1);
+        let (tx2, _rx) = mpsc::channel(1);
+
+        let enter = PlanEnterTool::new(tx1).definition(String::new()).await;
+        assert_eq!(enter.name, "plan_enter");
+
+        let exit = PlanExitTool::new(tx2).definition(String::new()).await;
+        assert_eq!(exit.name, "plan_exit");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,6 +385,8 @@ async fn main() -> anyhow::Result<()> {
             ask_rx,
             question_rx,
             plan_rx,
+            question_tx,
+            plan_tx,
             sandbox,
             #[cfg(feature = "mcp")]
             mcp_manager.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use clap::Parser;
 use compact_str::CompactString;
 use session::MessageRole;
 
+use crate::agent::tools::plan::{PlanSwitchReceiver, PlanSwitchSender};
 use crate::agent::tools::question::{QuestionReceiver, QuestionSender};
 use crate::permission::ask::AskSender;
 use crate::permission::checker::{PermCheck, PermissionChecker};
@@ -56,10 +57,12 @@ fn build_channels(
     Option<tokio::sync::mpsc::Receiver<crate::permission::ask::AskRequest>>,
     Option<QuestionSender>,
     Option<QuestionReceiver>,
+    Option<PlanSwitchSender>,
+    Option<PlanSwitchReceiver>,
 ) {
     let no_tools = cli.resolve_no_tools(cfg);
     if no_tools {
-        return (None, None, None, None, None);
+        return (None, None, None, None, None, None, None);
     }
 
     let perm_config: PermissionConfig = cfg
@@ -74,12 +77,15 @@ fn build_channels(
 
     let (ask_tx, ask_rx) = tokio::sync::mpsc::channel(64);
     let (question_tx, question_rx) = tokio::sync::mpsc::channel(64);
+    let (plan_tx, plan_rx) = tokio::sync::mpsc::channel(64);
     (
         Some(perm),
         Some(ask_tx),
         Some(ask_rx),
         Some(question_tx),
         Some(question_rx),
+        Some(plan_tx),
+        Some(plan_rx),
     )
 }
 
@@ -251,7 +257,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let sandbox = sandbox::Sandbox::new(cli.resolve_sandbox(&cfg));
-    let (permission, ask_tx, ask_rx, question_tx, question_rx) = build_channels(&cli, &cfg);
+    let (permission, ask_tx, ask_rx, question_tx, question_rx, plan_tx, plan_rx) =
+        build_channels(&cli, &cfg);
 
     if let Some(perm) = &permission {
         let allowlist: Vec<(String, String)> = session
@@ -275,6 +282,7 @@ async fn main() -> anyhow::Result<()> {
             permission,
             ask_tx,
             question_tx.clone(),
+            plan_tx.clone(),
             sandbox.clone(),
             #[cfg(feature = "mcp")]
             mcp_manager.as_ref(),
@@ -303,6 +311,7 @@ async fn main() -> anyhow::Result<()> {
                 permission,
                 ask_tx,
                 question_tx.clone(),
+            plan_tx.clone(),
                 sandbox.clone(),
                 #[cfg(feature = "mcp")]
                 mcp_manager.as_ref(),
@@ -321,6 +330,7 @@ async fn main() -> anyhow::Result<()> {
             permission.clone(),
             ask_tx.clone(),
             question_tx.clone(),
+            plan_tx.clone(),
             sandbox.clone(),
             #[cfg(feature = "mcp")]
             mcp_manager.as_ref(),
@@ -374,6 +384,7 @@ async fn main() -> anyhow::Result<()> {
             ask_tx,
             ask_rx,
             question_rx,
+            plan_rx,
             sandbox,
             #[cfg(feature = "mcp")]
             mcp_manager.as_ref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ async fn main() -> anyhow::Result<()> {
                 permission,
                 ask_tx,
                 question_tx.clone(),
-            plan_tx.clone(),
+                plan_tx.clone(),
                 sandbox.clone(),
                 #[cfg(feature = "mcp")]
                 mcp_manager.as_ref(),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -10,6 +10,7 @@ use crate::agent::builder;
 use crate::agent::prompt;
 use crate::agent::runner::{self, AgentRunner};
 use crate::agent::tools::ToolCache;
+use crate::agent::tools::plan::PlanSwitchSender;
 use crate::agent::tools::question::QuestionSender;
 use crate::cli::Cli;
 use crate::config::{Config, CustomProviderConfig};
@@ -436,6 +437,7 @@ pub async fn build_agent(
     permission: Option<PermCheck>,
     ask_tx: Option<AskSender>,
     question_tx: Option<QuestionSender>,
+    plan_tx: Option<PlanSwitchSender>,
     sandbox: Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
@@ -452,6 +454,7 @@ pub async fn build_agent(
                 permission,
                 ask_tx,
                 question_tx.clone(),
+                plan_tx.clone(),
                 sandbox.clone(),
                 Some(parent_model.clone()),
                 #[cfg(feature = "mcp")]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,6 +13,9 @@ use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
 use crossterm::style::Color;
 use tokio::sync::mpsc;
 
+use crate::agent::tools::plan::{
+    PlanAction, PlanSwitchReceiver, PlanSwitchResponse,
+};
 use crate::agent::tools::question::{QuestionReceiver, QuestionResponse};
 use crate::cli::Cli;
 use crate::config::Config;
@@ -117,6 +120,7 @@ pub async fn run_interactive(
     ask_tx: Option<AskSender>,
     mut ask_rx: Option<AskReceiver>,
     mut question_rx: Option<QuestionReceiver>,
+    mut plan_rx: Option<PlanSwitchReceiver>,
     sandbox: Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
@@ -760,6 +764,7 @@ pub async fn run_interactive(
                                                 permission.clone(),
                                                 ask_tx.clone(),
                                                 None,
+                                                None,
                                                 sandbox.clone(),
                                                 #[cfg(feature = "mcp")] mcp_manager,
                                                 #[cfg(feature = "semantic")] semantic_manager,
@@ -1225,6 +1230,7 @@ pub async fn run_interactive(
                                         permission.clone(),
                                         ask_tx.clone(),
                                         None,
+                                        None,
                                         sandbox.clone(),
                                         #[cfg(feature = "mcp")] mcp_manager,
                                         #[cfg(feature = "semantic")] semantic_manager,
@@ -1577,6 +1583,98 @@ pub async fn run_interactive(
                 }
 
                 renderer.write_line("", Color::White)?;
+                renderer.render_viewport()?;
+                renderer.draw_bottom(
+                    &input,
+                    &StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()),
+                    is_running,
+                )?;
+                if let Some(ref picker) = input.picker {
+                    picker.draw(renderer.input_top_row())?;
+                }
+            }
+            Some(plan_req) = async {
+                if let Some(rx) = &mut plan_rx {
+                    rx.recv().await
+                } else {
+                    std::future::pending().await
+                }
+            } => {
+                was_reasoning = false;
+                if agent_line_started {
+                    renderer.write_line("", Color::White)?;
+                    agent_line_started = false;
+                }
+
+                let (label, prompt_name) = match plan_req.action {
+                    PlanAction::Enter => ("plan mode", "plan"),
+                    PlanAction::Exit => ("implementation mode", "code"),
+                };
+
+                renderer.write_line(
+                    &format!("[plan] switch to {}? (y/n)", label),
+                    C_PERM,
+                )?;
+
+                let accepted = loop {
+                    tokio::select! {
+                        Some(ev) = user_rx.recv() => {
+                            if let UserEvent::Key(key) = ev {
+                                match key.code {
+                                    KeyCode::Char('y') | KeyCode::Enter => break true,
+                                    KeyCode::Char('n') | KeyCode::Esc => break false,
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                };
+
+                if accepted {
+                    // Update context with the new prompt
+                    if let Some(content) = context.prompts.get(prompt_name) {
+                        context.current_prompt = Some(content.clone());
+                        context.current_prompt_name = Some(prompt_name.to_string());
+                    }
+
+                    // Rebuild agent with new prompt mode
+                    let model = client.completion_model(session.model.to_string());
+                    agent = crate::provider::build_agent(
+                        model,
+                        cli,
+                        cfg,
+                        context,
+                        permission.clone(),
+                        ask_tx.clone(),
+                        None, // question_tx not available
+                        None, // plan_tx not available
+                        sandbox.clone(),
+                        #[cfg(feature = "mcp")]
+                        mcp_manager,
+                        #[cfg(feature = "semantic")]
+                        semantic_manager,
+                    )
+                    .await;
+
+                    let _ = plan_req.reply.send(PlanSwitchResponse::Accepted);
+                    renderer.write_line(
+                        &format!("  switched to {}", label),
+                        Color::Green,
+                    )?;
+
+                    // Re-render the session to show new prompt mode
+                    if !cli.print {
+                        if let Err(e) = render_session(&mut renderer, session, cli, cfg, context) {
+                            renderer.write_line(
+                                &format!("render error: {}", e),
+                                resolve_color(C_ERROR, cli.no_color),
+                            )?;
+                        }
+                    }
+                } else {
+                    let _ = plan_req.reply.send(PlanSwitchResponse::Rejected);
+                }
+
                 renderer.render_viewport()?;
                 renderer.draw_bottom(
                     &input,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1619,16 +1619,13 @@ pub async fn run_interactive(
                 )?;
 
                 let accepted = loop {
-                    tokio::select! {
-                        Some(ev) = user_rx.recv() => {
-                            if let UserEvent::Key(key) = ev {
-                                match key.code {
-                                    KeyCode::Char('y') | KeyCode::Enter => break true,
-                                    KeyCode::Char('n') | KeyCode::Esc => break false,
-                                    _ => {}
-                                }
-                            }
-                        }
+                    let Some(UserEvent::Key(key)) = user_rx.recv().await else {
+                        continue;
+                    };
+                    match key.code {
+                        KeyCode::Char('y') | KeyCode::Enter => break true,
+                        KeyCode::Char('n') | KeyCode::Esc => break false,
+                        _ => {}
                     }
                 };
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,9 +14,9 @@ use crossterm::style::Color;
 use tokio::sync::mpsc;
 
 use crate::agent::tools::plan::{
-    PlanAction, PlanSwitchReceiver, PlanSwitchResponse,
+    PlanAction, PlanSwitchReceiver, PlanSwitchResponse, PlanSwitchSender,
 };
-use crate::agent::tools::question::{QuestionReceiver, QuestionResponse};
+use crate::agent::tools::question::{QuestionReceiver, QuestionResponse, QuestionSender};
 use crate::cli::Cli;
 use crate::config::Config;
 use crate::context::ContextFiles;
@@ -121,6 +121,8 @@ pub async fn run_interactive(
     mut ask_rx: Option<AskReceiver>,
     mut question_rx: Option<QuestionReceiver>,
     mut plan_rx: Option<PlanSwitchReceiver>,
+    question_tx: Option<QuestionSender>,
+    plan_tx: Option<PlanSwitchSender>,
     sandbox: Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
@@ -1646,8 +1648,8 @@ pub async fn run_interactive(
                         context,
                         permission.clone(),
                         ask_tx.clone(),
-                        None, // question_tx not available
-                        None, // plan_tx not available
+                        question_tx.clone(),
+                        plan_tx.clone(),
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
                         mcp_manager,

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -124,6 +124,7 @@ pub async fn handle_compress(
         permission.clone(),
         ask_tx.clone(),
         None,
+        None,
         sandbox.clone(),
         #[cfg(feature = "mcp")]
         mcp_manager,
@@ -181,6 +182,7 @@ pub async fn handle_slash(
                     context,
                     permission.clone(),
                     ask_tx.clone(),
+                    None,
                     None,
                     sandbox.clone(),
                     #[cfg(feature = "mcp")]
@@ -498,6 +500,7 @@ pub async fn handle_slash(
                         permission.clone(),
                         ask_tx.clone(),
                         None,
+                        None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
                         mcp_manager,
@@ -606,6 +609,7 @@ pub async fn handle_slash(
                         permission.clone(),
                         ask_tx.clone(),
                         None,
+                        None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
                         mcp_manager,
@@ -627,6 +631,7 @@ pub async fn handle_slash(
                         context,
                         permission.clone(),
                         ask_tx.clone(),
+                        None,
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -676,6 +681,7 @@ pub async fn handle_slash(
                         context,
                         permission.clone(),
                         ask_tx.clone(),
+                        None,
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -826,6 +832,7 @@ pub async fn handle_slash(
                         context,
                         permission.clone(),
                         ask_tx.clone(),
+                        None,
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]


### PR DESCRIPTION
## Summary
- Two new tools that let the agent request a prompt-mode switch (`plan` ↔ `code`). UI prompts user for y/n confirmation, then rebuilds the agent with the new preamble. Question and plan senders flow through the rebuild so the tools remain available after a switch.

Stacked on #16.

## Test plan
- [x] `cargo build`
- [x] plan_enter / plan_exit unit tests (accepted / rejected)
- [ ] Manual: agent calls `plan_enter`, user confirms with y, status line shows `plan`; later `plan_exit` switches back to `code`
- [ ] Manual: after switching, agent can call `plan_enter`/`plan_exit` again (verifies the sender plumbing fix)