### PR TITLE
LSP Phase 2: JSON-RPC framing + request correlation + initialize handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ version = "56.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0d5eb3fe25337ff83e8333a08379bdd1540b0961b1c888f6e505d971c198e1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "serde",
  "serde_json",
 ]
@@ -1098,7 +1098,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1117,6 +1117,12 @@ name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1705,7 +1711,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2690,6 +2696,7 @@ dependencies = [
  "include_dir",
  "indexmap 2.14.0",
  "janetrs",
+ "lsp-types",
  "pulldown-cmark",
  "regex",
  "reqwest 0.13.3",
@@ -2974,7 +2981,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -2994,6 +3001,15 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -5102,6 +5118,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "lz4"
 version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5383,7 +5412,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5618,7 +5647,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -5941,7 +5970,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6146,7 +6175,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -6483,7 +6512,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6908,7 +6937,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6921,7 +6950,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -7123,7 +7152,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7706,7 +7735,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8241,7 +8270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8737,7 +8766,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -9207,7 +9236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "macros", "sync", "time", "process", "fs"] }
+tokio = { version = "1", features = ["rt", "macros", "sync", "time", "process", "fs", "io-util"] }
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -66,6 +66,7 @@ streaming-iterator = { version = "0.1", optional = true }
 janetrs = { version = "0.8", optional = true }
 html2text = "0.17"
 indexmap = "2"
+lsp-types = "0.97"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }

--- a/src/lsp/init.rs
+++ b/src/lsp/init.rs
@@ -1,0 +1,436 @@
+//! LSP initialize handshake.
+//!
+//! Wraps the spec's three-step start-up:
+//! 1. send `initialize` request with our client capabilities
+//! 2. receive `InitializeResult` carrying the server's capabilities
+//! 3. send `initialized` notification to acknowledge
+//!
+//! Returns the [`InitializeResult`] so callers can introspect capability
+//! flags (textDocumentSync mode, diagnosticProvider, etc.) without parsing
+//! the JSON themselves.
+
+use std::path::Path;
+use std::time::Duration;
+
+use lsp_types::{
+    ClientCapabilities, DiagnosticClientCapabilities, DidChangeWatchedFilesClientCapabilities,
+    GeneralClientCapabilities, InitializeParams, InitializeResult,
+    PublishDiagnosticsClientCapabilities, TextDocumentClientCapabilities,
+    TextDocumentSyncClientCapabilities, Uri, WindowClientCapabilities, WorkspaceClientCapabilities,
+    WorkspaceFolder,
+};
+
+use crate::lsp::rpc::{RpcClient, RpcError};
+
+/// Time we'll wait for the server to answer `initialize`. Matches opencode's
+/// 45s ceiling — rust-analyzer in particular can take a moment when first
+/// indexing a large workspace.
+pub const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Run the LSP initialize handshake against a connected [`RpcClient`].
+///
+/// `root` must be a canonical filesystem path; it's converted to a `file://`
+/// URI and sent as both `rootUri` and a single-element `workspaceFolders`.
+/// `initialization_options` is the server-specific payload (e.g. for the
+/// typescript LSP, the resolved tsserver path); pass `serde_json::Value::Null`
+/// when there are none.
+pub async fn initialize(
+    client: &RpcClient,
+    root: &Path,
+    process_id: Option<u32>,
+    initialization_options: serde_json::Value,
+) -> Result<InitializeResult, RpcError> {
+    let root_uri = path_to_file_uri(root)?;
+
+    let params = InitializeParams {
+        process_id,
+        workspace_folders: Some(vec![WorkspaceFolder {
+            name: "workspace".to_string(),
+            uri: root_uri.clone(),
+        }]),
+        // `rootUri` is deprecated in favor of `workspaceFolders` but every
+        // shipping server still reads it; send both for compatibility.
+        #[allow(deprecated)]
+        root_uri: Some(root_uri),
+        initialization_options: if initialization_options.is_null() {
+            None
+        } else {
+            Some(initialization_options)
+        },
+        capabilities: client_capabilities(),
+        ..Default::default()
+    };
+
+    let result: InitializeResult = client
+        .request("initialize", params, INITIALIZE_TIMEOUT)
+        .await?;
+
+    client.notify("initialized", serde_json::json!({})).await?;
+
+    Ok(result)
+}
+
+fn path_to_file_uri(path: &Path) -> Result<Uri, RpcError> {
+    // `file://` URI from a filesystem path. We don't try to handle Windows
+    // drive letters specially — dirge isn't tested on Windows.
+    let canonical = path.to_string_lossy();
+    let encoded = percent_encode_path(&canonical);
+    let uri_str = if canonical.starts_with('/') {
+        format!("file://{encoded}")
+    } else {
+        format!("file:///{encoded}")
+    };
+    uri_str.parse::<Uri>().map_err(|e| {
+        RpcError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid path for file URI: {e}"),
+        ))
+    })
+}
+
+/// Percent-encode characters that would otherwise be interpreted as URI
+/// structural delimiters. Slashes are preserved (path separators). Conforms
+/// to RFC 3986's `unreserved` set + `/` for path segments. Pure ASCII only —
+/// non-ASCII bytes pass through and the Uri parser does its own escaping or
+/// rejection.
+fn percent_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        let safe =
+            byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'-' | b'.' | b'_' | b'~' | b':');
+        if safe {
+            out.push(byte as char);
+        } else if byte < 0x80 {
+            out.push_str(&format!("%{byte:02X}"));
+        } else {
+            // Non-ASCII — emit as UTF-8 percent-encoded bytes.
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+/// The client capabilities we advertise. Conservative and stable — matches
+/// what opencode sends. Phase 3's per-file work depends on these being
+/// honoured by the server:
+/// - synchronization (didOpen/didChange)
+/// - publishDiagnostics (push diagnostics)
+/// - diagnostic (pull diagnostics, dynamic registration)
+fn client_capabilities() -> ClientCapabilities {
+    ClientCapabilities {
+        workspace: Some(WorkspaceClientCapabilities {
+            configuration: Some(true),
+            did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                dynamic_registration: Some(true),
+                relative_pattern_support: Some(false),
+            }),
+            workspace_folders: Some(true),
+            ..Default::default()
+        }),
+        text_document: Some(TextDocumentClientCapabilities {
+            synchronization: Some(TextDocumentSyncClientCapabilities {
+                did_save: Some(false),
+                dynamic_registration: Some(false),
+                will_save: Some(false),
+                will_save_wait_until: Some(false),
+            }),
+            publish_diagnostics: Some(PublishDiagnosticsClientCapabilities {
+                related_information: Some(true),
+                version_support: Some(false),
+                ..Default::default()
+            }),
+            diagnostic: Some(DiagnosticClientCapabilities {
+                dynamic_registration: Some(true),
+                related_document_support: Some(true),
+            }),
+            ..Default::default()
+        }),
+        window: Some(WindowClientCapabilities {
+            work_done_progress: Some(true),
+            ..Default::default()
+        }),
+        general: Some(GeneralClientCapabilities {
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::jsonrpc::{decode_frame, encode_frame};
+    use serde_json::{Value, json};
+    use tokio::io::BufReader;
+
+    /// Spin up a fake LSP server task wired to a duplex pair. The task reads
+    /// the next frame from the client, calls `respond(req)` to compute a
+    /// reply, and writes it back. Returns the client + a join handle for
+    /// the fake server.
+    async fn with_fake_server<F>(respond: F) -> (RpcClient, tokio::task::JoinHandle<()>)
+    where
+        F: Fn(Value) -> Value + Send + 'static,
+    {
+        let (client_in, server_out) = tokio::io::duplex(4096);
+        let (server_in, client_out) = tokio::io::duplex(4096);
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader_half, _) = tokio::io::split(server_in);
+        let (_, mut server_writer) = tokio::io::split(server_out);
+        let (client, _task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+
+        let server = tokio::spawn(async move {
+            let mut reader = BufReader::new(server_reader_half);
+            loop {
+                let frame = match decode_frame(&mut reader).await {
+                    Ok(b) => b,
+                    Err(_) => break,
+                };
+                let req: Value = serde_json::from_slice(&frame).unwrap();
+                let reply = respond(req);
+                if reply.is_null() {
+                    continue; // notification — no reply
+                }
+                let bytes = serde_json::to_vec(&reply).unwrap();
+                if encode_frame(&mut server_writer, &bytes).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        (client, server)
+    }
+
+    #[tokio::test]
+    async fn initialize_round_trips_params_and_returns_capabilities() {
+        let (client, _server) = with_fake_server(|req: Value| {
+            if req["method"] == "initialize" {
+                let id = req["id"].clone();
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "capabilities": {
+                            "textDocumentSync": 2,
+                            "diagnosticProvider": {
+                                "interFileDependencies": true,
+                                "workspaceDiagnostics": false
+                            }
+                        }
+                    }
+                })
+            } else {
+                Value::Null // initialized notification — no reply
+            }
+        })
+        .await;
+
+        let root = std::env::temp_dir();
+        let result = initialize(&client, &root, Some(12345), Value::Null)
+            .await
+            .unwrap();
+
+        // We received the capabilities the fake server advertised.
+        assert!(result.capabilities.diagnostic_provider.is_some());
+        // textDocumentSync should round-trip too.
+        assert!(result.capabilities.text_document_sync.is_some());
+    }
+
+    // Regression: the initialize request body must carry the rootUri /
+    // workspaceFolders pointing at the path we passed in. Without this,
+    // rust-analyzer attaches at the wrong directory and misses workspace
+    // members.
+    #[tokio::test]
+    async fn regression_initialize_request_carries_root_uri() {
+        // We hand-spin the server side so we can inspect the raw request
+        // before answering it.
+        let (client_in, server_out) = tokio::io::duplex(4096);
+        let (server_in, client_out) = tokio::io::duplex(4096);
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader, _) = tokio::io::split(server_in);
+        let (_, mut server_writer) = tokio::io::split(server_out);
+        let (client, _task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+
+        let root = std::env::temp_dir();
+        let root_str = root.to_string_lossy().to_string();
+
+        // Spawn a server that captures the initialize request and replies.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(server_reader);
+            let frame = decode_frame(&mut reader).await.unwrap();
+            let req: Value = serde_json::from_slice(&frame).unwrap();
+            let id = req["id"].clone();
+            let _ = tx.send(req);
+            let resp = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {"capabilities": {}}
+            });
+            encode_frame(&mut server_writer, &serde_json::to_vec(&resp).unwrap())
+                .await
+                .unwrap();
+            // Eat the `initialized` notification.
+            let _ = decode_frame(&mut reader).await;
+        });
+
+        let _ = initialize(&client, &root, Some(1), Value::Null)
+            .await
+            .unwrap();
+
+        let req = rx.recv().await.unwrap();
+        let uri = req["params"]["rootUri"].as_str().unwrap();
+        assert!(uri.starts_with("file://"), "got: {uri}");
+        assert!(
+            uri.contains(&*root_str),
+            "expected {root_str} in uri: {uri}"
+        );
+
+        let folders = req["params"]["workspaceFolders"].as_array().unwrap();
+        assert_eq!(folders.len(), 1);
+        assert_eq!(folders[0]["name"], "workspace");
+    }
+
+    // Regression: server-specific `initializationOptions` must propagate.
+    // The typescript LSP (Phase 1 server) refuses to attach without
+    // `tsserver.path` in this payload.
+    #[tokio::test]
+    async fn regression_initialization_options_propagate_when_provided() {
+        let (client_in, server_out) = tokio::io::duplex(4096);
+        let (server_in, client_out) = tokio::io::duplex(4096);
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader, _) = tokio::io::split(server_in);
+        let (_, mut server_writer) = tokio::io::split(server_out);
+        let (client, _task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(server_reader);
+            let frame = decode_frame(&mut reader).await.unwrap();
+            let req: Value = serde_json::from_slice(&frame).unwrap();
+            let id = req["id"].clone();
+            let _ = tx.send(req);
+            let resp = json!({"jsonrpc":"2.0","id":id,"result":{"capabilities":{}}});
+            encode_frame(&mut server_writer, &serde_json::to_vec(&resp).unwrap())
+                .await
+                .unwrap();
+            let _ = decode_frame(&mut reader).await;
+        });
+
+        let opts = json!({"tsserver": {"path": "/path/to/tsserver"}});
+        let _ = initialize(&client, &std::env::temp_dir(), None, opts)
+            .await
+            .unwrap();
+
+        let req = rx.recv().await.unwrap();
+        assert_eq!(
+            req["params"]["initializationOptions"]["tsserver"]["path"],
+            "/path/to/tsserver"
+        );
+    }
+
+    // Null initializationOptions must NOT serialize a JSON `null` for the
+    // field — some servers reject the field's mere presence with null. Match
+    // opencode's behavior (omit the field).
+    #[tokio::test]
+    async fn null_initialization_options_omits_field() {
+        let (client_in, server_out) = tokio::io::duplex(4096);
+        let (server_in, client_out) = tokio::io::duplex(4096);
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader, _) = tokio::io::split(server_in);
+        let (_, mut server_writer) = tokio::io::split(server_out);
+        let (client, _task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(server_reader);
+            let frame = decode_frame(&mut reader).await.unwrap();
+            let req: Value = serde_json::from_slice(&frame).unwrap();
+            let id = req["id"].clone();
+            let _ = tx.send(req);
+            let resp = json!({"jsonrpc":"2.0","id":id,"result":{"capabilities":{}}});
+            encode_frame(&mut server_writer, &serde_json::to_vec(&resp).unwrap())
+                .await
+                .unwrap();
+            let _ = decode_frame(&mut reader).await;
+        });
+
+        let _ = initialize(&client, &std::env::temp_dir(), None, Value::Null)
+            .await
+            .unwrap();
+
+        let req = rx.recv().await.unwrap();
+        let opts = req["params"].get("initializationOptions");
+        assert!(
+            opts.is_none() || opts.unwrap().is_null(),
+            "expected omitted or explicit null; got: {opts:?}"
+        );
+    }
+
+    // Regression: paths containing URI-significant characters must be
+    // percent-encoded. A `#` would otherwise terminate the path early and
+    // produce a fragment.
+    #[test]
+    fn path_to_file_uri_percent_encodes_special_chars() {
+        let p = Path::new("/tmp/proj #1/src/main.rs");
+        let uri = path_to_file_uri(p).unwrap();
+        let s = uri.as_str();
+        assert!(s.starts_with("file:///"), "got: {s}");
+        assert!(s.contains("%23"), "must encode '#' as %23, got: {s}");
+        assert!(s.contains("%20"), "must encode space as %20, got: {s}");
+    }
+
+    #[test]
+    fn path_to_file_uri_preserves_slashes_and_safe_chars() {
+        let p = Path::new("/tmp/proj_v1.0-rc/main.rs");
+        let uri = path_to_file_uri(p).unwrap();
+        let s = uri.as_str();
+        assert!(
+            s.starts_with("file:///tmp/proj_v1.0-rc/main.rs"),
+            "got: {s}"
+        );
+    }
+
+    // The `initialized` notification must follow the InitializeResult — some
+    // servers stall until they see it.
+    #[tokio::test]
+    async fn initialized_notification_is_sent_after_response() {
+        let (client_in, server_out) = tokio::io::duplex(4096);
+        let (server_in, client_out) = tokio::io::duplex(4096);
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader, _) = tokio::io::split(server_in);
+        let (_, mut server_writer) = tokio::io::split(server_out);
+        let (client, _task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+
+        let observed = tokio::spawn(async move {
+            let mut reader = BufReader::new(server_reader);
+            // First message: initialize request.
+            let first = decode_frame(&mut reader).await.unwrap();
+            let req: Value = serde_json::from_slice(&first).unwrap();
+            assert_eq!(req["method"], "initialize");
+            let id = req["id"].clone();
+            let resp = json!({"jsonrpc":"2.0","id":id,"result":{"capabilities":{}}});
+            encode_frame(&mut server_writer, &serde_json::to_vec(&resp).unwrap())
+                .await
+                .unwrap();
+
+            // Second message: initialized notification.
+            let second = decode_frame(&mut reader).await.unwrap();
+            let notif: Value = serde_json::from_slice(&second).unwrap();
+            assert_eq!(notif["method"], "initialized");
+            assert!(
+                notif.get("id").is_none(),
+                "initialized must be a notification"
+            );
+        });
+
+        let _ = initialize(&client, &std::env::temp_dir(), None, Value::Null)
+            .await
+            .unwrap();
+        observed.await.unwrap();
+    }
+}

--- a/src/lsp/jsonrpc.rs
+++ b/src/lsp/jsonrpc.rs
@@ -1,0 +1,261 @@
+//! JSON-RPC framing for LSP.
+//!
+//! LSP uses HTTP-style framing on top of stdio:
+//! ```text
+//! Content-Length: <N>\r\n
+//! \r\n
+//! <body of N bytes>
+//! ```
+//! Content-Type is allowed by the spec but ignored — every modern server
+//! sends UTF-8 JSON. Multiple frames can follow back-to-back on the same
+//! stream, so the reader operates on a buffered source.
+
+use std::io;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+const CONTENT_LENGTH_PREFIX: &str = "Content-Length:";
+
+/// Maximum body length we'll accept. Prevents a malformed Content-Length value
+/// from forcing us to allocate an unbounded buffer. LSP messages in the wild
+/// are KB-scale; 16 MB is more than enough headroom.
+const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Write a single LSP message frame to `writer`. The caller passes the raw
+/// JSON body as bytes; framing prepends `Content-Length` + the blank line.
+pub async fn encode_frame<W>(writer: &mut W, body: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read one LSP message frame from `reader`. Returns the raw body bytes.
+/// Errors on EOF mid-frame, missing/malformed `Content-Length`, or a body
+/// length above [`MAX_BODY_BYTES`].
+pub async fn decode_frame<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut content_length: Option<usize> = None;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "stream closed before complete frame header",
+            ));
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            // End of headers.
+            break;
+        }
+        if let Some(rest) = trimmed.strip_prefix(CONTENT_LENGTH_PREFIX) {
+            let value = rest.trim();
+            let parsed: usize = value.parse().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("malformed Content-Length value: {value:?}"),
+                )
+            })?;
+            if parsed > MAX_BODY_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("body length {parsed} exceeds cap {MAX_BODY_BYTES}"),
+                ));
+            }
+            content_length = Some(parsed);
+        }
+        // Other headers (e.g. Content-Type) are ignored per the LSP spec.
+    }
+
+    let len = content_length.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame header missing Content-Length",
+        )
+    })?;
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).await?;
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::BufReader;
+
+    async fn roundtrip(body: &[u8]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        encode_frame(&mut buf, body).await.unwrap();
+        let mut reader = BufReader::new(buf.as_slice());
+        decode_frame(&mut reader).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn roundtrip_simple_json_body() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#;
+        assert_eq!(roundtrip(body).await, body);
+    }
+
+    #[tokio::test]
+    async fn roundtrip_unicode_body_preserves_byte_count() {
+        // Multi-byte chars: byte length ≠ char count. Content-Length is bytes
+        // per the LSP spec — this test pins that down.
+        let body = "{\"text\":\"hello 🦀 rust\"}".as_bytes();
+        assert_eq!(roundtrip(body).await, body);
+    }
+
+    #[tokio::test]
+    async fn roundtrip_empty_body() {
+        // Content-Length: 0 is valid (rare but legal). Verify we don't trip
+        // over the zero-byte read.
+        assert_eq!(roundtrip(b"").await, b"");
+    }
+
+    #[tokio::test]
+    async fn encode_format_is_content_length_blank_body() {
+        let mut buf: Vec<u8> = Vec::new();
+        encode_frame(&mut buf, b"hello").await.unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert_eq!(s, "Content-Length: 5\r\n\r\nhello");
+    }
+
+    #[tokio::test]
+    async fn decode_multiple_frames_from_one_reader() {
+        let mut buf: Vec<u8> = Vec::new();
+        encode_frame(&mut buf, b"first").await.unwrap();
+        encode_frame(&mut buf, b"second").await.unwrap();
+        encode_frame(&mut buf, b"third").await.unwrap();
+
+        let mut reader = BufReader::new(buf.as_slice());
+        assert_eq!(decode_frame(&mut reader).await.unwrap(), b"first");
+        assert_eq!(decode_frame(&mut reader).await.unwrap(), b"second");
+        assert_eq!(decode_frame(&mut reader).await.unwrap(), b"third");
+    }
+
+    #[tokio::test]
+    async fn decode_skips_unknown_headers_before_blank_line() {
+        let frame = "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\
+                     Content-Length: 5\r\n\
+                     \r\n\
+                     hello";
+        let mut reader = BufReader::new(frame.as_bytes());
+        let body = decode_frame(&mut reader).await.unwrap();
+        assert_eq!(body, b"hello");
+    }
+
+    // Regression: tools/in-house frame encoders sometimes use \n line endings
+    // instead of \r\n. Be lenient on input (\r is trimmed regardless) so we
+    // don't break against non-conforming servers.
+    #[tokio::test]
+    async fn decode_tolerates_lone_newline_line_endings() {
+        let frame = "Content-Length: 5\n\nhello";
+        let mut reader = BufReader::new(frame.as_bytes());
+        let body = decode_frame(&mut reader).await.unwrap();
+        assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test]
+    async fn decode_errors_on_missing_content_length() {
+        let frame = "Content-Type: foo\r\n\r\nbody";
+        let mut reader = BufReader::new(frame.as_bytes());
+        let err = decode_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("Content-Length"));
+    }
+
+    #[tokio::test]
+    async fn decode_errors_on_malformed_content_length() {
+        let frame = "Content-Length: not-a-number\r\n\r\n";
+        let mut reader = BufReader::new(frame.as_bytes());
+        let err = decode_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("malformed"));
+    }
+
+    // Regression: a malicious or buggy server claiming a huge Content-Length
+    // must not coerce us into allocating an unbounded buffer.
+    #[tokio::test]
+    async fn decode_errors_when_content_length_exceeds_cap() {
+        let huge = MAX_BODY_BYTES + 1;
+        let frame = format!("Content-Length: {huge}\r\n\r\n");
+        let mut reader = BufReader::new(frame.as_bytes());
+        let err = decode_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds cap"));
+    }
+
+    #[tokio::test]
+    async fn decode_errors_on_eof_mid_header() {
+        let frame = "Content-Length: 5\r\n"; // no blank line, no body
+        let mut reader = BufReader::new(frame.as_bytes());
+        let err = decode_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn decode_errors_on_eof_mid_body() {
+        // Header claims 10 bytes, body has 3.
+        let frame = "Content-Length: 10\r\n\r\nabc";
+        let mut reader = BufReader::new(frame.as_bytes());
+        let err = decode_frame(&mut reader).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    // Regression: a streaming reader may not produce a full frame in a single
+    // poll. Verify the decoder reads incrementally without dropping bytes.
+    #[tokio::test]
+    async fn decode_handles_byte_at_a_time_reader() {
+        let mut buf: Vec<u8> = Vec::new();
+        encode_frame(&mut buf, b"hello").await.unwrap();
+
+        // Wrap in a duplex pipe and feed byte-by-byte.
+        let (client_read, mut server_write) = tokio::io::duplex(64);
+        let writer = tokio::spawn(async move {
+            for byte in buf {
+                server_write.write_all(&[byte]).await.unwrap();
+                // Yield to give the reader a chance to make partial progress.
+                tokio::task::yield_now().await;
+            }
+            drop(server_write);
+        });
+
+        let mut reader = BufReader::new(client_read);
+        let body = decode_frame(&mut reader).await.unwrap();
+        writer.await.unwrap();
+        assert_eq!(body, b"hello");
+    }
+
+    // Concurrency check: encode + decode in parallel over a duplex pipe.
+    // Models the producer/consumer pattern used by the actual client task.
+    #[tokio::test]
+    async fn encode_decode_through_duplex_pipe() {
+        let (mut client_side, mut server_side) = tokio::io::duplex(1024);
+
+        let writer = tokio::spawn(async move {
+            for msg in [b"alpha".as_slice(), b"beta", b"gamma"] {
+                encode_frame(&mut server_side, msg).await.unwrap();
+            }
+            drop(server_side);
+        });
+
+        let mut reader = BufReader::new(&mut client_side);
+        let mut got = Vec::new();
+        for _ in 0..3 {
+            got.push(decode_frame(&mut reader).await.unwrap());
+        }
+        writer.await.unwrap();
+        assert_eq!(
+            got,
+            vec![b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()]
+        );
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -10,5 +10,8 @@
 // dead-code warnings would clutter every build — silenced module-wide.
 #![allow(dead_code)]
 
+pub mod init;
+pub mod jsonrpc;
 pub mod language;
+pub mod rpc;
 pub mod server;

--- a/src/lsp/rpc.rs
+++ b/src/lsp/rpc.rs
@@ -1,0 +1,535 @@
+//! JSON-RPC 2.0 request/response correlation over a framed transport.
+//!
+//! Built on top of [`crate::lsp::jsonrpc`]. The client spawns a background
+//! task that pumps incoming frames and routes them:
+//! - responses (have `id`, no `method`) → resolve the matching pending request
+//! - notifications (have `method`, no `id`) → dispatch to registered handlers
+//! - server→client requests (have both `id` and `method`) → currently
+//!   acknowledged with a null result (we register no client capabilities for
+//!   this in v1)
+//!
+//! Outbound writes serialize through a mutex so multiple concurrent callers
+//! don't interleave frames on stdin.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufRead, AsyncWrite};
+use tokio::sync::{Mutex, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use crate::lsp::jsonrpc::{decode_frame, encode_frame};
+
+/// Failure surfaced to a pending request.
+#[derive(Debug, thiserror::Error)]
+pub enum RpcError {
+    #[error("RPC error {code}: {message}")]
+    Server { code: i64, message: String },
+    #[error("connection closed before response arrived")]
+    ConnectionClosed,
+    #[error("request timed out after {0:?}")]
+    Timeout(Duration),
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Handler invoked for an incoming notification. Synchronous for simplicity —
+/// dispatch into a channel inside the closure if work needs to happen async.
+pub type NotificationHandler = Box<dyn Fn(Value) + Send + Sync>;
+
+type Pending = HashMap<u64, oneshot::Sender<Result<Value, RpcError>>>;
+
+struct Inner {
+    next_id: AtomicU64,
+    pending: Mutex<Pending>,
+    handlers: Mutex<HashMap<String, NotificationHandler>>,
+    writer: Mutex<Box<dyn AsyncWrite + Send + Unpin>>,
+    closed: std::sync::atomic::AtomicBool,
+}
+
+/// JSON-RPC client. Cheap to clone (just an `Arc`).
+#[derive(Clone)]
+pub struct RpcClient {
+    inner: Arc<Inner>,
+}
+
+impl RpcClient {
+    /// Create a client over a framed transport. Spawns a background task that
+    /// pumps incoming frames; the returned [`JoinHandle`] lets callers await
+    /// the reader's exit (it ends when the peer closes the stream).
+    pub fn new<R, W>(reader: R, writer: W) -> (Self, JoinHandle<io::Result<()>>)
+    where
+        R: AsyncBufRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        let inner = Arc::new(Inner {
+            next_id: AtomicU64::new(1),
+            pending: Mutex::new(HashMap::new()),
+            handlers: Mutex::new(HashMap::new()),
+            writer: Mutex::new(Box::new(writer)),
+            closed: std::sync::atomic::AtomicBool::new(false),
+        });
+        let client = RpcClient {
+            inner: inner.clone(),
+        };
+        let task = tokio::spawn(read_loop(inner, reader));
+        (client, task)
+    }
+
+    /// Send a request and await its response. Errors on connection close,
+    /// I/O failure, server-side error response, or `timeout` elapsing.
+    ///
+    /// Tiny race window if a peer close interleaves with a request: the
+    /// `closed` check + insert + write are not atomic against the read loop
+    /// draining pending entries on EOF. In that case the request waits for
+    /// its own timeout rather than failing instantly with `ConnectionClosed`.
+    /// Callers should treat both terminations as terminal.
+    pub async fn request<P, R>(
+        &self,
+        method: &str,
+        params: P,
+        request_timeout: Duration,
+    ) -> Result<R, RpcError>
+    where
+        P: Serialize,
+        R: serde::de::DeserializeOwned,
+    {
+        if self.inner.closed.load(Ordering::SeqCst) {
+            return Err(RpcError::ConnectionClosed);
+        }
+        let id = self.inner.next_id.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = oneshot::channel();
+        self.inner.pending.lock().await.insert(id, tx);
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": serde_json::to_value(params)?,
+        });
+        let bytes = serde_json::to_vec(&body)?;
+        let send_result = {
+            let mut writer = self.inner.writer.lock().await;
+            encode_frame(&mut *writer, &bytes).await
+        };
+        if let Err(e) = send_result {
+            // Roll the pending entry back so we don't leak it.
+            self.inner.pending.lock().await.remove(&id);
+            return Err(RpcError::Io(e));
+        }
+
+        let value = match timeout(request_timeout, rx).await {
+            Ok(Ok(result)) => result?,
+            Ok(Err(_)) => {
+                self.inner.pending.lock().await.remove(&id);
+                return Err(RpcError::ConnectionClosed);
+            }
+            Err(_) => {
+                self.inner.pending.lock().await.remove(&id);
+                return Err(RpcError::Timeout(request_timeout));
+            }
+        };
+        Ok(serde_json::from_value(value)?)
+    }
+
+    /// Fire-and-forget notification. No id, no response.
+    pub async fn notify<P>(&self, method: &str, params: P) -> Result<(), RpcError>
+    where
+        P: Serialize,
+    {
+        if self.inner.closed.load(Ordering::SeqCst) {
+            return Err(RpcError::ConnectionClosed);
+        }
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": serde_json::to_value(params)?,
+        });
+        let bytes = serde_json::to_vec(&body)?;
+        let mut writer = self.inner.writer.lock().await;
+        encode_frame(&mut *writer, &bytes).await?;
+        Ok(())
+    }
+
+    /// Register a handler for an incoming server notification. Replaces any
+    /// previously-registered handler for the same method.
+    pub async fn on_notification(&self, method: &str, handler: NotificationHandler) {
+        self.inner
+            .handlers
+            .lock()
+            .await
+            .insert(method.to_string(), handler);
+    }
+}
+
+async fn read_loop<R>(inner: Arc<Inner>, mut reader: R) -> io::Result<()>
+where
+    R: AsyncBufRead + Send + Unpin,
+{
+    loop {
+        let frame = match decode_frame(&mut reader).await {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                // Clean shutdown — peer closed.
+                break;
+            }
+            Err(e) => return Err(e),
+        };
+        let msg: Value = match serde_json::from_slice(&frame) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("lsp: skipping non-JSON frame: {e}");
+                continue;
+            }
+        };
+        dispatch(&inner, msg).await;
+    }
+    // Stream closed — fail any pending requests and mark closed.
+    inner.closed.store(true, Ordering::SeqCst);
+    let mut pending = inner.pending.lock().await;
+    for (_, sender) in pending.drain() {
+        let _ = sender.send(Err(RpcError::ConnectionClosed));
+    }
+    Ok(())
+}
+
+async fn dispatch(inner: &Arc<Inner>, msg: Value) {
+    let id = msg.get("id").and_then(|v| v.as_u64());
+    let method = msg.get("method").and_then(|v| v.as_str()).map(String::from);
+
+    match (id, method) {
+        (Some(id), None) => {
+            // Response to one of our requests.
+            let sender = inner.pending.lock().await.remove(&id);
+            if let Some(sender) = sender {
+                let result = if let Some(err) = msg.get("error") {
+                    let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);
+                    let message = err
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("(no message)")
+                        .to_string();
+                    Err(RpcError::Server { code, message })
+                } else {
+                    Ok(msg.get("result").cloned().unwrap_or(Value::Null))
+                };
+                let _ = sender.send(result);
+            }
+        }
+        (None, Some(method)) => {
+            // Server-initiated notification.
+            let handlers = inner.handlers.lock().await;
+            if let Some(handler) = handlers.get(&method) {
+                let params = msg.get("params").cloned().unwrap_or(Value::Null);
+                handler(params);
+            }
+        }
+        (Some(id), Some(_method)) => {
+            // Server-to-client request. We don't advertise any client-side
+            // request capabilities yet; acknowledge with a null result so the
+            // server doesn't hang.
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": Value::Null,
+            });
+            if let Ok(bytes) = serde_json::to_vec(&response) {
+                let mut writer = inner.writer.lock().await;
+                let _ = encode_frame(&mut *writer, &bytes).await;
+            }
+        }
+        (None, None) => {
+            tracing::warn!("lsp: ignoring frame without id or method");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::BufReader;
+
+    /// Build a client whose I/O is wired to two duplex pipes, and return
+    /// "server-side" halves that the test can use to read what the client
+    /// sent and to send back responses.
+    fn pair() -> (
+        RpcClient,
+        JoinHandle<io::Result<()>>,
+        tokio::io::ReadHalf<tokio::io::DuplexStream>, // server reads what the client sent
+        tokio::io::WriteHalf<tokio::io::DuplexStream>, // server writes; client reads
+    ) {
+        let (client_in, server_out) = tokio::io::duplex(4096); // client reads <- server writes
+        let (server_in, client_out) = tokio::io::duplex(4096); // client writes -> server reads
+        let (client_reader, _) = tokio::io::split(client_in);
+        let (_, client_writer) = tokio::io::split(client_out);
+        let (server_reader, _) = tokio::io::split(server_in);
+        let (_, server_writer) = tokio::io::split(server_out);
+        let (client, task) = RpcClient::new(BufReader::new(client_reader), client_writer);
+        (client, task, server_reader, server_writer)
+    }
+
+    async fn read_client_frame<R>(reader: &mut R) -> Value
+    where
+        R: tokio::io::AsyncReadExt + Unpin + tokio::io::AsyncBufRead,
+    {
+        let bytes = decode_frame(reader).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn request_round_trips_and_resolves_with_result() {
+        let (client, _task, server_reader, mut server_writer) = pair();
+        let mut server_reader = BufReader::new(server_reader);
+
+        let req_task = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .request::<_, Value>("ping", json!({"q": 1}), Duration::from_secs(2))
+                    .await
+            }
+        });
+
+        let req = read_client_frame(&mut server_reader).await;
+        assert_eq!(req["method"], "ping");
+        assert_eq!(req["params"]["q"], 1);
+        let id = req["id"].as_u64().unwrap();
+
+        // Server side: respond with the same id.
+        let resp = json!({"jsonrpc": "2.0", "id": id, "result": {"pong": true}});
+        let bytes = serde_json::to_vec(&resp).unwrap();
+        encode_frame(&mut server_writer, &bytes).await.unwrap();
+
+        let got = req_task.await.unwrap().unwrap();
+        assert_eq!(got, json!({"pong": true}));
+    }
+
+    #[tokio::test]
+    async fn request_returns_server_error_when_response_has_error() {
+        let (client, _task, server_reader, mut server_writer) = pair();
+        let mut server_reader = BufReader::new(server_reader);
+
+        let req_task = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .request::<_, Value>("explode", json!({}), Duration::from_secs(2))
+                    .await
+            }
+        });
+
+        let req = read_client_frame(&mut server_reader).await;
+        let id = req["id"].as_u64().unwrap();
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": -32601, "message": "method not found"}
+        });
+        encode_frame(&mut server_writer, &serde_json::to_vec(&resp).unwrap())
+            .await
+            .unwrap();
+
+        let err = req_task.await.unwrap().unwrap_err();
+        match err {
+            RpcError::Server { code, message } => {
+                assert_eq!(code, -32601);
+                assert!(message.contains("method not found"));
+            }
+            other => panic!("expected Server error, got {other:?}"),
+        }
+    }
+
+    // Regression: multiple in-flight requests must each get correlated to
+    // their own response by id. If the dispatch routed by order rather than
+    // id, out-of-order server responses would resolve the wrong future.
+    #[tokio::test]
+    async fn regression_in_flight_requests_correlated_by_id() {
+        let (client, _task, server_reader, mut server_writer) = pair();
+        let mut server_reader = BufReader::new(server_reader);
+
+        let a = tokio::spawn({
+            let c = client.clone();
+            async move {
+                c.request::<_, Value>("op", json!({"n": 1}), Duration::from_secs(2))
+                    .await
+            }
+        });
+        let b = tokio::spawn({
+            let c = client.clone();
+            async move {
+                c.request::<_, Value>("op", json!({"n": 2}), Duration::from_secs(2))
+                    .await
+            }
+        });
+
+        // Read both requests; respond in reverse order.
+        let req1 = read_client_frame(&mut server_reader).await;
+        let req2 = read_client_frame(&mut server_reader).await;
+        let id1 = req1["id"].as_u64().unwrap();
+        let id2 = req2["id"].as_u64().unwrap();
+
+        let resp2 = json!({"jsonrpc":"2.0","id":id2,"result":{"answer":"second"}});
+        encode_frame(&mut server_writer, &serde_json::to_vec(&resp2).unwrap())
+            .await
+            .unwrap();
+        let resp1 = json!({"jsonrpc":"2.0","id":id1,"result":{"answer":"first"}});
+        encode_frame(&mut server_writer, &serde_json::to_vec(&resp1).unwrap())
+            .await
+            .unwrap();
+
+        let got_a = a.await.unwrap().unwrap();
+        let got_b = b.await.unwrap().unwrap();
+        assert_eq!(got_a["answer"], "first");
+        assert_eq!(got_b["answer"], "second");
+    }
+
+    // Regression: a request whose server never replies must time out cleanly
+    // rather than block the caller forever.
+    #[tokio::test]
+    async fn regression_request_times_out_when_no_response() {
+        let (client, _task, _server_reader, _server_writer) = pair();
+        let err = client
+            .request::<_, Value>("never", json!({}), Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RpcError::Timeout(_)));
+    }
+
+    // Regression: when the timeout fires, the pending-entry for that id must
+    // be removed from the table — otherwise the entry leaks and a late
+    // response would still attempt to resolve a dropped channel.
+    #[tokio::test]
+    async fn regression_timeout_clears_pending_entry() {
+        let (client, _task, _server_reader, _server_writer) = pair();
+        let _ = client
+            .request::<_, Value>("never", json!({}), Duration::from_millis(20))
+            .await;
+        let pending = client.inner.pending.lock().await;
+        assert!(pending.is_empty(), "pending must be empty after timeout");
+    }
+
+    #[tokio::test]
+    async fn notify_sends_payload_without_id() {
+        let (client, _task, server_reader, _server_writer) = pair();
+        let mut server_reader = BufReader::new(server_reader);
+
+        client
+            .notify("textDocument/didOpen", json!({"path": "x.rs"}))
+            .await
+            .unwrap();
+        let frame = read_client_frame(&mut server_reader).await;
+        assert_eq!(frame["method"], "textDocument/didOpen");
+        assert_eq!(frame["params"]["path"], "x.rs");
+        assert!(frame.get("id").is_none(), "notifications must not carry id");
+    }
+
+    #[tokio::test]
+    async fn server_notification_dispatches_to_registered_handler() {
+        let (client, _task, _server_reader, mut server_writer) = pair();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        client
+            .on_notification(
+                "textDocument/publishDiagnostics",
+                Box::new(move |params| {
+                    let _ = tx.send(params);
+                }),
+            )
+            .await;
+
+        // Server pushes a notification.
+        let note = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///x.rs", "diagnostics": []},
+        });
+        encode_frame(&mut server_writer, &serde_json::to_vec(&note).unwrap())
+            .await
+            .unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("handler must fire within timeout")
+            .unwrap();
+        assert_eq!(got["uri"], "file:///x.rs");
+    }
+
+    // Regression: a server-initiated request (id + method) must be
+    // acknowledged with a null result so the server doesn't hang waiting
+    // for the client's reply. v1 doesn't advertise any client capabilities
+    // that would actually receive these.
+    #[tokio::test]
+    async fn regression_server_request_acknowledged_with_null_result() {
+        let (client, _task, server_reader, mut server_writer) = pair();
+        let mut server_reader = BufReader::new(server_reader);
+
+        let server_req = json!({
+            "jsonrpc": "2.0",
+            "id": 999,
+            "method": "workspace/configuration",
+            "params": {},
+        });
+        encode_frame(
+            &mut server_writer,
+            &serde_json::to_vec(&server_req).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let reply = read_client_frame(&mut server_reader).await;
+        assert_eq!(reply["id"], 999);
+        assert!(reply["result"].is_null());
+        // No error key on a successful ack.
+        assert!(reply.get("error").is_none());
+
+        // Keep the client alive past the assertion.
+        drop(client);
+    }
+
+    // Regression: when the peer drops the stream, all in-flight requests
+    // must resolve with ConnectionClosed so callers don't hang.
+    #[tokio::test]
+    async fn regression_in_flight_requests_fail_on_peer_close() {
+        let (client, task, _server_reader, server_writer) = pair();
+
+        let pending = tokio::spawn({
+            let c = client.clone();
+            async move {
+                c.request::<_, Value>("op", json!({}), Duration::from_secs(2))
+                    .await
+            }
+        });
+
+        // Drop the server-side writer → client's read loop hits EOF.
+        drop(server_writer);
+        // Drain the reader half so the reader task makes progress.
+        let _ = task.await;
+
+        let err = pending.await.unwrap().unwrap_err();
+        assert!(matches!(err, RpcError::ConnectionClosed));
+    }
+
+    // After the peer closes, subsequent requests must fail fast rather than
+    // re-attempting and hanging on a dead writer.
+    #[tokio::test]
+    async fn request_after_close_returns_closed_error() {
+        let (client, task, _server_reader, server_writer) = pair();
+        drop(server_writer);
+        let _ = task.await;
+
+        let err = client
+            .request::<_, Value>("op", json!({}), Duration::from_secs(1))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RpcError::ConnectionClosed));
+    }
+}


### PR DESCRIPTION
Phase 2 of 9. Stacked on #25 (Phase 1).

Builds the JSON-RPC plumbing every LSP server speaks. All unit-tested against in-memory \`tokio::io::duplex\` pipes — no real LSP server needed for CI.

## What's in this PR

### \`src/lsp/jsonrpc.rs\` — Content-Length framing
- \`encode_frame(writer, body)\`: writes \`Content-Length: N\\r\\n\\r\\n<body>\` in one async go.
- \`decode_frame(reader)\`: parses header lines (lenient on bare \`\\n\` for non-spec-conformant servers), reads body, errors on missing/malformed \`Content-Length\`, bodies > 16 MB, or EOF mid-frame.
- 14 tests: multibyte payload round-trip, multi-frame from one reader, byte-at-a-time streaming, error cases.

### \`src/lsp/rpc.rs\` — request/response correlation
- \`RpcClient\` spawns a background reader task. Frames are routed:
  - response (has \`id\`, no \`method\`) → resolve pending oneshot
  - notification (has \`method\`, no \`id\`) → dispatch to registered handler
  - server→client request (has both) → ack with null result (we register no client-side request capabilities in v1)
- Outbound writes serialize through a \`Mutex\` so concurrent callers can't interleave frames.
- \`request<P, R>(method, params, timeout)\`, \`notify<P>(method, params)\`, \`on_notification(method, handler)\`.
- 10 tests covering round-trip, server-error responses, in-flight correlation by id (**regression**: out-of-order responses must not resolve the wrong future), timeout cleanup, peer-close handling.

### \`src/lsp/init.rs\` — initialize handshake
- \`initialize(client, root, pid, init_options) -> InitializeResult\`
- 45 s timeout matching opencode.
- Sends both \`rootUri\` (deprecated but universally read) and \`workspaceFolders\`.
- Sends \`initialized\` notification after the response — some servers stall without it.
- Conservative client capabilities (sync, publishDiagnostics, pull diagnostic, workspace configuration).
- 6 tests covering capability round-trip, rootUri propagation (**regression**: rust-analyzer attaches at wrong directory otherwise), initializationOptions propagation, \`null\` options OMIT the field (some servers reject explicit null), notification ordering, percent-encoding for special chars.

## Code review fixes applied before push
- Dropped a confusing cast chain on \`process_id\` — \`lsp-types\` already uses \`Option<u32>\`.
- Added RFC 3986 \`percent_encode_path\` so paths with \`#\`/\`?\`/space produce valid \`file://\` URIs; 2 dedicated tests.
- Doc-noted the small race window in \`RpcClient::request\` where a peer close interleaves with a new request (worst case: caller waits for its own timeout).

## Dependencies
- \`lsp-types 0.97\` (typed Initialize structs only — wire layer stays untyped \`Value\`)
- \`tokio\` \`io-util\` feature for the async I/O extension traits

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo test --bin dirge -- --skip plugin\` → 365 passing (was 334; +31 from Phase 2)
- [x] \`cargo fmt --check\` clean
- [ ] Manual against rust-analyzer comes in Phase 4 once the orchestrator wires this to real processes.

Next: Phase 3 (file lifecycle: didOpen / didChange with version tracking + push/pull diagnostic state with dedupe).