### PR TITLE
LSP Phase 8: feature gate + Channels struct refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["ai", "cli", "dev"]
 
 [features]
-default = ['loop', 'git-worktree', 'mcp']
+default = ['loop', 'git-worktree', 'mcp', 'lsp']
 loop = []
 git-worktree = []
 mcp = [
@@ -26,6 +26,7 @@ semantic-ts = ["semantic", "dep:tree-sitter-typescript"]
 semantic-python = ["semantic", "dep:tree-sitter-python"]
 semantic-bash = ["semantic", "dep:tree-sitter-bash"]
 plugin = ["dep:janetrs"]
+lsp = ["dep:lsp-types"]
 
 [dependencies]
 rig = { version = "0.37", features = ["rmcp"] }
@@ -66,7 +67,7 @@ streaming-iterator = { version = "0.1", optional = true }
 janetrs = { version = "0.8", optional = true }
 html2text = "0.17"
 indexmap = "2"
-lsp-types = "0.97"
+lsp-types = { version = "0.97", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -37,7 +37,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     question_tx: Option<QuestionSender>,
     plan_tx: Option<PlanSwitchSender>,
     bg_store: Option<BackgroundStore>,
-    lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
+    #[cfg(feature = "lsp")] lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
     sandbox: Sandbox,
     parent_model: Option<AnyModel>,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
@@ -141,6 +141,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 permission.clone(),
                 ask_tx.clone(),
                 cache.clone(),
+                #[cfg(feature = "lsp")]
                 lsp_manager.clone(),
             )),
             Box::new(tools::WriteTool::with_cache(
@@ -148,6 +149,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 plan_file.clone(),
                 cache.clone(),
+                #[cfg(feature = "lsp")]
                 lsp_manager.clone(),
             )),
             Box::new(tools::EditTool::with_cache(
@@ -155,6 +157,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 plan_file.clone(),
                 cache.clone(),
+                #[cfg(feature = "lsp")]
                 lsp_manager.clone(),
             )),
             Box::new(tools::BashTool::with_cache(
@@ -262,6 +265,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             builder = builder.tools(vec![task_tool, status_tool]);
         }
 
+        #[cfg(feature = "lsp")]
         if let Some(manager) = &lsp_manager {
             let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
             let lsp_tool = Box::new(tools::LspTool::new(

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+#[cfg(feature = "lsp")]
 use std::sync::Arc;
 
 use rig::completion::ToolDefinition;
@@ -6,6 +7,7 @@ use rig::tool::Tool;
 
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, EditArgs, PermCheck, ToolError, check_perm_path};
+#[cfg(feature = "lsp")]
 use crate::lsp::manager::LspManager;
 
 pub struct EditTool {
@@ -16,6 +18,7 @@ pub struct EditTool {
     /// When set, the tool touches the edited file on the LSP server and
     /// appends any diagnostic block to its output. `None` reproduces the
     /// pre-LSP behaviour.
+    #[cfg(feature = "lsp")]
     lsp_manager: Option<Arc<LspManager>>,
 }
 
@@ -31,6 +34,7 @@ impl EditTool {
             ask_tx,
             plan_file,
             cache: None,
+            #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
     }
@@ -40,13 +44,14 @@ impl EditTool {
         ask_tx: Option<AskSender>,
         plan_file: Option<PathBuf>,
         cache: ToolCache,
-        lsp_manager: Option<Arc<LspManager>>,
+        #[cfg(feature = "lsp")] lsp_manager: Option<Arc<LspManager>>,
     ) -> Self {
         EditTool {
             permission,
             ask_tx,
             plan_file,
             cache: Some(cache),
+            #[cfg(feature = "lsp")]
             lsp_manager,
         }
     }
@@ -212,6 +217,7 @@ impl Tool for EditTool {
             new_content
         };
 
+        #[cfg(feature = "lsp")]
         let write_at = std::time::Instant::now();
         tokio::fs::write(&args.path, &output).await?;
         // File mutated → invalidate cached reads/greps/listings for this turn.
@@ -236,15 +242,18 @@ impl Tool for EditTool {
             ));
         }
 
-        let path = std::path::Path::new(&args.path);
-        result.push_str(
-            &crate::agent::tools::write::append_lsp_block(
-                self.lsp_manager.as_ref(),
-                path,
-                write_at,
-            )
-            .await,
-        );
+        #[cfg(feature = "lsp")]
+        {
+            let path = std::path::Path::new(&args.path);
+            result.push_str(
+                &crate::agent::tools::write::append_lsp_block(
+                    self.lsp_manager.as_ref(),
+                    path,
+                    write_at,
+                )
+                .await,
+            );
+        }
         Ok(result)
     }
 }

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -7,6 +7,7 @@ mod find_files;
 mod glob;
 mod grep;
 mod list_dir;
+#[cfg(feature = "lsp")]
 mod lsp;
 mod memory;
 pub(crate) mod plan;
@@ -30,6 +31,7 @@ pub use find_files::FindFilesTool;
 pub use glob::GlobTool;
 pub use grep::GrepTool;
 pub use list_dir::ListDirTool;
+#[cfg(feature = "lsp")]
 pub use lsp::LspTool;
 pub use memory::MemoryTool;
 pub use plan::{PlanEnterTool, PlanExitTool};

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "lsp")]
 use std::sync::Arc;
 
 use rig::completion::ToolDefinition;
@@ -5,6 +6,7 @@ use rig::tool::Tool;
 
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ReadArgs, ToolError, check_perm_path};
+#[cfg(feature = "lsp")]
 use crate::lsp::manager::{LspManager, TouchMode};
 
 pub struct ReadTool {
@@ -14,6 +16,7 @@ pub struct ReadTool {
     /// When set, the tool fires off a `touch_file` to warm the LSP server
     /// so subsequent edits surface diagnostics quickly. Fire-and-forget:
     /// the read tool does not wait or surface diagnostics in its output.
+    #[cfg(feature = "lsp")]
     pub lsp_manager: Option<Arc<LspManager>>,
 }
 
@@ -24,6 +27,7 @@ impl ReadTool {
             permission,
             ask_tx,
             cache: None,
+            #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
     }
@@ -32,12 +36,13 @@ impl ReadTool {
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
         cache: ToolCache,
-        lsp_manager: Option<Arc<LspManager>>,
+        #[cfg(feature = "lsp")] lsp_manager: Option<Arc<LspManager>>,
     ) -> Self {
         ReadTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            #[cfg(feature = "lsp")]
             lsp_manager,
         }
     }
@@ -122,6 +127,7 @@ impl Tool for ReadTool {
         // Fire-and-forget LSP warmup so the server already has the file
         // open by the time the agent edits it (and we can wait_for_push
         // quickly). No diagnostic surfacing on read.
+        #[cfg(feature = "lsp")]
         if let Some(manager) = self.lsp_manager.clone() {
             let path = std::path::PathBuf::from(&args.path);
             tokio::spawn(async move {

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
+#[cfg(feature = "lsp")]
 use std::sync::Arc;
+#[cfg(feature = "lsp")]
 use std::time::{Duration, Instant};
 
 use rig::completion::ToolDefinition;
@@ -7,12 +9,15 @@ use rig::tool::Tool;
 
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ToolError, WriteArgs, check_perm_path};
+#[cfg(feature = "lsp")]
 use crate::lsp::diagnostic;
+#[cfg(feature = "lsp")]
 use crate::lsp::manager::{LspManager, TouchMode};
 
 /// How long to wait for the LSP server to publish fresh diagnostics after
 /// a write. Matches opencode's `DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS`. Bounded
 /// so a stuck server doesn't hold up the agent's turn.
+#[cfg(feature = "lsp")]
 const DIAGNOSTIC_WAIT: Duration = Duration::from_secs(10);
 
 pub struct WriteTool {
@@ -23,6 +28,7 @@ pub struct WriteTool {
     /// When set, the tool touches the file on the LSP server after writing
     /// and appends any resulting diagnostic block to its output. `None`
     /// reproduces the pre-LSP behaviour exactly.
+    #[cfg(feature = "lsp")]
     lsp_manager: Option<Arc<LspManager>>,
 }
 
@@ -38,6 +44,7 @@ impl WriteTool {
             ask_tx,
             plan_file,
             cache: None,
+            #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
     }
@@ -47,13 +54,14 @@ impl WriteTool {
         ask_tx: Option<AskSender>,
         plan_file: Option<PathBuf>,
         cache: ToolCache,
-        lsp_manager: Option<Arc<LspManager>>,
+        #[cfg(feature = "lsp")] lsp_manager: Option<Arc<LspManager>>,
     ) -> Self {
         WriteTool {
             permission,
             ask_tx,
             plan_file,
             cache: Some(cache),
+            #[cfg(feature = "lsp")]
             lsp_manager,
         }
     }
@@ -106,6 +114,7 @@ impl Tool for WriteTool {
             tokio::fs::create_dir_all(parent).await?;
         }
         let bytes = args.content.len();
+        #[cfg(feature = "lsp")]
         let write_at = Instant::now();
         tokio::fs::write(path, &args.content).await?;
         // File mutated → invalidate cached reads/greps/listings for this turn.
@@ -113,7 +122,9 @@ impl Tool for WriteTool {
             cache.clear();
         }
 
+        #[allow(unused_mut)]
         let mut output = format!("Written {} bytes to {}", bytes, args.path);
+        #[cfg(feature = "lsp")]
         output.push_str(&append_lsp_block(self.lsp_manager.as_ref(), path, write_at).await);
         Ok(output)
     }
@@ -124,6 +135,7 @@ impl Tool for WriteTool {
 /// Errors during touch/wait are intentionally swallowed — diagnostic
 /// surfacing is a side-effect; the write tool's primary contract is
 /// "wrote the file".
+#[cfg(feature = "lsp")]
 pub(crate) async fn append_lsp_block(
     manager: Option<&Arc<LspManager>>,
     path: &Path,
@@ -145,7 +157,7 @@ pub(crate) async fn append_lsp_block(
     diagnostic::build_report_block(path, &diagnostics)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "lsp"))]
 mod tests {
     use super::*;
     use crate::agent::tools::cache::ToolCache;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,7 @@ pub struct Cli {
     #[arg(long = "no-tools", help = "Disable all tools")]
     pub no_tools: bool,
 
+    #[cfg(feature = "lsp")]
     #[arg(
         long = "no-lsp",
         help = "Disable LSP integration (no diagnostics on edit/write, no `lsp` agent tool)"
@@ -167,6 +168,7 @@ impl Cli {
         self.no_tools || cfg.no_tools.unwrap_or(false)
     }
 
+    #[cfg(feature = "lsp")]
     pub fn resolve_lsp_enabled(&self, cfg: &config::Config) -> bool {
         if self.no_lsp || self.no_tools {
             return false;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,6 +32,7 @@ pub struct ToolsConfig {
 /// - `{ "disabled": true }` to turn off a built-in server entirely.
 /// - any subset of `{ command, extensions, env, initialization, disabled }`
 ///   to override pieces of the default.
+#[cfg(feature = "lsp")]
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct LspServerConfig {
@@ -46,6 +47,7 @@ pub struct LspServerConfig {
 /// `lsp = false` → disable LSP entirely.
 /// `lsp = { server-id = { … } }` → enable defaults, overriding the named
 ///   servers with the provided config.
+#[cfg(feature = "lsp")]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum LspConfig {
@@ -53,6 +55,7 @@ pub enum LspConfig {
     Servers(HashMap<String, LspServerConfig>),
 }
 
+#[cfg(feature = "lsp")]
 impl LspConfig {
     /// `true` when LSP should be on. Defaults to enabled.
     pub fn is_enabled(&self) -> bool {
@@ -102,6 +105,7 @@ pub struct Config {
     pub tool_result_max_chars: Option<usize>,
     pub default_prompt: Option<String>,
     pub tools: Option<ToolsConfig>,
+    #[cfg(feature = "lsp")]
     pub lsp: Option<LspConfig>,
     #[cfg(feature = "mcp")]
     pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
@@ -194,7 +198,7 @@ pub fn load() -> Config {
     cfg
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "lsp"))]
 mod tests {
     use super::*;
 

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -170,6 +170,7 @@ async fn run_prompt(
         None,
         None,
         None,
+        #[cfg(feature = "lsp")]
         None,
         sandbox,
         #[cfg(feature = "mcp")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod context;
 mod event;
 mod extras;
 mod image_util;
+#[cfg(feature = "lsp")]
 mod lsp;
 mod permission;
 mod plugin;
@@ -27,11 +28,33 @@ use session::MessageRole;
 use crate::agent::tools::background::{BackgroundStore, LifecycleReceiver};
 use crate::agent::tools::plan::{PlanSwitchReceiver, PlanSwitchSender};
 use crate::agent::tools::question::{QuestionReceiver, QuestionSender};
+#[cfg(feature = "lsp")]
 use crate::lsp::manager::LspManager;
+#[cfg(feature = "lsp")]
 use crate::lsp::spawn::{ProcessCommand, ProcessSpawner};
-use crate::permission::ask::AskSender;
+use crate::permission::ask::{AskReceiver, AskSender};
 use crate::permission::checker::{PermCheck, PermissionChecker};
 use crate::permission::{PermissionConfig, SecurityMode};
+
+/// Per-session channels and shared state, threaded through the agent build
+/// chain in place of a ten-position tuple. Cloneable senders + shared state
+/// (`bg_store`, `lsp_manager`, `permission`) survive being moved through
+/// `build_agent`; the receivers (`ask_rx`, `question_rx`, `plan_rx`,
+/// `lifecycle_rx`) are unique-owner and end up consumed by the UI loop.
+#[derive(Default)]
+struct Channels {
+    permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
+    ask_rx: Option<AskReceiver>,
+    question_tx: Option<QuestionSender>,
+    question_rx: Option<QuestionReceiver>,
+    plan_tx: Option<PlanSwitchSender>,
+    plan_rx: Option<PlanSwitchReceiver>,
+    bg_store: Option<BackgroundStore>,
+    lifecycle_rx: Option<LifecycleReceiver>,
+    #[cfg(feature = "lsp")]
+    lsp_manager: Option<std::sync::Arc<LspManager>>,
+}
 
 fn resolve_mode(cli: &cli::Cli, cfg: &config::Config) -> SecurityMode {
     if cli.yolo || cfg.yolo.unwrap_or(false) {
@@ -52,24 +75,9 @@ fn resolve_mode(cli: &cli::Cli, cfg: &config::Config) -> SecurityMode {
     }
 }
 
-fn build_channels(
-    cli: &cli::Cli,
-    cfg: &config::Config,
-) -> (
-    Option<PermCheck>,
-    Option<AskSender>,
-    Option<tokio::sync::mpsc::Receiver<crate::permission::ask::AskRequest>>,
-    Option<QuestionSender>,
-    Option<QuestionReceiver>,
-    Option<PlanSwitchSender>,
-    Option<PlanSwitchReceiver>,
-    Option<BackgroundStore>,
-    Option<LifecycleReceiver>,
-    Option<std::sync::Arc<LspManager>>,
-) {
-    let no_tools = cli.resolve_no_tools(cfg);
-    if no_tools {
-        return (None, None, None, None, None, None, None, None, None, None);
+fn build_channels(cli: &cli::Cli, cfg: &config::Config) -> Channels {
+    if cli.resolve_no_tools(cfg) {
+        return Channels::default();
     }
 
     let perm_config: PermissionConfig = cfg
@@ -88,6 +96,7 @@ fn build_channels(
     let (lifecycle_tx, lifecycle_rx) = tokio::sync::mpsc::unbounded_channel();
     let bg_store = BackgroundStore::with_ui_sink(lifecycle_tx);
 
+    #[cfg(feature = "lsp")]
     let lsp_manager = if cli.resolve_lsp_enabled(cfg) {
         let worktree = std::env::current_dir().unwrap_or_else(|_| ".".into());
         let commands = compile_lsp_commands(cfg);
@@ -97,23 +106,31 @@ fn build_channels(
         None
     };
 
-    (
-        Some(perm),
-        Some(ask_tx),
-        Some(ask_rx),
-        Some(question_tx),
-        Some(question_rx),
-        Some(plan_tx),
-        Some(plan_rx),
-        Some(bg_store),
-        Some(lifecycle_rx),
+    Channels {
+        permission: Some(perm),
+        ask_tx: Some(ask_tx),
+        ask_rx: Some(ask_rx),
+        question_tx: Some(question_tx),
+        question_rx: Some(question_rx),
+        plan_tx: Some(plan_tx),
+        plan_rx: Some(plan_rx),
+        bg_store: Some(bg_store),
+        lifecycle_rx: Some(lifecycle_rx),
+        #[cfg(feature = "lsp")]
         lsp_manager,
-    )
+    }
 }
 
 /// Compile the spawn commands by starting from `ProcessSpawner::default_commands`
 /// and applying per-server overrides from user config. A `disabled = true`
 /// override removes the entry; any non-empty `command` replaces the default.
+///
+/// Known limitation: `extensions` on the override is currently ignored. The
+/// claimed-extensions list lives in the static `builtin_servers()` registry
+/// (`lsp/server.rs`) — making it instance-overridable requires plumbing a
+/// per-session server set down through `LspManager`. Follow-up; users who
+/// need new extensions today must edit `server.rs`.
+#[cfg(feature = "lsp")]
 fn compile_lsp_commands(cfg: &config::Config) -> std::collections::HashMap<String, ProcessCommand> {
     let mut commands = ProcessSpawner::default_commands();
     let Some(lsp_cfg) = &cfg.lsp else {
@@ -334,7 +351,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let sandbox = sandbox::Sandbox::new(cli.resolve_sandbox(&cfg));
-    let (
+    let Channels {
         permission,
         ask_tx,
         ask_rx,
@@ -344,8 +361,9 @@ async fn main() -> anyhow::Result<()> {
         plan_rx,
         bg_store,
         lifecycle_rx,
+        #[cfg(feature = "lsp")]
         lsp_manager,
-    ) = build_channels(&cli, &cfg);
+    } = build_channels(&cli, &cfg);
 
     if let Some(perm) = &permission {
         let allowlist: Vec<(String, String)> = session
@@ -371,6 +389,7 @@ async fn main() -> anyhow::Result<()> {
             question_tx.clone(),
             plan_tx.clone(),
             bg_store.clone(),
+            #[cfg(feature = "lsp")]
             lsp_manager.clone(),
             sandbox.clone(),
             #[cfg(feature = "mcp")]
@@ -402,6 +421,7 @@ async fn main() -> anyhow::Result<()> {
                 question_tx.clone(),
                 plan_tx.clone(),
                 bg_store.clone(),
+                #[cfg(feature = "lsp")]
                 lsp_manager.clone(),
                 sandbox.clone(),
                 #[cfg(feature = "mcp")]
@@ -423,6 +443,7 @@ async fn main() -> anyhow::Result<()> {
             question_tx.clone(),
             plan_tx.clone(),
             bg_store.clone(),
+            #[cfg(feature = "lsp")]
             lsp_manager.clone(),
             sandbox.clone(),
             #[cfg(feature = "mcp")]
@@ -482,6 +503,7 @@ async fn main() -> anyhow::Result<()> {
             plan_tx,
             bg_store,
             lifecycle_rx,
+            #[cfg(feature = "lsp")]
             lsp_manager,
             sandbox,
             #[cfg(feature = "mcp")]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -439,7 +439,7 @@ pub async fn build_agent(
     question_tx: Option<QuestionSender>,
     plan_tx: Option<PlanSwitchSender>,
     bg_store: Option<crate::agent::tools::background::BackgroundStore>,
-    lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
+    #[cfg(feature = "lsp")] lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
     sandbox: Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
@@ -458,6 +458,7 @@ pub async fn build_agent(
                 question_tx.clone(),
                 plan_tx.clone(),
                 bg_store.clone(),
+                #[cfg(feature = "lsp")]
                 lsp_manager.clone(),
                 sandbox.clone(),
                 Some(parent_model.clone()),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -153,7 +153,7 @@ pub async fn run_interactive(
     plan_tx: Option<PlanSwitchSender>,
     bg_store: Option<crate::agent::tools::background::BackgroundStore>,
     mut lifecycle_rx: Option<crate::agent::tools::background::LifecycleReceiver>,
-    lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
+    #[cfg(feature = "lsp")] lsp_manager: Option<std::sync::Arc<crate::lsp::manager::LspManager>>,
     sandbox: Sandbox,
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
@@ -805,6 +805,7 @@ pub async fn run_interactive(
                                                 None,
                                                 None,
                                                 bg_store.clone(),
+                                                                                                #[cfg(feature = "lsp")]
                                                                                                 None,
                                                 sandbox.clone(),
                                                 #[cfg(feature = "mcp")] mcp_manager,
@@ -1282,6 +1283,7 @@ pub async fn run_interactive(
                                         None,
                                         None,
                                         bg_store.clone(),
+                                                                                #[cfg(feature = "lsp")]
                                                                                 None,
                                         sandbox.clone(),
                                         #[cfg(feature = "mcp")] mcp_manager,
@@ -1745,6 +1747,7 @@ pub async fn run_interactive(
                         question_tx.clone(),
                         plan_tx.clone(),
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         lsp_manager.clone(),
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -127,6 +127,7 @@ pub async fn handle_compress(
         None,
         None,
         bg_store.clone(),
+        #[cfg(feature = "lsp")]
         None,
         sandbox.clone(),
         #[cfg(feature = "mcp")]
@@ -189,6 +190,7 @@ pub async fn handle_slash(
                     None,
                     None,
                     bg_store.clone(),
+                    #[cfg(feature = "lsp")]
                     None,
                     sandbox.clone(),
                     #[cfg(feature = "mcp")]
@@ -508,6 +510,7 @@ pub async fn handle_slash(
                         None,
                         None,
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -619,6 +622,7 @@ pub async fn handle_slash(
                         None,
                         None,
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -644,6 +648,7 @@ pub async fn handle_slash(
                         None,
                         None,
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -696,6 +701,7 @@ pub async fn handle_slash(
                         None,
                         None,
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]
@@ -849,6 +855,7 @@ pub async fn handle_slash(
                         None,
                         None,
                         bg_store.clone(),
+                        #[cfg(feature = "lsp")]
                         None,
                         sandbox.clone(),
                         #[cfg(feature = "mcp")]


### PR DESCRIPTION
Phase 8 of 9. Stacked on #31 (Phase 7).

Two related changes in one PR. Splitting them would have required disentangling overlapping diffs in the same files (both touch the LSP-related fields in tool structs / call sites / Channels).

## Channels struct refactor

Phase 7's \`build_channels\` returned a 10-tuple that grew every time we added a slot. Now it returns a named struct:

\`\`\`rust
#[derive(Default)]
struct Channels {
    permission: Option<PermCheck>,
    ask_tx: Option<AskSender>,
    ask_rx: Option<AskReceiver>,
    question_tx: Option<QuestionSender>,
    question_rx: Option<QuestionReceiver>,
    plan_tx: Option<PlanSwitchSender>,
    plan_rx: Option<PlanSwitchReceiver>,
    bg_store: Option<BackgroundStore>,
    lifecycle_rx: Option<LifecycleReceiver>,
    #[cfg(feature = "lsp")]
    lsp_manager: Option<std::sync::Arc<LspManager>>,
}
\`\`\`

main.rs destructures the same locals it already used. No behavior change, but the call site is no longer a positional 10-tuple unpacking.

Also doc-noted: \`compile_lsp_commands\` currently ignores the \`extensions\` field on per-server overrides — the claimed-extensions list lives in the static \`builtin_servers()\` registry. Follow-up.

## Phase 8: \`feature = "lsp"\` (default-on)

Added \`lsp\` to the default feature set. With it off (\`cargo build --no-default-features --features 'loop git-worktree mcp'\`):
- \`lsp\` module not compiled; \`lsp-types\` dep stays optional + skipped.
- \`Channels.lsp_manager\` field gated out (also gated out of destructure in main.rs).
- \`build_agent\` / \`build_agent_inner\` / \`run_interactive\` drop their \`lsp_manager\` arg via \`#[cfg(feature = "lsp")]\` on the param.
- Read/Write/Edit tools drop their \`lsp_manager\` field + integration call.
- \`LspTool\` not registered; \`--no-lsp\` CLI flag not exposed.
- \`LspConfig\` / \`LspServerConfig\` types gated; \`cfg.lsp\` field gated.
- ACP path, slash sub-rebuilds, plan-switch all use \`#[cfg(feature = "lsp")]\` on the \`None\` args.

## Verified configurations

| Command | Result |
|---|---|
| \`cargo build --no-default-features --features 'loop git-worktree mcp'\` | Clean, no lsp deps |
| \`cargo build\` (default) | Clean, all 4 LSP servers wired |
| \`cargo test --bin dirge --no-default-features --features 'loop git-worktree mcp' -- --skip plugin\` | 305 passing |
| \`cargo test --bin dirge -- --skip plugin\` (default) | 426 passing |

The +121 tests with the feature on are the LSP module's tests + the diagnostic integration tests, correctly excluded when the feature is off.

## Test plan
- [x] Both feature configurations build clean
- [x] Both feature configurations test clean
- [x] \`cargo fmt --check\` clean

Next: Phase 9 (docs + manual end-to-end test against real rust-analyzer).