### PR TITLE
docs: plugin author's guide + multi-file plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ dirge --provider glm       # defaults to glm-4
 | `/reasoning` | Toggle reasoning visibility |
 | `/btw <question>` | Ask a quick question (no tools, doesn't affect session) |
 | `/sessions` | List/save/load sessions |
+| `/tree [id-prefix]` | Show session tree; with prefix, switch the active branch to that leaf |
+| `/fork [id-prefix]` | Branch off the chosen message (default: last user message) and restore its text to the editor |
+| `/clone <id-prefix>` | Switch the active branch to the entry without restoring text |
 | `/loop [prompt]` | Start iterative coding loop |
 | `/worktree <name>` | Create a git worktree on branch |
 | `/wt-merge [branch]` | Merge worktree branch |
@@ -212,93 +215,23 @@ Skills are auto-discovered at agent startup and listed in the `skill` tool descr
 
 ## Plugin system (Janet)
 
-When built with `--features plugin`, dirge embeds the [Janet](https://janet-lang.org) scripting language for harness-driven workflows. Plugins are Janet scripts placed in `~/.config/dirge/plugins/` or `./.dirge/plugins/` that define hooks called at specific points in the agent lifecycle:
+When built with `--features plugin`, dirge embeds the [Janet](https://janet-lang.org) scripting language for harness-driven workflows. Plugins are Janet scripts placed in `~/.config/dirge/plugins/` (global) or `./.dirge/plugins/` (project-local) that define hooks at specific points in the agent lifecycle and call into `harness/*` APIs to log, gate tools, transform prompts, render custom entries, control the session tree, and more.
 
-| Hook | When | Context |
-|------|------|---------|
-| `on-init` | Session start | `{:model "..." :cwd "..." :provider "..."}` |
-| `on-prompt` | Before LLM call | `{:prompt "..."}` |
-| `on-response` | After LLM response | `{:response "..."}` |
-| `on-tool-start` | Before tool execution | `{:tool "bash" :args {...}}` |
-| `on-tool-end` | After tool completes | `{:output "..."}` |
-| `on-error` | Error occurred | `{:error "..."}` |
-| `on-complete` | Agent turn finishes | (no context — use on-response) |
-| `on-turn-start` | Start of one LLM call cycle within a run | `{:index N}` |
-| `on-message-update` | Every ~16 streamed tokens within a turn | `{:index N :partial "text-so-far"}` |
-| `on-turn-end` | After the turn's tool results return | `{:index N :message "full text"}` |
-
-### Harness APIs
-
-Janet scripts access harness capabilities through built-in functions:
+A minimal plugin:
 
 ```janet
-(harness/log "message")          # Log to stderr
-(harness/get-cwd)                 # Get current working directory
-(harness/set-phase :architect)    # Set workflow phase
-(harness/request-prompt "text")   # Queue prompt for the LLM
-(harness/store-response "text")   # Not called directly — harness stores automatically
-
-# Tool interception (inside on-tool-start / on-tool-end hooks):
-(harness/block "reason")          # Abort the tool call; LLM sees the reason
-(harness/mutate-input json-str)   # Rewrite tool args before the tool runs
-(harness/replace-result text)     # Swap the tool output the LLM sees
-
-# Slash-command registration (call at plugin load time):
-(harness/register-command "cmd" "handler-fn-name")
-# Then define the handler. It receives one arg string and returns nil
-# or a string the chat will display.
-(defn handler-fn-name [args] (string "result: " args))
-
-# Notifications (fire-and-forget; rendered as colored chat lines):
-(harness/notify "msg")              # default :info, dim grey
-(harness/notify "watch out" :warn)  # yellow
-(harness/notify "broken" :error)    # red
-
-# Input transform (from on-prompt hooks):
-(harness/replace-prompt "rewritten user message")
-# Replaces the user's message for the current turn entirely.
-# Distinct from harness/request-prompt, which queues a follow-up turn.
-
-# Blocking user-input dialogs (rendered by the UI; safe to call from
-# any hook — the worker thread blocks while the UI handles the dialog):
-(harness/confirm "title" "really delete?")           # -> true|false
-(harness/select  "pick one" ["alpha" "beta" "gamma"]) # -> string|nil
-
-# Typed session entries + custom renderers (P2):
-(harness/append-entry "bookmark" "label-text")  # display=true by default
-(harness/append-entry "telemetry" "{\"cost\":0.02}" false)  # persisted but not displayed
-(harness/register-renderer "bookmark" "render-bookmark-fn")
-(defn render-bookmark-fn [data]
-  (harness/render "cyan" (string "★ " data)))
-
-# Custom LLM provider registration (P1):
-#   Plugins can declare an OpenAI-compatible (or any rig-supported)
-#   provider at startup. Config-declared custom_providers win on
-#   name collision.
-(harness/register-provider "local-openai" "openai"
-                            "http://localhost:8000/v1"
-                            "LOCAL_OPENAI_API_KEY")
-
-# Session-tree control (P4d) — mirrors pi's ctx.setLabel /
-# ctx.fork / ctx.navigateTree / ctx.newSession / ctx.switchSession.
-# Queued through the host and applied between UI events.
-(harness/set-label entry-id "milestone")   # bookmark a node; pass nil to clear
-(harness/fork entry-id)                    # branch at parent + restore prompt
-(harness/fork entry-id :at)                # branch at this entry, no editor pop
-(harness/navigate-tree entry-id)           # switch active leaf
-(harness/new-session)                      # reset in place; optional parent id
-(harness/switch-session "id-prefix")       # load saved session by id prefix
+(defn on-prompt [ctx]
+  (when (string/find "security" (ctx :prompt))
+    (harness/notify "running with security mindset" :info)))
 ```
 
-Plugins live in `~/.config/dirge/plugins/*.janet` (global) or
-`./.dirge/plugins/*.janet` (project-local). Janet runs on a dedicated
-worker thread so blocking dialogs don't freeze the UI.
+**See [`docs/PLUGINS.md`](docs/PLUGINS.md)** for the complete plugin author's guide — hook reference, the full `harness/*` API surface (logging, tool interception, dialogs, custom commands, renderers, providers, session-tree control), worked examples, and debugging tips.
 
-Example plugins in `plugins/`:
+Example plugins in [`plugins/`](plugins/):
 
 | File | Demonstrates |
 |------|--------------|
-| `workflow.janet` | Built-in architect → implementor → review orchestration |
+| `workflow.janet` | Architect → implementor → review orchestration via inversion of control |
 | `protected_paths.janet` | `harness/block` + `harness/replace-result` (deny + truncate) |
 | `hello_cmd.janet` | `harness/register-command` (custom `/cmd`) |
 | `notify_example.janet` | `harness/notify` for chat notifications |
@@ -309,30 +242,7 @@ Example plugins in `plugins/`:
 | `bookmark.janet` | `harness/append-entry` + `harness/register-renderer` — typed entries with custom rendering |
 | `local_openai.janet` | `harness/register-provider` declaring vLLM/Ollama/LMStudio local endpoints |
 | `session_tree.janet` | `harness/set-label` + `harness/new-session` — `/label` and `/fresh` slash commands |
-
-### Workflow plugin
-
-The built-in `workflow.janet` plugin automatically drives architect → implementor → review phases when a feature request is detected. It uses **inversion of control** — the harness drives the model through scripted phases rather than waiting for the model to decide:
-
-1. **Architect phase**: plans code layout, produces mermaid diagrams, plans file structure, creates function stubs
-2. **Implementor phase**: enforces TDD — write failing test first, then implement, verify green
-3. **Review phase**: reviews all changes, finds bugs, runs tests, fixes failures
-
-The plugin detects feature requests by matching patterns like "add a feature", "implement", "build a", etc., and then orchestrates the entire development cycle automatically.
-
-### Custom plugins
-
-Create `~/.config/dirge/plugins/my-plugin.janet`:
-
-```janet
-(defn on-prompt [ctx]
-  (let [prompt (ctx :prompt)]
-    (if (string/find "security" prompt)
-      (string "SECURITY REVIEW — check for:"
-              "\n- SQL injection"
-              "\n- XSS vectors"
-              "\n- Authentication bypass"))))
-```
+| `turn_timer/` | Multi-file plugin — state, hooks, and a `/timer-stats` command split across three files in a single directory |
 
 ## LSP integration
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,520 @@
+# Plugin author's guide
+
+dirge embeds [Janet](https://janet-lang.org) as a plugin language. Plugins
+are small Janet scripts that hook into the agent loop, observe and rewrite
+inputs and outputs, register custom slash commands, gate tool execution,
+and (with the P4 session-tree work) drive branch/fork/navigation from
+code.
+
+This guide covers every hook, every `harness/*` API, and the patterns
+that make plugins easy to write and easy to debug.
+
+> Requires building with `--features plugin`. The default `cargo install`
+> already includes it; verify with `dirge --version`.
+
+---
+
+## Table of contents
+
+1. [Where plugins live](#where-plugins-live)
+2. [Anatomy of a plugin](#anatomy-of-a-plugin)
+3. [Hook reference](#hook-reference)
+4. [Harness API reference](#harness-api-reference)
+   1. [Logging and introspection](#logging-and-introspection)
+   2. [Prompt control](#prompt-control)
+   3. [Tool interception](#tool-interception)
+   4. [Notifications and entries](#notifications-and-entries)
+   5. [Renderers](#renderers)
+   6. [Slash commands](#slash-commands)
+   7. [User dialogs](#user-dialogs)
+   8. [Custom LLM providers](#custom-llm-providers)
+   9. [Session-tree control](#session-tree-control)
+5. [Workflow patterns](#workflow-patterns)
+6. [Debugging plugins](#debugging-plugins)
+7. [Threading model and pitfalls](#threading-model-and-pitfalls)
+8. [Worked examples](#worked-examples)
+
+---
+
+## Where plugins live
+
+dirge auto-loads plugins from these directories, in order:
+
+| Path | Scope |
+|------|-------|
+| `~/.config/dirge/plugins/` (or `$XDG_CONFIG_HOME/dirge/plugins/`) | Global — applies to every project |
+| `./.dirge/plugins/` (relative to cwd at startup) | Project-local — overrides globals |
+
+Project-local plugins are loaded after globals, so if both declare a hook
+or slash command with the same name, the project-local one wins.
+
+A plugin is **either**:
+
+- A single `*.janet` file. The file's stem (`my-plugin.janet` → `my-plugin`)
+  becomes the plugin's namespace.
+- A directory containing one or more `*.janet` files. The directory name
+  is the plugin's namespace, and every `*.janet` file inside is loaded
+  into the *same* Janet environment in alphabetical order. Files share
+  state, harness registrations, helper functions — they're effectively
+  concatenated.
+
+```
+~/.config/dirge/plugins/
+  hello.janet                   ← single-file plugin (namespace: "hello")
+  my-workflow/                  ← multi-file plugin (namespace: "my-workflow")
+    00-state.janet              ← loaded first (alpha order)
+    01-hooks.janet              ← can reference vars from 00-state.janet
+    02-commands.janet           ← can reference everything above
+```
+
+Conventional alphabetical filenames (`00-state.janet`, `01-hooks.janet`)
+let you control load order when one file depends on definitions in
+another. Naming is convention only — there's no manifest, no required
+entry point, no file-level metadata.
+
+---
+
+## Anatomy of a plugin
+
+A plugin is just Janet code. The harness looks for top-level functions
+with specific names and calls them on matching events. Anything else the
+file does at load time (registering renderers, providers, slash commands)
+takes effect immediately.
+
+Minimal plugin:
+
+```janet
+# ~/.config/dirge/plugins/hello.janet
+
+(defn on-prompt [ctx]
+  (harness/notify (string "user said: " (ctx :prompt)) :info))
+```
+
+That's it. No exports, no setup boilerplate. Load dirge with the plugin
+feature, type a message, and the notify line appears in the chat.
+
+### How hooks are discovered
+
+After your plugin is loaded, the harness scans the Janet environment for
+hook functions. You can define them in two equivalent styles:
+
+```janet
+# Bare style — most natural; the host aliases this to
+# `{namespace}-on-prompt` under the hood so it survives other plugins
+# defining the same bare name.
+(defn on-prompt [ctx] ...)
+
+# Namespaced style — explicit; useful when you want the function name
+# to match what shows up in the host's `registered hook:` log line.
+(defn my-workflow-on-prompt [ctx] ...)
+```
+
+For a multi-file plugin, define the hook in any of the plugin's files —
+the host scans the shared environment, so it doesn't matter which file
+the function lives in.
+
+Multiple plugins can register the same hook; they each contribute a
+distinct result, and dispatch order is load order.
+
+### How `harness/*` calls work
+
+`harness/*` symbols are pre-loaded by the host before your plugin file
+runs, so they're always available. Most of them either:
+
+- **Queue an op** on a per-session buffer that the host drains between
+  events (notifications, entries, tree mutations).
+- **Set a slot** the host reads after the hook returns (tool gating,
+  prompt rewrite, pending prompt).
+- **Block-call the host** via a registered C function (dialogs).
+
+You don't need to know the implementation — just call them and the host
+takes care of the rest.
+
+---
+
+## Hook reference
+
+Every hook takes a single `ctx` table (immutable from the plugin's POV)
+and returns either nil or a string. The return value is hook-specific —
+some accumulate into a chat-visible response, some get ignored.
+
+| Hook | Fires | `ctx` contents | Return value |
+|------|-------|---------------|--------------|
+| `on-init` | Once at session start, after config + agent are ready | `{:model "..." :cwd "..." :provider "..."}` | Ignored |
+| `on-prompt` | After the user submits a message, before the LLM call | `{:prompt "<text>"}` | Optional string — appended to the system prompt for this turn; `harness/replace-prompt` replaces the user message itself |
+| `on-response` | After a single LLM response is received | `{:response "<text>"}` | Ignored (use for logging/notifications) |
+| `on-tool-start` | Before any tool call (`bash`, `read`, `write`, MCP tools) | `{:tool "<name>" :args {...}}` | Ignored — use `harness/block` / `harness/mutate-input` |
+| `on-tool-end` | After the tool returns its result | `{:tool "<name>" :output "<text>"}` | Ignored — use `harness/replace-result` |
+| `on-error` | A tool or LLM call raised an error | `{:error "<msg>"}` | Ignored |
+| `on-complete` | The agent has finished its multi-turn response | `{}` | Ignored |
+| `on-turn-start` | Start of one LLM call cycle within a single run | `{:index N}` | Ignored |
+| `on-message-update` | Every ~16 streamed tokens during the turn | `{:index N :partial "<text-so-far>"}` | Ignored |
+| `on-turn-end` | After this turn's tool results return | `{:index N :message "<full-text>"}` | Ignored |
+
+### Subtle distinctions
+
+- **`on-prompt` vs `on-turn-start`**: `on-prompt` fires once per user
+  message; `on-turn-start` fires once per LLM call (a single user message
+  can spawn multiple turns when the model uses tools).
+- **`on-response` vs `on-turn-end`**: `on-response` is the legacy
+  one-call-per-agent-completion hook; `on-turn-end` fires for every
+  intermediate turn, with `:index` so you can distinguish them.
+- **`on-tool-start` runs *after* permission checks**. If the user denied
+  the tool, neither `on-tool-start` nor the actual tool runs.
+
+---
+
+## Harness API reference
+
+### Logging and introspection
+
+```janet
+(harness/log "message")          # prints "[plugin] message" to stderr
+(harness/get-cwd)                # returns the agent's working directory
+```
+
+Plain debugging aids. `harness/log` shows up in the dirge log file (or
+stderr in dev), not in the chat — use `harness/notify` for chat-visible
+output.
+
+### Prompt control
+
+```janet
+# Queue a follow-up prompt — runs as a fresh turn after the current one.
+(harness/request-prompt "now run the tests")
+
+# Replace the *current* user message before the LLM sees it. Call from
+# on-prompt. The original user message is discarded entirely.
+(harness/replace-prompt "rewritten version of the user's message")
+```
+
+- `harness/request-prompt`: think of it as "the plugin pushing a prompt
+  onto a queue." Useful for `on-response` hooks that want to chain a
+  follow-up turn automatically.
+- `harness/replace-prompt`: think of it as "rewrite what the LLM sees
+  this turn." Only meaningful from `on-prompt`.
+
+### Tool interception
+
+These three set slots that the host inspects right after each tool hook.
+Most useful inside `on-tool-start` / `on-tool-end`:
+
+```janet
+(defn on-tool-start [ctx]
+  (when (= (ctx :tool) "bash")
+    (let [cmd (get-in ctx [:args "command"])]
+      (when (string/find "rm -rf" cmd)
+        (harness/block "denied: dangerous deletion")))))
+
+(defn on-tool-start [ctx]
+  (when (= (ctx :tool) "write")
+    # Force every write under /tmp/safe regardless of what the LLM asked.
+    (harness/mutate-input "{\"path\":\"/tmp/safe/out.txt\",\"content\":\"...\"}")))
+
+(defn on-tool-end [ctx]
+  (when (= (ctx :tool) "bash")
+    (let [out (ctx :output)]
+      (when (> (length out) 5000)
+        (harness/replace-result (string/slice out 0 5000))))))
+```
+
+| API | Effect |
+|-----|--------|
+| `harness/block reason` | Tool is not executed; the LLM sees `reason` as the tool error. Plugins after this one in the chain still run, but their slot writes are ignored. |
+| `harness/mutate-input json-str` | The tool runs with the rewritten args. Pass a JSON string — the host re-parses it into the tool's input shape. |
+| `harness/replace-result text` | The actual tool output is discarded; the LLM sees `text` instead. |
+
+If multiple plugins set the same slot, the first non-nil wins (block beats
+mutate beats nothing).
+
+### Notifications and entries
+
+```janet
+# One-shot chat lines, levels map to colors.
+(harness/notify "task complete")              # :info — dim grey
+(harness/notify "drift detected" :warn)       # yellow
+(harness/notify "broken: see log" :error)     # red
+
+# Typed timeline entries that survive save/load.
+(harness/append-entry "bookmark" "milestone-1")           # display=true (default)
+(harness/append-entry "telemetry" "{\"cost\":0.02}" false) # persisted, not shown
+```
+
+**Notifications** are ephemeral — they render once and aren't stored.
+
+**Entries** are persistent — they become part of the session. Pair them
+with a renderer (next section) for custom display, or rely on the default
+dim JSON dump.
+
+`display=false` is for plugin state that should round-trip via session
+save/load but isn't user-facing (think: a counter, a last-seen timestamp,
+a cached scrape).
+
+### Renderers
+
+A renderer turns a persisted entry's opaque `data` string into displayable
+lines. Register one at load time:
+
+```janet
+(defn render-bookmark [data]
+  # data is whatever you passed as the second arg to append-entry.
+  (harness/render "cyan" (string "★ " data)))
+
+(harness/register-renderer "bookmark" "render-bookmark")
+```
+
+| API | Description |
+|-----|-------------|
+| `(harness/register-renderer type fn-name)` | Associates a custom_type with a Janet function. Pass the function's name as a string; the host looks it up later. |
+| `(harness/render color text)` | Inside a renderer, emits one chat line. Colors: `cyan`, `red`, `yellow`, `green`, `blue`, `magenta`, `white`, `black`, `grey` (alias `darkgrey`), plus `dark*` variants (`darkred`, `darkgreen`, etc.). Keyword forms like `:cyan` are accepted. Unknown names fall back to grey. |
+
+If no renderer is registered for the entry's type, the host dumps the raw
+`data` in dim grey.
+
+### Slash commands
+
+```janet
+(defn echo-handler [args]
+  (string "you said: " args))
+
+(harness/register-command "echo" "echo-handler")
+```
+
+Now typing `/echo hello world` in the chat calls `(echo-handler "hello world")`
+and displays the return string. Return `nil` to display nothing.
+
+The handler runs synchronously on the Janet worker thread; long-running
+handlers will stall the agent until they return.
+
+### User dialogs
+
+These are the only synchronous APIs that round-trip through the UI. The
+Janet worker thread blocks while the dialog is shown; the UI thread
+continues to render. The pair is safe to call from any hook.
+
+```janet
+# Returns true if the user confirms, false on Cancel/Esc.
+(if (harness/confirm "Confirm" "Run the migration?")
+  (harness/notify "running..." :info)
+  (harness/block "user said no"))
+
+# Returns the selected string, or nil on cancel.
+(let [choice (harness/select "Pick a model" ["gpt-4" "claude-4" "deepseek"])]
+  (when choice
+    (harness/notify (string "switching to " choice) :info)))
+```
+
+These dialogs respect the UI's selection picker, so users can use arrow
+keys / Esc to cancel. If the host is shutting down while a dialog is
+in flight, the dialog returns `false` / `nil` so the plugin can unblock.
+
+### Custom LLM providers
+
+Register an OpenAI-compatible (or any other rig-supported) endpoint as
+a first-class provider:
+
+```janet
+(harness/register-provider
+  "local-openai"                       # name surfaced in /model
+  "openai"                              # provider type
+  "http://localhost:8000/v1"            # base URL
+  "LOCAL_OPENAI_API_KEY")               # env var holding the API key
+```
+
+After registration, `/model local-openai/<model-id>` switches to that
+provider. Config-declared `custom_providers` in `~/.config/dirge/config.toml`
+win on name collision, so users can override plugin defaults.
+
+### Session-tree control
+
+The session is stored as a node-based tree (each message has a parent
+link), and these APIs let plugins drive navigation programmatically.
+They mirror pi's `ctx.setLabel` / `ctx.fork` / `ctx.navigateTree` /
+`ctx.newSession` / `ctx.switchSession`.
+
+Plugins queue ops on a per-session buffer; the host drains and applies
+them between UI events. There's no synchronous return value — verify via
+`/tree` or subsequent hook context.
+
+```janet
+# Label a node so it's easy to find later in /tree.
+(harness/set-label entry-id "milestone-1")
+(harness/set-label entry-id nil)            # clears the label
+
+# Branch off the chosen entry. Default position is :before — the
+# entry's *parent* becomes the new leaf and the entry's text is
+# restored to the editor so the user can re-edit and re-submit.
+(harness/fork entry-id)
+
+# :at position — the entry itself becomes the leaf. No editor restore.
+(harness/fork entry-id :at)
+
+# Move the active leaf to entry-id. Role-aware: user messages go to
+# the parent + restore text (same as fork :before); other roles
+# become the new leaf directly.
+(harness/navigate-tree entry-id)
+
+# Persist the current session and start a fresh one in place.
+# Optionally record the prior session id as parent lineage.
+(harness/new-session)
+(harness/new-session "previous-session-uuid")
+
+# Load a saved session by id prefix. The current session is persisted
+# first; the agent's model/provider/cwd are preserved.
+(harness/switch-session "abc12345")
+```
+
+| API | Slash equivalent | Notes |
+|-----|------------------|-------|
+| `harness/set-label` | (none) | Read back via `/tree` (labels render in `[brackets]`) |
+| `harness/fork` | `/fork [id]` | `:before` (default) is the same as `/fork`; `:at` skips the editor restore |
+| `harness/navigate-tree` | `/tree <id>` (non-user msgs) or `/fork <id>` (user msgs) | Picks the right behavior based on the target's role |
+| `harness/new-session` | `/clear` (rough equivalent) | Stronger than `/clear` — assigns a new session id and persists the old one |
+| `harness/switch-session` | `/sessions <prefix>` | Same id-prefix resolution semantics |
+
+**Where do entry ids come from?** Hook contexts. The host plans to thread
+`:id` through `on-message-update` / `on-turn-end` so plugins can stash
+them. For now, a plugin that wants to label "the most recent entry" can
+track that itself across hooks (see `plugins/session_tree.janet`).
+
+---
+
+## Workflow patterns
+
+### Inversion of control
+
+The harness drives the LLM through scripted phases rather than waiting for
+the model to decide what to do. The built-in `workflow.janet` plugin
+demonstrates this:
+
+1. `on-prompt` detects a feature-request prompt and sets a phase var.
+2. `on-response` checks the phase var — when the model says "done with
+   the plan," the plugin calls `harness/request-prompt` to start the
+   implementation phase.
+3. After implementation, the plugin queues another prompt to start the
+   review phase.
+
+Net effect: the user types one prompt, and the harness shepherds three
+turns through architect → implementor → review.
+
+### Gate-then-augment
+
+`on-tool-start` is the natural place to combine `harness/confirm` with
+`harness/block`:
+
+```janet
+(defn on-tool-start [ctx]
+  (when (and (= (ctx :tool) "bash")
+             (string/find "rm" (get-in ctx [:args "command"])))
+    (unless (harness/confirm "Confirm" "Run dangerous bash?")
+      (harness/block "user denied dangerous bash"))))
+```
+
+The plugin pauses the tool call, asks the user, and either allows or
+blocks. The agent sees nothing about the dialog — just the block (or
+the tool's normal result).
+
+### Cross-hook state
+
+The Janet env is shared across hooks in the same plugin file. Use a
+plain `var`:
+
+```janet
+(var last-tool-name nil)
+
+(defn on-tool-start [ctx]
+  (set last-tool-name (ctx :tool)))
+
+(defn on-tool-end [ctx]
+  (harness/notify (string last-tool-name " finished") :info))
+```
+
+State persists for the life of the session — survives between turns.
+
+---
+
+## Debugging plugins
+
+- **`harness/log`** writes to dirge's log file (not the chat). Use it
+  freely.
+- **Janet errors** in a hook are caught and rendered as a chat error,
+  not a crash. The line/file should appear in the error message.
+- **Hook didn't fire?** Double-check the function name matches the
+  hook reference exactly — `on_prompt` (underscore) is a different
+  symbol than `on-prompt`.
+- **`harness/notify`** is the easiest "did this code run?" probe — it
+  lights up the chat without dumping data into the LLM context.
+- **No plugin feature?** Run `dirge --version`; if "plugin" isn't in the
+  feature list, rebuild with `cargo install --features plugin ...`.
+
+### Reading existing plugin state
+
+For non-trivial debugging, drop a slash command:
+
+```janet
+(defn dump-handler [_args]
+  (string "last-tool-name=" last-tool-name "\n"
+          "phase=" current-phase))
+
+(harness/register-command "dump-state" "dump-handler")
+```
+
+Now `/dump-state` shows your plugin's internal state in the chat.
+
+---
+
+## Threading model and pitfalls
+
+Janet runs on a **dedicated worker thread**. The agent and UI run on
+separate threads. Implications:
+
+- Hooks are serialized — only one runs at a time. You can't accidentally
+  introduce race conditions inside Janet code.
+- `harness/confirm` / `harness/select` are safe — the worker blocks
+  while the UI thread renders. They are the only APIs that block the
+  worker on user input.
+- Long-running Janet code blocks every subsequent tool call. If you need
+  to compute something expensive, do it asynchronously by having the
+  host fire a follow-up turn (`harness/request-prompt`) once the work is
+  ready.
+- **Hot reloading** — there isn't any. Edit a plugin file, restart
+  dirge to pick up changes.
+
+Common gotchas:
+
+- **Janet table key types matter**. `(get ctx :tool)` works; `(get ctx
+  "tool")` does not (the host passes keywords). If unsure, do
+  `(harness/notify (string ctx))` to dump the structure.
+- **Strings vs keywords for harness args**. Most APIs accept both
+  (e.g. `:info` and `"info"` for `harness/notify` levels). When in doubt,
+  use the keyword form — that's what the host serializes back internally.
+- **`harness/block` only takes effect inside hooks**. Calling it from a
+  slash-command handler does nothing.
+
+---
+
+## Worked examples
+
+The [`plugins/`](../plugins/) directory has a working example of each
+feature. Read these in order to build intuition:
+
+1. **`hello_cmd.janet`** — simplest plugin: one slash command.
+2. **`notify_example.janet`** — `harness/notify` from a hook.
+3. **`prefix_lang.janet`** — `harness/replace-prompt` for input rewrites.
+4. **`protected_paths.janet`** — `harness/block` gating bash + writes.
+5. **`confirm_destructive.janet`** — adds `harness/confirm` to the gate.
+6. **`select_persona.janet`** — `harness/select` + a slash command.
+7. **`bookmark.janet`** — `harness/append-entry` + custom renderer.
+8. **`turn_timing.janet`** — `on-turn-start` / `on-turn-end` for telemetry.
+9. **`local_openai.janet`** — `harness/register-provider` for a local LLM.
+10. **`session_tree.janet`** — `harness/set-label` + `harness/new-session`
+    with cross-hook state.
+11. **`turn_timer/`** — a *multi-file* plugin. `00-state.janet` defines
+    vars, `01-hooks.janet` defines `on-turn-start` / `on-turn-end`, and
+    `02-commands.janet` registers a `/timer-stats` slash command — all
+    in the same Janet env.
+12. **`workflow.janet`** — the full inversion-of-control pattern. Read
+    this last; it ties many APIs together.
+
+Each is heavily commented. The reading order above goes from "one API"
+to "everything at once."

--- a/plugins/turn_timer/00-state.janet
+++ b/plugins/turn_timer/00-state.janet
@@ -1,0 +1,12 @@
+# Shared state for the multi-file `turn_timer` plugin.
+#
+# Demonstrates how dirge loads every `*.janet` file in a plugin
+# directory into the *same* Janet env, in alphabetical order. This
+# file defines vars; the next file (`01-hooks.janet`) reads them.
+#
+# Compare with the single-file `turn_timing.janet` — same idea, but
+# split across files to show off the multi-file layout.
+
+(var turn-start-ms 0)
+(var total-elapsed-ms 0)
+(var turn-count 0)

--- a/plugins/turn_timer/01-hooks.janet
+++ b/plugins/turn_timer/01-hooks.janet
@@ -1,0 +1,19 @@
+# Hook definitions for the `turn_timer` plugin. References the vars
+# from 00-state.janet — the same Janet env is shared across both
+# files because they're in the same plugin directory.
+#
+# The host aliases bare `on-turn-start` / `on-turn-end` to
+# `turn_timer-on-turn-start` / `turn_timer-on-turn-end` after load so
+# these hooks survive other plugins also defining bare names.
+
+(defn on-turn-start [ctx]
+  (set turn-start-ms (os/time)))
+
+(defn on-turn-end [ctx]
+  (let [elapsed (- (os/time) turn-start-ms)]
+    (set total-elapsed-ms (+ total-elapsed-ms elapsed))
+    (set turn-count (+ turn-count 1))
+    (harness/notify
+      (string "turn " (get ctx :index) " took " elapsed "s (running total: "
+              total-elapsed-ms "s across " turn-count " turns)")
+      :info)))

--- a/plugins/turn_timer/02-commands.janet
+++ b/plugins/turn_timer/02-commands.janet
@@ -1,0 +1,11 @@
+# Slash command for the `turn_timer` plugin. Loaded last (per
+# alphabetical order) so the var refs resolve cleanly.
+
+(defn timer-stats-handler [_args]
+  (if (= turn-count 0)
+    "no turns recorded yet"
+    (string "turns: " turn-count
+            " | total elapsed: " total-elapsed-ms "s"
+            " | avg: " (/ total-elapsed-ms turn-count) "s")))
+
+(harness/register-command "timer-stats" "timer-stats-handler")

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,18 +309,6 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "plugin")]
     if let Some(pm_arc) = plugin_manager.as_ref() {
         use std::path::PathBuf;
-        let hook_names = [
-            "on-init",
-            "on-prompt",
-            "on-response",
-            "on-turn-start",
-            "on-turn-end",
-            "on-message-update",
-            "on-tool-start",
-            "on-tool-end",
-            "on-error",
-            "on-complete",
-        ];
         let candidate_dirs: Vec<PathBuf> = vec![
             dirs::home_dir()
                 .unwrap_or_default()
@@ -343,26 +331,34 @@ async fn main() -> anyhow::Result<()> {
 
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().map_or(false, |e| e == "janet") {
-                    eprintln!("loading plugin: {}", path.display());
-                    let mut mgr = pm_arc.lock().unwrap_or_else(|e| e.into_inner());
-                    match mgr.load_file(&path) {
-                        Ok(()) => {
-                            let stem = path
-                                .file_stem()
-                                .and_then(|s| s.to_str())
-                                .unwrap_or("unknown");
-                            for hook in &hook_names {
-                                let fn_name = format!("{}-{}", stem, hook);
-                                if mgr.has_symbol(&fn_name) {
-                                    mgr.register(hook, &fn_name);
-                                    eprintln!("  registered hook: {} -> {}", hook, fn_name);
-                                }
-                            }
+                // A plugin is either:
+                //   - a single `.janet` file (legacy)
+                //   - a directory whose name is the plugin id and whose
+                //     `*.janet` contents are concatenated into one Janet
+                //     env (multi-file plugins)
+                let is_janet_file =
+                    path.is_file() && path.extension().map_or(false, |e| e == "janet");
+                let is_plugin_dir = path.is_dir();
+                if !is_janet_file && !is_plugin_dir {
+                    continue;
+                }
+                eprintln!("loading plugin: {}", path.display());
+                let mut mgr = pm_arc.lock().unwrap_or_else(|e| e.into_inner());
+                match plugin::load_plugin(&mut mgr, &path) {
+                    Ok(loaded) => {
+                        if loaded.files.len() > 1 {
+                            eprintln!(
+                                "  loaded {} files from plugin '{}'",
+                                loaded.files.len(),
+                                loaded.stem,
+                            );
                         }
-                        Err(e) => {
-                            eprintln!("warning: failed to load plugin {}: {}", path.display(), e);
+                        for hook in &loaded.hooks_registered {
+                            eprintln!("  registered hook: {} -> {}-{}", hook, loaded.stem, hook);
                         }
+                    }
+                    Err(e) => {
+                        eprintln!("warning: failed to load plugin {}: {}", path.display(), e);
                     }
                 }
             }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1288,6 +1288,104 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], TreeOp::SetLabel { .. }));
     }
+
+    // --- load_plugin: single-file + directory + bare-name aliasing ------
+
+    /// Helper: write `text` into a unique tmp file and return its path.
+    /// Tests are responsible for cleanup but caller can skip on success.
+    fn tmpfile(label: &str, content: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "dirge-plugin-loadtest-{}-{}.janet",
+            std::process::id(),
+            label
+        ));
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    /// A single-file plugin with a bare hook name gets the bare hook
+    /// aliased to `{stem}-{hook}` and registered for dispatch.
+    #[test]
+    fn load_plugin_aliases_bare_hooks_to_stem_prefix() {
+        let path = tmpfile("bare-aliased", r#"(defn on-prompt [ctx] "from-bare")"#);
+        let mut mgr = PluginManager::try_new().unwrap();
+        let loaded = super::load_plugin(&mut mgr, &path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+        assert_eq!(loaded.stem, stem);
+        assert!(loaded.hooks_registered.contains(&"on-prompt".to_string()));
+        let out = mgr.dispatch("on-prompt", "@{:prompt \"x\"}").unwrap();
+        assert_eq!(out, vec!["from-bare".to_string()]);
+    }
+
+    /// Two plugins both using *bare* hook names don't clobber each
+    /// other — the alias step preserves each plugin's hook under its
+    /// own `{stem}-on-prompt` namespace, so both fire on dispatch.
+    #[test]
+    fn load_plugin_isolates_bare_hooks_across_plugins() {
+        let p1 = tmpfile("alpha-iso", r#"(defn on-prompt [ctx] "from-alpha")"#);
+        let p2 = tmpfile("beta-iso", r#"(defn on-prompt [ctx] "from-beta")"#);
+        let mut mgr = PluginManager::try_new().unwrap();
+        super::load_plugin(&mut mgr, &p1).unwrap();
+        super::load_plugin(&mut mgr, &p2).unwrap();
+        let _ = std::fs::remove_file(&p1);
+        let _ = std::fs::remove_file(&p2);
+        let out = mgr.dispatch("on-prompt", "@{:prompt \"x\"}").unwrap();
+        assert_eq!(out.len(), 2, "both plugins fire: {out:?}");
+        assert!(out.contains(&"from-alpha".to_string()));
+        assert!(out.contains(&"from-beta".to_string()));
+    }
+
+    /// A directory plugin loads every `*.janet` file inside in
+    /// alphabetical order. The stem is the directory name; multi-file
+    /// plugins share the same Janet env so files can collaborate.
+    #[test]
+    fn load_plugin_supports_directory_of_files() {
+        let dir = std::env::temp_dir().join(format!("dirge-multifile-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("00-state.janet"), r#"(var shared-counter 0)"#).unwrap();
+        std::fs::write(
+            dir.join("01-hooks.janet"),
+            r#"(defn on-prompt [ctx]
+                 (++ shared-counter)
+                 (string "counter=" shared-counter))"#,
+        )
+        .unwrap();
+
+        let mut mgr = PluginManager::try_new().unwrap();
+        let loaded = super::load_plugin(&mut mgr, &dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(loaded.files.len(), 2);
+        // 00-state.janet sorts before 01-hooks.janet so the var is
+        // defined before the hook references it.
+        assert!(
+            loaded.files[0]
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("00-")
+        );
+        assert!(loaded.stem.starts_with("dirge-multifile-"));
+        let out = mgr.dispatch("on-prompt", "@{:prompt \"x\"}").unwrap();
+        assert_eq!(out, vec!["counter=1".to_string()]);
+        // Counter persists — proves shared state across hook invocations.
+        let out2 = mgr.dispatch("on-prompt", "@{:prompt \"x\"}").unwrap();
+        assert_eq!(out2, vec!["counter=2".to_string()]);
+    }
+
+    /// Empty directory plugins return an error rather than silently
+    /// registering nothing — typo'd plugin dirs should surface visibly.
+    #[test]
+    fn load_plugin_rejects_empty_directory() {
+        let dir = std::env::temp_dir().join(format!("dirge-empty-plugin-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut mgr = PluginManager::try_new().unwrap();
+        let err = super::load_plugin(&mut mgr, &dir).unwrap_err();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(err.contains("no .janet files"), "got: {err}");
+    }
 }
 
 use std::collections::HashMap;
@@ -1356,6 +1454,123 @@ pub fn decide_post_done_action(
 #[cfg_attr(not(feature = "plugin"), allow(dead_code))]
 pub fn filter_existing_dirs(candidates: &[std::path::PathBuf]) -> Vec<std::path::PathBuf> {
     candidates.iter().filter(|p| p.is_dir()).cloned().collect()
+}
+
+/// All hook names the host knows about. Plugins define functions with
+/// these names (bare or stem-prefixed) and the loader hooks them up.
+/// Centralized so the loader and any future telemetry stay in sync.
+pub const HOOK_NAMES: &[&str] = &[
+    "on-init",
+    "on-prompt",
+    "on-response",
+    "on-turn-start",
+    "on-turn-end",
+    "on-message-update",
+    "on-tool-start",
+    "on-tool-end",
+    "on-error",
+    "on-complete",
+];
+
+/// One loaded plugin's stem (used for hook-name namespacing) and the
+/// source path(s) that contributed code. For single-file plugins this
+/// is one path; for directory plugins it's every `.janet` file inside
+/// in load order.
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
+#[derive(Debug, Clone)]
+pub struct LoadedPlugin {
+    pub stem: String,
+    pub files: Vec<std::path::PathBuf>,
+    pub hooks_registered: Vec<String>,
+}
+
+/// Discover, evaluate, and register a plugin from `path`.
+///
+/// `path` may be:
+/// - A `*.janet` file — single-file plugin; stem = file stem.
+/// - A directory — multi-file plugin; stem = directory name. All
+///   `*.janet` files inside are loaded in alphabetical order into the
+///   shared Janet env, so split files share state and `harness/*`
+///   registrations.
+///
+/// After eval, any bare hook fns (`on-prompt`, `on-tool-start`, etc.)
+/// get a `{stem}-{hook}` alias so they survive subsequent plugin loads
+/// that would otherwise overwrite the bare symbol in the shared Janet
+/// env. Then `{stem}-{hook}` is what we register for dispatch — that
+/// way two plugins both defining `on-tool-start` no longer collide.
+///
+/// Returns the [`LoadedPlugin`] descriptor (stem + which files were
+/// read + which hooks fired). Errors short-circuit: a malformed first
+/// file aborts the whole plugin load.
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
+pub fn load_plugin(
+    mgr: &mut PluginManager,
+    path: &std::path::Path,
+) -> Result<LoadedPlugin, String> {
+    let (stem, files) = if path.is_dir() {
+        let dir_name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("plugin dir has no name: {}", path.display()))?
+            .to_string();
+        let mut janet_files: Vec<std::path::PathBuf> = std::fs::read_dir(path)
+            .map_err(|e| format!("cannot read plugin dir {}: {}", path.display(), e))?
+            .filter_map(|e| e.ok().map(|x| x.path()))
+            .filter(|p| p.is_file() && p.extension().map_or(false, |ext| ext == "janet"))
+            .collect();
+        janet_files.sort();
+        if janet_files.is_empty() {
+            return Err(format!(
+                "plugin dir {} contains no .janet files",
+                path.display()
+            ));
+        }
+        (dir_name, janet_files)
+    } else {
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("plugin file has no stem: {}", path.display()))?
+            .to_string();
+        (stem, vec![path.to_path_buf()])
+    };
+
+    for file in &files {
+        mgr.load_file(file)
+            .map_err(|e| format!("failed to load {}: {}", file.display(), e))?;
+    }
+
+    // Promote any bare hook symbols to stem-prefixed copies so a later
+    // plugin redefining the bare name can't shadow ours. We construct
+    // the prefixed name at runtime via curenv-mutation because Janet's
+    // `def` requires a literal symbol.
+    let mut hooks_registered = Vec::new();
+    for hook in HOOK_NAMES {
+        let prefixed = format!("{}-{}", stem, hook);
+        let escaped_hook = escape_janet_string(hook);
+        let escaped_prefixed = escape_janet_string(&prefixed);
+        let alias_code = format!(
+            r#"(let [env (curenv)
+                    bare-sym (symbol "{bare}")
+                    prefixed-sym (symbol "{prefixed}")
+                    bare-entry (get env bare-sym)]
+                 (when (and bare-entry (not (get env prefixed-sym)))
+                   (put env prefixed-sym bare-entry)))"#,
+            bare = escaped_hook,
+            prefixed = escaped_prefixed,
+        );
+        let _ = mgr.eval(&alias_code);
+        if mgr.has_symbol(&prefixed) {
+            mgr.register(hook, &prefixed);
+            hooks_registered.push(hook.to_string());
+        }
+    }
+
+    Ok(LoadedPlugin {
+        stem,
+        files,
+        hooks_registered,
+    })
 }
 
 pub struct PluginManager {

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -18,6 +18,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+#[cfg_attr(not(feature = "plugin"), allow(unused_imports))]
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -240,7 +241,13 @@ const HARNESS_DIALOG_INIT: &str = r#"
 
 /// What the UI is being asked to render. Carries a one-shot reply
 /// channel back so the worker can resume once the user answers.
+///
+/// Variants are only constructed when the plugin feature is enabled,
+/// but the *type* is referenced unconditionally by the UI's channel
+/// signature — hence the cfg-gated dead-code allow rather than a
+/// feature gate on the whole enum.
 #[derive(Debug)]
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
 pub enum DialogRequest {
     Confirm {
         title: String,
@@ -255,6 +262,7 @@ pub enum DialogRequest {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
 pub enum DialogReply {
     /// User answered yes/no. False also covers cancel/timeout.
     Confirm(bool),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -91,28 +91,6 @@ pub struct SessionTree {
     pub leaf_id: Option<CompactString>,
 }
 
-impl SessionTree {
-    /// Walk from `leaf_id` to root, returning the chain of ids in
-    /// chronological order (root first, leaf last). Used to confirm
-    /// the tree's current path matches `Session::messages`.
-    ///
-    /// Returns an empty Vec if `leaf_id` is None or any link is
-    /// broken (defensive — a healthy tree always reconstructs).
-    pub fn path_from_leaf(&self) -> Vec<&TreeNode> {
-        let mut path = Vec::new();
-        let mut cursor = self.leaf_id.as_ref();
-        while let Some(id) = cursor {
-            let Some(node) = self.entries.get(id) else {
-                return Vec::new();
-            };
-            path.push(node);
-            cursor = node.parent.as_ref();
-        }
-        path.reverse();
-        path
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PermissionAllowEntry {
     pub tool: String,
@@ -444,6 +422,7 @@ impl Session {
 
     /// Set or clear a label on a tree node. Used by
     /// `harness/set-label` (P4d) and by `/bookmark`-style commands.
+    #[cfg_attr(not(feature = "plugin"), allow(dead_code))]
     pub fn set_label(
         &mut self,
         entry_id: &CompactString,
@@ -471,6 +450,7 @@ impl Session {
     /// recorded as `name` for lineage; pi stores this in a session
     /// header field. We piggyback on `name` to avoid bumping the
     /// session schema for one optional field.
+    #[cfg_attr(not(feature = "plugin"), allow(dead_code))]
     pub fn reset_to_new(&mut self, parent_session: Option<&str>) {
         let now = CompactString::new(chrono::Utc::now().to_rfc3339());
         self.id = CompactString::new(Uuid::new_v4().to_string());
@@ -706,20 +686,6 @@ mod tests {
         assert_eq!(s.tree.leaf_id.as_ref(), Some(&second_id));
         // Second node's parent is the first node.
         assert_eq!(s.tree.entries[&second_id].parent.as_ref(), Some(&first_id));
-    }
-
-    /// `path_from_leaf` walks back to root and reports the chain in
-    /// chronological order. Matches the linear `messages` Vec ordering.
-    #[test]
-    fn path_from_leaf_matches_messages_order() {
-        let mut s = Session::new("p", "m", 0);
-        s.add_message(MessageRole::User, "a");
-        s.add_message(MessageRole::Assistant, "b");
-        s.add_message(MessageRole::User, "c");
-        let path = s.tree.path_from_leaf();
-        let path_ids: Vec<_> = path.iter().map(|n| n.id.as_str()).collect();
-        let msg_ids: Vec<_> = s.messages.iter().map(|m| m.id.as_str()).collect();
-        assert_eq!(path_ids, msg_ids);
     }
 
     /// Pre-P4b session JSON (no `tree` field) deserializes with an


### PR DESCRIPTION
## Summary

Two-part change driven by README staleness after the P4 epic:

1. **`docs/PLUGINS.md`** — new comprehensive plugin author's guide
   (where plugins live, hook reference, full `harness/*` API surface,
   workflow patterns, debugging tips, worked examples). README plugin
   section was bloated with API listings the doc now covers; trimmed
   to a one-paragraph overview + pointer.

2. **Multi-file plugin support** — a plugin can now be either a
   single `*.janet` file or a directory containing many. Directory
   plugins share one Janet env so state/helpers/hooks can be split
   across files. Loaded alphabetically so `00-state.janet`,
   `01-hooks.janet`-style prefixes can enforce order.

## Latent bug fix

Discovered while writing the doc: the old loader only registered
`{stem}-{hook}` symbols, but most example plugins define bare
`on-prompt` / `on-tool-start`. Two plugins both using bare names
were silently clobbering each other in the shared Janet env. The
new `load_plugin` aliases each bare hook to `{namespace}-{hook}`
*before* the next plugin loads, so both fire on dispatch. Covered
by `load_plugin_isolates_bare_hooks_across_plugins`.

## Test plan

- [x] 4 new `plugin::tests`:
  - `load_plugin_aliases_bare_hooks_to_stem_prefix`
  - `load_plugin_isolates_bare_hooks_across_plugins` (clobber-bug regression)
  - `load_plugin_supports_directory_of_files`
  - `load_plugin_rejects_empty_directory`
- [x] `cargo test --features plugin` -> 596 pass, 0 fail.
- [x] `cargo build --features plugin` -> 0 warnings.
- [x] `cargo build` -> 0 warnings.

## Dead-code cleanup

- `SessionTree::path_from_leaf` deleted (only its own test used it).
- `set_label`, `reset_to_new`, `DialogRequest`/`DialogReply` variants
  gated with `cfg_attr(not(feature = \"plugin\"), allow(dead_code))`.
- `use std::thread::{self, ...}` import gated similarly.

## Examples

`plugins/turn_timer/` — new multi-file example plugin
(`00-state.janet` + `01-hooks.janet` + `02-commands.janet`).
README slash-commands table picks up `/tree`, `/fork`, `/clone`
(missing since P4c).