### PR TITLE
ui: phosphor theme (80s CRT green)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -81,6 +81,7 @@ Accepted top-level keys:
 | `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
 | `tool_result_max_chars`   | integer | Maximum characters to show before truncating tool output with `[N more chars]`. Default: `500`.                                                                              |
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`.                                                                                                                        |
+| `theme`                   | string  | UI color theme. `phosphor` (default — 80s CRT green-on-black) or `plain` (pre-theme white/cyan). Unknown values fall back to `phosphor` with a warning.                       |
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, defaults to a single Exa Web Search server; see below.                                                   |
 | `acp_servers`             | object  | ACP server config map when compiled with the `acp` feature. See the ACP section below.                                                                                       |
 | `acp_host`                | string  | TCP bind host for ACP server mode (equivalent to `--acp-host`).                                                                                                              |

--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ Session allowlists persist approvals for the session. Doom-loop detection trigge
 
 See [CONFIG.md](CONFIG.md) for config file location, accepted keys, provider aliases, permission rules, and MCP server configuration.
 
+### UI theme
+
+dirge ships with an 80s-CRT phosphor green palette by default. To opt out, set `"theme": "plain"` in `config.json` for the pre-theme white/cyan look:
+
+```json
+{ "theme": "plain" }
+```
+
+Errors stay red and warnings stay yellow under every theme — those colors are part of the load-bearing semantic contract.
+
 ## Supported providers
 
 - OpenRouter (default)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,10 @@ pub struct Config {
     pub show_edit_diff: Option<bool>,
     pub tool_result_max_chars: Option<usize>,
     pub default_prompt: Option<String>,
+    /// UI color theme. Known values: `phosphor` (default, 80s CRT
+    /// green) and `plain` (the pre-theme white/cyan look). Unknown
+    /// values fall back to `phosphor` with a warning.
+    pub theme: Option<String>,
     pub tools: Option<ToolsConfig>,
     #[cfg(feature = "lsp")]
     pub lsp: Option<LspConfig>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,10 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = cli::Cli::parse();
     let cfg = config::load();
+    // Initialize the global UI theme before any rendering happens. The
+    // theme is global state; setting it once at boot keeps every
+    // render site from having to thread it explicitly.
+    ui::theme::init(cfg.theme.as_deref().unwrap_or("phosphor"));
     let mut context = context::load(cli.resolve_no_context_files(&cfg));
 
     let default_prompt = cfg.default_prompt.as_deref().unwrap_or("code");

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -63,47 +63,50 @@ pub fn render_session(
     }
     let total = session.messages.len();
     for (idx, msg) in session.messages.iter().enumerate() {
-        let (badge, line_color) = match msg.role {
-            MessageRole::User => ("▌▌ USR ▏", theme::user()),
-            MessageRole::Assistant => ("▌▌ AI  ▏", theme::agent()),
-            MessageRole::System => ("▌▌ SYS ▏", theme::system()),
+        // IRC-style angle-bracketed handle. All three handles padded
+        // to 8 columns so multi-role chats stay visually aligned.
+        // Continuation lines are indented to that same width so the
+        // handle isn't repeated on every wrap.
+        let (handle, line_color) = match msg.role {
+            MessageRole::User => ("<you>   ", theme::user()),
+            MessageRole::Assistant => ("<dirge> ", theme::agent()),
+            MessageRole::System => ("<sys>   ", theme::system()),
         };
+        let cont_indent = " ".repeat(handle.chars().count());
+
         if msg.role == MessageRole::Assistant {
             let max_width = renderer.line_width();
             let mut styled = markdown::markdown_to_styled(&msg.content, max_width);
-            if !styled.is_empty() {
-                styled[0].text = CompactString::from(format!("{} {}", badge, styled[0].text));
+            for (i, entry) in styled.iter_mut().enumerate() {
+                if i == 0 {
+                    entry.text = CompactString::from(format!("{} {}", handle, entry.text));
+                } else {
+                    entry.text = CompactString::from(format!("{}{}", cont_indent, entry.text));
+                }
             }
             for entry in styled {
                 renderer.write_line(&entry.text, entry.color)?;
             }
         } else {
-            for line in msg.content.lines() {
-                renderer.write_line(&format!("{} {}", badge, line), line_color)?;
+            for (i, line) in msg.content.lines().enumerate() {
+                let prefix = if i == 0 {
+                    handle.to_string()
+                } else {
+                    cont_indent.clone()
+                };
+                renderer.write_line(&format!("{} {}", prefix, line), line_color)?;
             }
         }
-        // Insert a thin gradient turn-divider between messages (but not
-        // after the last one). Visual rhythm hint without dominating.
+        // Thin chamber-bar divider between turns. Single character,
+        // not a full-width gradient — the bar runs flush against the
+        // left margin like an IRC log's timeline.
         if idx + 1 < total {
-            renderer.write_line(&turn_divider(renderer.line_width()), theme::divider())?;
+            renderer.write_line("·", theme::divider())?;
         } else {
             renderer.write_line("", Color::Reset)?;
         }
     }
     Ok(())
-}
-
-/// A thin half-width gradient divider used between chat turns. Subtle
-/// enough not to noise up the scrollback but distinctive enough to
-/// signal a turn boundary at a glance.
-fn turn_divider(term_w: usize) -> String {
-    let w = term_w.min(60).max(20);
-    let mut out = String::with_capacity(w);
-    // Use ░▒ alternation for a phosphor scanline feel.
-    for i in 0..w {
-        out.push(if i % 2 == 0 { '░' } else { '▒' });
-    }
-    out
 }
 
 /// Block-letter "DIRGE" in the ANSI Shadow figlet style. Period-correct
@@ -117,87 +120,77 @@ const DIRGE_BLOCK_ART: &[&str] = &[
     "╚═════╝ ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝",
 ];
 
-/// Welcome banner for the phosphor/plain theme. Renders a chunky
-/// block-letter "DIRGE" wordmark sandwiched between gradient bars,
-/// followed by a status line. Falls back to a single-line text banner
-/// when the terminal is too narrow (< 42 cols) for the ASCII art.
+/// Welcome banner — block-letter "DIRGE" wordmark inside a rounded
+/// frame with the theme/version/provider/model on the bottom border.
+/// Mirrors the btop / cool-retro-term reference: every UI region is a
+/// rounded panel with its label sitting on the border, no heavy
+/// gradient stripes. Falls back to a single-line text banner on
+/// terminals narrower than 50 cols.
 fn render_banner(renderer: &mut Renderer, provider: &str, model: &str) -> anyhow::Result<()> {
     let label = theme::current().label;
     let version = env!("CARGO_PKG_VERSION");
     let term_w = renderer.line_width().max(20);
 
-    // The block art is 38 cols wide; we need ~42 for it to breathe.
-    // Narrow terminals get a one-line text banner instead.
-    if term_w < 42 {
-        let line = format!("▓▒░ DIRGE · {} · v{} ░▒▓", label, version);
-        renderer.write_line(&line, theme::banner_primary())?;
+    if term_w < 50 {
         renderer.write_line(
-            &format!("    provider: {} · model: {}", provider, model),
+            &format!("╭─ DIRGE · {} · v{} ", label, version),
+            theme::banner_primary(),
+        )?;
+        renderer.write_line(
+            &format!("│ provider: {} · model: {}", provider, model),
             theme::banner_secondary(),
         )?;
+        renderer.write_line("╰─", theme::banner_secondary())?;
         renderer.write_line("", Color::Reset)?;
         return Ok(());
     }
 
-    // Gradient bar — runs the full visible width (capped at 78) so the
-    // banner anchors a "screen header" feel without bleeding into the
-    // right-hand panel.
-    let bar_width = term_w.min(78);
-    let gradient = build_gradient_bar(bar_width);
+    // Frame width: cap at 78 so the banner doesn't sprawl on wide
+    // monitors, and so it sits visually proportionate to the chat.
+    let frame_w = term_w.min(78);
+    let inner_w = frame_w.saturating_sub(2);
 
-    renderer.write_line(&gradient, theme::banner_secondary())?;
-    renderer.write_line("", Color::Reset)?;
-    for art_line in DIRGE_BLOCK_ART {
-        renderer.write_line(&format!("   {}", art_line), theme::banner_primary())?;
-    }
-    renderer.write_line("", Color::Reset)?;
-    // Status line in the wordmark's right gutter; centered under the
-    // art for symmetry.
-    let status = format!(
-        "▓▒░ {} · v{} · {} · {} ░▒▓",
-        label, version, provider, model
-    );
-    let pad = bar_width.saturating_sub(status.chars().count()) / 2;
+    // Top border with the wordmark label sitting on it.
+    let top_label = format!(" DIRGE · {} ", label);
+    let top_label_len = top_label.chars().count();
+    let top_filler = inner_w.saturating_sub(top_label_len + 2);
+    let top_left = "─".repeat(2);
+    let top_right = "─".repeat(top_filler);
+    let top_border = format!("╭{}{}{}╮", top_left, top_label, top_right);
+
+    // Bottom border with the status label.
+    let bot_label = format!(" v{} · {} · {} ", version, provider, model);
+    let bot_label_len = bot_label.chars().count();
+    let bot_left = "─".repeat(inner_w.saturating_sub(bot_label_len + 2));
+    let bot_right = "─".repeat(2);
+    let bot_border = format!("╰{}{}{}╯", bot_left, bot_label, bot_right);
+
+    renderer.write_line(&top_border, theme::banner_secondary())?;
+    // Padding row above the art.
     renderer.write_line(
-        &format!("{}{}", " ".repeat(pad), status),
+        &format!("│{}│", " ".repeat(inner_w)),
         theme::banner_secondary(),
     )?;
-    renderer.write_line("", Color::Reset)?;
-    renderer.write_line(&gradient, theme::banner_secondary())?;
+    // Block-letter art, padded on both sides to fill the frame.
+    // The whole line renders in the bright banner_primary tone so the
+    // wordmark glows; the surrounding empty padding rows + borders
+    // stay dim, giving the eye a clear focal point.
+    for art_line in DIRGE_BLOCK_ART {
+        let art_len = art_line.chars().count();
+        let total_pad = inner_w.saturating_sub(art_len);
+        let left = total_pad / 2;
+        let right = total_pad - left;
+        let line = format!("│{}{}{}│", " ".repeat(left), art_line, " ".repeat(right),);
+        renderer.write_line(&line, theme::banner_primary())?;
+    }
+    // Padding row below the art.
+    renderer.write_line(
+        &format!("│{}│", " ".repeat(inner_w)),
+        theme::banner_secondary(),
+    )?;
+    renderer.write_line(&bot_border, theme::banner_secondary())?;
     renderer.write_line("", Color::Reset)?;
     Ok(())
-}
-
-/// Build a `▓▒░░░▒▓` gradient bar exactly `width` chars wide. The
-/// pattern fades from solid to sparse across each end, suggesting CRT
-/// scanline edge dither without doing anything that actually depends
-/// on color depth.
-fn build_gradient_bar(width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    let glyphs = ['█', '▓', '▒', '░', ' ', '░', '▒', '▓', '█'];
-    // We want a smooth left-edge gradient that reaches solid blocks in
-    // the middle and fades back out on the right.
-    let mut out = String::with_capacity(width * 3);
-    // Build half-gradients of length min(8, width / 3) and a solid
-    // middle filling the remainder.
-    let half = (width / 3).min(8);
-    let solid = width.saturating_sub(half * 2);
-    for i in 0..half {
-        // Map left edge: 0..half -> indices 3..0 of glyphs (░▒▓█)
-        let glyph_idx = 3usize.saturating_sub((i * 4) / half.max(1));
-        out.push(glyphs[glyph_idx]);
-    }
-    for _ in 0..solid {
-        out.push('█');
-    }
-    for i in 0..half {
-        // Right edge: mirror the left.
-        let glyph_idx = (((i + 1) * 4) / half.max(1)).min(3);
-        out.push(glyphs[5 + glyph_idx]); // skip the space; reach ▒▓█
-    }
-    out
 }
 
 pub fn sanitize_output(text: &str) -> CompactString {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -41,6 +41,12 @@ pub fn render_session(
     } else {
         cli.resolve_model(cfg)
     };
+    // Top padding rows. Without this, when the user scrolls all the
+    // way up, the banner's top border `╭───╮` sits pressed against
+    // the terminal's top edge, which reads as "cut off." Two blank
+    // rows give the eye breathing room above the banner.
+    renderer.write_line("", Color::Reset)?;
+    renderer.write_line("", Color::Reset)?;
     render_banner(renderer, &provider, &model)?;
     if context.agents.is_some() {
         renderer.write_line("░ loaded AGENTS.md", theme::dim())?;

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -81,7 +81,13 @@ pub fn render_session(
         let cont_indent = " ".repeat(handle.chars().count());
 
         if msg.role == MessageRole::Assistant {
-            let max_width = renderer.line_width();
+            // Wrap chat to the same width tool chambers use so chat
+            // and chamber blocks line up visually. The 8-col handle
+            // prefix is subtracted so wrapped continuation text fits
+            // beneath the handle position.
+            let max_width = renderer
+                .content_width()
+                .saturating_sub(handle.chars().count() + 1);
             let mut styled = markdown::markdown_to_styled(&msg.content, max_width);
             for (i, entry) in styled.iter_mut().enumerate() {
                 if i == 0 {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -61,78 +61,143 @@ pub fn render_session(
         )?;
         renderer.write_line("", Color::Reset)?;
     }
-    for msg in &session.messages {
-        let (prefix, line_color) = match msg.role {
-            MessageRole::User => (">", theme::user()),
-            MessageRole::Assistant => ("<", theme::agent()),
-            MessageRole::System => ("#", theme::system()),
+    let total = session.messages.len();
+    for (idx, msg) in session.messages.iter().enumerate() {
+        let (badge, line_color) = match msg.role {
+            MessageRole::User => ("▌▌ USR ▏", theme::user()),
+            MessageRole::Assistant => ("▌▌ AI  ▏", theme::agent()),
+            MessageRole::System => ("▌▌ SYS ▏", theme::system()),
         };
         if msg.role == MessageRole::Assistant {
             let max_width = renderer.line_width();
             let mut styled = markdown::markdown_to_styled(&msg.content, max_width);
             if !styled.is_empty() {
-                styled[0].text = CompactString::from(format!("{} {}", prefix, styled[0].text));
+                styled[0].text = CompactString::from(format!("{} {}", badge, styled[0].text));
             }
             for entry in styled {
                 renderer.write_line(&entry.text, entry.color)?;
             }
         } else {
             for line in msg.content.lines() {
-                renderer.write_line(&format!("{} {}", prefix, line), line_color)?;
+                renderer.write_line(&format!("{} {}", badge, line), line_color)?;
             }
         }
-        renderer.write_line("", Color::Reset)?;
+        // Insert a thin gradient turn-divider between messages (but not
+        // after the last one). Visual rhythm hint without dominating.
+        if idx + 1 < total {
+            renderer.write_line(&turn_divider(renderer.line_width()), theme::divider())?;
+        } else {
+            renderer.write_line("", Color::Reset)?;
+        }
     }
     Ok(())
 }
 
-/// 80s-CRT welcome banner. Four lines: top border, wordmark + theme +
-/// version, provider/model summary, bottom border. Width clamps to the
-/// terminal so narrow windows don't see overrunning box-drawing chars.
+/// A thin half-width gradient divider used between chat turns. Subtle
+/// enough not to noise up the scrollback but distinctive enough to
+/// signal a turn boundary at a glance.
+fn turn_divider(term_w: usize) -> String {
+    let w = term_w.min(60).max(20);
+    let mut out = String::with_capacity(w);
+    // Use ░▒ alternation for a phosphor scanline feel.
+    for i in 0..w {
+        out.push(if i % 2 == 0 { '░' } else { '▒' });
+    }
+    out
+}
+
+/// Block-letter "DIRGE" in the ANSI Shadow figlet style. Period-correct
+/// 80s BBS aesthetic. Six lines tall, 38 chars wide.
+const DIRGE_BLOCK_ART: &[&str] = &[
+    "██████╗ ██╗██████╗  ██████╗ ███████╗",
+    "██╔══██╗██║██╔══██╗██╔════╝ ██╔════╝",
+    "██║  ██║██║██████╔╝██║  ███╗█████╗  ",
+    "██║  ██║██║██╔══██╗██║   ██║██╔══╝  ",
+    "██████╔╝██║██║  ██║╚██████╔╝███████╗",
+    "╚═════╝ ╚═╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝",
+];
+
+/// Welcome banner for the phosphor/plain theme. Renders a chunky
+/// block-letter "DIRGE" wordmark sandwiched between gradient bars,
+/// followed by a status line. Falls back to a single-line text banner
+/// when the terminal is too narrow (< 42 cols) for the ASCII art.
 fn render_banner(renderer: &mut Renderer, provider: &str, model: &str) -> anyhow::Result<()> {
     let label = theme::current().label;
     let version = env!("CARGO_PKG_VERSION");
-    let title = format!("░ DIRGE ░ {} ░ v{}", label, version);
-    let subtitle = format!("provider: {} · model: {}", provider, model);
-    // Inner width = max content length + 2 padding on each side.
-    // Clamp to terminal width − 4 (margin) so we don't push the banner
-    // past the visible region.
     let term_w = renderer.line_width().max(20);
-    let max_inner = term_w.saturating_sub(4);
-    let inner = title
-        .chars()
-        .count()
-        .max(subtitle.chars().count())
-        .min(max_inner);
-    let inner_width = inner + 2; // single-space padding each side
 
-    let border_top = format!("╔{}╗", "═".repeat(inner_width));
-    let border_bot = format!("╚{}╝", "═".repeat(inner_width));
-    let title_line = format!("║ {:width$} ║", truncate(&title, inner), width = inner);
-    let sub_line = format!("║ {:width$} ║", truncate(&subtitle, inner), width = inner);
+    // The block art is 38 cols wide; we need ~42 for it to breathe.
+    // Narrow terminals get a one-line text banner instead.
+    if term_w < 42 {
+        let line = format!("▓▒░ DIRGE · {} · v{} ░▒▓", label, version);
+        renderer.write_line(&line, theme::banner_primary())?;
+        renderer.write_line(
+            &format!("    provider: {} · model: {}", provider, model),
+            theme::banner_secondary(),
+        )?;
+        renderer.write_line("", Color::Reset)?;
+        return Ok(());
+    }
 
-    renderer.write_line(&border_top, theme::banner_secondary())?;
-    renderer.write_line(&title_line, theme::banner_primary())?;
-    renderer.write_line(&sub_line, theme::banner_secondary())?;
-    renderer.write_line(&border_bot, theme::banner_secondary())?;
+    // Gradient bar — runs the full visible width (capped at 78) so the
+    // banner anchors a "screen header" feel without bleeding into the
+    // right-hand panel.
+    let bar_width = term_w.min(78);
+    let gradient = build_gradient_bar(bar_width);
+
+    renderer.write_line(&gradient, theme::banner_secondary())?;
+    renderer.write_line("", Color::Reset)?;
+    for art_line in DIRGE_BLOCK_ART {
+        renderer.write_line(&format!("   {}", art_line), theme::banner_primary())?;
+    }
+    renderer.write_line("", Color::Reset)?;
+    // Status line in the wordmark's right gutter; centered under the
+    // art for symmetry.
+    let status = format!(
+        "▓▒░ {} · v{} · {} · {} ░▒▓",
+        label, version, provider, model
+    );
+    let pad = bar_width.saturating_sub(status.chars().count()) / 2;
+    renderer.write_line(
+        &format!("{}{}", " ".repeat(pad), status),
+        theme::banner_secondary(),
+    )?;
+    renderer.write_line("", Color::Reset)?;
+    renderer.write_line(&gradient, theme::banner_secondary())?;
     renderer.write_line("", Color::Reset)?;
     Ok(())
 }
 
-/// Truncate a string to `max` *characters* (not bytes), adding an
-/// ellipsis when shortened. Used by the banner so wordmarks stay
-/// inside the box drawing.
-fn truncate(s: &str, max: usize) -> String {
-    let count = s.chars().count();
-    if count <= max {
-        s.to_string()
-    } else if max <= 1 {
-        s.chars().take(max).collect()
-    } else {
-        let mut out: String = s.chars().take(max - 1).collect();
-        out.push('…');
-        out
+/// Build a `▓▒░░░▒▓` gradient bar exactly `width` chars wide. The
+/// pattern fades from solid to sparse across each end, suggesting CRT
+/// scanline edge dither without doing anything that actually depends
+/// on color depth.
+fn build_gradient_bar(width: usize) -> String {
+    if width == 0 {
+        return String::new();
     }
+    let glyphs = ['█', '▓', '▒', '░', ' ', '░', '▒', '▓', '█'];
+    // We want a smooth left-edge gradient that reaches solid blocks in
+    // the middle and fades back out on the right.
+    let mut out = String::with_capacity(width * 3);
+    // Build half-gradients of length min(8, width / 3) and a solid
+    // middle filling the remainder.
+    let half = (width / 3).min(8);
+    let solid = width.saturating_sub(half * 2);
+    for i in 0..half {
+        // Map left edge: 0..half -> indices 3..0 of glyphs (░▒▓█)
+        let glyph_idx = 3usize.saturating_sub((i * 4) / half.max(1));
+        out.push(glyphs[glyph_idx]);
+    }
+    for _ in 0..solid {
+        out.push('█');
+    }
+    for i in 0..half {
+        // Right edge: mirror the left.
+        let glyph_idx = (((i + 1) * 4) / half.max(1)).min(3);
+        out.push(glyphs[5 + glyph_idx]); // skip the space; reach ▒▓█
+    }
+    out
 }
 
 pub fn sanitize_output(text: &str) -> CompactString {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -8,6 +8,7 @@ use crate::context::ContextFiles;
 use crate::session::{MessageRole, Session};
 use crate::ui::markdown;
 use crate::ui::renderer::Renderer;
+use crate::ui::theme;
 
 pub fn format_time(rfc3339: &str) -> CompactString {
     let dt = chrono::DateTime::parse_from_rfc3339(rfc3339).ok();
@@ -40,22 +41,15 @@ pub fn render_session(
     } else {
         cli.resolve_model(cfg)
     };
-    let welcome = format!(
-        "dirge {}  {}  {}",
-        provider,
-        model,
-        env!("CARGO_PKG_VERSION")
-    );
-    renderer.write_line(&welcome, Color::Cyan)?;
-    renderer.write_line("", Color::White)?;
+    render_banner(renderer, &provider, &model)?;
     if context.agents.is_some() {
-        renderer.write_line("loaded AGENTS.md", Color::DarkGrey)?;
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("░ loaded AGENTS.md", theme::dim())?;
+        renderer.write_line("", Color::Reset)?;
     }
     if !session.compactions.is_empty() {
         renderer.write_line(
             &format!(
-                "compacted {} times (saved ~{} tokens)",
+                "░ compacted {} times (saved ~{} tokens)",
                 session.compactions.len(),
                 session
                     .compactions
@@ -63,15 +57,15 @@ pub fn render_session(
                     .map(|c| c.token_savings)
                     .unwrap_or(0),
             ),
-            Color::DarkGrey,
+            theme::dim(),
         )?;
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", Color::Reset)?;
     }
     for msg in &session.messages {
-        let (prefix, _c) = match msg.role {
-            MessageRole::User => (">", Color::Green),
-            MessageRole::Assistant => ("<", Color::White),
-            MessageRole::System => ("#", Color::DarkGrey),
+        let (prefix, line_color) = match msg.role {
+            MessageRole::User => (">", theme::user()),
+            MessageRole::Assistant => ("<", theme::agent()),
+            MessageRole::System => ("#", theme::system()),
         };
         if msg.role == MessageRole::Assistant {
             let max_width = renderer.line_width();
@@ -84,12 +78,61 @@ pub fn render_session(
             }
         } else {
             for line in msg.content.lines() {
-                renderer.write_line(&format!("{} {}", prefix, line), _c)?;
+                renderer.write_line(&format!("{} {}", prefix, line), line_color)?;
             }
         }
-        renderer.write_line("", Color::White)?;
+        renderer.write_line("", Color::Reset)?;
     }
     Ok(())
+}
+
+/// 80s-CRT welcome banner. Four lines: top border, wordmark + theme +
+/// version, provider/model summary, bottom border. Width clamps to the
+/// terminal so narrow windows don't see overrunning box-drawing chars.
+fn render_banner(renderer: &mut Renderer, provider: &str, model: &str) -> anyhow::Result<()> {
+    let label = theme::current().label;
+    let version = env!("CARGO_PKG_VERSION");
+    let title = format!("░ DIRGE ░ {} ░ v{}", label, version);
+    let subtitle = format!("provider: {} · model: {}", provider, model);
+    // Inner width = max content length + 2 padding on each side.
+    // Clamp to terminal width − 4 (margin) so we don't push the banner
+    // past the visible region.
+    let term_w = renderer.line_width().max(20);
+    let max_inner = term_w.saturating_sub(4);
+    let inner = title
+        .chars()
+        .count()
+        .max(subtitle.chars().count())
+        .min(max_inner);
+    let inner_width = inner + 2; // single-space padding each side
+
+    let border_top = format!("╔{}╗", "═".repeat(inner_width));
+    let border_bot = format!("╚{}╝", "═".repeat(inner_width));
+    let title_line = format!("║ {:width$} ║", truncate(&title, inner), width = inner);
+    let sub_line = format!("║ {:width$} ║", truncate(&subtitle, inner), width = inner);
+
+    renderer.write_line(&border_top, theme::banner_secondary())?;
+    renderer.write_line(&title_line, theme::banner_primary())?;
+    renderer.write_line(&sub_line, theme::banner_secondary())?;
+    renderer.write_line(&border_bot, theme::banner_secondary())?;
+    renderer.write_line("", Color::Reset)?;
+    Ok(())
+}
+
+/// Truncate a string to `max` *characters* (not bytes), adding an
+/// ellipsis when shortened. Used by the banner so wordmarks stay
+/// inside the box drawing.
+fn truncate(s: &str, max: usize) -> String {
+    let count = s.chars().count();
+    if count <= max {
+        s.to_string()
+    } else if max <= 1 {
+        s.chars().take(max).collect()
+    } else {
+        let mut out: String = s.chars().take(max - 1).collect();
+        out.push('…');
+        out
+    }
 }
 
 pub fn sanitize_output(text: &str) -> CompactString {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -194,8 +194,16 @@ fn render_banner(renderer: &mut Renderer, provider: &str, model: &str) -> anyhow
 }
 
 pub fn sanitize_output(text: &str) -> CompactString {
-    let mut result = String::with_capacity(text.len());
-    let mut chars = text.chars();
+    // Two-pass: first strip orphan SGR mouse reports of the form
+    // `[<digits;digits;digits(M|m)` (no leading escape). These can
+    // leak into tool output when a shell command captures terminal
+    // input bytes, and without this guard they smear `[<65;79;32M…`
+    // through the chamber. Then run the regular ANSI/control-char
+    // sanitizer over the cleaned text.
+    let stripped = strip_orphan_mouse_reports(text);
+
+    let mut result = String::with_capacity(stripped.len());
+    let mut chars = stripped.chars();
     while let Some(c) = chars.next() {
         if c == '\x1b' {
             match chars.next() {
@@ -216,4 +224,47 @@ pub fn sanitize_output(text: &str) -> CompactString {
         }
     }
     CompactString::from(result)
+}
+
+/// Strip orphan SGR mouse-report sequences (e.g. `[<65;79;32M`) that
+/// arrive without their leading `\x1b`. Walks the input scanning for
+/// the literal pattern `[<` followed by digits and semicolons ending
+/// in `M` or `m`; matched runs are dropped. Anything else passes
+/// through unchanged.
+fn strip_orphan_mouse_reports(text: &str) -> String {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == '[' && i + 1 < bytes.len() && bytes[i + 1] == '<' {
+            // Try to match `[<digits;digits;digits(M|m)`.
+            let mut j = i + 2;
+            let mut saw_digit_or_semi = false;
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c.is_ascii_digit() || c == ';' {
+                    saw_digit_or_semi = true;
+                    j += 1;
+                } else if (c == 'M' || c == 'm') && saw_digit_or_semi {
+                    i = j + 1;
+                    break;
+                } else {
+                    // Not a mouse report — pass `[` through and resume
+                    // scanning at the next position.
+                    out.push(bytes[i]);
+                    i += 1;
+                    break;
+                }
+            }
+            if j >= bytes.len() {
+                // Truncated input — pass through what we have.
+                out.push(bytes[i]);
+                i += 1;
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
 }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -87,17 +87,17 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
             Event::Start(tag) => match tag {
                 Tag::Paragraph => {}
                 Tag::Heading { level: _, .. } => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
                     acc.clear();
                     in_heading = true;
                 }
                 Tag::CodeBlock(_kind) => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
                     acc.clear();
                     in_code_block = true;
                 }
                 Tag::BlockQuote(_) => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
                     acc.clear();
                     in_blockquote = true;
                 }
@@ -106,7 +106,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     list_item_count = 0;
                 }
                 Tag::Item => {
-                    flush_acc(&acc, Color::White, max_width, &mut result);
+                    flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
                     acc.clear();
                     list_item_count += 1;
                 }
@@ -122,7 +122,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     let color = if in_blockquote {
                         Color::DarkGrey
                     } else {
-                        Color::White
+                        crate::ui::theme::agent()
                     };
                     flush_acc(&acc, color, max_width, &mut result);
                     acc.clear();
@@ -133,7 +133,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     in_heading = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: crate::ui::theme::agent(),
                     });
                 }
                 TagEnd::CodeBlock => {
@@ -155,7 +155,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     in_code_block = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: crate::ui::theme::agent(),
                     });
                 }
                 TagEnd::BlockQuote(_) => {
@@ -182,14 +182,14 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     in_blockquote = false;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: crate::ui::theme::agent(),
                     });
                 }
                 TagEnd::Item => {
                     let color = if in_blockquote {
                         Color::DarkGrey
                     } else {
-                        Color::White
+                        crate::ui::theme::agent()
                     };
                     let bullet = if ordered_list {
                         format!(" {}. ", list_item_count)
@@ -225,7 +225,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     list_item_count = 0;
                     result.push(LineEntry {
                         text: CompactString::new(""),
-                        color: Color::White,
+                        color: crate::ui::theme::agent(),
                     });
                 }
                 TagEnd::FootnoteDefinition => {}
@@ -257,7 +257,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 }
             }
             Event::Rule => {
-                flush_acc(&acc, Color::White, max_width, &mut result);
+                flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
                 acc.clear();
                 let rule: String = std::iter::repeat('─').take(max_width.min(40)).collect();
                 result.push(LineEntry {
@@ -266,7 +266,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 });
                 result.push(LineEntry {
                     text: CompactString::new(""),
-                    color: Color::White,
+                    color: crate::ui::theme::agent(),
                 });
             }
             Event::Html(t) => {
@@ -297,7 +297,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
         } else if in_heading {
             Color::Cyan
         } else {
-            Color::White
+            crate::ui::theme::agent()
         };
         flush_acc(&acc, color, max_width, &mut result);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -140,12 +140,9 @@ fn render_plugin_entry(
 
     // Default rendering: identify the custom type and dump the data.
     // Keeps entries visible even when their plugin is uninstalled.
-    renderer.write_line(&format!("[entry: {}]", entry.custom_type), Color::DarkGrey)?;
+    renderer.write_line(&format!("[entry: {}]", entry.custom_type), theme::dim())?;
     if !entry.data.is_empty() {
-        renderer.write_line(
-            &format!("  {}", sanitize_output(&entry.data)),
-            Color::DarkGrey,
-        )?;
+        renderer.write_line(&format!("  {}", sanitize_output(&entry.data)), theme::dim())?;
     }
     Ok(())
 }
@@ -531,7 +528,7 @@ pub async fn run_interactive(
                 let color = match level.as_str() {
                     "warn" => Color::Yellow,
                     "error" => c_error(),
-                    _ => Color::DarkGrey,
+                    _ => theme::dim(),
                 };
                 renderer.write_line(&format!("[plugin] {}", msg), color)?;
             }
@@ -577,7 +574,7 @@ pub async fn run_interactive(
                 let effect = plugin_tree::apply_tree_op(op, session, &mut input);
                 match effect {
                     plugin_tree::TreeOpEffect::Applied(msg) => {
-                        renderer.write_line(&msg, Color::DarkGrey)?;
+                        renderer.write_line(&msg, theme::dim())?;
                     }
                     plugin_tree::TreeOpEffect::Failed(msg) => {
                         renderer.write_line(&msg, c_error())?;
@@ -771,7 +768,7 @@ pub async fn run_interactive(
                                     "dropped 1 queued message ({} remaining)",
                                     interjection_queue.len()
                                 ),
-                                Color::DarkGrey,
+                                theme::dim(),
                             )?;
                             renderer.draw_bottom(
                                 &input,
@@ -930,7 +927,7 @@ pub async fn run_interactive(
                                 }
                             }
                             last_esc = Some(now);
-                            renderer.write_line("Press Esc again to rewind...", Color::DarkGrey)?;
+                            renderer.write_line("Press Esc again to rewind...", theme::dim())?;
                             renderer.draw_bottom(
                                 &input,
                                 &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1049,7 +1046,7 @@ pub async fn run_interactive(
                                     shell::ShellPrefix::Visible(cmd) => {
                                         match run_shell_command(&cmd, &sandbox).await {
                                             Ok(output) => {
-                                                renderer.write_line(&output, Color::DarkGrey)?;
+                                                renderer.write_line(&output, theme::dim())?;
                                                 let msg = format!("I ran: $ {}\n\nOutput:\n{}", cmd, output);
                                                 let history = crate::agent::runner::convert_history(session);
                                                 session.add_message(MessageRole::User, &msg);
@@ -1070,7 +1067,7 @@ pub async fn run_interactive(
                                     shell::ShellPrefix::Invisible(cmd) => {
                                         match run_shell_command(&cmd, &sandbox).await {
                                             Ok(output) => {
-                                                renderer.write_line(&output, Color::DarkGrey)?;
+                                                renderer.write_line(&output, theme::dim())?;
                                             }
                                             Err(e) => {
                                                 renderer.write_line(&format!("shell error: {}", e), c_error())?;
@@ -1252,14 +1249,14 @@ pub async fn run_interactive(
                                     let safe_line = sanitize_output(line);
                                     renderer.write_line(
                                         &format!("» {}", safe_line),
-                                        Color::DarkGrey,
+                                        theme::dim(),
                                     )?;
                                 }
                                 renderer.write_line(
                                     &format!(
                                         "(queued; runner will stop at next safe boundary — Ctrl+X drops, Ctrl+C cancels)"
                                     ),
-                                    Color::DarkGrey,
+                                    theme::dim(),
                                 )?;
                             } else {
                                 for line in text.lines() {
@@ -1288,7 +1285,7 @@ pub async fn run_interactive(
                                             for line in &results {
                                                 renderer.write_line(
                                                     &format!("[plugin] {}", line),
-                                                    Color::DarkGrey,
+                                                    theme::dim(),
                                                 )?;
                                             }
                                             plugin_hint = Some(results.join("\n"));
@@ -1319,12 +1316,12 @@ pub async fn run_interactive(
                                     // it looks like their message vanished.
                                     renderer.write_line(
                                         "[plugin] prompt rewritten:",
-                                        Color::DarkGrey,
+                                        theme::dim(),
                                     )?;
                                     for line in replacement.lines() {
                                         renderer.write_line(
                                             &format!("  {}", sanitize_output(line)),
-                                            Color::DarkGrey,
+                                            theme::dim(),
                                         )?;
                                     }
                                     replacement
@@ -1443,7 +1440,19 @@ pub async fn run_interactive(
                         }
                         response_buf.clear();
                         response_start_line = None;
-                        let line = format!("◈ {}", format_tool_call_summary(&name, &args));
+                        // Tool-call line: framed BBS-style banner that
+                        // visually demarcates the agent's tool use from
+                        // its prose. `▒░ NAME ░▒ args…` puts the tool
+                        // name on a small gradient pedestal so the eye
+                        // immediately sees what's running.
+                        let upper = name.to_ascii_uppercase();
+                        let summary = format_tool_call_summary(&name, &args);
+                        // Strip the leading "name " that format_tool_call_summary
+                        // produces, since the framed badge already shows it.
+                        let trimmed = summary
+                            .strip_prefix(&format!("{} ", name))
+                            .unwrap_or(&summary);
+                        let line = format!("▒░ {} ░▒ {}", upper, trimmed);
                         renderer.write_line(&sanitize_output(&line), c_tool())?;
 
                         // Note: on-tool-start fires from HookedToolDyn now,
@@ -1474,12 +1483,14 @@ pub async fn run_interactive(
                                     .iter()
                                     .position(|l| l.starts_with("--- a/"));
                                 if let Some(pre) = diff_start {
-                                    // Show non-diff prefix
+                                    // Show non-diff prefix in the
+                                    // chamber so it sits visually
+                                    // attached to the tool-call banner.
                                     for l in &lines[..pre] {
                                         if !l.is_empty() {
                                             renderer.write_line(
-                                                &format!("◈ {}", sanitize_output(l)),
-                                                Color::DarkGrey,
+                                                &format!("▏ {}", sanitize_output(l)),
+                                                theme::result(),
                                             )?;
                                         }
                                     }
@@ -1496,7 +1507,7 @@ pub async fn run_interactive(
                                         } else {
                                             renderer.write_line(
                                                 &sanitize_output(l),
-                                                Color::DarkGrey,
+                                                theme::dim(),
                                             )?;
                                         }
                                     }
@@ -1534,7 +1545,7 @@ pub async fn run_interactive(
                                     for line in &results {
                                         renderer.write_line(
                                             &format!("[plugin] {}", line),
-                                            Color::DarkGrey,
+                                            theme::dim(),
                                         )?;
                                     }
                                     plugin_followup = Some(results.join("\n"));
@@ -1591,7 +1602,7 @@ pub async fn run_interactive(
                             && session.needs_compaction(cfg.resolve_reserve_tokens())
                             && !cli.no_session
                         {
-                            renderer.write_line("auto-compacting...", Color::DarkGrey)?;
+                            renderer.write_line("auto-compacting...", theme::dim())?;
                             let compress_result = handle_compress(
                                 None,
                                 &mut agent, &client, &mut renderer, session, cli, cfg, context,
@@ -1781,7 +1792,7 @@ pub async fn run_interactive(
                         renderer.write_line("", Color::White)?;
                         renderer.write_line(
                             "(interjected — stopped at last tool-result boundary)",
-                            Color::DarkGrey,
+                            theme::dim(),
                         )?;
                         renderer.write_line("", Color::White)?;
 
@@ -1969,14 +1980,28 @@ pub async fn run_interactive(
                     agent_line_started = false;
                 }
 
+                // Framed permission prompt. The double-bar border +
+                // ALERT wordmark visually arrests the eye — this is
+                // the single most important UX moment and the user
+                // must not miss it. Box width = 64 for a stable look
+                // independent of terminal width; the chat area
+                // requires at least 60 cols anyway.
+                const BOX_W: usize = 64;
+                let top_label = "╔══[ ⚠ ALERT · PERMISSION ]";
+                let top_pad = BOX_W.saturating_sub(top_label.chars().count() + 1);
+                let bot_bar = "═".repeat(BOX_W.saturating_sub(2));
                 renderer.write_line(
-                    &format!("[permission] {}: {}", ask_req.tool, ask_req.input),
+                    &format!("{}{}╗", top_label, "═".repeat(top_pad)),
                     c_perm(),
                 )?;
+                renderer.write_line(&format!("║ tool : {}", ask_req.tool), c_perm())?;
+                renderer.write_line(&format!("║ args : {}", ask_req.input), c_perm())?;
+                renderer.write_line(&format!("╠{}╣", bot_bar), c_perm())?;
                 renderer.write_line(
-                    "  (y) allow once  (a) allow always  (n) deny  (ESC) abort",
+                    "║  (y) allow once   (a) allow always   (n) deny   (ESC) abort",
                     c_perm(),
                 )?;
+                renderer.write_line(&format!("╚{}╝", bot_bar), c_perm())?;
 
                 let decision = loop {
                     tokio::select! {
@@ -2370,7 +2395,7 @@ pub async fn run_interactive(
                         let _ = reply.send(DialogReply::Confirm(answer));
                         renderer.write_line(
                             &format!("  -> {}", if answer { "yes" } else { "no" }),
-                            Color::DarkGrey,
+                            theme::dim(),
                         )?;
                     }
                     DialogRequest::Select { title, options, reply } => {
@@ -2418,7 +2443,7 @@ pub async fn run_interactive(
                         let _ = reply.send(DialogReply::Select(answer));
                         renderer.write_line(
                             &format!("  -> {}", label),
-                            Color::DarkGrey,
+                            theme::dim(),
                         )?;
                     }
                 }
@@ -2578,15 +2603,22 @@ fn render_tool_output(
 ) -> anyhow::Result<()> {
     let sanitized = sanitize_output(output);
     let char_count = sanitized.chars().count();
-    if char_count <= max_chars {
-        renderer.write_line(&sanitized, Color::DarkGrey)?;
+    let body: String = if char_count <= max_chars {
+        sanitized.into_string()
     } else {
-        let preview: String = sanitized.chars().take(max_chars).collect();
+        sanitized.chars().take(max_chars).collect()
+    };
+    // Prefix every output line with `▏ ` so the tool's text reads
+    // like a chamber attached to the tool-call banner above. Empty
+    // lines still get the prefix so the chamber stays continuous.
+    for line in body.lines() {
+        renderer.write_line(&format!("▏ {}", line), theme::result())?;
+    }
+    if char_count > max_chars {
         let remaining = char_count - max_chars;
-        renderer.write_line(&preview, Color::DarkGrey)?;
         renderer.write_line(
-            &format!("  [truncated: {} more chars]", remaining),
-            Color::DarkCyan,
+            &format!("▏ ░░ +{} chars truncated ░░", remaining),
+            theme::dim(),
         )?;
     }
     Ok(())

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1412,7 +1412,7 @@ pub async fn run_interactive(
                             continue;
                         }
 
-                        let max_width = renderer.line_width();
+                        let max_width = renderer.content_width().saturating_sub(9); // 8-col handle + space
                         let mut styled =
                             crate::ui::markdown::markdown_to_styled(&response_buf, max_width);
 
@@ -1603,7 +1603,7 @@ pub async fn run_interactive(
                         }
 
                         if !response_buf.is_empty() {
-                            let max_width = renderer.line_width();
+                            let max_width = renderer.content_width().saturating_sub(9); // 8-col handle + space
                             let mut styled = crate::ui::markdown::markdown_to_styled(
                                 &response_buf,
                                 max_width,
@@ -1812,7 +1812,7 @@ pub async fn run_interactive(
                         // the conversation history reflects what the user saw,
                         // not a phantom turn that "never happened".
                         if !response_buf.is_empty() {
-                            let max_width = renderer.line_width();
+                            let max_width = renderer.content_width().saturating_sub(9); // 8-col handle + space
                             let mut styled = crate::ui::markdown::markdown_to_styled(
                                 &response_buf,
                                 max_width,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,6 +10,7 @@ mod status;
 #[cfg(feature = "plugin")]
 mod streaming;
 mod terminal;
+pub(crate) mod theme;
 mod tree;
 
 use std::collections::VecDeque;
@@ -48,10 +49,25 @@ use crate::ui::slash::{handle_compress, handle_slash};
 use crate::ui::status::StatusLine;
 use crate::ui::terminal::TerminalGuard;
 
-const C_AGENT: Color = Color::White;
-const C_ERROR: Color = Color::Red;
-const C_TOOL: Color = Color::Yellow;
-const C_PERM: Color = Color::Magenta;
+// Themed color accessors. These wrap `theme::agent()` etc. so we can
+// keep the existing call-site spelling (e.g. `c_agent()` is now a fn).
+// Active palette is set at startup via `theme::init`.
+#[inline]
+fn c_agent() -> Color {
+    theme::agent()
+}
+#[inline]
+fn c_error() -> Color {
+    theme::error()
+}
+#[inline]
+fn c_tool() -> Color {
+    theme::tool()
+}
+#[inline]
+fn c_perm() -> Color {
+    theme::perm()
+}
 
 /// Append a `q:N` queue-depth suffix to the status line when there are
 /// interjections waiting to be sent to the agent. Hidden when the queue
@@ -514,7 +530,7 @@ pub async fn run_interactive(
             for (level, msg) in pending {
                 let color = match level.as_str() {
                     "warn" => Color::Yellow,
-                    "error" => C_ERROR,
+                    "error" => c_error(),
                     _ => Color::DarkGrey,
                 };
                 renderer.write_line(&format!("[plugin] {}", msg), color)?;
@@ -564,10 +580,10 @@ pub async fn run_interactive(
                         renderer.write_line(&msg, Color::DarkGrey)?;
                     }
                     plugin_tree::TreeOpEffect::Failed(msg) => {
-                        renderer.write_line(&msg, C_ERROR)?;
+                        renderer.write_line(&msg, c_error())?;
                     }
                     plugin_tree::TreeOpEffect::SessionReplaced(msg) => {
-                        renderer.write_line(&msg, C_AGENT)?;
+                        renderer.write_line(&msg, c_agent())?;
                         any_session_replaced = true;
                     }
                 }
@@ -713,10 +729,10 @@ pub async fn run_interactive(
                                 if dropped > 0 {
                                     renderer.write_line(
                                         &format!("interrupted ({} queued message{} dropped)", dropped, if dropped == 1 { "" } else { "s" }),
-                                        C_ERROR,
+                                        c_error(),
                                     )?;
                                 } else {
-                                    renderer.write_line("interrupted", C_ERROR)?;
+                                    renderer.write_line("interrupted", c_error())?;
                                 }
                                 renderer.draw_bottom(
                                     &input,
@@ -869,7 +885,7 @@ pub async fn run_interactive(
                                 ls.active = false;
                                 loop_label = None;
                             }
-                            renderer.write_line("interrupted (Esc)", C_ERROR)?;
+                            renderer.write_line("interrupted (Esc)", c_error())?;
                             renderer.draw_bottom(
                                 &input,
                                 &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1003,7 +1019,7 @@ pub async fn run_interactive(
                         if let Some(text) = input.handle_key(key) {
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
-                                renderer.write_line("loop active: /loop stop to cancel", C_ERROR)?;
+                                renderer.write_line("loop active: /loop stop to cancel", c_error())?;
                                 renderer.draw_bottom(
                                     &input,
                                     &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1016,7 +1032,7 @@ pub async fn run_interactive(
                             }
                             if let Some(prefix) = shell::parse_shell_prefix(&text) {
                                 if is_running {
-                                    renderer.write_line("agent is busy, wait or interrupt first", C_ERROR)?;
+                                    renderer.write_line("agent is busy, wait or interrupt first", c_error())?;
                                     renderer.draw_bottom(
                                         &input,
                                         &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1047,7 +1063,7 @@ pub async fn run_interactive(
                                                 is_running = true;
                                             }
                                             Err(e) => {
-                                                renderer.write_line(&format!("shell error: {}", e), C_ERROR)?;
+                                                renderer.write_line(&format!("shell error: {}", e), c_error())?;
                                             }
                                         }
                                     }
@@ -1057,7 +1073,7 @@ pub async fn run_interactive(
                                                 renderer.write_line(&output, Color::DarkGrey)?;
                                             }
                                             Err(e) => {
-                                                renderer.write_line(&format!("shell error: {}", e), C_ERROR)?;
+                                                renderer.write_line(&format!("shell error: {}", e), c_error())?;
                                             }
                                         }
                                     }
@@ -1074,7 +1090,7 @@ pub async fn run_interactive(
                                     text.split_whitespace().next().unwrap_or(""),
                                     "/quit" | "/help" | "/reasoning"
                                 ) {
-                                    renderer.write_line("agent is busy — wait, interrupt (Ctrl+C), or use /quit", C_ERROR)?;
+                                    renderer.write_line("agent is busy — wait, interrupt (Ctrl+C), or use /quit", c_error())?;
                                     renderer.draw_bottom(
                                         &input,
                                         &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1103,12 +1119,12 @@ pub async fn run_interactive(
                                             #[cfg(feature = "semantic")] semantic_manager,
                                         ).await;
                                         if let Err(e) = compress_result {
-                                            renderer.write_line(&format!("compress error: {}", e), C_ERROR)?;
+                                            renderer.write_line(&format!("compress error: {}", e), c_error())?;
                                         }
                                         if let Err(e) = crate::session::storage::save_session(session) {
                                             renderer.write_line(
                                                 &format!("warning: failed to save session: {}", e),
-                                                C_ERROR,
+                                                c_error(),
                                             )?;
                                         }
                                     }
@@ -1172,7 +1188,7 @@ pub async fn run_interactive(
                                             render_session(&mut renderer, session, cli, cfg, context)?;
                                             renderer.write_line(
                                                 &format!("returned to main repo at {}", main_path),
-                                                C_AGENT,
+                                                c_agent(),
                                             )?;
                                         }
                                     }
@@ -1180,7 +1196,7 @@ pub async fn run_interactive(
                                         if e.downcast_ref::<std::io::Error>().is_some_and(|e: &std::io::Error| e.kind() == std::io::ErrorKind::Interrupted) {
                                             break;
                                         }
-                                        renderer.write_line(&format!("error: {}", e), C_ERROR)?;
+                                        renderer.write_line(&format!("error: {}", e), c_error())?;
                                     }
                                     Ok(_) => {
                                         if !cli.no_session
@@ -1188,7 +1204,7 @@ pub async fn run_interactive(
                                         {
                                             renderer.write_line(
                                                 &format!("warning: failed to save session: {}", e),
-                                                C_ERROR,
+                                                c_error(),
                                             )?;
                                         }
                                         #[cfg(feature = "loop")]
@@ -1214,7 +1230,7 @@ pub async fn run_interactive(
                                 {
                                     renderer.write_line(
                                         &format!("warning: failed to save session: {}", e),
-                                        C_ERROR,
+                                        c_error(),
                                     )?;
                                 }
                             } else if is_running {
@@ -1281,7 +1297,7 @@ pub async fn run_interactive(
                                         Err(e) => {
                                             renderer.write_line(
                                                 &format!("[plugin] on-prompt error: {e}"),
-                                                C_ERROR,
+                                                c_error(),
                                             )?;
                                         }
                                     }
@@ -1428,7 +1444,7 @@ pub async fn run_interactive(
                         response_buf.clear();
                         response_start_line = None;
                         let line = format!("◈ {}", format_tool_call_summary(&name, &args));
-                        renderer.write_line(&sanitize_output(&line), C_TOOL)?;
+                        renderer.write_line(&sanitize_output(&line), c_tool())?;
 
                         // Note: on-tool-start fires from HookedToolDyn now,
                         // around the actual tool invocation. The UI no
@@ -1527,7 +1543,7 @@ pub async fn run_interactive(
                                 Err(e) => {
                                     renderer.write_line(
                                         &format!("[plugin] on-response error: {e}"),
-                                        C_ERROR,
+                                        c_error(),
                                     )?;
                                 }
                             }
@@ -1553,7 +1569,7 @@ pub async fn run_interactive(
                                 renderer.render_viewport()?;
                             }
                         } else if !agent_line_started {
-                            renderer.write("< ", C_AGENT)?;
+                            renderer.write("< ", c_agent())?;
                         }
 
                         renderer.write_line("", Color::White)?;
@@ -1584,7 +1600,7 @@ pub async fn run_interactive(
                                 #[cfg(feature = "semantic")] semantic_manager,
                             ).await;
                             if let Err(e) = compress_result {
-                                renderer.write_line(&format!("auto-compact error: {}", e), C_ERROR)?;
+                                renderer.write_line(&format!("auto-compact error: {}", e), c_error())?;
                             }
                         }
 
@@ -1593,7 +1609,7 @@ pub async fn run_interactive(
                         {
                             renderer.write_line(
                                 &format!("warning: failed to save session: {}", e),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                         is_running = false;
@@ -1640,7 +1656,7 @@ pub async fn run_interactive(
                                             "[loop] max iterations ({}) reached, stopping",
                                             ls.iteration
                                         ),
-                                        C_AGENT,
+                                        c_agent(),
                                     )?;
                                     ls.active = false;
                                     loop_label = None;
@@ -1664,7 +1680,7 @@ pub async fn run_interactive(
                                     loop_label = Some(ls.iteration_label());
                                     renderer.write_line(
                                         &format!("[loop] launching {}", ls.iteration_label()),
-                                        C_AGENT,
+                                        c_agent(),
                                     )?;
                                 }
                             }
@@ -1697,13 +1713,13 @@ pub async fn run_interactive(
                                     render_session(&mut renderer, session, cli, cfg, context)?;
                                     renderer.write_line(
                                         &format!("merged and returned to main repo at {}", main_path),
-                                        C_AGENT,
+                                        c_agent(),
                                     )?;
                                 }
                                 Err(e) => {
                                     renderer.write_line(
                                         &format!("warning: failed to change back to main repo: {}", e),
-                                        C_ERROR,
+                                        c_error(),
                                     )?;
                                 }
                             }
@@ -1785,7 +1801,7 @@ pub async fn run_interactive(
                         {
                             renderer.write_line(
                                 &format!("warning: failed to save session: {}", e),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                         is_running = false;
@@ -1826,7 +1842,7 @@ pub async fn run_interactive(
                         was_reasoning = false;
                         last_tool_name = None;
                         let safe = sanitize_output(&e);
-                        renderer.write_line(&format!("error: {}", safe), C_ERROR)?;
+                        renderer.write_line(&format!("error: {}", safe), c_error())?;
 
                         #[cfg(feature = "plugin")]
                         if let Some(pm) = plugin_manager {
@@ -1840,7 +1856,7 @@ pub async fn run_interactive(
                             ) {
                                 renderer.write_line(
                                     &format!("[plugin] on-error error: {dispatch_err}"),
-                                    C_ERROR,
+                                    c_error(),
                                 )?;
                             }
                         }
@@ -1866,7 +1882,7 @@ pub async fn run_interactive(
                                     dropped,
                                     if dropped == 1 { "" } else { "s" }
                                 ),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                     }
@@ -1955,11 +1971,11 @@ pub async fn run_interactive(
 
                 renderer.write_line(
                     &format!("[permission] {}: {}", ask_req.tool, ask_req.input),
-                    C_PERM,
+                    c_perm(),
                 )?;
                 renderer.write_line(
                     "  (y) allow once  (a) allow always  (n) deny  (ESC) abort",
-                    C_PERM,
+                    c_perm(),
                 )?;
 
                 let decision = loop {
@@ -1999,7 +2015,7 @@ pub async fn run_interactive(
                         if let Err(e) = crate::session::storage::save_session(session) {
                             renderer.write_line(
                                 &format!("warning: failed to save session: {}", e),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                     }
@@ -2036,7 +2052,7 @@ pub async fn run_interactive(
                 let (label, color) = match &lifecycle_evt {
                     LifecycleEvent::Started { id } => {
                         let short: String = id.chars().take(8).collect();
-                        (format!("[task {} started]", short), C_TOOL)
+                        (format!("[task {} started]", short), c_tool())
                     }
                     LifecycleEvent::Finished(notif) => {
                         let short: String = notif.id.chars().take(8).collect();
@@ -2046,7 +2062,7 @@ pub async fn run_interactive(
                             }
                             TS::Failed(err) => {
                                 let head = sanitize_single_line(err, 80);
-                                (format!("[task {} failed: {}]", short, head), C_ERROR)
+                                (format!("[task {} failed: {}]", short, head), c_error())
                             }
                             // Running is never queued for notification.
                             TS::Running => continue,
@@ -2086,12 +2102,12 @@ pub async fn run_interactive(
                     if let Some(header) = &question.header {
                         renderer.write_line(
                             &format!("\n--- {} ---", header),
-                            C_PERM,
+                            c_perm(),
                         )?;
                     }
                     renderer.write_line(
                         &format!("\n[question {}] {}", qi + 1, question.question),
-                        C_PERM,
+                        c_perm(),
                     )?;
 
                     let multi = question.multi_select.unwrap_or(false);
@@ -2127,7 +2143,7 @@ pub async fn run_interactive(
                                 text: compact_str::CompactString::new(
                                     &format!("  {} {} — {}", marker, opt.label, opt.description),
                                 ),
-                                color: C_PERM,
+                                color: c_perm(),
                             });
                         }
                         if custom {
@@ -2139,7 +2155,7 @@ pub async fn run_interactive(
                             };
                             lines.push(LineEntry {
                                 text: compact_str::CompactString::new(&custom_label),
-                                color: C_PERM,
+                                color: c_perm(),
                             });
                         }
                         lines.push(LineEntry {
@@ -2148,7 +2164,7 @@ pub async fn run_interactive(
                             } else {
                                 "  ↑↓ navigate  Enter select  Esc reject all"
                             }),
-                            color: C_PERM,
+                            color: c_perm(),
                         });
 
                         // Replace previous render with updated options
@@ -2178,7 +2194,7 @@ pub async fn run_interactive(
                                 if custom && cursor == num_options {
                                     // Custom text input (works for both single and multi)
                                     let mut buf = String::new();
-                                    renderer.write_line("  enter your answer:", C_PERM)?;
+                                    renderer.write_line("  enter your answer:", c_perm())?;
                                     let input_anchor = renderer.buffer_len();
                                     loop {
                                         renderer.replace_from(
@@ -2187,7 +2203,7 @@ pub async fn run_interactive(
                                                 text: compact_str::CompactString::new(
                                                     &format!("  > {}", buf),
                                                 ),
-                                                color: C_PERM,
+                                                color: c_perm(),
                                             }],
                                         );
                                         renderer.render_viewport()?;
@@ -2238,7 +2254,7 @@ pub async fn run_interactive(
                                     if picked.is_empty() {
                                         renderer.write_line(
                                             "  select at least one option",
-                                            C_PERM,
+                                            c_perm(),
                                         )?;
                                     } else {
                                         answers.push(picked);
@@ -2313,11 +2329,11 @@ pub async fn run_interactive(
                     DialogRequest::Confirm { title, question, reply } => {
                         renderer.write_line(
                             &format!("[plugin {}] {}", title, question),
-                            C_PERM,
+                            c_perm(),
                         )?;
                         renderer.write_line(
                             "  (y) yes  (n) no  (ESC) cancel = no",
-                            C_PERM,
+                            c_perm(),
                         )?;
                         let answer = loop {
                             tokio::select! {
@@ -2360,17 +2376,17 @@ pub async fn run_interactive(
                     DialogRequest::Select { title, options, reply } => {
                         renderer.write_line(
                             &format!("[plugin {}] pick one:", title),
-                            C_PERM,
+                            c_perm(),
                         )?;
                         for (i, opt) in options.iter().enumerate() {
                             renderer.write_line(
                                 &format!("  {}: {}", i + 1, opt),
-                                C_PERM,
+                                c_perm(),
                             )?;
                         }
                         renderer.write_line(
                             "  (1-9) select  (ESC) cancel",
-                            C_PERM,
+                            c_perm(),
                         )?;
                         let answer: Option<String> = loop {
                             tokio::select! {
@@ -2438,7 +2454,7 @@ pub async fn run_interactive(
 
                 renderer.write_line(
                     &format!("[plan] switch to {}? (y/n)", label),
-                    C_PERM,
+                    c_perm(),
                 )?;
 
                 let accepted = loop {
@@ -2492,7 +2508,7 @@ pub async fn run_interactive(
                         if let Err(e) = render_session(&mut renderer, session, cli, cfg, context) {
                             renderer.write_line(
                                 &format!("render error: {}", e),
-                                resolve_color(C_ERROR, cli.no_color),
+                                resolve_color(c_error(), cli.no_color),
                             )?;
                         }
                     }
@@ -2593,7 +2609,7 @@ fn update_search(renderer: &Renderer, query: &str, matches: &mut Vec<usize>, sel
 }
 
 fn draw_search_bar(query: &str, matches: &[usize], selected: usize) -> std::io::Result<()> {
-    use crossterm::style::{Color, ResetColor, SetForegroundColor};
+    use crossterm::style::{ResetColor, SetForegroundColor};
     use crossterm::terminal::{Clear, ClearType};
     use std::io::Write;
 
@@ -2606,7 +2622,7 @@ fn draw_search_bar(query: &str, matches: &[usize], selected: usize) -> std::io::
     };
     let bar = format!("Search: {} [{}]", query, indicator);
     crossterm::execute!(stdout, Clear(ClearType::CurrentLine))?;
-    crossterm::execute!(stdout, SetForegroundColor(Color::Cyan))?;
+    crossterm::execute!(stdout, SetForegroundColor(theme::accent()))?;
     write!(stdout, "\r\n")?;
     write!(stdout, "{}", bar)?;
     crossterm::execute!(stdout, ResetColor)?;
@@ -2650,7 +2666,7 @@ fn rewind_session(
         let removed = session.messages.len() - msg_idx;
         session.messages.truncate(msg_idx);
         session.total_estimated_tokens = session.messages.iter().map(|m| m.estimated_tokens).sum();
-        renderer.write_line(&format!("rewound {} message(s)", removed), Color::Cyan)?;
+        renderer.write_line(&format!("rewound {} message(s)", removed), theme::accent())?;
     }
     Ok(())
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1433,6 +1433,12 @@ pub async fn run_interactive(
                     }
                     AgentEvent::ToolCall { name, args } => {
                         was_reasoning = false;
+                        // If a previous tool's chamber never closed
+                        // (errored without a ToolResult, etc.), close
+                        // it before opening the new one. Without this
+                        // the new `╭─ NAME ─ args` lands inside the
+                        // stale chamber.
+                        close_tool_chamber_if_open(&mut renderer, &mut last_tool_name)?;
                         last_tool_name = Some(name.to_string());
                         if agent_line_started {
                             renderer.write_line("", Color::White)?;
@@ -1800,7 +1806,7 @@ pub async fn run_interactive(
                     }
                     AgentEvent::Interjected { partial_response, tokens } => {
                         was_reasoning = false;
-                        last_tool_name = None;
+                        close_tool_chamber_if_open(&mut renderer, &mut last_tool_name)?;
 
                         // Finalize whatever assistant text streamed so far so
                         // the conversation history reflects what the user saw,
@@ -1882,7 +1888,7 @@ pub async fn run_interactive(
                     }
                     AgentEvent::Error(e) => {
                         was_reasoning = false;
-                        last_tool_name = None;
+                        close_tool_chamber_if_open(&mut renderer, &mut last_tool_name)?;
                         let safe = sanitize_output(&e);
                         renderer.write_line(&format!("error: {}", safe), c_error())?;
 
@@ -2011,6 +2017,12 @@ pub async fn run_interactive(
                     agent_line_started = false;
                 }
 
+                // If a tool chamber is open (the in-flight tool that
+                // triggered this permission check), close it first so
+                // the alert renders outside the chamber rather than
+                // nested inside it.
+                close_tool_chamber_if_open(&mut renderer, &mut last_tool_name)?;
+
                 // Framed permission prompt. The double-bar border +
                 // ALERT wordmark visually arrests the eye — this is
                 // the single most important UX moment and the user
@@ -2038,8 +2050,8 @@ pub async fn run_interactive(
                 let decision = loop {
                     tokio::select! {
                         Some(ev) = user_rx.recv() => {
-                            if let UserEvent::Key(key) = ev {
-                                match key.code {
+                            match ev {
+                                UserEvent::Key(key) => match key.code {
                                     KeyCode::Char('y') => break UserDecision::AllowOnce,
                                     KeyCode::Char('a') => {
                                         let pattern = suggest_pattern(&ask_req.tool, &ask_req.input);
@@ -2051,7 +2063,21 @@ pub async fn run_interactive(
                                     }
                                     KeyCode::Char('n') | KeyCode::Esc => break UserDecision::Deny,
                                     _ => {}
+                                },
+                                // Keep scroll responsive while the
+                                // alert is up — previously these
+                                // events were dropped on the floor
+                                // inside this loop, locking the chat
+                                // viewport.
+                                UserEvent::ScrollUp => {
+                                    renderer.scroll_line_up();
+                                    renderer.render_viewport()?;
                                 }
+                                UserEvent::ScrollDown => {
+                                    renderer.scroll_line_down();
+                                    renderer.render_viewport()?;
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -2626,6 +2652,24 @@ fn suggest_pattern(tool: &str, input: &str) -> String {
         }
         _ => "*".to_string(),
     }
+}
+
+/// Close the in-flight tool chamber if one is open. Used at every
+/// site that fires without going through `render_tool_output` (which
+/// closes the chamber itself): permission alerts, agent errors,
+/// interjections, fresh `ToolCall` events when the previous chamber
+/// wasn't terminated by a `ToolResult`. Idempotent — calling twice
+/// emits one bottom border at most.
+fn close_tool_chamber_if_open(
+    renderer: &mut Renderer,
+    last_tool_name: &mut Option<String>,
+) -> anyhow::Result<()> {
+    if last_tool_name.is_some() {
+        let (frame_w, _) = chamber_widths(renderer);
+        renderer.write_line(&chamber_bottom(frame_w), theme::dim())?;
+        *last_tool_name = None;
+    }
+    Ok(())
 }
 
 fn render_tool_output(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1440,17 +1440,27 @@ pub async fn run_interactive(
                         }
                         response_buf.clear();
                         response_start_line = None;
-                        // Tool-call line: rounded chamber header with
-                        // the tool name on the border. Output lines
-                        // below get `│ ` chamber prefixes; the chamber
-                        // is closed with `╰─` after the ToolResult.
+                        // Tool-call line: rounded chamber TOP border
+                        // with the tool name on it. Output lines below
+                        // get `│ ` chamber rows; the chamber is closed
+                        // by `╰────╯` after the ToolResult. Header
+                        // border pads with dashes out to the frame
+                        // width so it visually mates with the closing
+                        // bottom border (matching btop's framed cards).
                         let upper = name.to_ascii_uppercase();
                         let summary = format_tool_call_summary(&name, &args);
                         let trimmed = summary
                             .strip_prefix(&format!("{} ", name))
                             .unwrap_or(&summary);
-                        let line = format!("╭─ {} ─ {}", upper, trimmed);
-                        renderer.write_line(&sanitize_output(&line), c_tool())?;
+                        let pre = format!("╭─ {} ─ {} ", upper, trimmed);
+                        let pre_clean = sanitize_output(&pre).into_string();
+                        let (frame_w, _) = chamber_widths(&renderer);
+                        let pre_len = pre_clean.chars().count();
+                        let dashes = frame_w
+                            .saturating_sub(pre_len + 1) // 1 for closing ╮
+                            .max(0);
+                        let header = format!("{}{}╮", pre_clean, "─".repeat(dashes));
+                        renderer.write_line(&header, c_tool())?;
 
                         // Note: on-tool-start fires from HookedToolDyn now,
                         // around the actual tool invocation. The UI no
@@ -1480,38 +1490,58 @@ pub async fn run_interactive(
                                     .iter()
                                     .position(|l| l.starts_with("--- a/"));
                                 if let Some(pre) = diff_start {
-                                    // Show non-diff prefix in the
-                                    // chamber so it sits visually
-                                    // attached to the tool-call banner.
+                                    let (frame_w, inner) = chamber_widths(&renderer);
+                                    // Pre-diff prose (the edit tool's
+                                    // header line, etc.) renders in
+                                    // the chamber's standard tone.
                                     for l in &lines[..pre] {
                                         if !l.is_empty() {
+                                            let txt = sanitize_output(l).into_string();
                                             renderer.write_line(
-                                                &format!("│ {}", sanitize_output(l)),
+                                                &chamber_row(&txt, inner),
                                                 theme::result(),
                                             )?;
                                         }
                                     }
-                                    // Show colorized diff. Each line gets
-                                    // the `│ ` chamber prefix so the diff
-                                    // sits inside the tool's frame.
+                                    // Colorized diff with opencode-style
+                                    // tinted backgrounds: + lines get a
+                                    // dim-green bg (palette 22), - lines
+                                    // get a dim-red bg (palette 52).
+                                    // Header (`--- ` / `+++ ` / `@@`) and
+                                    // context lines have no bg.
                                     for l in &lines[pre..] {
-                                        let painted = if l.starts_with("--- ") || l.starts_with("+++ ") {
-                                            (Color::Cyan, sanitize_output(l).into_string())
+                                        let txt = sanitize_output(l).into_string();
+                                        if l.starts_with("--- ") || l.starts_with("+++ ") {
+                                            renderer.write_line(
+                                                &chamber_row(&txt, inner),
+                                                Color::Cyan,
+                                            )?;
                                         } else if l.starts_with("@@") {
-                                            (Color::DarkCyan, sanitize_output(l).into_string())
+                                            renderer.write_line(
+                                                &chamber_row(&txt, inner),
+                                                Color::DarkCyan,
+                                            )?;
                                         } else if l.starts_with('+') {
-                                            (Color::Green, sanitize_output(l).into_string())
+                                            renderer.write_line(
+                                                &chamber_row_with_bg(&txt, inner, 22),
+                                                Color::Green,
+                                            )?;
                                         } else if l.starts_with('-') {
-                                            (Color::Red, sanitize_output(l).into_string())
+                                            renderer.write_line(
+                                                &chamber_row_with_bg(&txt, inner, 52),
+                                                Color::Red,
+                                            )?;
                                         } else {
-                                            (theme::dim(), sanitize_output(l).into_string())
-                                        };
-                                        renderer.write_line(
-                                            &format!("│ {}", painted.1),
-                                            painted.0,
-                                        )?;
+                                            renderer.write_line(
+                                                &chamber_row(&txt, inner),
+                                                theme::dim(),
+                                            )?;
+                                        }
                                     }
-                                    renderer.write_line("╰─", theme::dim())?;
+                                    renderer.write_line(
+                                        &chamber_bottom(frame_w),
+                                        theme::dim(),
+                                    )?;
                                 } else {
                                     // No diff section found, show normally
                                     render_tool_output(
@@ -2610,19 +2640,83 @@ fn render_tool_output(
     } else {
         sanitized.chars().take(max_chars).collect()
     };
-    // Tool output renders inside a rounded chamber attached to the
-    // tool-call header (`╭─ NAME ─ args` above). Every line gets a
-    // `│ ` chamber prefix; the chamber is closed by a `╰─` footer
-    // so the eye can scan tool boundaries top-to-bottom.
+    // Tool output renders inside a closed rounded chamber:
+    //   ╭─ READ ─ /path
+    //   │ contents ...                    │
+    //   ╰─────────────────────────────────╯
+    // Lines are padded/truncated to a fixed inner width so the right
+    // border stays aligned across the chamber.
+    let (frame_w, inner) = chamber_widths(renderer);
     for line in body.lines() {
-        renderer.write_line(&format!("│ {}", line), theme::result())?;
+        renderer.write_line(&chamber_row(line, inner), theme::result())?;
     }
     if char_count > max_chars {
         let remaining = char_count - max_chars;
-        renderer.write_line(&format!("│ ░ +{} chars truncated", remaining), theme::dim())?;
+        let note = format!("░ +{} chars truncated", remaining);
+        renderer.write_line(&chamber_row(&note, inner), theme::dim())?;
     }
-    renderer.write_line("╰─", theme::dim())?;
+    renderer.write_line(&chamber_bottom(frame_w), theme::dim())?;
     Ok(())
+}
+
+/// Standard tool-chamber widths derived from the renderer's content
+/// area. Capped at 120 so very wide terminals don't produce sprawling
+/// chambers that overwhelm the content.
+fn chamber_widths(renderer: &Renderer) -> (usize, usize) {
+    let term_w = renderer.line_width().max(20);
+    let frame_w = term_w.min(120);
+    let inner = frame_w.saturating_sub(4); // `│ ` + ` │`
+    (frame_w, inner)
+}
+
+/// `╰────────────╯` footer of a tool chamber, sized to `frame_w`.
+fn chamber_bottom(frame_w: usize) -> String {
+    format!("╰{}╯", "─".repeat(frame_w.saturating_sub(2)))
+}
+
+/// `│ content (truncated/padded to inner) │` row of a tool chamber.
+fn chamber_row(content: &str, inner: usize) -> String {
+    let chars: Vec<char> = content.chars().collect();
+    let trimmed: String = if chars.len() <= inner {
+        chars.iter().collect()
+    } else if inner == 0 {
+        String::new()
+    } else {
+        let mut out: String = chars[..inner.saturating_sub(1)].iter().collect();
+        out.push('…');
+        out
+    };
+    let pad = inner.saturating_sub(trimmed.chars().count());
+    format!("│ {}{} │", trimmed, " ".repeat(pad))
+}
+
+/// Background-tinted chamber row for diff `+`/`-` lines. Emits raw
+/// SGR `48;5;{bg}` background sequence inside the row so the diff
+/// tint fills the inner width; the left + right border glyphs sit
+/// outside the bg span so they keep the chamber color.
+///
+/// Opencode uses subtly-tinted backgrounds (`tint(bg, green, 0.15)`
+/// etc.) to mark added/removed lines without overwhelming the
+/// scanability. We approximate that with the 256-color palette:
+/// dim green (22) for adds, dim red (52) for removes.
+fn chamber_row_with_bg(content: &str, inner: usize, bg_idx: u8) -> String {
+    let chars: Vec<char> = content.chars().collect();
+    let trimmed: String = if chars.len() <= inner {
+        chars.iter().collect()
+    } else if inner == 0 {
+        String::new()
+    } else {
+        let mut out: String = chars[..inner.saturating_sub(1)].iter().collect();
+        out.push('…');
+        out
+    };
+    let pad = inner.saturating_sub(trimmed.chars().count());
+    format!(
+        "│ \x1b[48;5;{}m{}{}\x1b[49m │",
+        bg_idx,
+        trimmed,
+        " ".repeat(pad),
+    )
 }
 
 fn update_search(renderer: &Renderer, query: &str, matches: &mut Vec<usize>, selected: &mut usize) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1039,7 +1039,7 @@ pub async fn run_interactive(
                                 }
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("<you>   {}", safe_line), theme::user())?;
                                 }
                                 renderer.write_line("", Color::White)?;
                                 match prefix {
@@ -1097,7 +1097,7 @@ pub async fn run_interactive(
                                 }
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("<you>   {}", safe_line), theme::user())?;
                                 }
                                 renderer.write_line("", Color::White)?;
                                 let result = handle_slash(&text, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut is_running, &mut input, &permission, &ask_tx, &mut todo_tools_enabled, &bg_store, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager, #[cfg(feature = "semantic")] semantic_manager).await;
@@ -1261,7 +1261,7 @@ pub async fn run_interactive(
                             } else {
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
-                                    renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    renderer.write_line(&format!("<you>   {}", safe_line), theme::user())?;
                                 }
                                 renderer.write_line("", Color::White)?;
 
@@ -1367,7 +1367,7 @@ pub async fn run_interactive(
                             continue;
                         }
                         if !agent_line_started {
-                            renderer.write("< ", Color::DarkMagenta)?;
+                            renderer.write("<dirge> ", Color::DarkMagenta)?;
                             agent_line_started = true;
                         }
                         let safe = sanitize_output(&text);
@@ -1418,7 +1418,7 @@ pub async fn run_interactive(
 
                         if !styled.is_empty() {
                             styled[0].text =
-                                CompactString::from(format!("< {}", styled[0].text));
+                                CompactString::from(format!("<dirge> {}", styled[0].text));
                         }
 
                         if let Some(start) = response_start_line {
@@ -1440,19 +1440,16 @@ pub async fn run_interactive(
                         }
                         response_buf.clear();
                         response_start_line = None;
-                        // Tool-call line: framed BBS-style banner that
-                        // visually demarcates the agent's tool use from
-                        // its prose. `▒░ NAME ░▒ args…` puts the tool
-                        // name on a small gradient pedestal so the eye
-                        // immediately sees what's running.
+                        // Tool-call line: rounded chamber header with
+                        // the tool name on the border. Output lines
+                        // below get `│ ` chamber prefixes; the chamber
+                        // is closed with `╰─` after the ToolResult.
                         let upper = name.to_ascii_uppercase();
                         let summary = format_tool_call_summary(&name, &args);
-                        // Strip the leading "name " that format_tool_call_summary
-                        // produces, since the framed badge already shows it.
                         let trimmed = summary
                             .strip_prefix(&format!("{} ", name))
                             .unwrap_or(&summary);
-                        let line = format!("▒░ {} ░▒ {}", upper, trimmed);
+                        let line = format!("╭─ {} ─ {}", upper, trimmed);
                         renderer.write_line(&sanitize_output(&line), c_tool())?;
 
                         // Note: on-tool-start fires from HookedToolDyn now,
@@ -1489,28 +1486,32 @@ pub async fn run_interactive(
                                     for l in &lines[..pre] {
                                         if !l.is_empty() {
                                             renderer.write_line(
-                                                &format!("▏ {}", sanitize_output(l)),
+                                                &format!("│ {}", sanitize_output(l)),
                                                 theme::result(),
                                             )?;
                                         }
                                     }
-                                    // Show colorized diff
+                                    // Show colorized diff. Each line gets
+                                    // the `│ ` chamber prefix so the diff
+                                    // sits inside the tool's frame.
                                     for l in &lines[pre..] {
-                                        if l.starts_with("--- ") || l.starts_with("+++ ") {
-                                            renderer.write_line(l, Color::Cyan)?;
+                                        let painted = if l.starts_with("--- ") || l.starts_with("+++ ") {
+                                            (Color::Cyan, sanitize_output(l).into_string())
                                         } else if l.starts_with("@@") {
-                                            renderer.write_line(l, Color::DarkCyan)?;
+                                            (Color::DarkCyan, sanitize_output(l).into_string())
                                         } else if l.starts_with('+') {
-                                            renderer.write_line(l, Color::Green)?;
+                                            (Color::Green, sanitize_output(l).into_string())
                                         } else if l.starts_with('-') {
-                                            renderer.write_line(l, Color::Red)?;
+                                            (Color::Red, sanitize_output(l).into_string())
                                         } else {
-                                            renderer.write_line(
-                                                &sanitize_output(l),
-                                                theme::dim(),
-                                            )?;
-                                        }
+                                            (theme::dim(), sanitize_output(l).into_string())
+                                        };
+                                        renderer.write_line(
+                                            &format!("│ {}", painted.1),
+                                            painted.0,
+                                        )?;
                                     }
+                                    renderer.write_line("╰─", theme::dim())?;
                                 } else {
                                     // No diff section found, show normally
                                     render_tool_output(
@@ -1573,14 +1574,14 @@ pub async fn run_interactive(
                             );
                             if !styled.is_empty() {
                                 styled[0].text =
-                                    CompactString::from(format!("< {}", styled[0].text));
+                                    CompactString::from(format!("<dirge> {}", styled[0].text));
                             }
                             if let Some(start) = response_start_line {
                                 renderer.replace_from(start, styled);
                                 renderer.render_viewport()?;
                             }
                         } else if !agent_line_started {
-                            renderer.write("< ", c_agent())?;
+                            renderer.write("<dirge> ", c_agent())?;
                         }
 
                         renderer.write_line("", Color::White)?;
@@ -1747,7 +1748,7 @@ pub async fn run_interactive(
                             for line in combined.lines() {
                                 let safe_line = sanitize_output(line);
                                 renderer
-                                    .write_line(&format!("> {}", safe_line), Color::Green)?;
+                                    .write_line(&format!("<you>   {}", safe_line), theme::user())?;
                             }
                             renderer.write_line("", Color::White)?;
 
@@ -1782,7 +1783,7 @@ pub async fn run_interactive(
                             );
                             if !styled.is_empty() {
                                 styled[0].text =
-                                    CompactString::from(format!("< {}", styled[0].text));
+                                    CompactString::from(format!("<dirge> {}", styled[0].text));
                             }
                             if let Some(start) = response_start_line {
                                 renderer.replace_from(start, styled);
@@ -1829,7 +1830,7 @@ pub async fn run_interactive(
                             let combined = queued.join("\n\n");
                             for line in combined.lines() {
                                 let safe_line = sanitize_output(line);
-                                renderer.write_line(&format!("> {}", safe_line), Color::Green)?;
+                                renderer.write_line(&format!("<you>   {}", safe_line), theme::user())?;
                             }
                             renderer.write_line("", Color::White)?;
 
@@ -1987,21 +1988,22 @@ pub async fn run_interactive(
                 // independent of terminal width; the chat area
                 // requires at least 60 cols anyway.
                 const BOX_W: usize = 64;
-                let top_label = "╔══[ ⚠ ALERT · PERMISSION ]";
-                let top_pad = BOX_W.saturating_sub(top_label.chars().count() + 1);
-                let bot_bar = "═".repeat(BOX_W.saturating_sub(2));
+                let pre = "╭─ ⚠ ALERT · PERMISSION ";
+                let pre_len = pre.chars().count();
+                let top_fill = BOX_W.saturating_sub(pre_len + 1);
+                let bot_bar = "─".repeat(BOX_W.saturating_sub(2));
                 renderer.write_line(
-                    &format!("{}{}╗", top_label, "═".repeat(top_pad)),
+                    &format!("{}{}╮", pre, "─".repeat(top_fill)),
                     c_perm(),
                 )?;
-                renderer.write_line(&format!("║ tool : {}", ask_req.tool), c_perm())?;
-                renderer.write_line(&format!("║ args : {}", ask_req.input), c_perm())?;
-                renderer.write_line(&format!("╠{}╣", bot_bar), c_perm())?;
+                renderer.write_line(&format!("│ tool : {}", ask_req.tool), c_perm())?;
+                renderer.write_line(&format!("│ args : {}", ask_req.input), c_perm())?;
+                renderer.write_line(&format!("├{}┤", bot_bar), c_perm())?;
                 renderer.write_line(
-                    "║  (y) allow once   (a) allow always   (n) deny   (ESC) abort",
+                    "│ [y] allow once  [a] allow always  [n] deny  [ESC] abort",
                     c_perm(),
                 )?;
-                renderer.write_line(&format!("╚{}╝", bot_bar), c_perm())?;
+                renderer.write_line(&format!("╰{}╯", bot_bar), c_perm())?;
 
                 let decision = loop {
                     tokio::select! {
@@ -2608,19 +2610,18 @@ fn render_tool_output(
     } else {
         sanitized.chars().take(max_chars).collect()
     };
-    // Prefix every output line with `▏ ` so the tool's text reads
-    // like a chamber attached to the tool-call banner above. Empty
-    // lines still get the prefix so the chamber stays continuous.
+    // Tool output renders inside a rounded chamber attached to the
+    // tool-call header (`╭─ NAME ─ args` above). Every line gets a
+    // `│ ` chamber prefix; the chamber is closed by a `╰─` footer
+    // so the eye can scan tool boundaries top-to-bottom.
     for line in body.lines() {
-        renderer.write_line(&format!("▏ {}", line), theme::result())?;
+        renderer.write_line(&format!("│ {}", line), theme::result())?;
     }
     if char_count > max_chars {
         let remaining = char_count - max_chars;
-        renderer.write_line(
-            &format!("▏ ░░ +{} chars truncated ░░", remaining),
-            theme::dim(),
-        )?;
+        renderer.write_line(&format!("│ ░ +{} chars truncated", remaining), theme::dim())?;
     }
+    renderer.write_line("╰─", theme::dim())?;
     Ok(())
 }
 

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -83,17 +83,26 @@ impl ListPicker {
     pub fn draw(&self) -> std::io::Result<()> {
         use std::io::Write;
         let mut stdout = std::io::stdout();
-        crossterm::execute!(stdout, SetForegroundColor(self.color(Color::Cyan)),)?;
+        crossterm::execute!(
+            stdout,
+            SetForegroundColor(self.color(crate::ui::theme::accent())),
+        )?;
         writeln!(stdout, "  {}", self.prompt)?;
         writeln!(stdout)?;
 
         for (i, item) in self.items.iter().enumerate() {
             let truncated: String = item.chars().take(60).collect();
             if i == self.selected {
-                crossterm::execute!(stdout, SetForegroundColor(self.color(Color::Green)),)?;
+                crossterm::execute!(
+                    stdout,
+                    SetForegroundColor(self.color(crate::ui::theme::accent())),
+                )?;
                 writeln!(stdout, " ▸ {}", truncated)?;
             } else {
-                crossterm::execute!(stdout, SetForegroundColor(self.color(Color::DarkGrey)),)?;
+                crossterm::execute!(
+                    stdout,
+                    SetForegroundColor(self.color(crate::ui::theme::dim())),
+                )?;
                 writeln!(stdout, "   {}", truncated)?;
             }
         }
@@ -247,7 +256,7 @@ impl FilePicker {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkGrey))
+                SetForegroundColor(self.color(crate::ui::theme::dim()))
             )?;
             write!(stdout, "{}", "no matches")?;
             write!(stdout, "{}", ResetColor)?;
@@ -281,13 +290,17 @@ impl FilePicker {
                 .collect();
 
             if i == self.selected {
-                write!(stdout, "{}", SetForegroundColor(self.color(Color::Green)))?;
+                write!(
+                    stdout,
+                    "{}",
+                    SetForegroundColor(self.color(crate::ui::theme::accent()))
+                )?;
                 write!(stdout, "▸ {}", truncated)?;
             } else {
                 write!(
                     stdout,
                     "{}",
-                    SetForegroundColor(self.color(Color::DarkGrey))
+                    SetForegroundColor(self.color(crate::ui::theme::dim()))
                 )?;
                 write!(stdout, "  {}", truncated)?;
             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -644,10 +644,11 @@ impl Renderer {
         let cursor_line_idx = full_input[..cursor_line_start].matches('\n').count();
         let cursor_col_in_line = full_cursor - cursor_line_start;
 
-        // Wrap width: content width minus the 2-char prompt prefix that
-        // sits in front of every visible row. Min 1 to avoid div-by-zero in
-        // wrap math on ridiculous terminal sizes.
-        let wrap_width = (cols.saturating_sub(2) as usize).max(1);
+        // Wrap width: content width minus the 3-char prompt prefix
+        // (`▌▌ ` idle, `░▌ `/`▒▌ ` spinner, `▏  ` continuation — all 3
+        // columns) that sits in front of every visible row. Min 1 to
+        // avoid div-by-zero in wrap math on ridiculous terminal sizes.
+        let wrap_width = (cols.saturating_sub(3) as usize).max(1);
 
         // Pre-render each logical line (placeholder expansion etc.) into the
         // displayable form, alongside the cursor's display column on its line.
@@ -778,7 +779,8 @@ impl Renderer {
         // Place the visible cursor on its row at the right column.
         let cursor_row =
             input_top + (cursor_visual_row.saturating_sub(first_visible_visual)) as u16;
-        let cursor_x = (2 + cursor_visual_col).min(cols.saturating_sub(1) as usize) as u16;
+        // Match the 3-column prompt prefix used in the loop above.
+        let cursor_x = (3 + cursor_visual_col).min(cols.saturating_sub(1) as usize) as u16;
         stdout.execute(MoveTo(cursor_x, cursor_row))?;
 
         if self.panel_visible() {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -745,13 +745,22 @@ impl Renderer {
             } else {
                 write!(stdout, "{}", prompt_cont)?;
             }
-            write!(stdout, "{}", ResetColor)?;
+            // Switch to the user-input text tone (bright phosphor)
+            // before writing what the user typed, so the prompt
+            // accent and the input text are visually distinct but
+            // both on the green axis.
+            write!(
+                stdout,
+                "{}",
+                SetForegroundColor(self.color(crate::ui::theme::user()))
+            )?;
             if let Some(vr) = visual_rows.get(vr_idx)
                 && let Some(chars) = display_chars.get(vr.logical_line)
             {
                 let slice: String = chars[vr.char_start..vr.char_end].iter().collect();
                 write!(stdout, "{}", slice)?;
             }
+            write!(stdout, "{}", ResetColor)?;
         }
 
         // Status row.
@@ -885,49 +894,57 @@ impl Renderer {
             }
         };
 
-        // Panel top: rounded-corner SYS header with label-on-border,
-        // mirroring the btop reference where every region is wrapped
-        // in `╭─ Label ─╮` frames. This panel has no right border
-        // (it's a vertical strip), so we use a half-frame
-        // `╭─ Label ────`.
+        // Inner width inside the frame's left+right borders.
+        let inner = width.saturating_sub(2);
+        // Helper: format a content row inside a closed pill — left
+        // border, padded content, right border. Truncates content
+        // that overflows so the pill stays a perfect rectangle.
+        let row = |text: &str| -> String {
+            let trimmed = truncate(text, inner);
+            let len = trimmed.chars().count();
+            let pad = inner.saturating_sub(len);
+            format!("│{}{}│", trimmed, " ".repeat(pad))
+        };
+        // Helper: bottom border of a pill (`╰────────╯`).
+        let bottom = || -> String { format!("╰{}╯", "─".repeat(inner)) };
+
+        // Panel top pill: `╭─ DIRGE.SYS ────╮` … `╰──────────╯`.
         let dirge_label = " DIRGE.SYS ";
         let dirge_pre_len = dirge_label.chars().count() + 2;
-        let dirge_dashes = width.saturating_sub(dirge_pre_len);
+        let dirge_dashes = inner.saturating_sub(dirge_label.chars().count() + 1);
+        let _ = dirge_pre_len;
         out.push((
-            format!("╭─{}{}", dirge_label, "─".repeat(dirge_dashes)),
+            format!("╭─{}{}╮", dirge_label, "─".repeat(dirge_dashes)),
             Color::Cyan,
         ));
-        out.push((truncate(&format!("│ {}", d.cwd), width), Color::White));
+        out.push((row(&format!(" {}", d.cwd)), Color::White));
+        out.push((bottom(), Color::Cyan));
 
-        // Section helper: rounded-corner half-frame with the section
-        // name living *on* the border (`╭─ MCP ─────`). The `│`
-        // left-bar continues down the section so each block reads as
-        // a vertical chamber. Empty sections show `│ · (none)` in the
-        // dim phosphor tone rather than grey.
+        // Section helper: closed pill with the section name on the
+        // top border (`╭─ MCP ─────╮ … ╰────────╯`). Every content
+        // row gets a `│ … │` left+right border so the section reads
+        // as a discrete card, matching the btop / cool-retro-term
+        // reference. Empty sections show `· (none)` in the dim
+        // phosphor tone rather than grey.
         let push_section =
             |out: &mut Vec<(String, Color)>, title: &str, items: Vec<(String, Color)>| {
                 out.push((String::new(), Color::Reset));
                 let label = format!(" {} ", title);
-                let pre_len = label.chars().count() + 2;
-                let dashes = width.saturating_sub(pre_len);
-                let header = format!("╭─{}{}", label, "─".repeat(dashes));
-                out.push((truncate(&header, width), Color::Cyan));
+                let pre_len = label.chars().count() + 1;
+                let dashes = inner.saturating_sub(pre_len);
+                let header = format!("╭─{}{}╮", label, "─".repeat(dashes));
+                out.push((header, Color::Cyan));
                 if items.is_empty() {
-                    out.push((truncate("│ · (none)", width), Color::Reset));
+                    out.push((row(" · (none)"), Color::Reset));
                 } else {
                     for (text, color) in items {
-                        // Items already arrive with a leading "  ";
-                        // swap that for "│ " so the chamber bar runs
-                        // continuously down the left edge of the
-                        // section.
-                        let prefixed = if let Some(rest) = text.strip_prefix("  ") {
-                            format!("│ {}", rest)
-                        } else {
-                            format!("│ {}", text)
-                        };
-                        out.push((truncate(&prefixed, width), color));
+                        // Items arrive with a leading "  "; strip it
+                        // and let `row` re-add the chamber prefix.
+                        let content = text.strip_prefix("  ").unwrap_or(&text);
+                        out.push((row(&format!(" {}", content)), color));
                     }
                 }
+                out.push((bottom(), Color::Cyan));
             };
 
         let mcp_items: Vec<(String, Color)> = d

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -157,6 +157,22 @@ impl Renderer {
         self.max_line_width()
     }
 
+    /// Target width for chat content. Caps at 120 cols so wide
+    /// terminals don't stretch chambers + chat lines into sprawling
+    /// rivers of text. Matches the cap used by tool chambers.
+    pub fn content_width(&self) -> usize {
+        self.line_width().min(120)
+    }
+
+    /// Left padding in columns to horizontally center the chat
+    /// content area (`content_width`) within the visible chat band
+    /// (`line_width`). Zero when content already fills the band.
+    pub fn content_indent(&self) -> usize {
+        let band = self.line_width();
+        let target = self.content_width();
+        band.saturating_sub(target) / 2
+    }
+
     pub fn buffer_len(&self) -> usize {
         self.buffer.len()
     }
@@ -373,12 +389,23 @@ impl Renderer {
         // `content_cols`). All chat text is clipped here; the remaining
         // columns belong to the divider + panel.
         let content_band = content_cols.saturating_sub(1) as usize;
+        // Left indent in columns to horizontally center chat content
+        // inside the band. We then clip the per-line text to
+        // `content_band - indent` so wide content can't spill into
+        // the divider/panel.
+        let indent = self.content_indent();
+        let line_cap = content_band.saturating_sub(indent);
         for i in 0..visible {
             stdout.execute(MoveTo(0, i as u16))?;
+            // Paint indent spaces (no color) so any stale text on the
+            // left edge from a wider previous line gets wiped.
+            if indent > 0 {
+                write!(stdout, "{}", " ".repeat(indent))?;
+            }
             let text_chars: usize = if start + i < end {
                 let entry = &self.buffer[start + i];
                 let line_idx = start + i;
-                let text: String = entry.text.chars().take(content_band).collect();
+                let text: String = entry.text.chars().take(line_cap).collect();
                 let actual_chars = text.chars().count();
 
                 let is_selected = self.selection_active
@@ -420,9 +447,12 @@ impl Renderer {
                 0
             };
             if self.panel_visible() {
-                // Manually pad to the content band; ClearType::UntilNewLine
-                // would wipe the panel area to our right.
-                let pad = content_band.saturating_sub(text_chars);
+                // Pad to fill the content band so stale chars from
+                // wider previous lines get wiped. With centering,
+                // the written length per row is `indent + text_chars`;
+                // the trailing pad fills `content_band - (indent + text)`.
+                let written = indent + text_chars;
+                let pad = content_band.saturating_sub(written);
                 if pad > 0 {
                     write!(stdout, "{}", " ".repeat(pad))?;
                 }
@@ -728,12 +758,16 @@ impl Renderer {
         let display_chars: Vec<Vec<char>> =
             display_lines.iter().map(|s| s.chars().collect()).collect();
 
+        // Input rows + status row also center under the chat band so
+        // the prompt + status visually align with the chat content
+        // above.
+        let bottom_indent = self.content_indent();
         for row_offset in 0..visible_input_rows {
             let row = input_top + row_offset as u16;
             let vr_idx = first_visible_visual + row_offset;
             stdout.execute(MoveTo(0, row))?;
             write!(stdout, "{}", " ".repeat(cols as usize))?;
-            stdout.execute(MoveTo(0, row))?;
+            stdout.execute(MoveTo(bottom_indent as u16, row))?;
             write!(
                 stdout,
                 "{}",
@@ -763,10 +797,10 @@ impl Renderer {
             write!(stdout, "{}", ResetColor)?;
         }
 
-        // Status row.
+        // Status row — also centered under the chat band.
         stdout.execute(MoveTo(0, status_row))?;
         write!(stdout, "{}", " ".repeat(cols as usize))?;
-        stdout.execute(MoveTo(0, status_row))?;
+        stdout.execute(MoveTo(bottom_indent as u16, status_row))?;
         write!(
             stdout,
             "{}",
@@ -803,7 +837,10 @@ impl Renderer {
         let cursor_row =
             input_top + (cursor_visual_row.saturating_sub(first_visible_visual)) as u16;
         // Match the 3-column prompt prefix used in the loop above.
-        let cursor_x = (3 + cursor_visual_col).min(cols.saturating_sub(1) as usize) as u16;
+        // Match the indented prompt (`bottom_indent + 3-col prompt
+        // prefix` + cursor offset within content).
+        let cursor_x =
+            (bottom_indent + 3 + cursor_visual_col).min(cols.saturating_sub(1) as usize) as u16;
         stdout.execute(MoveTo(cursor_x, cursor_row))?;
 
         if self.panel_visible() {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -521,6 +521,7 @@ impl Renderer {
     pub fn write_line(&mut self, text: &str, color: Color) -> io::Result<()> {
         self.commit_partial();
         let max_width = self.max_line_width();
+        let indent = self.content_indent();
         for segment in text.split('\n') {
             let wrapped = self.wrap_line(segment, max_width);
             for chunk in &wrapped {
@@ -538,6 +539,15 @@ impl Renderer {
                     let r = self.content_row();
                     stdout.execute(MoveTo(0, r))?;
                     stdout.execute(Clear(ClearType::CurrentLine))?;
+                    // Indent so the directly-painted line matches the
+                    // centered layout that `render_viewport` produces.
+                    // Without this, the streaming path writes at col 0
+                    // and the chat visibly jumps from centered (after
+                    // a render_viewport repaint) to left-aligned
+                    // (immediately after each write).
+                    if indent > 0 {
+                        write!(stdout, "{}", " ".repeat(indent))?;
+                    }
                     write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                     writeln!(stdout, "{}", chunk)?;
                     write!(stdout, "{}", ResetColor)?;
@@ -565,6 +575,11 @@ impl Renderer {
         if self.scroll_offset == 0 {
             io::stdout().execute(Hide)?;
         }
+        // Same centering offset render_viewport / write_line use.
+        // Without this the streaming token path paints at col 0 while
+        // the rest of the chat is centered — content jumps left as it
+        // streams and back to center on the next full repaint.
+        let indent = self.content_indent() as u16;
         let parts: Vec<&str> = text.split('\n').collect();
         let last = parts.len() - 1;
         for (i, segment) in parts.iter().enumerate() {
@@ -586,7 +601,7 @@ impl Renderer {
                     self.ensure_room();
                     let mut stdout = io::stdout();
                     let r = self.content_row();
-                    stdout.execute(MoveTo(self.col, r))?;
+                    stdout.execute(MoveTo(indent + self.col, r))?;
                     if !segment.is_empty() {
                         write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", segment)?;
@@ -617,7 +632,7 @@ impl Renderer {
                         self.ensure_room();
                         let mut stdout = io::stdout();
                         let r = self.content_row();
-                        stdout.execute(MoveTo(self.col, r))?;
+                        stdout.execute(MoveTo(indent + self.col, r))?;
                         write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", chunk)?;
                         write!(stdout, "{}", ResetColor)?;

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -689,16 +689,24 @@ impl Renderer {
 
         let status_row = rows.saturating_sub(1);
         let input_top = rows.saturating_sub(self.input_rows + 1);
+        // Heavy block prompt indicator. While running, we tick a 4-stage
+        // gradient through the block characters to suggest a phosphor
+        // pulse — readable without becoming distracting.
         let prompt_main = if is_running {
             self.spinner_tick = !self.spinner_tick;
-            if self.spinner_tick { ". " } else { ": " }
+            // Two-state spinner using ░/▒ blocks so the eye registers
+            // motion at slow refresh rates.
+            if self.spinner_tick {
+                "▒▌ "
+            } else {
+                "░▌ "
+            }
         } else {
-            "> "
+            "▌▌ "
         };
-        // Continuation rows get a dimmer prompt. We mark the *first* visual
-        // row of the *first* logical line as the prompt row; everything else
-        // (later logical lines, wrapped continuations) gets the cont prefix.
-        let prompt_cont = "· ";
+        // Continuation rows show a fainter single-block guide so wrapped
+        // text reads as a vertical "chamber" attached to the prompt.
+        let prompt_cont = "▏  ";
 
         // Pre-collect chars per logical line so each visual row's slice can
         // be cut without re-iterating.
@@ -740,25 +748,28 @@ impl Renderer {
             "{}",
             SetForegroundColor(self.color(crate::ui::theme::dim()))
         )?;
-        let mut status_display = if self.scroll_offset > 0 {
-            format!("-- SCROLL -- {}", status)
+        // Status bar with bracketed BBS-style segments. Reads as a row
+        // of small chips: `▒░ STATUS ░▒  ▒░ NEXT ░▒  …` so each fact
+        // gets visual breathing room and the bar feels like a single
+        // designed element rather than dim flowing text.
+        let scroll_prefix = if self.scroll_offset > 0 {
+            "▒░ SCROLL ░▒  "
         } else {
-            status.to_string()
+            ""
         };
+        let mut status_display = format!("{}▒░ {} ░▒", scroll_prefix, status);
         if line_count > 1 || total_visual > MAX_INPUT_VISIBLE_LINES {
-            // Surface logical line count and visual-row overflow so the user
-            // knows there is content scrolled off the top of the input box.
             let hidden = total_visual.saturating_sub(visible_input_rows);
             if hidden > 0 {
                 status_display
-                    .push_str(&format!(" [{} lines, {} rows hidden]", line_count, hidden));
+                    .push_str(&format!("  ▒░ {} lines · {} hidden ░▒", line_count, hidden));
             } else if line_count > 1 {
-                status_display.push_str(&format!(" [{} lines]", line_count));
+                status_display.push_str(&format!("  ▒░ {} lines ░▒", line_count));
             }
         }
         let token_est = editor.expanded().len() as u64 / 4;
         if token_est > 0 {
-            status_display.push_str(&format!(" ({} tk)", token_est));
+            status_display.push_str(&format!("  ▒░ {} tk ░▒", token_est));
         }
         let truncated: String = status_display.chars().take(cols as usize).collect();
         write!(stdout, "{}", truncated)?;
@@ -858,15 +869,33 @@ impl Renderer {
             }
         };
 
-        // Header
-        out.push((truncate(&format!(" {}", d.cwd), width), Color::Cyan));
+        // Top header: gradient bar + SYS banner + cwd. The banner
+        // anchors the panel with the same aesthetic as the welcome
+        // banner so the eye treats both surfaces as one design system.
+        let bar_len = width.saturating_sub(1).max(4);
+        let top_bar: String = std::iter::repeat('▓')
+            .take(bar_len / 3)
+            .chain(std::iter::repeat('▒').take(bar_len / 3))
+            .chain(std::iter::repeat('░').take(bar_len - 2 * (bar_len / 3)))
+            .collect();
+        out.push((top_bar, Color::Cyan));
+        out.push((truncate(&format!(" ▒░ DIRGE.SYS ░▒"), width), Color::Cyan));
+        out.push((truncate(&format!(" {}", d.cwd), width), Color::White));
 
+        // Section helper: framed header `─[ NAME ]──…` then items.
+        // Empty sections render a single dimmed "  · (none)" line so
+        // the user sees the section is checked-and-empty rather than
+        // missing.
         let push_section =
             |out: &mut Vec<(String, Color)>, title: &str, items: Vec<(String, Color)>| {
                 out.push((String::new(), Color::Reset));
-                out.push((truncate(title, width), Color::Cyan));
+                let pre = format!("─[ {} ]", title);
+                let pre_len = pre.chars().count();
+                let dashes = width.saturating_sub(pre_len);
+                let header = format!("{}{}", pre, "─".repeat(dashes));
+                out.push((truncate(&header, width), Color::Cyan));
                 if items.is_empty() {
-                    out.push((truncate("  (none)", width), Color::DarkGrey));
+                    out.push((truncate("  · (none)", width), Color::Reset));
                 } else {
                     for (text, color) in items {
                         out.push((truncate(&text, width), color));
@@ -901,14 +930,14 @@ impl Renderer {
             .iter()
             .map(|(status, text)| (format!("  {} {}", status, text), Color::White))
             .collect();
-        push_section(&mut out, "Todos", todo_items);
+        push_section(&mut out, "TODOS", todo_items);
 
         let mod_items: Vec<(String, Color)> = d
             .modified
             .iter()
             .map(|p| (format!("  {}", p), Color::White))
             .collect();
-        push_section(&mut out, "Modified", mod_items);
+        push_section(&mut out, "MODIFIED", mod_items);
 
         out
     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -828,7 +828,12 @@ impl Renderer {
         let (cols, _) = self.terminal_size();
         let panel_x = cols.saturating_sub(PANEL_WIDTH);
         let divider_x = panel_x.saturating_sub(1);
-        let width = PANEL_WIDTH as usize;
+        // Effective panel content width = PANEL_WIDTH - 1 so we never
+        // write to the terminal's absolute last column. On most
+        // terminals, writing the bottom-right cell triggers an
+        // implicit scroll-up — that shifts the panel content up by a
+        // row each redraw and eats the DIRGE.SYS frame's top border.
+        let width = (PANEL_WIDTH as usize).saturating_sub(1);
         let last_row = rows.saturating_sub(1); // status row — leave alone
 
         // Build the rendered lines first so we know how many we have, then
@@ -893,6 +898,15 @@ impl Renderer {
                 t
             }
         };
+
+        // Top padding rows. Same reasoning as the chat banner — without
+        // these the DIRGE.SYS frame's `╭───╮` sits flush against the
+        // terminal's row 0 and reads as cut off; some terminals also
+        // shift the panel up by a row when the bottom-right cell is
+        // touched, eating the top frame entirely. The padding gives
+        // both visual breathing room and a buffer against that.
+        out.push((String::new(), Color::Reset));
+        out.push((String::new(), Color::Reset));
 
         // Inner width inside the frame's left+right borders.
         let inner = width.saturating_sub(2);

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -395,8 +395,22 @@ impl Renderer {
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::Reverse))?;
                 }
+                // Bold attribute simulates the CRT phosphor bloom: on
+                // most modern terminals it nudges the glyphs to a
+                // heavier weight and a brighter shade of the chosen
+                // color. We apply it to bright tones only (the dim
+                // green / dim grey colors must stay un-bloomed to
+                // preserve the two-tone phosphor depth shown in the
+                // reference btop screenshots).
+                let bloom = crate::ui::theme::is_bright(entry.color);
+                if bloom {
+                    write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+                }
                 write!(stdout, "{}", SetForegroundColor(self.color(entry.color)))?;
                 write!(stdout, "{}", text)?;
+                if bloom {
+                    write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
+                }
                 if is_selected {
                     write!(stdout, "{}", SetAttribute(Attribute::NoReverse))?;
                 }
@@ -871,36 +885,47 @@ impl Renderer {
             }
         };
 
-        // Top header: gradient bar + SYS banner + cwd. The banner
-        // anchors the panel with the same aesthetic as the welcome
-        // banner so the eye treats both surfaces as one design system.
-        let bar_len = width.saturating_sub(1).max(4);
-        let top_bar: String = std::iter::repeat('▓')
-            .take(bar_len / 3)
-            .chain(std::iter::repeat('▒').take(bar_len / 3))
-            .chain(std::iter::repeat('░').take(bar_len - 2 * (bar_len / 3)))
-            .collect();
-        out.push((top_bar, Color::Cyan));
-        out.push((truncate(&format!(" ▒░ DIRGE.SYS ░▒"), width), Color::Cyan));
-        out.push((truncate(&format!(" {}", d.cwd), width), Color::White));
+        // Panel top: rounded-corner SYS header with label-on-border,
+        // mirroring the btop reference where every region is wrapped
+        // in `╭─ Label ─╮` frames. This panel has no right border
+        // (it's a vertical strip), so we use a half-frame
+        // `╭─ Label ────`.
+        let dirge_label = " DIRGE.SYS ";
+        let dirge_pre_len = dirge_label.chars().count() + 2;
+        let dirge_dashes = width.saturating_sub(dirge_pre_len);
+        out.push((
+            format!("╭─{}{}", dirge_label, "─".repeat(dirge_dashes)),
+            Color::Cyan,
+        ));
+        out.push((truncate(&format!("│ {}", d.cwd), width), Color::White));
 
-        // Section helper: framed header `─[ NAME ]──…` then items.
-        // Empty sections render a single dimmed "  · (none)" line so
-        // the user sees the section is checked-and-empty rather than
-        // missing.
+        // Section helper: rounded-corner half-frame with the section
+        // name living *on* the border (`╭─ MCP ─────`). The `│`
+        // left-bar continues down the section so each block reads as
+        // a vertical chamber. Empty sections show `│ · (none)` in the
+        // dim phosphor tone rather than grey.
         let push_section =
             |out: &mut Vec<(String, Color)>, title: &str, items: Vec<(String, Color)>| {
                 out.push((String::new(), Color::Reset));
-                let pre = format!("─[ {} ]", title);
-                let pre_len = pre.chars().count();
+                let label = format!(" {} ", title);
+                let pre_len = label.chars().count() + 2;
                 let dashes = width.saturating_sub(pre_len);
-                let header = format!("{}{}", pre, "─".repeat(dashes));
+                let header = format!("╭─{}{}", label, "─".repeat(dashes));
                 out.push((truncate(&header, width), Color::Cyan));
                 if items.is_empty() {
-                    out.push((truncate("  · (none)", width), Color::Reset));
+                    out.push((truncate("│ · (none)", width), Color::Reset));
                 } else {
                     for (text, color) in items {
-                        out.push((truncate(&text, width), color));
+                        // Items already arrive with a leading "  ";
+                        // swap that for "│ " so the chamber bar runs
+                        // continuously down the left edge of the
+                        // section.
+                        let prefixed = if let Some(rest) = text.strip_prefix("  ") {
+                            format!("│ {}", rest)
+                        } else {
+                            format!("│ {}", text)
+                        };
+                        out.push((truncate(&prefixed, width), color));
                     }
                 }
             };

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -431,7 +431,7 @@ impl Renderer {
             write!(
                 stdout,
                 "{}",
-                SetForegroundColor(self.color(Color::DarkYellow))
+                SetForegroundColor(self.color(crate::ui::theme::warn()))
             )?;
             write!(stdout, "{}", indicator)?;
             write!(stdout, "{}", ResetColor)?;
@@ -711,7 +711,11 @@ impl Renderer {
             stdout.execute(MoveTo(0, row))?;
             write!(stdout, "{}", " ".repeat(cols as usize))?;
             stdout.execute(MoveTo(0, row))?;
-            write!(stdout, "{}", SetForegroundColor(self.color(Color::Cyan)))?;
+            write!(
+                stdout,
+                "{}",
+                SetForegroundColor(self.color(crate::ui::theme::accent()))
+            )?;
             let is_prompt_row = vr_idx == 0;
             if is_prompt_row {
                 write!(stdout, "{}", prompt_main)?;
@@ -734,7 +738,7 @@ impl Renderer {
         write!(
             stdout,
             "{}",
-            SetForegroundColor(self.color(Color::DarkGrey))
+            SetForegroundColor(self.color(crate::ui::theme::dim()))
         )?;
         let mut status_display = if self.scroll_offset > 0 {
             format!("-- SCROLL -- {}", status)
@@ -795,9 +799,15 @@ impl Renderer {
         // paint top-to-bottom up to last_row-1.
         let lines = self.build_panel_lines(width);
 
-        let divider_color = self.color(Color::DarkGrey);
-        let header_color = self.color(Color::Cyan);
-        let dim = self.color(Color::DarkGrey);
+        // Themed panel colors. Source lines still use the legacy
+        // sentinels (Color::Cyan = header, Color::Reset = dim,
+        // Color::White = body, Color::Green/Red = status); the paint
+        // stage remaps them to the active theme so the phosphor look
+        // applies without rewriting `build_panel_lines`.
+        let divider_color = self.color(crate::ui::theme::divider());
+        let header_color = self.color(crate::ui::theme::header());
+        let dim = self.color(crate::ui::theme::dim());
+        let body = self.color(crate::ui::theme::agent());
 
         for row in 0..last_row {
             stdout.execute(MoveTo(divider_x, row))?;
@@ -807,11 +817,11 @@ impl Renderer {
 
             stdout.execute(MoveTo(panel_x, row))?;
             if let Some((text, color)) = lines.get(row as usize) {
-                let c = if *color == Color::Reset { dim } else { *color };
-                let painted = if *color == Color::Cyan {
-                    header_color
-                } else {
-                    c
+                let painted = match *color {
+                    Color::Cyan => header_color,
+                    Color::Reset | Color::DarkGrey => dim,
+                    Color::White => body,
+                    other => self.color(other),
                 };
                 write!(stdout, "{}", SetForegroundColor(painted))?;
                 write!(stdout, "{}", text)?;

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -18,11 +18,21 @@ use crate::session::{MessageRole, Session};
 use crate::ui::events::{format_time, render_session};
 use crate::ui::input::InputEditor;
 use crate::ui::renderer::Renderer;
+use crate::ui::theme;
 use crate::ui::tree::{self, short_id};
 
-const C_AGENT: Color = Color::White;
-const C_RESULT: Color = Color::DarkGrey;
-const C_ERROR: Color = Color::Red;
+#[inline]
+fn c_agent() -> Color {
+    theme::agent()
+}
+#[inline]
+fn c_result() -> Color {
+    theme::result()
+}
+#[inline]
+fn c_error() -> Color {
+    theme::error()
+}
 
 pub fn undo_last(session: &mut Session) -> usize {
     let len = session.messages.len();
@@ -68,7 +78,7 @@ pub async fn handle_compress(
     #[cfg(feature = "mcp")] mcp_manager: Option<&McpClientManager>,
     #[cfg(feature = "semantic")] semantic_manager: Option<&SemanticManager>,
 ) -> anyhow::Result<()> {
-    renderer.write_line("compressing...", C_AGENT)?;
+    renderer.write_line("compressing...", c_agent())?;
     renderer.write_line("", Color::White)?;
 
     let reserve = cfg.resolve_reserve_tokens();
@@ -76,7 +86,7 @@ pub async fn handle_compress(
     let max_tokens = session.context_window.saturating_sub(reserve);
 
     if session.total_estimated_tokens <= max_tokens {
-        renderer.write_line("context within limits, no compression needed", C_AGENT)?;
+        renderer.write_line("context within limits, no compression needed", c_agent())?;
         return Ok(());
     }
 
@@ -91,7 +101,7 @@ pub async fn handle_compress(
     }
 
     if cut_idx == 0 {
-        renderer.write_line("nothing to compress (entire context is recent)", C_AGENT)?;
+        renderer.write_line("nothing to compress (entire context is recent)", c_agent())?;
         return Ok(());
     }
 
@@ -134,7 +144,7 @@ pub async fn handle_compress(
         semantic_manager,
     )
     .await;
-    renderer.write_line("prompt cleared (back to default behavior)", C_AGENT)?;
+    renderer.write_line("prompt cleared (back to default behavior)", c_agent())?;
 
     render_session(renderer, session, cli, cfg, context)?;
     renderer.write_line(
@@ -142,7 +152,7 @@ pub async fn handle_compress(
             "compressed {} messages (saved ~{} tokens)",
             cut_idx, tokens_before,
         ),
-        C_AGENT,
+        c_agent(),
     )?;
 
     Ok(())
@@ -174,7 +184,7 @@ pub async fn handle_slash(
     match parts[0] {
         "/model" => {
             if parts.len() < 2 {
-                renderer.write_line(&format!("current model: {}", session.model), C_AGENT)?;
+                renderer.write_line(&format!("current model: {}", session.model), c_agent())?;
             } else {
                 let new_model = CompactString::new(parts[1].trim());
                 let model = client.completion_model(new_model.to_string());
@@ -199,17 +209,17 @@ pub async fn handle_slash(
                 .await;
                 session.model = new_model.clone();
                 session.provider = cli.resolve_provider(cfg);
-                renderer.write_line(&format!("switched to model: {}", new_model), C_AGENT)?;
+                renderer.write_line(&format!("switched to model: {}", new_model), c_agent())?;
             }
         }
         "/sessions" => {
             if parts.len() < 2 {
                 let sessions = crate::session::storage::find_recent_sessions(20)?;
                 if sessions.is_empty() {
-                    renderer.write_line("no saved sessions", C_AGENT)?;
+                    renderer.write_line("no saved sessions", c_agent())?;
                 } else {
                     renderer
-                        .write_line(&format!("recent sessions ({}):", sessions.len()), C_AGENT)?;
+                        .write_line(&format!("recent sessions ({}):", sessions.len()), c_agent())?;
                     for s in &sessions {
                         let last = s
                             .messages
@@ -228,7 +238,7 @@ pub async fn handle_slash(
                                 s.model,
                                 last
                             ),
-                            C_RESULT,
+                            c_result(),
                         )?;
                     }
                 }
@@ -236,7 +246,7 @@ pub async fn handle_slash(
                 let prefix = parts[2].trim();
                 let sessions = crate::session::storage::find_sessions_by_prefix(prefix)?;
                 if sessions.is_empty() {
-                    renderer.write_line(&format!("no session matching '{}'", prefix), C_AGENT)?;
+                    renderer.write_line(&format!("no session matching '{}'", prefix), c_agent())?;
                 } else if sessions.len() == 1 {
                     if let Some(s) = sessions.into_iter().next() {
                         let id = s.id.clone();
@@ -248,18 +258,18 @@ pub async fn handle_slash(
                             })
                             .unwrap_or_default();
                         if let Err(e) = crate::session::storage::delete_session(&id) {
-                            renderer.write_line(&format!("failed to delete: {}", e), C_ERROR)?;
+                            renderer.write_line(&format!("failed to delete: {}", e), c_error())?;
                         } else {
                             renderer.write_line(
                                 &format!("deleted session {} {}", &id[..8], preview),
-                                C_AGENT,
+                                c_agent(),
                             )?;
                         }
                     }
                 } else {
                     renderer.write_line(
                         &format!("multiple sessions match '{}', be more specific", prefix),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                     for s in &sessions {
                         let last = s
@@ -279,7 +289,7 @@ pub async fn handle_slash(
                                 s.model,
                                 last
                             ),
-                            C_RESULT,
+                            c_result(),
                         )?;
                     }
                 }
@@ -287,18 +297,20 @@ pub async fn handle_slash(
                 let prefix = parts[1].trim();
                 let sessions = crate::session::storage::find_sessions_by_prefix(prefix)?;
                 if sessions.is_empty() {
-                    renderer.write_line(&format!("no session matching '{}'", prefix), C_AGENT)?;
+                    renderer.write_line(&format!("no session matching '{}'", prefix), c_agent())?;
                 } else if sessions.len() == 1 {
                     if let Some(s) = sessions.into_iter().next() {
                         let msg_count = s.messages.len();
                         *session = s;
                         render_session(renderer, session, cli, cfg, context)?;
-                        renderer
-                            .write_line(&format!("loaded session ({} msgs)", msg_count), C_AGENT)?;
+                        renderer.write_line(
+                            &format!("loaded session ({} msgs)", msg_count),
+                            c_agent(),
+                        )?;
                     }
                 } else {
                     renderer
-                        .write_line(&format!("multiple sessions match '{}':", prefix), C_AGENT)?;
+                        .write_line(&format!("multiple sessions match '{}':", prefix), c_agent())?;
                     for s in &sessions {
                         let last = s
                             .messages
@@ -317,7 +329,7 @@ pub async fn handle_slash(
                                 s.model,
                                 last
                             ),
-                            C_RESULT,
+                            c_result(),
                         )?;
                     }
                 }
@@ -330,7 +342,7 @@ pub async fn handle_slash(
                     "reasoning visibility: {}",
                     if *show_reasoning { "on" } else { "off" }
                 ),
-                C_AGENT,
+                c_agent(),
             )?;
         }
         "/mode" => {
@@ -340,21 +352,24 @@ pub async fn handle_slash(
                 .unwrap_or(SecurityMode::Standard);
 
             if parts.len() < 2 {
-                renderer.write_line("security mode:", C_AGENT)?;
-                renderer.write_line(&format!("  current: {}", current_mode), C_RESULT)?;
-                renderer.write_line("", C_AGENT)?;
+                renderer.write_line("security mode:", c_agent())?;
+                renderer.write_line(&format!("  current: {}", current_mode), c_result())?;
+                renderer.write_line("", c_agent())?;
                 renderer.write_line(
                     "  /mode standard      use configured permission rules",
-                    C_RESULT,
-                )?;
-                renderer.write_line("  /mode restrictive   default all tools to ask", C_RESULT)?;
-                renderer.write_line(
-                    "  /mode accept        auto-accept within working directory",
-                    C_RESULT,
+                    c_result(),
                 )?;
                 renderer
-                    .write_line("  /mode yolo          auto-accept ALL operations", C_RESULT)?;
-                renderer.write_line("", C_AGENT)?;
+                    .write_line("  /mode restrictive   default all tools to ask", c_result())?;
+                renderer.write_line(
+                    "  /mode accept        auto-accept within working directory",
+                    c_result(),
+                )?;
+                renderer.write_line(
+                    "  /mode yolo          auto-accept ALL operations",
+                    c_result(),
+                )?;
+                renderer.write_line("", c_agent())?;
             } else {
                 match parts[1] {
                     "standard" => {
@@ -362,9 +377,9 @@ pub async fn handle_slash(
                             p.lock()
                                 .unwrap_or_else(|e| e.into_inner())
                                 .set_mode(SecurityMode::Standard);
-                            renderer.write_line("security mode: standard", C_AGENT)?;
+                            renderer.write_line("security mode: standard", c_agent())?;
                         } else {
-                            renderer.write_line("permission system not active", C_ERROR)?;
+                            renderer.write_line("permission system not active", c_error())?;
                         }
                     }
                     "restrictive" => {
@@ -372,9 +387,9 @@ pub async fn handle_slash(
                             p.lock()
                                 .unwrap_or_else(|e| e.into_inner())
                                 .set_mode(SecurityMode::Restrictive);
-                            renderer.write_line("security mode: restrictive", C_AGENT)?;
+                            renderer.write_line("security mode: restrictive", c_agent())?;
                         } else {
-                            renderer.write_line("permission system not active", C_ERROR)?;
+                            renderer.write_line("permission system not active", c_error())?;
                         }
                     }
                     "accept" => {
@@ -384,10 +399,10 @@ pub async fn handle_slash(
                                 .set_mode(SecurityMode::Accept);
                             renderer.write_line(
                                 "security mode: accept (auto-allow within CWD)",
-                                C_AGENT,
+                                c_agent(),
                             )?;
                         } else {
-                            renderer.write_line("permission system not active", C_ERROR)?;
+                            renderer.write_line("permission system not active", c_error())?;
                         }
                     }
                     "yolo" => {
@@ -397,14 +412,14 @@ pub async fn handle_slash(
                                 .set_mode(SecurityMode::Yolo);
                             renderer.write_line(
                                 "security mode: YOLO (all operations allowed)",
-                                C_AGENT,
+                                c_agent(),
                             )?;
                         } else {
-                            renderer.write_line("permission system not active", C_ERROR)?;
+                            renderer.write_line("permission system not active", c_error())?;
                         }
                     }
                     _ => {
-                        renderer.write_line(&format!("unknown mode: {}", parts[1]), C_ERROR)?;
+                        renderer.write_line(&format!("unknown mode: {}", parts[1]), c_error())?;
                     }
                 }
             }
@@ -412,25 +427,25 @@ pub async fn handle_slash(
         #[cfg(feature = "mcp")]
         "/mcp" => {
             let Some(mgr) = mcp_manager else {
-                renderer.write_line("no MCP servers configured", C_AGENT)?;
+                renderer.write_line("no MCP servers configured", c_agent())?;
                 return Ok(());
             };
             if mgr.handles.is_empty() {
-                renderer.write_line("no MCP servers connected", C_AGENT)?;
+                renderer.write_line("no MCP servers connected", c_agent())?;
             } else if parts.len() == 1 {
-                renderer.write_line("MCP servers:", C_AGENT)?;
+                renderer.write_line("MCP servers:", c_agent())?;
                 for handle in &mgr.handles {
                     match handle.list_tools().await {
                         Ok(tools) => {
                             renderer.write_line(
                                 &format!("  {} ({} tools)", handle.server_name, tools.len()),
-                                C_RESULT,
+                                c_result(),
                             )?;
                         }
                         Err(e) => {
                             renderer.write_line(
                                 &format!("  {} (error: {})", handle.server_name, e),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                     }
@@ -443,15 +458,15 @@ pub async fn handle_slash(
                             if tools.is_empty() {
                                 renderer.write_line(
                                     &format!("server '{}' has no tools", name),
-                                    C_AGENT,
+                                    c_agent(),
                                 )?;
                             } else {
-                                renderer.write_line(&format!("tools on '{}':", name), C_AGENT)?;
+                                renderer.write_line(&format!("tools on '{}':", name), c_agent())?;
                                 for tool in &tools {
                                     let desc = tool.description.as_deref().unwrap_or("");
                                     renderer.write_line(
                                         &format!("  {}  {}", tool.name, desc),
-                                        C_RESULT,
+                                        c_result(),
                                     )?;
                                 }
                             }
@@ -459,30 +474,32 @@ pub async fn handle_slash(
                         Err(e) => {
                             renderer.write_line(
                                 &format!("error listing tools on '{}': {}", name, e),
-                                C_ERROR,
+                                c_error(),
                             )?;
                         }
                     }
                 } else {
-                    renderer.write_line(&format!("unknown MCP server: '{}'", name), C_ERROR)?;
+                    renderer.write_line(&format!("unknown MCP server: '{}'", name), c_error())?;
                 }
             }
         }
         "/toggle" => {
             if parts.len() < 2 {
-                renderer.write_line("usage: /toggle <feature> [on|off]", C_AGENT)?;
-                renderer.write_line("features:", C_AGENT)?;
+                renderer.write_line("usage: /toggle <feature> [on|off]", c_agent())?;
+                renderer.write_line("features:", c_agent())?;
                 renderer.write_line(
                     &format!("  todo  {}", if *todo_tools_enabled { "on" } else { "off" }),
-                    C_RESULT,
+                    c_result(),
                 )?;
             } else {
                 let new_state = match parts.get(2).copied() {
                     Some("on") => true,
                     Some("off") => false,
                     Some(other) => {
-                        renderer
-                            .write_line(&format!("invalid: '{}', use on or off", other), C_ERROR)?;
+                        renderer.write_line(
+                            &format!("invalid: '{}', use on or off", other),
+                            c_error(),
+                        )?;
                         return Ok(());
                     }
                     None => !*todo_tools_enabled,
@@ -493,7 +510,7 @@ pub async fn handle_slash(
                             "todo tools already {}",
                             if new_state { "on" } else { "off" }
                         ),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                 } else {
                     *todo_tools_enabled = new_state;
@@ -522,7 +539,7 @@ pub async fn handle_slash(
                             "todo tools: {}",
                             if *todo_tools_enabled { "on" } else { "off" }
                         ),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                 }
             }
@@ -549,23 +566,23 @@ pub async fn handle_slash(
                                 ls.iteration_label(),
                                 ls.plan_file.display()
                             ),
-                            C_AGENT,
+                            c_agent(),
                         )?;
                     } else {
-                        renderer.write_line("no active loop", C_AGENT)?;
-                        renderer.write_line("usage: /loop <prompt>  |  /loop stop", C_RESULT)?;
+                        renderer.write_line("no active loop", c_agent())?;
+                        renderer.write_line("usage: /loop <prompt>  |  /loop stop", c_result())?;
                     }
                 } else if parts[1] == "stop" {
                     if let Some(ls) = loop_state {
                         ls.active = false;
-                        renderer.write_line("loop stopped", C_AGENT)?;
+                        renderer.write_line("loop stopped", c_agent())?;
                     } else {
-                        renderer.write_line("no active loop", C_AGENT)?;
+                        renderer.write_line("no active loop", c_agent())?;
                     }
                 } else {
                     let prompt = parts[1..].join(" ");
                     if prompt.is_empty() {
-                        renderer.write_line("usage: /loop <prompt>", C_ERROR)?;
+                        renderer.write_line("usage: /loop <prompt>", c_error())?;
                         return Ok(());
                     }
                     let plan_file = std::path::PathBuf::from("LOOP_PLAN.md");
@@ -573,7 +590,7 @@ pub async fn handle_slash(
                     *loop_state = Some(ls);
                     renderer.write_line(
                         "loop started — iteration 1 will run after this message",
-                        C_AGENT,
+                        c_agent(),
                     )?;
                 }
             }
@@ -581,7 +598,7 @@ pub async fn handle_slash(
             {
                 renderer.write_line(
                     "/loop requires the 'loop' feature: cargo build --features loop",
-                    C_ERROR,
+                    c_error(),
                 )?;
             }
         }
@@ -590,22 +607,22 @@ pub async fn handle_slash(
             sorted.sort();
             if parts.len() < 2 {
                 if sorted.is_empty() {
-                    renderer.write_line("no prompts available", C_AGENT)?;
+                    renderer.write_line("no prompts available", c_agent())?;
                 } else {
                     let current = context.current_prompt_name.as_deref().unwrap_or("(none)");
                     renderer.write_line(
                         &format!("available prompts (current: {}):", current),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                     for name in &sorted {
-                        renderer.write_line(&format!("  {}", name), C_RESULT)?;
+                        renderer.write_line(&format!("  {}", name), c_result())?;
                     }
-                    renderer.write_line("", C_AGENT)?;
-                    renderer.write_line("usage: /prompt <name>  |  /prompt default", C_RESULT)?;
+                    renderer.write_line("", c_agent())?;
+                    renderer.write_line("usage: /prompt <name>  |  /prompt default", c_result())?;
                 }
             } else if parts[1] == "default" {
                 if context.current_prompt.is_none() {
-                    renderer.write_line("no active prompt to clear", C_AGENT)?;
+                    renderer.write_line("no active prompt to clear", c_agent())?;
                 } else {
                     context.current_prompt = None;
                     context.current_prompt_name = None;
@@ -655,13 +672,13 @@ pub async fn handle_slash(
                         semantic_manager,
                     )
                     .await;
-                    renderer.write_line(&format!("active prompt: {}", name), C_AGENT)?;
+                    renderer.write_line(&format!("active prompt: {}", name), c_agent())?;
                 } else {
-                    renderer.write_line(&format!("unknown prompt: '{}'", name), C_ERROR)?;
+                    renderer.write_line(&format!("unknown prompt: '{}'", name), c_error())?;
                     if !sorted.is_empty() {
-                        renderer.write_line("available prompts:", C_AGENT)?;
+                        renderer.write_line("available prompts:", c_agent())?;
                         for p in &sorted {
-                            renderer.write_line(&format!("  {}", p), C_RESULT)?;
+                            renderer.write_line(&format!("  {}", p), c_result())?;
                         }
                     }
                 }
@@ -670,14 +687,14 @@ pub async fn handle_slash(
         #[cfg(feature = "git-worktree")]
         "/worktree" => {
             if parts.len() < 2 {
-                renderer.write_line("usage: /worktree <name>", C_ERROR)?;
+                renderer.write_line("usage: /worktree <name>", c_error())?;
                 return Ok(());
             }
             let name = parts[1].trim();
             if name.is_empty() || name.contains(' ') || name.contains('/') {
                 renderer.write_line(
                     "invalid name: use a single word without spaces or slashes",
-                    C_ERROR,
+                    c_error(),
                 )?;
                 return Ok(());
             }
@@ -711,11 +728,11 @@ pub async fn handle_slash(
                     render_session(renderer, session, cli, cfg, context)?;
                     renderer.write_line(
                         &format!("worktree created: branch '{}' at {}", name, path.display()),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                 }
                 Err(e) => {
-                    renderer.write_line(&format!("failed: {}", e), C_ERROR)?;
+                    renderer.write_line(&format!("failed: {}", e), c_error())?;
                 }
             }
         }
@@ -724,7 +741,7 @@ pub async fn handle_slash(
             let info = match crate::extras::git_worktree::detect() {
                 Some(i) => i,
                 None => {
-                    renderer.write_line("not in a git worktree", C_ERROR)?;
+                    renderer.write_line("not in a git worktree", c_error())?;
                     return Ok(());
                 }
             };
@@ -736,7 +753,7 @@ pub async fn handle_slash(
                     None => {
                         renderer.write_line(
                             "no target branch specified and couldn't detect main/master",
-                            C_ERROR,
+                            c_error(),
                         )?;
                         return Ok(());
                     }
@@ -750,7 +767,7 @@ pub async fn handle_slash(
                     "merging '{}' into '{}' in {}...",
                     info.branch, target, repo_name
                 ),
-                C_AGENT,
+                c_agent(),
             )?;
             return Err(anyhow::anyhow!(
                 "DEFER_WT_MERGE:{}:{}:{}:{}:{}",
@@ -766,12 +783,15 @@ pub async fn handle_slash(
             let info = match crate::extras::git_worktree::detect() {
                 Some(i) => i,
                 None => {
-                    renderer.write_line("not in a git worktree", C_ERROR)?;
+                    renderer.write_line("not in a git worktree", c_error())?;
                     return Ok(());
                 }
             };
             let main_path = info.main_repo_path.display();
-            renderer.write_line(&format!("returning to main repo at {}", main_path), C_AGENT)?;
+            renderer.write_line(
+                &format!("returning to main repo at {}", main_path),
+                c_agent(),
+            )?;
             return Err(anyhow::anyhow!(
                 "DEFER_WT_EXIT:{}:{}",
                 main_path,
@@ -781,10 +801,10 @@ pub async fn handle_slash(
         "/regen-prompts" => match crate::context::prompts::regen() {
             Ok(()) => {
                 context.prompts = crate::context::prompts::load();
-                renderer.write_line("default prompts regenerated", C_AGENT)?;
+                renderer.write_line("default prompts regenerated", c_agent())?;
             }
             Err(e) => {
-                renderer.write_line(&format!("failed to regenerate prompts: {}", e), C_ERROR)?;
+                renderer.write_line(&format!("failed to regenerate prompts: {}", e), c_error())?;
             }
         },
         "/quit" => {
@@ -813,26 +833,26 @@ pub async fn handle_slash(
             let arg = parts.get(1).copied().unwrap_or("").trim();
             if arg.is_empty() {
                 if session.tree.entries.is_empty() {
-                    renderer.write_line("(empty session)", C_AGENT)?;
+                    renderer.write_line("(empty session)", c_agent())?;
                 } else {
                     for line in tree::render_tree(session) {
-                        renderer.write_line(&line, C_RESULT)?;
+                        renderer.write_line(&line, c_result())?;
                     }
                 }
             } else {
                 match tree::resolve_id_prefix(session, arg) {
                     Ok(id) => {
                         if let Err(e) = session.switch_to_leaf(&id) {
-                            renderer.write_line(&format!("switch failed: {}", e), C_ERROR)?;
+                            renderer.write_line(&format!("switch failed: {}", e), c_error())?;
                         } else {
                             render_session(renderer, session, cli, cfg, context)?;
                             renderer.write_line(
                                 &format!("switched to leaf {}", short_id(&id)),
-                                C_AGENT,
+                                c_agent(),
                             )?;
                         }
                     }
-                    Err(e) => renderer.write_line(&format!("/tree: {}", e), C_ERROR)?,
+                    Err(e) => renderer.write_line(&format!("/tree: {}", e), c_error())?,
                 }
             }
         }
@@ -870,12 +890,12 @@ pub async fn handle_slash(
                                 "forked at {} — original prompt restored to editor",
                                 short_id(&id)
                             ),
-                            C_AGENT,
+                            c_agent(),
                         )?;
                     }
-                    Err(e) => renderer.write_line(&format!("/fork: {}", e), C_ERROR)?,
+                    Err(e) => renderer.write_line(&format!("/fork: {}", e), c_error())?,
                 },
-                Err(e) => renderer.write_line(&format!("/fork: {}", e), C_ERROR)?,
+                Err(e) => renderer.write_line(&format!("/fork: {}", e), c_error())?,
             }
         }
         "/clone" => {
@@ -886,7 +906,7 @@ pub async fn handle_slash(
             session.ensure_message_store_initialized();
             let arg = parts.get(1).copied().unwrap_or("").trim();
             if arg.is_empty() {
-                renderer.write_line("usage: /clone <id-prefix>", C_ERROR)?;
+                renderer.write_line("usage: /clone <id-prefix>", c_error())?;
             } else {
                 match tree::resolve_id_prefix(session, arg) {
                     Ok(id) => match session.clone_at(&id) {
@@ -894,12 +914,12 @@ pub async fn handle_slash(
                             render_session(renderer, session, cli, cfg, context)?;
                             renderer.write_line(
                                 &format!("cloned path through {}", short_id(&id)),
-                                C_AGENT,
+                                c_agent(),
                             )?;
                         }
-                        Err(e) => renderer.write_line(&format!("/clone: {}", e), C_ERROR)?,
+                        Err(e) => renderer.write_line(&format!("/clone: {}", e), c_error())?,
                     },
-                    Err(e) => renderer.write_line(&format!("/clone: {}", e), C_ERROR)?,
+                    Err(e) => renderer.write_line(&format!("/clone: {}", e), c_error())?,
                 }
             }
         }
@@ -914,7 +934,7 @@ pub async fn handle_slash(
                 other => {
                     renderer.write_line(
                         &format!("unknown /panel mode '{}' (use on|off|auto)", other),
-                        C_ERROR,
+                        c_error(),
                     )?;
                     return Ok(());
                 }
@@ -933,13 +953,13 @@ pub async fn handle_slash(
                     current,
                     if visible { "shown" } else { "hidden" }
                 ),
-                C_AGENT,
+                c_agent(),
             )?;
         }
         "/btw" => {
             let query = parts.get(1..).map(|p| p.join(" ")).unwrap_or_default();
             if query.is_empty() {
-                renderer.write_line("usage: /btw <question>", C_ERROR)?;
+                renderer.write_line("usage: /btw <question>", c_error())?;
             } else {
                 let model = client.completion_model(session.model.to_string());
                 renderer.write_line(&format!("btw: {}", query), Color::DarkGrey)?;
@@ -954,7 +974,7 @@ pub async fn handle_slash(
                         renderer.write_line("", Color::White)?;
                     }
                     Err(e) => {
-                        renderer.write_line(&format!("btw error: {}", e), C_ERROR)?;
+                        renderer.write_line(&format!("btw error: {}", e), c_error())?;
                     }
                 }
             }
@@ -1004,11 +1024,11 @@ pub async fn handle_slash(
                     render_session(renderer, session, cli, cfg, context)?;
                     renderer.write_line(
                         &format!("changed directory to {}", session.working_dir),
-                        C_AGENT,
+                        c_agent(),
                     )?;
                 }
                 Err(e) => {
-                    renderer.write_line(&format!("cd: {}", e), C_ERROR)?;
+                    renderer.write_line(&format!("cd: {}", e), c_error())?;
                 }
             }
         }
@@ -1016,9 +1036,9 @@ pub async fn handle_slash(
             let removed = undo_last(session);
             if removed > 0 {
                 render_session(renderer, session, cli, cfg, context)?;
-                renderer.write_line(&format!("removed {} message(s)", removed), C_AGENT)?;
+                renderer.write_line(&format!("removed {} message(s)", removed), c_agent())?;
             } else {
-                renderer.write_line("nothing to undo", C_AGENT)?;
+                renderer.write_line("nothing to undo", c_agent())?;
             }
         }
         "/retry" => {
@@ -1032,149 +1052,152 @@ pub async fn handle_slash(
                 Some(msg) => {
                     input.buffer = msg.content.clone();
                     input.cursor = msg.content.len();
-                    renderer.write_line("edit last message and press Enter to retry", C_AGENT)?;
+                    renderer.write_line("edit last message and press Enter to retry", c_agent())?;
                 }
                 None => {
-                    renderer.write_line("no previous message to retry", C_AGENT)?;
+                    renderer.write_line("no previous message to retry", c_agent())?;
                 }
             }
         }
         "/help" => {
-            renderer.write_line("commands:", C_AGENT)?;
-            renderer.write_line("  /model [name]          show or switch model", C_RESULT)?;
-            renderer.write_line("  /sessions              list recent sessions", C_RESULT)?;
+            renderer.write_line("commands:", c_agent())?;
+            renderer.write_line("  /model [name]          show or switch model", c_result())?;
+            renderer.write_line("  /sessions              list recent sessions", c_result())?;
             renderer.write_line(
                 "  /sessions <id>         load a session (by ID prefix)",
-                C_RESULT,
+                c_result(),
             )?;
-            renderer.write_line("  /sessions delete <id>  delete a session", C_RESULT)?;
+            renderer.write_line("  /sessions delete <id>  delete a session", c_result())?;
             renderer.write_line(
                 "  /reasoning             toggle reasoning visibility",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /mode                  show/change security mode",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /mode <mode>           set mode (standard|restrictive|accept|yolo)",
-                C_RESULT,
+                c_result(),
             )?;
             #[cfg(feature = "mcp")]
             {
                 let _ = renderer.write_line(
                     "  /mcp                   list MCP servers and tools",
-                    C_RESULT,
+                    c_result(),
                 );
                 let _ = renderer.write_line(
                     "  /mcp <server>          list tools of an MCP server",
-                    C_RESULT,
+                    c_result(),
                 );
             }
             renderer.write_line(
                 "  /clear                 clear screen + reset tree",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /tree                  show the session tree (use /tree <id-prefix> to switch branches)",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /fork [id-prefix]      branch off at the chosen message (default: last user message)",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /clone <id-prefix>     switch to the branch ending at the chosen entry",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /panel [on|off|auto]   toggle right-hand info panel",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /cd [path]             change working directory",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /btw <question>        ask a quick question (no tools, doesn't affect session)",
-                C_RESULT,
+                c_result(),
             )?;
-            renderer.write_line("  /undo                  undo last exchange", C_RESULT)?;
-            renderer.write_line("  /retry                 retry last prompt", C_RESULT)?;
+            renderer.write_line("  /undo                  undo last exchange", c_result())?;
+            renderer.write_line("  /retry                 retry last prompt", c_result())?;
             renderer.write_line(
                 "  /compress [/compact]   compress conversation history",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  /compress [instr]      compress with custom instructions",
-                C_RESULT,
+                c_result(),
             )?;
             #[cfg(feature = "loop")]
             {
                 let _ = renderer.write_line(
                     "  /loop [prompt]         start iterative coding loop",
-                    C_RESULT,
+                    c_result(),
                 );
-                let _ = renderer.write_line("  /loop stop             stop the loop", C_RESULT);
+                let _ = renderer.write_line("  /loop stop             stop the loop", c_result());
             }
             #[cfg(not(feature = "loop"))]
             {
                 let _ = renderer.write_line(
                     "  /loop [prompt]         start iterative coding loop (req. 'loop' feature)",
-                    C_RESULT,
+                    c_result(),
                 );
             }
-            renderer.write_line("  /prompt                list available prompts", C_RESULT)?;
-            renderer.write_line("  /prompt <name>         activate a prompt", C_RESULT)?;
-            renderer.write_line("  /prompt default        clear active prompt", C_RESULT)?;
+            renderer.write_line(
+                "  /prompt                list available prompts",
+                c_result(),
+            )?;
+            renderer.write_line("  /prompt <name>         activate a prompt", c_result())?;
+            renderer.write_line("  /prompt default        clear active prompt", c_result())?;
             renderer.write_line(
                 "  /regen-prompts        restore built-in prompts to global dir",
-                C_RESULT,
+                c_result(),
             )?;
             #[cfg(feature = "git-worktree")]
             {
                 let _ = renderer.write_line(
                     "  /worktree <name>       create a git worktree on <name> branch and cd into it",
-                    C_RESULT,
+                    c_result(),
                 );
                 let _ = renderer.write_line(
                     "  /wt-merge [branch]     merge worktree branch into [branch] (default: main/master)",
-                    C_RESULT,
+                    c_result(),
                 );
                 let _ = renderer.write_line(
                     "  /wt-exit               exit worktree and return to main repo",
-                    C_RESULT,
+                    c_result(),
                 );
             }
-            renderer.write_line("  /quit                  exit dirge", C_RESULT)?;
-            renderer.write_line("  /help                  show this message", C_RESULT)?;
-            renderer.write_line("", C_AGENT)?;
-            renderer.write_line("keys:", C_AGENT)?;
-            renderer.write_line("  PgUp/PgDn             scroll chat history", C_RESULT)?;
-            renderer.write_line("  Home/End               jump to top/bottom", C_RESULT)?;
+            renderer.write_line("  /quit                  exit dirge", c_result())?;
+            renderer.write_line("  /help                  show this message", c_result())?;
+            renderer.write_line("", c_agent())?;
+            renderer.write_line("keys:", c_agent())?;
+            renderer.write_line("  PgUp/PgDn             scroll chat history", c_result())?;
+            renderer.write_line("  Home/End               jump to top/bottom", c_result())?;
             renderer.write_line(
                 "  @<query>               file picker (Tab/Enter select, Esc cancel)",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  mouse drag             select text (copies to clipboard on release)",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  Esc (while selected)   clear selection (no copy)",
-                C_RESULT,
+                c_result(),
             )?;
-            renderer.write_line("  Ctrl+R                 toggle reasoning", C_RESULT)?;
-            renderer.write_line("  Ctrl+C / Ctrl+D        interrupt/quit", C_RESULT)?;
+            renderer.write_line("  Ctrl+R                 toggle reasoning", c_result())?;
+            renderer.write_line("  Ctrl+C / Ctrl+D        interrupt/quit", c_result())?;
             renderer.write_line(
                 "  Ctrl+X                 drop last queued interjection",
-                C_RESULT,
+                c_result(),
             )?;
             renderer.write_line(
                 "  (type while agent runs to queue a follow-up message)",
-                C_RESULT,
+                c_result(),
             )?;
-            renderer.write_line("  mouse scroll           scroll chat", C_RESULT)?;
+            renderer.write_line("  mouse scroll           scroll chat", c_result())?;
 
             // Plugin-registered commands, if any. Listed last so they sit
             // visually after the built-ins and the keybindings.
@@ -1185,10 +1208,11 @@ pub async fn handle_slash(
                     mgr.list_commands()
                 };
                 if !cmds.is_empty() {
-                    renderer.write_line("", C_AGENT)?;
-                    renderer.write_line("plugin commands:", C_AGENT)?;
+                    renderer.write_line("", c_agent())?;
+                    renderer.write_line("plugin commands:", c_agent())?;
                     for (cmd, handler) in cmds {
-                        renderer.write_line(&format!("  /{:<20} -> {}", cmd, handler), C_RESULT)?;
+                        renderer
+                            .write_line(&format!("  /{:<20} -> {}", cmd, handler), c_result())?;
                     }
                 }
             }
@@ -1217,15 +1241,17 @@ pub async fn handle_slash(
                     match result {
                         Ok(Some(text)) => {
                             for line in text.lines() {
-                                renderer.write_line(line, C_AGENT)?;
+                                renderer.write_line(line, c_agent())?;
                             }
                         }
                         Ok(None) => {
                             // Handler ran cleanly but had nothing to say — no-op.
                         }
                         Err(e) => {
-                            renderer
-                                .write_line(&format!("[plugin] {} failed: {}", cmd, e), C_ERROR)?;
+                            renderer.write_line(
+                                &format!("[plugin] {} failed: {}", cmd, e),
+                                c_error(),
+                            )?;
                         }
                     }
                     return Ok(());
@@ -1233,7 +1259,7 @@ pub async fn handle_slash(
             }
             renderer.write_line(
                 &format!("unknown command: {} (try /help)", parts[0]),
-                C_ERROR,
+                c_error(),
             )?;
         }
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -185,6 +185,23 @@ pub fn banner_secondary() -> Color {
     current().banner_secondary
 }
 
+/// Whether the given color should render with the Bold attribute to
+/// fake the CRT phosphor "bloom" effect. Bright phosphor tones glow;
+/// dim secondary tones stay un-bloomed so the two-tone depth in the
+/// reference screenshots is preserved.
+pub fn is_bright(c: Color) -> bool {
+    matches!(
+        c,
+        Color::Green
+            | Color::Red
+            | Color::Yellow
+            | Color::Cyan
+            | Color::Magenta
+            | Color::Blue
+            | Color::White
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,225 @@
+//! UI color theme.
+//!
+//! Centralizes semantic color choices (agent, tool, error, accent, …)
+//! so the whole UI can swap palettes without rewriting call sites.
+//! The active theme is selected at startup via `ui::theme::init` (from
+//! the user's `theme = "..."` config) and read everywhere else through
+//! the helper functions exposed at the bottom of this file.
+//!
+//! Currently shipping presets:
+//! - `phosphor` (default) — CRT-green 80s-hacker palette. Errors stay
+//!   red and warnings stay yellow so semantic urgency isn't sacrificed
+//!   for aesthetics.
+//! - `plain` — the pre-theme look (white assistant text, cyan accents).
+//!   Use this if green-on-black hurts your eyes or clashes with your
+//!   terminal background.
+//!
+//! Adding a theme means appending a `pub const fn`-style preset here
+//! and matching its name in `init` — no other code changes needed.
+
+use std::sync::OnceLock;
+
+use crossterm::style::Color;
+
+/// Semantic colors for every role in the UI. Concrete colors are
+/// chosen by the active preset; call sites should reach for the helper
+/// functions below (`agent()`, `error()`, …) rather than poking the
+/// struct directly so future additions stay backwards-compatible.
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    /// Assistant chat text.
+    pub agent: Color,
+    /// User-message prefix (and prompt indicator).
+    pub user: Color,
+    /// System/info messages — context loaded, compactions, etc.
+    pub system: Color,
+    /// Tool execution headers (`bash:`, `read:`, …).
+    pub tool: Color,
+    /// Permission prompts. Stays loud (yellow/red family) because the
+    /// user must notice — never go subtle here.
+    pub perm: Color,
+    /// Secondary result text (slash command output, tool stdout dim).
+    pub result: Color,
+    /// Hard errors. Always red-family; theme can choose the exact red
+    /// but must keep it semantically distinct from everything else.
+    pub error: Color,
+    /// Warnings. Yellow-family; same rule as `error`.
+    pub warn: Color,
+    /// Headers, focused picker rows, banner accent. The "look at this"
+    /// color.
+    pub accent: Color,
+    /// Dim auxiliary text — placeholders, separators, low-noise hints.
+    pub dim: Color,
+    /// Panel headers in the right-hand info panel.
+    pub header: Color,
+    /// Horizontal divider line color.
+    pub divider: Color,
+    /// Welcome-banner primary stroke.
+    pub banner_primary: Color,
+    /// Welcome-banner secondary stroke (border, decorations).
+    pub banner_secondary: Color,
+    /// Human-readable name surfaced in the banner ("PHOSPHOR", "PLAIN").
+    pub label: &'static str,
+}
+
+impl Theme {
+    /// 80s-CRT phosphor green. Default. Errors red, warnings yellow.
+    pub const fn phosphor() -> Self {
+        Theme {
+            agent: Color::Green,
+            user: Color::Green,
+            system: Color::DarkGreen,
+            tool: Color::DarkGreen,
+            perm: Color::Yellow,
+            result: Color::DarkGreen,
+            error: Color::Red,
+            warn: Color::Yellow,
+            accent: Color::Green,
+            dim: Color::DarkGrey,
+            header: Color::Green,
+            divider: Color::DarkGreen,
+            banner_primary: Color::Green,
+            banner_secondary: Color::DarkGreen,
+            label: "PHOSPHOR",
+        }
+    }
+
+    /// Pre-theme look. Use this when the green doesn't suit your
+    /// terminal background or you just want the boring default.
+    pub const fn plain() -> Self {
+        Theme {
+            agent: Color::White,
+            user: Color::Green,
+            system: Color::DarkGrey,
+            tool: Color::Yellow,
+            perm: Color::Magenta,
+            result: Color::DarkGrey,
+            error: Color::Red,
+            warn: Color::Yellow,
+            accent: Color::Cyan,
+            dim: Color::DarkGrey,
+            header: Color::Cyan,
+            divider: Color::DarkGrey,
+            banner_primary: Color::Cyan,
+            banner_secondary: Color::DarkGrey,
+            label: "PLAIN",
+        }
+    }
+}
+
+/// Global theme set once at startup. Defaults to `phosphor` if `init`
+/// is never called (handy for tests + the `--no-tools` no-UI mode).
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+/// Initialize the global theme from a name. Unknown names fall back
+/// to `phosphor` with a stderr warning so a typo doesn't make the UI
+/// unreadable. Safe to call once; subsequent calls are ignored.
+pub fn init(name: &str) {
+    let theme = match name.to_ascii_lowercase().as_str() {
+        "phosphor" | "" => Theme::phosphor(),
+        "plain" => Theme::plain(),
+        other => {
+            eprintln!(
+                "warning: unknown theme '{}'; using phosphor. Valid: phosphor, plain.",
+                other,
+            );
+            Theme::phosphor()
+        }
+    };
+    let _ = THEME.set(theme);
+}
+
+/// Read the active theme. Lazy-initializes to `phosphor` if no `init`
+/// call has happened (the happy path during `cargo test`).
+pub fn current() -> &'static Theme {
+    THEME.get_or_init(Theme::phosphor)
+}
+
+// Convenience accessors. Call sites use these instead of touching the
+// struct so renaming/restructuring fields in `Theme` doesn't ripple
+// across the codebase.
+
+pub fn agent() -> Color {
+    current().agent
+}
+pub fn user() -> Color {
+    current().user
+}
+pub fn system() -> Color {
+    current().system
+}
+pub fn tool() -> Color {
+    current().tool
+}
+pub fn perm() -> Color {
+    current().perm
+}
+pub fn result() -> Color {
+    current().result
+}
+pub fn error() -> Color {
+    current().error
+}
+pub fn warn() -> Color {
+    current().warn
+}
+pub fn accent() -> Color {
+    current().accent
+}
+pub fn dim() -> Color {
+    current().dim
+}
+pub fn header() -> Color {
+    current().header
+}
+pub fn divider() -> Color {
+    current().divider
+}
+pub fn banner_primary() -> Color {
+    current().banner_primary
+}
+pub fn banner_secondary() -> Color {
+    current().banner_secondary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `phosphor` and `plain` differ in their agent color — quick
+    /// sanity check that the presets aren't accidentally identical.
+    #[test]
+    fn presets_are_distinct() {
+        assert_ne!(Theme::phosphor().agent, Theme::plain().agent);
+        assert_ne!(Theme::phosphor().accent, Theme::plain().accent);
+    }
+
+    /// Errors and warnings must stay in the red/yellow family across
+    /// every preset — that's the load-bearing semantic contract.
+    #[test]
+    fn error_and_warn_stay_loud() {
+        for t in [Theme::phosphor(), Theme::plain()] {
+            assert!(
+                matches!(t.error, Color::Red | Color::DarkRed),
+                "theme {} broke error contract",
+                t.label,
+            );
+            assert!(
+                matches!(t.warn, Color::Yellow | Color::DarkYellow),
+                "theme {} broke warn contract",
+                t.label,
+            );
+        }
+    }
+
+    /// `init` with an unknown name does not panic and the theme still
+    /// resolves (falls back to phosphor).
+    #[test]
+    fn init_with_unknown_name_falls_back() {
+        // Can't actually call init() — it's OnceLock-backed and a
+        // prior test may have already set the global. Instead verify
+        // `current()` resolves without panicking and has a label.
+        let t = current();
+        assert!(!t.label.is_empty());
+    }
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -64,18 +64,21 @@ pub struct Theme {
 
 impl Theme {
     /// 80s-CRT phosphor green. Default. Errors red, warnings yellow.
+    /// No grey anywhere on the green axis — secondary tones use
+    /// DarkGreen so the whole display reads like a single-phosphor
+    /// monochrome monitor.
     pub const fn phosphor() -> Self {
         Theme {
             agent: Color::Green,
             user: Color::Green,
             system: Color::DarkGreen,
-            tool: Color::DarkGreen,
+            tool: Color::Green,
             perm: Color::Yellow,
             result: Color::DarkGreen,
             error: Color::Red,
             warn: Color::Yellow,
             accent: Color::Green,
-            dim: Color::DarkGrey,
+            dim: Color::DarkGreen,
             header: Color::Green,
             divider: Color::DarkGreen,
             banner_primary: Color::Green,


### PR DESCRIPTION
## Summary

Adds a centralized UI color theme with two presets and a default-on
**phosphor green** palette inspired by 80s CRT terminals. Usability
preserved: errors stay red and warnings stay yellow across every
preset — semantic colors are not sacrificed for aesthetics.

## What's new

- **`src/ui/theme.rs`** — `Theme` struct with semantic roles plus two
  presets:
  - `phosphor` (default): green accents on black, dim green for
    secondary text, yellow for permission prompts (loud on purpose).
  - `plain`: the pre-theme white/cyan look. Opt back in with
    `\"theme\": \"plain\"` in config.json.
  Active theme is initialized once at boot and read everywhere via
  helper fns (`theme::agent()`, `theme::error()`, …) so adding a new
  preset is a one-file change.

- **CRT-style welcome banner** — 4 lines, box-drawn:
  ```
  ╔══════════════════════════════════════════╗
  ║ ░ DIRGE ░ PHOSPHOR ░ v1.0.0              ║
  ║ provider: openai · model: gpt-4          ║
  ╚══════════════════════════════════════════╝
  ```
  Truncates gracefully on narrow terminals.

- **`theme: Option<String>` config** — documented in `CONFIG.md` +
  README note.

## Migration

The 213 references to `C_AGENT` / `C_ERROR` / `C_TOOL` / `C_PERM` /
`C_RESULT` constants in `src/ui/mod.rs` + `src/ui/slash.rs` are now
`c_agent()` / `c_error()` / … fn calls that delegate to the theme
module. Spelling stayed similar so the diff is mostly mechanical.
`renderer.rs` panel + status + input-prompt color literals and
`picker.rs` selection colors were replaced with theme accessors.

## Test plan

- [x] 3 new `ui::theme::tests`:
  - `presets_are_distinct`
  - `error_and_warn_stay_loud` (locks the red/yellow contract)
  - `init_with_unknown_name_falls_back`
- [x] `cargo test --features plugin` -> 599 pass, 0 fail (was 596).
- [x] `cargo build --features plugin` -> 0 warnings.
- [x] `cargo build` -> 0 warnings.
- [x] Binary runs (`./target/debug/dirge --version`).
- [ ] Eyeball: launch dirge and verify the banner + chat colors
      render correctly on your terminal.

CLI flag intentionally omitted — palette is a long-lived per-user
preference, not a per-invocation choice.