### PR TITLE
feat: auto-detect provider from API key env vars

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,7 @@ impl Cli {
             .as_deref()
             .or(cfg.provider.as_deref())
             .map(CompactString::new)
+            .or_else(|| crate::provider::auto_detect_provider().map(CompactString::new))
             .unwrap_or_else(|| CompactString::new("openrouter"))
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -133,6 +133,29 @@ fn provider_env_var(kind: ProviderKind) -> &'static str {
     }
 }
 
+/// Auto-detect provider from environment variables when none is explicitly configured.
+/// Returns the provider name string (e.g. "deepseek") for the first matching env var.
+pub fn auto_detect_provider() -> Option<&'static str> {
+    let candidates: &[(&str, &str)] = &[
+        ("DEEPSEEK_API_KEY", "deepseek"),
+        ("OPENAI_API_KEY", "openai"),
+        ("ANTHROPIC_API_KEY", "anthropic"),
+        ("GEMINI_API_KEY", "gemini"),
+        ("GLM_API_KEY", "glm"),
+        ("OLLAMA_API_KEY", "ollama"),
+        ("OPENROUTER_API_KEY", "openrouter"),
+    ];
+    for (env_var, provider_name) in candidates {
+        if std::env::var(env_var)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
+            return Some(provider_name);
+        }
+    }
+    None
+}
+
 fn resolve_api_key(
     kind: ProviderKind,
     api_key_env_override: Option<&str>,
@@ -517,5 +540,60 @@ pub async fn build_agent(
         AnyModel::Glm(m) => build_inner!(m, Glm),
         AnyModel::Ollama(m) => build_inner!(m, Ollama),
         AnyModel::Custom(m) => build_inner!(m, Custom),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean_env() {
+        for var in &[
+            "DEEPSEEK_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GLM_API_KEY",
+            "OLLAMA_API_KEY",
+            "OPENROUTER_API_KEY",
+        ] {
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    #[test]
+    fn auto_detect_returns_none_when_no_vars_set() {
+        clean_env();
+        assert_eq!(auto_detect_provider(), None);
+    }
+
+    #[test]
+    fn auto_detect_finds_deepseek_when_key_set() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-test-123") };
+        assert_eq!(auto_detect_provider(), Some("deepseek"));
+    }
+
+    #[test]
+    fn auto_detect_finds_openai_when_key_set() {
+        clean_env();
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-456") };
+        assert_eq!(auto_detect_provider(), Some("openai"));
+    }
+
+    #[test]
+    fn auto_detect_skips_empty_var() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "") };
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-789") };
+        assert_eq!(auto_detect_provider(), Some("openai"));
+    }
+
+    #[test]
+    fn auto_detect_returns_first_match_in_order() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-ds") };
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-oai") };
+        assert_eq!(auto_detect_provider(), Some("deepseek"));
     }
 }


### PR DESCRIPTION
Hey! Small quality-of-life improvement here.

**The problem:** Setting `DEEPSEEK_API_KEY` (or any provider's API key) still required explicitly passing `--provider deepseek` or configuring it — otherwise dirge would fall back to openrouter. Felt a bit fiddly.

**What this does:** If no provider is set via CLI flag, `DIRGE_PROVIDER` env var, or config file, dirge now checks for known API key environment variables and picks the matching provider automatically.

Resolution order is:
1. `--provider` CLI flag / `DIRGE_PROVIDER` env var
2. `provider` in config file
3. Auto-detect from `*_API_KEY` env vars (new!)
4. Default to `"openrouter"`

Supported vars: `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GLM_API_KEY`, `OLLAMA_API_KEY`, `OPENROUTER_API_KEY`

**Changes:**
- `src/provider.rs` — new `auto_detect_provider()` + 5 unit tests
- `src/cli.rs` — `resolve_provider()` calls auto-detect as a fallback

cargo clippy is clean (no new warnings), cargo fmt passes, and all 5 new tests + all 497 existing non-plugin tests pass.

Thanks for the great project!


edit: written with dirge and deepseek v4 pro i looked at the code changes, looked okay