### PR TITLE
chore: audit fixes (5 rounds — CRITICAL/HIGH/MEDIUM/LOW)

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -217,8 +217,11 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             )),
         ];
 
-        let question_tool = question_tx
-            .map(|tx| Box::new(tools::QuestionTool::new(tx)) as Box<dyn rig::tool::ToolDyn>);
+        let question_tool = question_tx.map(|tx| {
+            Box::new(
+                tools::QuestionTool::new(tx).with_permission(permission.clone(), ask_tx.clone()),
+            ) as Box<dyn rig::tool::ToolDyn>
+        });
 
         let plan_tools = plan_tx.map(|tx| {
             let enter =

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -282,8 +282,10 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 pm,
                 store.clone(),
             ));
-            let status_tool =
-                Box::new(tools::TaskStatusTool::new(store)) as Box<dyn rig::tool::ToolDyn>;
+            let status_tool = Box::new(
+                tools::TaskStatusTool::new(store)
+                    .with_permission(permission.clone(), ask_tx.clone()),
+            ) as Box<dyn rig::tool::ToolDyn>;
             builder = builder.tools(hookify(vec![task_tool, status_tool]));
         }
 

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -194,7 +194,11 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 ask_tx.clone(),
                 cache.clone(),
             )),
-            Box::new(tools::GlobTool::new(permission.clone(), ask_tx.clone())),
+            Box::new(tools::GlobTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+            )),
             Box::new(tools::ListDirTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),

--- a/src/agent/tools/glob.rs
+++ b/src/agent/tools/glob.rs
@@ -5,16 +5,42 @@ use serde::Deserialize;
 use std::path::Path;
 
 use crate::agent::tools::MAX_FIND_RESULTS;
+use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
 pub struct GlobTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
+    pub cache: Option<ToolCache>,
 }
 
 impl GlobTool {
+    /// Construct without a cache. Retained for parity with other
+    /// tools (Read/Grep/FindFiles/ListDir) and exercised by unit
+    /// tests; production paths use `with_cache`.
+    #[allow(dead_code)]
     pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        Self { permission, ask_tx }
+        Self {
+            permission,
+            ask_tx,
+            cache: None,
+        }
+    }
+
+    /// Builder that matches the dual-constructor pattern used by
+    /// Read/Grep/FindFiles/ListDir. Same `ToolCache` is shared
+    /// across tools so a `bash`/`write` that mutates the filesystem
+    /// invalidates glob results too via `cache.clear()`.
+    pub fn with_cache(
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+        cache: ToolCache,
+    ) -> Self {
+        Self {
+            permission,
+            ask_tx,
+            cache: Some(cache),
+        }
     }
 }
 
@@ -95,6 +121,17 @@ impl Tool for GlobTool {
         )
         .await?;
 
+        let cache_key = format!(
+            "glob:{}:{}",
+            args.pattern,
+            args.path.as_deref().unwrap_or("."),
+        );
+        if let Some(ref cache) = self.cache
+            && let Some(cached) = cache.get(&cache_key)
+        {
+            return Ok(cached);
+        }
+
         let re = glob_to_regex(&args.pattern).map_err(|e| ToolError::Msg(e))?;
 
         let root = args
@@ -150,11 +187,15 @@ impl Tool for GlobTool {
         });
 
         let results: Vec<String> = matches.into_iter().map(|(rel, _)| rel).collect();
-        if results.is_empty() {
-            Ok(String::new())
+        let out = if results.is_empty() {
+            String::new()
         } else {
-            Ok(results.join("\n"))
+            results.join("\n")
+        };
+        if let Some(ref cache) = self.cache {
+            cache.set(&cache_key, out.clone());
         }
+        Ok(out)
     }
 }
 

--- a/src/agent/tools/lsp.rs
+++ b/src/agent/tools/lsp.rs
@@ -176,7 +176,7 @@ impl Tool for LspTool {
                     },
                     "query": {
                         "type": "string",
-                        "description": "Search string for workspaceSymbol. Empty string returns all symbols."
+                        "description": "Search string for workspaceSymbol — REQUIRED when operation is 'workspaceSymbol' (pass empty string to list all symbols). Ignored for other operations."
                     }
                 },
                 "required": ["operation", "file_path"]

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -62,6 +62,12 @@ impl Tool for PlanEnterTool {
     }
 
     async fn call(&self, _args: PlanEnterArgs) -> Result<String, ToolError> {
+        // Note: this tool doesn't go through `check_perm` because the
+        // plan_tx channel itself surfaces a confirmation dialog to the
+        // user — the user has to explicitly Accept or Reject the mode
+        // switch via `PlanSwitchResponse`. Routing through `check_perm`
+        // would double-ask. This matches how `harness/confirm` works
+        // in the plugin layer.
         let (reply_tx, reply_rx) = oneshot::channel();
 
         self.plan_tx

--- a/src/agent/tools/question.rs
+++ b/src/agent/tools/question.rs
@@ -3,7 +3,7 @@ use rig::tool::Tool;
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
 
-use crate::agent::tools::ToolError;
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
 pub type QuestionSender = mpsc::Sender<QuestionRequest>;
 pub type QuestionReceiver = mpsc::Receiver<QuestionRequest>;
@@ -48,11 +48,30 @@ pub struct QuestionOption {
 
 pub struct QuestionTool {
     pub question_tx: QuestionSender,
+    pub permission: Option<PermCheck>,
+    pub ask_tx: Option<AskSender>,
 }
 
 impl QuestionTool {
     pub fn new(question_tx: QuestionSender) -> Self {
-        Self { question_tx }
+        Self {
+            question_tx,
+            permission: None,
+            ask_tx: None,
+        }
+    }
+
+    /// Builder for the production path: wires the permission checker
+    /// + ask channel so `question` invocations go through the same
+    /// allow/ask/deny rules as every other behaviour-altering tool.
+    pub fn with_permission(
+        mut self,
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+    ) -> Self {
+        self.permission = permission;
+        self.ask_tx = ask_tx;
+        self
     }
 }
 
@@ -116,6 +135,17 @@ impl Tool for QuestionTool {
     }
 
     async fn call(&self, args: QuestionArgs) -> Result<String, ToolError> {
+        // Route through the same permission system as task / write /
+        // bash. `question` rewrites what the LLM sees by injecting
+        // user input — that's behavior-altering and shouldn't bypass
+        // user rules.
+        let summary = args
+            .questions
+            .first()
+            .map(|q| q.question.clone())
+            .unwrap_or_default();
+        check_perm(&self.permission, &self.ask_tx, "question", &summary).await?;
+
         let (reply_tx, reply_rx) = oneshot::channel();
 
         self.question_tx

--- a/src/agent/tools/task_status.rs
+++ b/src/agent/tools/task_status.rs
@@ -3,16 +3,32 @@ use rig::tool::Tool;
 use serde::Deserialize;
 use std::time::Duration;
 
-use crate::agent::tools::ToolError;
 use crate::agent::tools::background::{BackgroundStore, TaskState};
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
 pub struct TaskStatusTool {
     bg_store: BackgroundStore,
+    permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
 }
 
 impl TaskStatusTool {
     pub fn new(bg_store: BackgroundStore) -> Self {
-        Self { bg_store }
+        Self {
+            bg_store,
+            permission: None,
+            ask_tx: None,
+        }
+    }
+
+    pub fn with_permission(
+        mut self,
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+    ) -> Self {
+        self.permission = permission;
+        self.ask_tx = ask_tx;
+        self
     }
 }
 
@@ -52,6 +68,10 @@ impl Tool for TaskStatusTool {
     }
 
     async fn call(&self, args: TaskStatusArgs) -> Result<String, ToolError> {
+        // Same permission gate as `task` — status polling can side-
+        // channel sensitive subagent results, and the wait=true path
+        // can hold the parent turn open for up to 10 minutes.
+        check_perm(&self.permission, &self.ask_tx, "task_status", &args.task_id).await?;
         let wait = args.wait.unwrap_or(false);
 
         if wait {

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -91,7 +91,8 @@ impl Tool for WebFetchTool {
                         "description": "URLs to fetch (may be comma-separated)"
                     },
                     "max_chars": {
-                        "type": "number",
+                        "type": "integer",
+                        "minimum": 1,
                         "description": "Maximum characters to return per URL (default: 3000)"
                     }
                 },

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -2063,7 +2063,14 @@ fn parse_tree_op_line(line: &str) -> Option<TreeOp> {
                 Some(TreeOp::SwitchSession { id_prefix: arg1 })
             }
         }
-        _ => None,
+        // Forward compat: a future plugin shipping an op verb we
+        // don't know yet shouldn't poison the rest of the drain. Log
+        // at WARN so a confused plugin author can spot the typo
+        // instead of silently failing.
+        other => {
+            tracing::warn!(target: "dirge::plugin", op = other, "drain_tree_ops: unknown op verb (skipped)");
+            None
+        }
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -315,12 +315,15 @@ impl Session {
     pub fn pop_last_message(&mut self) -> Option<SessionMessage> {
         self.ensure_back_compat_initialized();
         let msg = self.messages.pop()?;
-        // Move leaf back to the popped node's parent.
-        let parent = self
-            .tree
-            .entries
-            .get(&msg.id)
-            .and_then(|n| n.parent.clone());
+        // Pull the popped node's parent for leaf rewind. If the tree
+        // somehow lacks this node (corruption / external mutation),
+        // fall back to the previous message in the linear cache rather
+        // than wiping the leaf — wiping would leave the tree dangling
+        // when the user pops on a branched session.
+        let parent = match self.tree.entries.get(&msg.id) {
+            Some(node) => node.parent.clone(),
+            None => self.messages.last().map(|m| m.id.clone()),
+        };
         self.tree.leaf_id = parent;
         // Only prune the node if nothing else (e.g. a forked branch)
         // refers to it as a parent.
@@ -391,6 +394,13 @@ impl Session {
     /// chosen message so the next add_message creates a divergent
     /// branch. Returns the message content (so the UI can restore
     /// it into the input editor for re-editing).
+    ///
+    /// **Root-node behaviour**: if `entry_id` has no parent (it is
+    /// the conversation root), the current `messages` cache is
+    /// cleared and `tree.leaf_id` is set to `None` so the next
+    /// `add_message` starts a fresh root. The tree's other entries
+    /// (sibling branches) are *not* pruned — they remain reachable
+    /// via `/tree`.
     ///
     /// Mirrors pi's `ctx.fork(entryId, { position: "before" })`.
     pub fn fork_at(&mut self, entry_id: &CompactString) -> Result<SessionMessage, String> {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -489,7 +489,14 @@ impl Session {
     }
 
     pub fn compress(&mut self, summary: String, first_kept_index: usize, token_savings: u64) {
+        // Bounds check — callers compute `first_kept_index` from a
+        // reverse-scan of `messages` so it should always be in range,
+        // but a buggy/racy caller could pass out-of-bounds. Clamp
+        // rather than panic on `drain(..)` so a misuse degrades to
+        // "summarize everything" instead of a hard crash.
+        let first_kept_index = first_kept_index.min(self.messages.len());
         let summarized_count = first_kept_index;
+
         // Subtract the saved tokens from estimated total
         self.total_estimated_tokens = self.total_estimated_tokens.saturating_sub(token_savings);
         // Add back estimated tokens for the summary itself
@@ -513,6 +520,8 @@ impl Session {
             .iter()
             .map(|m| m.id.clone())
             .collect();
+        let dropped_set: std::collections::HashSet<CompactString> =
+            dropped_ids.iter().cloned().collect();
 
         // Remove summarized messages and insert summary
         self.messages.drain(..first_kept_index);
@@ -544,7 +553,26 @@ impl Session {
                 node.parent = Some(summary_id.clone());
             }
         } else {
-            self.tree.leaf_id = Some(summary_id);
+            self.tree.leaf_id = Some(summary_id.clone());
+        }
+        // Re-point the tree leaf if the previous leaf was one of the
+        // pruned nodes (e.g. a branched session compressed the branch
+        // that owned the leaf). Without this the leaf dangles at an
+        // id that no longer exists in `tree.entries`.
+        let leaf_dropped = self
+            .tree
+            .leaf_id
+            .as_ref()
+            .map(|id| dropped_set.contains(id))
+            .unwrap_or(false);
+        if leaf_dropped {
+            // Anchor the leaf to the new first-kept message, or to the
+            // summary if nothing else survived.
+            self.tree.leaf_id = self
+                .messages
+                .get(1)
+                .map(|m| m.id.clone())
+                .or(Some(summary_id.clone()));
         }
 
         self.compactions.push(Compaction {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -231,6 +231,18 @@ impl Session {
         self.tree.leaf_id = prev;
     }
 
+    /// Run both back-compat initializers as a unit. Use this instead
+    /// of calling `ensure_message_store_initialized` and
+    /// `ensure_tree_initialized` separately — they're individually
+    /// idempotent but the combined invariant ("tree + store both
+    /// reflect `messages`") is what every mutation actually depends
+    /// on. A panic between two separate calls would leave the
+    /// session half-initialized; this helper does both in one shot.
+    pub fn ensure_back_compat_initialized(&mut self) {
+        self.ensure_message_store_initialized();
+        self.ensure_tree_initialized();
+    }
+
     /// Append a plugin entry to this session. Assigns the next
     /// monotonic `seq` so renderers can produce a deterministic
     /// ordering even within a single-second timestamp bucket. Plugins
@@ -259,8 +271,7 @@ impl Session {
         // from a pre-P4b/P4c session file BEFORE we append the new
         // one — otherwise the rebuild would re-insert this new message
         // with the wrong parent.
-        self.ensure_tree_initialized();
-        self.ensure_message_store_initialized();
+        self.ensure_back_compat_initialized();
         let tokens = Self::estimate_tokens(content);
         let id = new_message_id();
         let timestamp = chrono::Utc::now().timestamp();
@@ -302,8 +313,7 @@ impl Session {
     /// fork's children stay reachable. In the linear case it's
     /// always safe to remove.
     pub fn pop_last_message(&mut self) -> Option<SessionMessage> {
-        self.ensure_tree_initialized();
-        self.ensure_message_store_initialized();
+        self.ensure_back_compat_initialized();
         let msg = self.messages.pop()?;
         // Move leaf back to the popped node's parent.
         let parent = self
@@ -340,8 +350,7 @@ impl Session {
     /// would indicate corruption). On error, leaves the session
     /// state untouched.
     pub fn switch_to_leaf(&mut self, new_leaf_id: &CompactString) -> Result<(), String> {
-        self.ensure_tree_initialized();
-        self.ensure_message_store_initialized();
+        self.ensure_back_compat_initialized();
         if !self.tree.entries.contains_key(new_leaf_id) {
             return Err(format!("unknown entry id: {}", new_leaf_id));
         }
@@ -385,8 +394,7 @@ impl Session {
     ///
     /// Mirrors pi's `ctx.fork(entryId, { position: "before" })`.
     pub fn fork_at(&mut self, entry_id: &CompactString) -> Result<SessionMessage, String> {
-        self.ensure_tree_initialized();
-        self.ensure_message_store_initialized();
+        self.ensure_back_compat_initialized();
         let node = self
             .tree
             .entries
@@ -530,8 +538,7 @@ impl Session {
         // Mirror into the tree + store: remove dropped nodes, insert
         // the new summary node as the new root, and re-parent the
         // first kept node to point at the summary.
-        self.ensure_tree_initialized();
-        self.ensure_message_store_initialized();
+        self.ensure_back_compat_initialized();
         for id in &dropped_ids {
             self.tree.entries.remove(id);
             self.message_store.remove(id);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -582,6 +582,14 @@ impl Session {
                 .or(Some(summary_id.clone()));
         }
 
+        // On compress we replace every prior compaction record with a
+        // single fresh one. `Compaction::first_kept_index` is meant to
+        // mark the message-index boundary for the *latest* compaction
+        // only — keeping a stale list of records from earlier compresses
+        // makes their indices meaningless after subsequent drains. The
+        // latest summary IS the conversation prefix; older summaries
+        // are folded into it via `previous_summary` in the LLM context.
+        self.compactions.clear();
         self.compactions.push(Compaction {
             summary: CompactString::from(summary),
             first_kept_index: 1, // The summary is at index 0
@@ -590,8 +598,6 @@ impl Session {
             created_at: CompactString::new(chrono::Utc::now().to_rfc3339()),
         });
 
-        // Adjust all compaction first_kept indices for the removed messages
-        // (since we never have >1 compaction with the current simple approach, this is fine)
         self.updated_at = CompactString::new(chrono::Utc::now().to_rfc3339());
     }
 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -28,7 +28,32 @@ pub(crate) fn config_path() -> PathBuf {
     home.join(".config").join("dirge")
 }
 
+/// Validate that a session id is safe to interpolate into a path.
+/// Session ids are normally UUIDs (hex + hyphens), but they round-trip
+/// through JSON on disk so a tampered-with file could carry an id like
+/// `../../etc/passwd`. Reject anything that isn't strictly
+/// `[A-Za-z0-9._-]+` so a malicious id can't escape the session dir.
+fn validate_session_id(id: &str) -> anyhow::Result<()> {
+    if id.is_empty() {
+        anyhow::bail!("session id is empty");
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        anyhow::bail!("session id contains disallowed characters: {:?}", id);
+    }
+    // Belt-and-braces: `..` or leading `.` would still resolve relatively
+    // via `Path::join` even after the char check (`.` is allowed for
+    // legitimate ids like `2024.session`).
+    if id == "." || id == ".." || id.contains("/") || id.contains("\\") {
+        anyhow::bail!("session id resolves outside the session dir: {:?}", id);
+    }
+    Ok(())
+}
+
 pub fn save_session(session: &Session) -> anyhow::Result<()> {
+    validate_session_id(&session.id)?;
     let dir = session_dir();
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{}.json", session.id));
@@ -38,6 +63,7 @@ pub fn save_session(session: &Session) -> anyhow::Result<()> {
 }
 
 pub fn load_session(id: &str) -> anyhow::Result<Session> {
+    validate_session_id(id)?;
     let dir = session_dir();
     let path = dir.join(format!("{}.json", id));
     let json = std::fs::read_to_string(path)?;
@@ -45,12 +71,40 @@ pub fn load_session(id: &str) -> anyhow::Result<Session> {
 }
 
 pub fn delete_session(id: &str) -> anyhow::Result<()> {
+    validate_session_id(id)?;
     let dir = session_dir();
     let path = dir.join(format!("{}.json", id));
     if path.exists() {
         std::fs::remove_file(path)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_session_id_accepts_uuids() {
+        assert!(validate_session_id("a1b2c3d4-e5f6-7890-abcd-ef1234567890").is_ok());
+        assert!(validate_session_id("plain-id").is_ok());
+        assert!(validate_session_id("2024.session").is_ok());
+        assert!(validate_session_id("session_42").is_ok());
+    }
+
+    #[test]
+    fn validate_session_id_rejects_traversal() {
+        assert!(validate_session_id("../../../etc/passwd").is_err());
+        assert!(validate_session_id("..\\windows").is_err());
+        assert!(validate_session_id("..").is_err());
+        assert!(validate_session_id(".").is_err());
+        assert!(validate_session_id("a/b").is_err());
+        assert!(validate_session_id("a\\b").is_err());
+        assert!(validate_session_id("").is_err());
+        // Null bytes, newlines, spaces — anything non-id-shaped.
+        assert!(validate_session_id("foo bar").is_err());
+        assert!(validate_session_id("foo\nbar").is_err());
+    }
 }
 
 pub fn find_sessions_by_prefix(prefix: &str) -> anyhow::Result<Vec<Session>> {

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -60,11 +60,8 @@ fn flush_acc(acc: &str, color: Color, max_width: usize, out: &mut Vec<LineEntry>
     }
 }
 
-fn bullet_prefix(col: Color) -> &'static str {
-    match col {
-        Color::DarkGrey => "  ┊ ",
-        _ => "  • ",
-    }
+fn bullet_prefix(in_blockquote: bool) -> &'static str {
+    if in_blockquote { "  ┊ " } else { "  • " }
 }
 
 pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
@@ -120,7 +117,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
             Event::End(tag_end) => match tag_end {
                 TagEnd::Paragraph => {
                     let color = if in_blockquote {
-                        Color::DarkGrey
+                        crate::ui::theme::dim()
                     } else {
                         crate::ui::theme::agent()
                     };
@@ -128,7 +125,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     acc.clear();
                 }
                 TagEnd::Heading(_) => {
-                    flush_acc(&acc, Color::Cyan, max_width, &mut result);
+                    flush_acc(&acc, crate::ui::theme::header(), max_width, &mut result);
                     acc.clear();
                     in_heading = false;
                     result.push(LineEntry {
@@ -142,12 +139,12 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         if trimmed.is_empty() {
                             result.push(LineEntry {
                                 text: CompactString::new(""),
-                                color: Color::DarkYellow,
+                                color: crate::ui::theme::tool(),
                             });
                         } else {
                             result.push(LineEntry {
                                 text: CompactString::from(trimmed),
-                                color: Color::DarkYellow,
+                                color: crate::ui::theme::tool(),
                             });
                         }
                     }
@@ -165,14 +162,14 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                         if trimmed.is_empty() {
                             quoted.push(LineEntry {
                                 text: CompactString::new(""),
-                                color: Color::DarkGrey,
+                                color: crate::ui::theme::dim(),
                             });
                         } else {
                             let prefixed = format!("│ {}", trimmed);
                             for chunk in word_wrap(&prefixed, max_width) {
                                 quoted.push(LineEntry {
                                     text: chunk,
-                                    color: Color::DarkGrey,
+                                    color: crate::ui::theme::dim(),
                                 });
                             }
                         }
@@ -187,14 +184,14 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 }
                 TagEnd::Item => {
                     let color = if in_blockquote {
-                        Color::DarkGrey
+                        crate::ui::theme::dim()
                     } else {
                         crate::ui::theme::agent()
                     };
                     let bullet = if ordered_list {
                         format!(" {}. ", list_item_count)
                     } else {
-                        format!("{}", bullet_prefix(color))
+                        bullet_prefix(in_blockquote).to_string()
                     };
                     let mut item_lines = Vec::new();
                     let mut first = true;
@@ -262,7 +259,7 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                 let rule: String = std::iter::repeat('─').take(max_width.min(40)).collect();
                 result.push(LineEntry {
                     text: CompactString::from(rule),
-                    color: Color::DarkGrey,
+                    color: crate::ui::theme::dim(),
                 });
                 result.push(LineEntry {
                     text: CompactString::new(""),
@@ -291,11 +288,11 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
 
     if !acc.is_empty() {
         let color = if in_blockquote {
-            Color::DarkGrey
+            crate::ui::theme::dim()
         } else if in_code_block {
-            Color::DarkYellow
+            crate::ui::theme::tool()
         } else if in_heading {
-            Color::Cyan
+            crate::ui::theme::header()
         } else {
             crate::ui::theme::agent()
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1051,6 +1051,7 @@ pub async fn run_interactive(
                                                 let msg = format!("I ran: $ {}\n\nOutput:\n{}", cmd, output);
                                                 let history = crate::agent::runner::convert_history(session);
                                                 session.add_message(MessageRole::User, &msg);
+                                renderer.set_avatar_state(avatar::AvatarState::Idle);
                                                 let runner = agent.clone().spawn_runner(
                                                     crate::agent::tools::background::prepend_pending_notifications(&msg, bg_store.as_ref()),
                                                     history,
@@ -1145,6 +1146,7 @@ pub async fn run_interactive(
                                             );
                                             let history = crate::agent::runner::convert_history(session);
                                             session.add_message(MessageRole::User, &prompt);
+                                            renderer.set_avatar_state(avatar::AvatarState::Idle);
                                             let runner = agent.clone().spawn_runner(
                                                 crate::agent::tools::background::prepend_pending_notifications(&prompt, bg_store.as_ref()),
                                                 history,
@@ -1342,6 +1344,7 @@ pub async fn run_interactive(
                                 is_running = true;
 
                                 session.add_message(MessageRole::User, &text);
+                                renderer.set_avatar_state(avatar::AvatarState::Idle);
                             }
                         }
                         renderer.draw_bottom(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1605,6 +1605,23 @@ pub async fn run_interactive(
                                 plugin_followup = Some(pending);
                             }
                             mgr.store_response(&response);
+                            // Fire on-complete after on-response so
+                            // plugins can react to "turn fully done."
+                            // Previously this hook was in HOOK_NAMES
+                            // (so plugins defining it got auto-aliased)
+                            // but no host site dispatched — silent fail.
+                            match mgr.dispatch("on-complete", "@{}") {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    renderer.write_line(
+                                        &format!("[plugin] on-complete error: {e}"),
+                                        c_error(),
+                                    )?;
+                                }
+                            }
+                            // Clear `harness-response` so the next hook
+                            // doesn't see stale text from this turn.
+                            let _ = mgr.eval("(set harness-response nil)");
                         }
 
                         if !response_buf.is_empty() {
@@ -1956,6 +1973,18 @@ pub async fn run_interactive(
                                     "on-turn-start",
                                     &format!("@{{:index {}}}", index),
                                 );
+                                // Clear tool-hook slots after the turn
+                                // hook runs so a `(harness/block ...)`
+                                // call inside on-turn-start can't bleed
+                                // into the *first* tool of the next
+                                // turn. `dispatch_tool_hook` clears
+                                // slots before tool hooks, but turn
+                                // hooks bypass that path.
+                                let _ = mgr.eval(
+                                    "(do (set harness-block nil) \
+                                         (set harness-mutate-input nil) \
+                                         (set harness-replace-result nil))",
+                                );
                             }
                         }
                         #[cfg(not(feature = "plugin"))]
@@ -1994,6 +2023,15 @@ pub async fn run_interactive(
                                         index,
                                         crate::plugin::escape_janet_string(&current_turn_text),
                                     ),
+                                );
+                                // Same defense as on-turn-start: clear
+                                // tool-hook slots so turn-end can't
+                                // leak block/mutate/replace into the
+                                // next tool call.
+                                let _ = mgr.eval(
+                                    "(do (set harness-block nil) \
+                                         (set harness-mutate-input nil) \
+                                         (set harness-replace-result nil))",
                                 );
                             }
                         }

--- a/src/ui/plugin_tree.rs
+++ b/src/ui/plugin_tree.rs
@@ -117,10 +117,27 @@ pub fn apply_tree_op(op: TreeOp, session: &mut Session, input: &mut InputEditor)
                             short(new_id.as_str()),
                         ))
                     }
-                    n => TreeOpEffect::Failed(format!(
-                        "[plugin] switch-session: prefix '{}' matches {} sessions",
-                        id_prefix, n
-                    )),
+                    n => {
+                        // Surface the first few matches so the plugin
+                        // author / user can pick a longer prefix.
+                        let ids: Vec<String> = matches
+                            .iter()
+                            .take(3)
+                            .map(|s| short(s.id.as_str()))
+                            .collect();
+                        let suffix = if n > 3 {
+                            format!(" (and {} more)", n - 3)
+                        } else {
+                            String::new()
+                        };
+                        TreeOpEffect::Failed(format!(
+                            "[plugin] switch-session: prefix '{}' matches {} sessions ({}){}",
+                            id_prefix,
+                            n,
+                            ids.join(", "),
+                            suffix,
+                        ))
+                    }
                 },
                 Err(e) => TreeOpEffect::Failed(format!("[plugin] switch-session: {}", e)),
             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -873,22 +873,26 @@ impl Renderer {
         // prefix` + cursor offset within content).
         let cursor_x =
             (bottom_indent + 3 + cursor_visual_col).min(cols.saturating_sub(1) as usize) as u16;
-        stdout.execute(MoveTo(cursor_x, cursor_row))?;
+
+        // Hide the cursor BEFORE painting panel + avatar — those paints
+        // execute many `MoveTo` calls and the hardware cursor would
+        // visibly flicker across the right-hand panel while iterating
+        // its rows. Hidden cursor stays invisible until the final Show
+        // below puts it back at the input prompt.
+        stdout.execute(Hide)?;
 
         if self.panel_visible() {
             self.draw_panel(&mut stdout, rows)?;
-            // draw_panel moves the cursor — return it to the input.
-            stdout.execute(MoveTo(cursor_x, cursor_row))?;
         }
-
         // Paint the avatar in the bottom-left margin (cols 0..AVATAR_W,
         // rows just above the input row). Only painted when the
         // centering indent leaves room — on narrow terminals where
         // the chat band already starts at col 0, there's no margin to
         // put a face into.
         self.draw_avatar(&mut stdout, input_top)?;
-        // The avatar paint moves the cursor — return it to the input
-        // position for the visible Show below.
+
+        // Place the cursor at the input position; the Show below will
+        // make it visible exactly there.
         stdout.execute(MoveTo(cursor_x, cursor_row))?;
 
         // draw_bottom is the only place the visible cursor belongs (at the


### PR DESCRIPTION
Five rounds of audit fixes from the codebase audit.

## Round 1 — Security + crashes (CRITICAL/HIGH)
- Session storage path-traversal validation (\`save_session\` / \`load_session\` / \`delete_session\` now reject ids containing \`..\`, slashes, etc.)
- Compress bounds clamp + branched-session leaf-tracking fix
- QuestionTool routes through permission system

## Round 2 — Silent failures (HIGH/MEDIUM)
- \`on-complete\` hook now actually dispatches (was in HOOK_NAMES but never fired)
- Turn-hook slot reset (block/mutate/replace no longer leak from turn boundaries into tool calls)
- harness-response cleared after store_response
- drain_tree_ops warns on unknown op verbs

## Round 3 — Theme + UI polish (CRITICAL/HIGH/MEDIUM)
- 13 hardcoded color literals in markdown.rs swept to theme accessors
- Cursor flicker fixed (Hide before draw_panel)
- Avatar resets to Idle on user submit
- ensure_back_compat_initialized atomic helper

## Round 4 — Schema + permission hygiene (MEDIUM)
- TaskStatusTool routes through permission
- PlanEnter/PlanExit kept un-gated (have their own confirm flow) — documented
- WebFetch max_chars: number → integer
- LSP workspaceSymbol query constraint documented in schema
- Compress now replaces compactions list instead of appending stale records

## Round 5 — Low hygiene (LOW)
- GlobTool dual-constructor with cache support
- pop_last_message tree-corruption fallback
- fork_at root-node behaviour documented
- switch-session ambiguity error lists candidate session ids

## Totals
- 606 tests pass, 0 fail
- Both build profiles -> 0 warnings
- 22 of 24 audit findings resolved; remaining 2 deferred (workflow.janet example coverage, line-only selection — both pure feature work)