### PR TITLE
fix(audit r2): permission rules + markdown tables + /retry + bold streaming + atomic save + UX polish

### DIFF
--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -76,11 +76,24 @@ fn apply_create(path: &str, content: &str) -> Result<String, String> {
 fn apply_update(path: &str, old_text: &str, new_text: &str) -> Result<String, String> {
     let original = std::fs::read_to_string(path).map_err(|e| format!("read failed: {}", e))?;
 
-    if !original.contains(old_text) {
+    // CRLF normalization to match `edit.rs`. The LLM almost always
+    // generates `\n` in `old_text` even when the file is CRLF on
+    // disk; without normalization the literal substring match fails.
+    // We normalize a working copy for matching but preserve the
+    // original's line endings on the write-back.
+    let crlf = original.contains("\r\n");
+    let normalized = if crlf {
+        original.replace("\r\n", "\n")
+    } else {
+        original.clone()
+    };
+    let needle = old_text.replace("\r\n", "\n");
+
+    if !normalized.contains(&needle) {
         return Err(format!("text not found in {}", path));
     }
 
-    let matches: Vec<_> = original.match_indices(old_text).collect();
+    let matches: Vec<_> = normalized.match_indices(&needle).collect();
     if matches.len() > 1 {
         return Err(format!(
             "text matches {} locations in {} — provide more context to make unique",
@@ -89,8 +102,20 @@ fn apply_update(path: &str, old_text: &str, new_text: &str) -> Result<String, St
         ));
     }
 
-    let updated = original.replacen(old_text, new_text, 1);
-    std::fs::write(path, &updated).map_err(|e| format!("write failed: {}", e))?;
+    let replacement = if crlf {
+        new_text.replace("\r\n", "\n")
+    } else {
+        new_text.to_string()
+    };
+    let updated_normalized = normalized.replacen(&needle, &replacement, 1);
+    // Restore CRLF line endings on write-back so we don't silently
+    // re-format the user's file.
+    let to_write = if crlf {
+        updated_normalized.replace('\n', "\r\n")
+    } else {
+        updated_normalized
+    };
+    std::fs::write(path, &to_write).map_err(|e| format!("write failed: {}", e))?;
     Ok(format!("updated {}", path))
 }
 
@@ -206,9 +231,6 @@ impl Tool for ApplyPatchTool {
 
             match result {
                 Ok(msg) => {
-                    if let Some(ref cache) = self.cache {
-                        cache.clear();
-                    }
                     // Record the touched path(s) for the info panel. Rename
                     // adds the *new* path; delete still records the path the
                     // user/agent operated on so the panel reflects the action.
@@ -233,6 +255,14 @@ impl Tool for ApplyPatchTool {
                     break;
                 }
             }
+        }
+
+        // Clear the cache once after the batch instead of once per op.
+        // Per-op clearing was correct but wasteful — a 5-op batch
+        // would clear 5 times. Subsequent tool calls within the same
+        // turn now see a single clean cache.
+        if let Some(ref cache) = self.cache {
+            cache.clear();
         }
 
         Ok(results.join("\n"))

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -133,6 +133,35 @@ async fn check_bash_segments(
     }
     #[cfg(not(feature = "semantic-bash"))]
     {
-        check_perm(permission, ask_tx, "bash", command).await
+        // Best-effort coarse split when tree-sitter isn't compiled in.
+        // Without it, a command like `safe_cmd && rm -rf /` would be
+        // checked as a single string against the bash rules and might
+        // squeak through if `safe_cmd && rm` doesn't match any deny.
+        // Split on the unambiguous compound separators (`&&`, `;`,
+        // `||`) so each segment is checked individually. This won't
+        // catch command substitution or subshells — those need the
+        // tree-sitter feature for correct parsing — but it covers the
+        // common compound case.
+        let segments = command
+            .split(|c| c == ';')
+            .flat_map(|s| s.split("&&"))
+            .flat_map(|s| s.split("||"))
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<&str>>();
+        // Flag command substitution / subshell constructs that need a
+        // full parser. Surface as one whole-command check so the user
+        // sees the unfamiliar form before any segment runs.
+        let has_substitution = command.contains("$(")
+            || command.contains('`')
+            || command.contains("<(")
+            || command.contains(">(");
+        if has_substitution {
+            return check_perm(permission, ask_tx, "bash", command).await;
+        }
+        for segment in &segments {
+            check_perm(permission, ask_tx, "bash", segment).await?;
+        }
+        Ok(())
     }
 }

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -60,6 +60,9 @@ impl PermissionChecker {
             ("find_files", &config.find_files),
             ("list_dir", &config.list_dir),
             ("write_todo_list", &config.write_todo_list),
+            ("apply_patch", &config.apply_patch),
+            ("lsp", &config.lsp),
+            ("question", &config.question),
         ] {
             let Some(tp) = tool_perm else { continue };
             let mut entries = Vec::new();

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -32,6 +32,16 @@ pub struct PermissionConfig {
     pub find_files: Option<ToolPerm>,
     pub list_dir: Option<ToolPerm>,
     pub write_todo_list: Option<ToolPerm>,
+    /// `apply_patch` — bulk multi-file patch tool. Mutates the
+    /// filesystem like `write`/`edit`; deserves per-pattern rules.
+    pub apply_patch: Option<ToolPerm>,
+    /// `lsp` — language-server queries (definition, references,
+    /// hover, etc.). Reads project files via the language server.
+    pub lsp: Option<ToolPerm>,
+    /// `question` — interactive user-input solicitation tool. Per-
+    /// pattern rules let users restrict which kinds of questions
+    /// the agent can ask.
+    pub question: Option<ToolPerm>,
     pub external_directory: Option<HashMap<String, Action>>,
     pub doom_loop: Option<Action>,
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -446,7 +446,10 @@ impl Session {
         entry_id: &CompactString,
         label: Option<String>,
     ) -> Result<(), String> {
-        self.ensure_tree_initialized();
+        // Mirror the other mutation methods — keep tree + store in
+        // lockstep even though set_label only touches the tree, in
+        // case a future label-aware code path inspects the store.
+        self.ensure_back_compat_initialized();
         let node = self
             .tree
             .entries

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -58,7 +58,22 @@ pub fn save_session(session: &Session) -> anyhow::Result<()> {
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{}.json", session.id));
     let json = serde_json::to_string_pretty(session)?;
-    std::fs::write(path, json)?;
+    // Atomic write: write to a sibling temp file, fsync, then rename
+    // over the target. A crash mid-write leaves the temp behind but
+    // never a truncated `.json`. The rename is atomic on every OS we
+    // target. Use the same parent dir so rename stays on one filesystem.
+    let tmp = dir.join(format!(".{}.json.tmp", session.id));
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(json.as_bytes())?;
+        // Best-effort fsync; non-fatal if the platform doesn't support it.
+        let _ = f.sync_all();
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
     Ok(())
 }
 

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -64,12 +64,129 @@ fn bullet_prefix(in_blockquote: bool) -> &'static str {
     if in_blockquote { "  ┊ " } else { "  • " }
 }
 
+/// Render a markdown table as `| col | col |` rows with a separator
+/// line below the header. Columns are padded so the right borders
+/// align. Caps each cell's display at the available width so a
+/// long cell doesn't break alignment. No-ops when both header and
+/// rows are empty.
+fn render_table(
+    header: &[String],
+    rows: &[Vec<String>],
+    max_width: usize,
+    out: &mut Vec<LineEntry>,
+) {
+    if header.is_empty() && rows.is_empty() {
+        return;
+    }
+    // Compute per-column max char width.
+    let ncols = header
+        .len()
+        .max(rows.iter().map(|r| r.len()).max().unwrap_or(0));
+    if ncols == 0 {
+        return;
+    }
+    let mut widths = vec![0usize; ncols];
+    for (i, cell) in header.iter().enumerate() {
+        widths[i] = widths[i].max(cell.chars().count());
+    }
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+    // Cap any single column to avoid one runaway cell blowing the
+    // line width. Distribute available width: target inner width =
+    // max_width - 4 (for outer `| ` + ` |`), minus 3*(ncols-1) for
+    // ` | ` separators. Cells get clipped to fit.
+    let inner = max_width.saturating_sub(2 * 2);
+    let sep_overhead = if ncols > 1 { 3 * (ncols - 1) } else { 0 };
+    let cell_budget = inner.saturating_sub(sep_overhead);
+    let per_col = if ncols > 0 { cell_budget / ncols } else { 0 };
+    for w in widths.iter_mut() {
+        if per_col > 0 && *w > per_col {
+            *w = per_col;
+        }
+    }
+
+    let fit = |cell: &str, w: usize| -> String {
+        let chars: Vec<char> = cell.chars().collect();
+        if chars.len() <= w {
+            let mut s: String = chars.iter().collect();
+            for _ in chars.len()..w {
+                s.push(' ');
+            }
+            s
+        } else if w <= 1 {
+            chars.iter().take(w).collect()
+        } else {
+            let mut s: String = chars.iter().take(w - 1).collect();
+            s.push('…');
+            s
+        }
+    };
+
+    let render_row = |row: &[String], widths: &[usize]| -> String {
+        let mut s = String::with_capacity(max_width);
+        s.push_str("│ ");
+        for i in 0..widths.len() {
+            if i > 0 {
+                s.push_str(" │ ");
+            }
+            let cell = row.get(i).map(String::as_str).unwrap_or("");
+            s.push_str(&fit(cell, widths[i]));
+        }
+        s.push_str(" │");
+        s
+    };
+
+    let sep = {
+        let mut s = String::with_capacity(max_width);
+        s.push('├');
+        for (i, w) in widths.iter().enumerate() {
+            if i > 0 {
+                s.push('┼');
+            }
+            for _ in 0..(w + 2) {
+                s.push('─');
+            }
+        }
+        s.push('┤');
+        s
+    };
+
+    if !header.is_empty() {
+        out.push(LineEntry {
+            text: CompactString::new(&render_row(header, &widths)),
+            color: crate::ui::theme::header(),
+        });
+        out.push(LineEntry {
+            text: CompactString::new(&sep),
+            color: crate::ui::theme::dim(),
+        });
+    }
+    for row in rows {
+        out.push(LineEntry {
+            text: CompactString::new(&render_row(row, &widths)),
+            color: crate::ui::theme::agent(),
+        });
+    }
+    out.push(LineEntry {
+        text: CompactString::new(""),
+        color: crate::ui::theme::agent(),
+    });
+}
+
 pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
     if text.is_empty() {
         return Vec::new();
     }
 
-    let parser = pulldown_cmark::Parser::new(text);
+    // Enable GFM tables so `Tag::Table*` events actually fire.
+    // Without this, table syntax falls back to plain paragraphs and
+    // the table never reaches `render_table`.
+    let mut opts = pulldown_cmark::Options::empty();
+    opts.insert(pulldown_cmark::Options::ENABLE_TABLES);
+    let parser = pulldown_cmark::Parser::new_ext(text, opts);
     let mut result = Vec::new();
     let mut acc = String::new();
 
@@ -78,6 +195,17 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
     let mut in_blockquote = false;
     let mut ordered_list = false;
     let mut list_item_count: u64 = 0;
+    // Table accumulation: pulldown_cmark emits TableHead → (Row × N
+    // cells) for the header row, then more TableRow blocks for body.
+    // We collect cells into `current_cell`, rows into `current_row`,
+    // and the whole table into `table_header` + `table_rows`, then
+    // render with column-aligned padding when the table ends.
+    let mut in_table = false;
+    let mut in_table_head = false;
+    let mut current_cell = String::new();
+    let mut current_row: Vec<String> = Vec::new();
+    let mut table_header: Vec<String> = Vec::new();
+    let mut table_rows: Vec<Vec<String>> = Vec::new();
 
     for event in parser {
         match event {
@@ -108,10 +236,23 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     list_item_count += 1;
                 }
                 Tag::FootnoteDefinition(_) => {}
-                Tag::Table(_) => {}
-                Tag::TableHead => {}
-                Tag::TableRow => {}
-                Tag::TableCell => {}
+                Tag::Table(_) => {
+                    flush_acc(&acc, crate::ui::theme::agent(), max_width, &mut result);
+                    acc.clear();
+                    in_table = true;
+                    table_header.clear();
+                    table_rows.clear();
+                }
+                Tag::TableHead => {
+                    in_table_head = true;
+                    current_row.clear();
+                }
+                Tag::TableRow => {
+                    current_row.clear();
+                }
+                Tag::TableCell => {
+                    current_cell.clear();
+                }
                 _ => {}
             },
             Event::End(tag_end) => match tag_end {
@@ -226,21 +367,37 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
                     });
                 }
                 TagEnd::FootnoteDefinition => {}
-                TagEnd::Table => {}
-                TagEnd::TableHead => {}
-                TagEnd::TableRow => {}
-                TagEnd::TableCell => {}
+                TagEnd::Table => {
+                    render_table(&table_header, &table_rows, max_width, &mut result);
+                    in_table = false;
+                }
+                TagEnd::TableHead => {
+                    table_header = std::mem::take(&mut current_row);
+                    in_table_head = false;
+                }
+                TagEnd::TableRow => {
+                    if !in_table_head {
+                        table_rows.push(std::mem::take(&mut current_row));
+                    }
+                }
+                TagEnd::TableCell => {
+                    current_row.push(std::mem::take(&mut current_cell));
+                }
                 _ => {}
             },
             Event::Text(t) => {
-                if in_code_block {
+                if in_table {
+                    current_cell.push_str(&t);
+                } else if in_code_block {
                     acc.push_str(&t);
                 } else {
                     acc.push_str(&t);
                 }
             }
             Event::Code(t) => {
-                if in_code_block {
+                if in_table {
+                    current_cell.push_str(&t);
+                } else if in_code_block {
                     acc.push_str(&t);
                 } else {
                     acc.push_str(&t);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2106,6 +2106,26 @@ pub async fn run_interactive(
                 // nested inside it.
                 close_tool_chamber_if_open(&mut renderer, &mut last_tool_name)?;
                 renderer.set_avatar_state(avatar::AvatarState::Alert);
+                // Force a bottom-row repaint so the avatar updates to
+                // the Alert face immediately, before the user reads
+                // the prompt and reaches for a key. Without this, the
+                // avatar still showed the in-flight tool's face
+                // (Reading/Writing/Bash) until the next keystroke.
+                renderer.draw_bottom(
+                    &input,
+                    &with_queue(
+                        StatusLine::render(
+                            session,
+                            is_running,
+                            0,
+                            loop_label.as_deref(),
+                            context.current_prompt_name.as_deref(),
+                            perm_mode().as_deref(),
+                        ),
+                        interjection_queue.len(),
+                    ),
+                    is_running,
+                )?;
 
                 // Framed permission prompt. The double-bar border +
                 // ALERT wordmark visually arrests the eye — this is
@@ -2929,7 +2949,7 @@ fn update_search(renderer: &Renderer, query: &str, matches: &mut Vec<usize>, sel
 }
 
 fn draw_search_bar(query: &str, matches: &[usize], selected: usize) -> std::io::Result<()> {
-    use crossterm::style::{ResetColor, SetForegroundColor};
+    use crossterm::style::{Attribute, ResetColor, SetAttribute, SetForegroundColor};
     use crossterm::terminal::{Clear, ClearType};
     use std::io::Write;
 
@@ -2942,9 +2962,19 @@ fn draw_search_bar(query: &str, matches: &[usize], selected: usize) -> std::io::
     };
     let bar = format!("Search: {} [{}]", query, indicator);
     crossterm::execute!(stdout, Clear(ClearType::CurrentLine))?;
+    // Bold-glow on accent so the search bar reads consistently with
+    // the rest of the chat. Without Bold it was visibly duller than
+    // surrounding content.
+    let bloom = theme::is_bright(theme::accent());
+    if bloom {
+        crossterm::execute!(stdout, SetAttribute(Attribute::Bold))?;
+    }
     crossterm::execute!(stdout, SetForegroundColor(theme::accent()))?;
     write!(stdout, "\r\n")?;
     write!(stdout, "{}", bar)?;
+    if bloom {
+        crossterm::execute!(stdout, SetAttribute(Attribute::NormalIntensity))?;
+    }
     crossterm::execute!(stdout, ResetColor)?;
     Ok(())
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1666,7 +1666,14 @@ pub async fn run_interactive(
                             && session.needs_compaction(cfg.resolve_reserve_tokens())
                             && !cli.no_session
                         {
-                            renderer.write_line("auto-compacting...", theme::dim())?;
+                            // Auto-compact failure used to render as a
+                            // single dim red line that scrolled past
+                            // unnoticed — users kept typing into an
+                            // over-full context and saw mysterious
+                            // context-length errors next turn. Frame
+                            // the warning so it visibly stops the eye
+                            // and tells the user what to do next.
+                            renderer.write_line("▒░ auto-compacting context ░▒", theme::accent())?;
                             let compress_result = handle_compress(
                                 None,
                                 &mut agent, &client, &mut renderer, session, cli, cfg, context,
@@ -1675,7 +1682,34 @@ pub async fn run_interactive(
                                 #[cfg(feature = "semantic")] semantic_manager,
                             ).await;
                             if let Err(e) = compress_result {
-                                renderer.write_line(&format!("auto-compact error: {}", e), c_error())?;
+                                renderer.write_line(
+                                    "╭─ ⚠ AUTO-COMPACT FAILED ─────────────────────────────╮",
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    &format!("│ cause: {}", e),
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    "│ context is over the threshold — replies may start",
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    "│ hitting context-length errors. Try /compress",
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    "│ manually, /clear to start fresh, or restart with",
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    "│ a larger context_window in config.",
+                                    c_error(),
+                                )?;
+                                renderer.write_line(
+                                    "╰─────────────────────────────────────────────────────╯",
+                                    c_error(),
+                                )?;
                             }
                         }
 

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -646,8 +646,20 @@ impl Renderer {
                     if indent > 0 {
                         write!(stdout, "{}", " ".repeat(indent))?;
                     }
+                    // Bold-glow for bright tones so streamed text
+                    // reads the same as the post-redraw render_viewport
+                    // path. Without this, streaming chunks look flat
+                    // until the next full repaint shifts them to the
+                    // bright/bold weight.
+                    let bloom = crate::ui::theme::is_bright(color);
+                    if bloom {
+                        write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+                    }
                     write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                     writeln!(stdout, "{}", chunk)?;
+                    if bloom {
+                        write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
+                    }
                     write!(stdout, "{}", ResetColor)?;
                     self.lines = self.lines.saturating_add(1);
                     self.col = 0;
@@ -701,8 +713,15 @@ impl Renderer {
                     let r = self.content_row();
                     stdout.execute(MoveTo(indent + self.col, r))?;
                     if !segment.is_empty() {
+                        let bloom = crate::ui::theme::is_bright(color);
+                        if bloom {
+                            write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+                        }
                         write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", segment)?;
+                        if bloom {
+                            write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
+                        }
                         write!(stdout, "{}", ResetColor)?;
                     }
                     writeln!(stdout)?;
@@ -731,8 +750,15 @@ impl Renderer {
                         let mut stdout = io::stdout();
                         let r = self.content_row();
                         stdout.execute(MoveTo(indent + self.col, r))?;
+                        let bloom = crate::ui::theme::is_bright(color);
+                        if bloom {
+                            write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+                        }
                         write!(stdout, "{}", SetForegroundColor(self.color(color)))?;
                         write!(stdout, "{}", chunk)?;
+                        if bloom {
+                            write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
+                        }
                         write!(stdout, "{}", ResetColor)?;
                         self.col = self.col.saturating_add(chunk.chars().count() as u16);
                     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -908,6 +908,13 @@ impl Renderer {
             stdout.execute(MoveTo(0, row))?;
             write!(stdout, "{}", " ".repeat(cols as usize))?;
             stdout.execute(MoveTo(bottom_indent as u16, row))?;
+            // Bold-glow the prompt indicator + input text so they
+            // match the chat above. Without this the bottom area
+            // looked dimmer than the chat that scrolled past it.
+            let accent_bloom = crate::ui::theme::is_bright(crate::ui::theme::accent());
+            if accent_bloom {
+                write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+            }
             write!(
                 stdout,
                 "{}",
@@ -919,10 +926,17 @@ impl Renderer {
             } else {
                 write!(stdout, "{}", prompt_cont)?;
             }
+            if accent_bloom {
+                write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
+            }
             // Switch to the user-input text tone (bright phosphor)
             // before writing what the user typed, so the prompt
             // accent and the input text are visually distinct but
             // both on the green axis.
+            let user_bloom = crate::ui::theme::is_bright(crate::ui::theme::user());
+            if user_bloom {
+                write!(stdout, "{}", SetAttribute(Attribute::Bold))?;
+            }
             write!(
                 stdout,
                 "{}",
@@ -933,6 +947,9 @@ impl Renderer {
             {
                 let slice: String = chars[vr.char_start..vr.char_end].iter().collect();
                 write!(stdout, "{}", slice)?;
+            }
+            if user_bloom {
+                write!(stdout, "{}", SetAttribute(Attribute::NormalIntensity))?;
             }
             write!(stdout, "{}", ResetColor)?;
         }

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -1050,8 +1050,14 @@ pub async fn handle_slash(
                 .cloned();
             match last_user {
                 Some(msg) => {
+                    // Pop the trailing assistant response (if any) so a
+                    // /retry doesn't leave the failed reply in the
+                    // session — the agent would otherwise see its own
+                    // bad answer as context on the retry.
+                    let _ = undo_last(session);
                     input.buffer = msg.content.clone();
                     input.cursor = msg.content.len();
+                    render_session(renderer, session, cli, cfg, context)?;
                     renderer.write_line("edit last message and press Enter to retry", c_agent())?;
                 }
                 None => {


### PR DESCRIPTION
Second sweep of audit fixes — 4 rounds, 15 of 16 outstanding findings resolved.

## Round 1 — CRITICAL/HIGH
- `apply_patch`, `lsp`, `question` added to \`PermissionConfig\` so per-pattern rules work
- Markdown tables now render as box-drawn cards (was silently dropping content); enabled \`Options::ENABLE_TABLES\`

## Round 2 — HIGH
- \`/retry\` pops the previous assistant response before restoring the prompt
- \`write_line\` / \`write\` apply Bold for bright colors so streaming text reads consistent with the post-redraw viewport
- \`apply_patch\` update operation normalizes CRLF (Windows files now work)
- \`apply_patch\` clears the cache once after the batch instead of per-op

## Round 3 — MEDIUM
- \`save_session\` is now atomic (write-temp + fsync + rename) — no more truncated session files
- Auto-compact failure renders as a framed alert with recovery hints instead of a single dim line
- \`set_label\` uses \`ensure_back_compat_initialized\` for consistency
- Bash command splitting works without \`semantic-bash\` feature (best-effort \`&&\`/\`;\`/\`||\` split + command-substitution detection)

## Round 4 — LOW
- Prompt indicator + input text + search bar get Bold-glow for bright colors
- Avatar updates to Alert immediately when permission prompt appears (was waiting for next keystroke)

## Skipped
- grep \`glob_to_regex\` "doesn't escape \`.\`" — false positive; line 43 already pushes \`\\.\`

## Totals
- 612 tests pass, 0 fail
- Both build profiles -> 0 warnings
- Audit findings: 22 of 24 from the prior round + 15 of 16 from this round = **37 of 40 fixed across both audits**; remaining 3 are doc/style nitpicks (restrictive-mode docstring clarity, etc.)