### PR TITLE
fix(audit r4): per-provider defaults + bwrap warn + loop queue + file size caps + nonce hardening

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" width="100%" height="100%">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7397AB" />
+      <stop offset="50%" stop-color="#C29D9C" />
+      <stop offset="100%" stop-color="#F9B596" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background Circle -->
+  <circle cx="400" cy="400" r="350" fill="url(#bgGrad)" />
+
+  <!-- Ambient Stars / Particles -->
+  <circle cx="200" cy="220" r="2" fill="#FFF" opacity="0.6" />
+  <circle cx="250" cy="550" r="1.5" fill="#FFF" opacity="0.4" />
+  <circle cx="650" cy="250" r="2.5" fill="#FFF" opacity="0.5" />
+  <circle cx="580" cy="150" r="1.5" fill="#FBD065" opacity="0.7" />
+  <circle cx="300" cy="350" r="1" fill="#FFF" opacity="0.3" />
+  <circle cx="600" cy="450" r="2" fill="#FFF" opacity="0.6" />
+  <circle cx="220" cy="450" r="2" fill="#FBD065" opacity="0.6" />
+
+  <!-- Isometric Ground Shadow -->
+  <polygon points="322,525 442,595 650,715 728,670 608,600 530,645" fill="#5A3A42" opacity="0.3" />
+
+  <!-- Layer 1: Left Pillar Inner Wall (Backdrop of the Hole) -->
+  <polygon points="374,495 452,450 452,210 374,255" fill="#14353E" stroke="#14353E" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 2: Golden Keyhole & Eye (Suspended on the backdrop) -->
+  <g id="keyhole">
+    <path d="M 413 342 A 18 18 0 1 0 399 371 L 391 405 L 435 405 L 427 371 A 18 18 0 0 0 413 342 Z" fill="#FBD065" />
+    <path d="M 401 360 Q 413 350 425 360 Q 413 370 401 360 Z" fill="#14353E" />
+    <circle cx="413" cy="360" r="5" fill="#FBD065" />
+  </g>
+
+  <!-- Layer 3: Bottom Bridge Top Face -->
+  <polygon points="374,495 452,450 530,495 452,540" fill="#98D4C8" stroke="#98D4C8" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 4: Left Pillar Front Face -->
+  <polygon points="322,525 374,555 374,255 322,225" fill="#367C80" stroke="#367C80" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 5: Bottom Bridge Front Face -->
+  <polygon points="374,555 452,600 452,540 374,495" fill="#367C80" stroke="#367C80" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Doorway Arch in Bottom Bridge -->
+  <polygon points="403,572 403,545 413,535 423,550 423,583 413,578" fill="#14353E" stroke="#14353E" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 6: Right Pillar Front Face -->
+  <polygon points="452,600 530,645 530,345 452,300" fill="#367C80" stroke="#367C80" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 7: Impossible Bridge Front Face (Connecting Front Left to Back Right) -->
+  <polygon points="322,225 478,225 530,255 374,255" fill="#367C80" stroke="#367C80" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 8: Impossible Bridge Top Face -->
+  <polygon points="322,225 400,180 556,180 478,225" fill="#98D4C8" stroke="#98D4C8" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 9: Right Pillar Outer Face -->
+  <polygon points="530,645 608,600 608,300 530,345" fill="#19404B" stroke="#19404B" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Layer 10: Right Pillar Top Face (Tucked seamlessly under the Impossible Bridge) -->
+  <polygon points="452,300 530,345 608,300 530,255" fill="#98D4C8" stroke="#98D4C8" stroke-width="1" stroke-linejoin="round" />
+
+  <!-- Glowing Runes -->
+  <g id="runes" stroke="#FBD065" stroke-width="2" fill="none" opacity="0.8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 342 390 L 354 395 M 348 392 L 348 408 L 340 404" />
+    <path d="M 485 475 L 497 480 L 491 490 Z" />
+    <line x1="491" y1="477" x2="491" y2="495" />
+    <circle cx="426" cy="240" r="4" stroke-width="1.5" />
+    <line x1="418" y1="240" x2="434" y2="240" stroke-width="1.5" />
+  </g>
+
+  <!-- Stylized Figure on the Bridge -->
+  <g id="figure">
+    <path d="M 436 195 L 444 195 L 440 170 Z" fill="#102830" />
+    <circle cx="440" cy="164" r="4" fill="#102830" />
+    <path d="M 438 195 L 436 205 L 439 205 L 440 195 Z" fill="#102830" />
+    <path d="M 442 195 L 444 203 L 447 203 L 443 195 Z" fill="#102830" />
+    <path d="M 440 170 L 448 185 L 440 185 Z" fill="#FBD065" opacity="0.9" />
+  </g>
+
+  <!-- Low Poly Abstract Birds -->
+  <path d="M 270 300 L 280 305 L 290 295 L 280 308 Z" fill="#FFF" opacity="0.6" />
+  <path d="M 540 200 L 550 205 L 560 195 L 550 208 Z" fill="#FFF" opacity="0.4" />
+</svg>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,14 +104,11 @@ pub struct Cli {
     )]
     pub acp_enabled: bool,
 
-    #[cfg(feature = "acp")]
-    #[arg(long = "acp-host", help = "ACP TCP bind host [default: stdio mode]")]
-    pub acp_host: Option<String>,
-
-    #[cfg(feature = "acp")]
-    #[arg(long = "acp-port", help = "ACP TCP bind port [default: 7243]")]
-    pub acp_port: Option<u16>,
-
+    // Note: --acp-host / --acp-port are intentionally NOT exposed.
+    // The current ACP implementation only supports stdio transport
+    // (see `src/extras/acp/mod.rs`). The historical config keys still
+    // deserialize for backward compatibility but are ignored. If TCP
+    // ACP support is added in the future, restore these flags then.
     #[cfg(feature = "loop")]
     #[arg(long = "loop-prompt", help = "Prompt for each loop iteration")]
     pub loop_prompt: Option<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -182,6 +182,24 @@ pub fn load() -> Config {
         })
     };
 
+    // Validate `custom_providers` at load time so a typo in
+    // `provider_type` surfaces immediately instead of failing at
+    // first agent call with a cryptic "unknown provider" deep in the
+    // call stack.
+    if let Some(providers) = cfg.custom_providers.as_ref() {
+        for (name, p) in providers {
+            if crate::provider::parse_provider(&p.provider_type).is_none() {
+                eprintln!(
+                    "error: custom provider {:?} has invalid provider_type {:?}.\n\
+                     Must be one of: openrouter, openai, anthropic, gemini,\n\
+                     deepseek, glm, ollama, custom.",
+                    name, p.provider_type,
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
     #[cfg(feature = "mcp")]
     if cfg.mcp_servers.is_none() {
         let mut headers = HashMap::new();

--- a/src/extras/memory.rs
+++ b/src/extras/memory.rs
@@ -94,7 +94,20 @@ pub fn read_file(dir: &Path, path: &str) -> Result<String, String> {
     if !resolved.is_file() {
         return Err(format!("Memory '{}' not found", path));
     }
-    std::fs::read_to_string(&resolved).map_err(|e| format!("Failed to read memory: {e}"))
+    // 1 MB cap with truncation marker — same reasoning as the skill
+    // size cap. Memories are meant to be terse notes; multi-MB
+    // memories almost certainly need a different storage mechanism
+    // (and would explode LLM context if loaded raw).
+    const MEMORY_MAX_BYTES: usize = 1024 * 1024;
+    let raw =
+        std::fs::read_to_string(&resolved).map_err(|e| format!("Failed to read memory: {e}"))?;
+    if raw.len() > MEMORY_MAX_BYTES {
+        let mut truncated: String = raw.chars().take(MEMORY_MAX_BYTES).collect();
+        truncated.push_str("\n\n…[truncated: memory exceeds 1 MB cap]");
+        Ok(truncated)
+    } else {
+        Ok(raw)
+    }
 }
 
 pub fn write_file(dir: &Path, path: &str, content: &str) -> Result<(), String> {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -38,9 +38,21 @@ pub enum ProviderKind {
 }
 
 pub fn default_model_for(provider_name: &str) -> &'static str {
+    // Per-provider sensible defaults. Without per-provider defaults
+    // an unspecified `--model` against OpenAI/Anthropic/Gemini/Ollama
+    // would pass `deepseek/deepseek-v4-flash` and the API would reject
+    // with a confusing 404. Each provider gets a current-as-of-2026
+    // first-class model id; OpenRouter keeps the multi-vendor prefix
+    // form since that's what its API expects.
     match parse_provider(provider_name) {
+        Some(ProviderKind::OpenAI) => "gpt-4o",
+        Some(ProviderKind::Anthropic) => "claude-sonnet-4-6",
+        Some(ProviderKind::Gemini) => "gemini-2.0-flash",
         Some(ProviderKind::DeepSeek) => "deepseek-v4-pro",
         Some(ProviderKind::Glm) => "glm-4",
+        Some(ProviderKind::Ollama) => "llama3",
+        // OpenRouter + Custom + unknown — keep the historical default
+        // since OpenRouter wants the `vendor/model` form.
         _ => "deepseek/deepseek-v4-flash",
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -7,7 +7,29 @@ pub struct Sandbox {
 
 impl Sandbox {
     pub fn new(enabled: bool) -> Self {
+        if enabled && !Self::bwrap_available() {
+            eprintln!(
+                "warning: --sandbox is enabled but `bwrap` is not in PATH.\n  \
+                 Install bubblewrap (apt install bubblewrap / dnf install bubblewrap /\n  \
+                 pacman -S bubblewrap) or remove the sandbox flag. Bash commands will\n  \
+                 fail with a confusing 'No such file or directory' error until bwrap is\n  \
+                 installed."
+            );
+        }
         Sandbox { enabled }
+    }
+
+    /// Check whether `bwrap` is on the user's PATH. Used at construction
+    /// to warn early instead of letting the first bash call fail with
+    /// a cryptic "No such file or directory".
+    fn bwrap_available() -> bool {
+        std::process::Command::new("bwrap")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
     }
 
     pub fn wrap_command(&self, command: &str) -> Command {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -63,18 +63,22 @@ pub fn save_session(session: &Session) -> anyhow::Result<()> {
     // never a truncated `.json`. The rename is atomic on every OS we
     // target. Use the same parent dir so rename stays on one filesystem.
     //
-    // The tmp filename includes a per-call nonce (pid + nanos) so two
-    // concurrent saves of the same session id don't collide on the
-    // tmp file. Each thread/process writes to its own tmp; the rename
-    // race is harmless (last-writer wins on the target, but neither
-    // tmp is partial because each was fully written before rename).
+    // The tmp filename includes a per-call nonce (pid + nanos +
+    // monotonic counter) so two concurrent saves of the same session
+    // id don't collide on the tmp file. The counter is the
+    // load-bearing piece — two threads firing in the same nanosecond
+    // still get distinct counter values, eliminating same-process
+    // collisions. The rename race remains harmless (last writer wins
+    // on the target; each tmp is fully written before rename).
+    static SAVE_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let nonce = format!(
-        "{}-{}",
+        "{}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0),
+        SAVE_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
     );
     let tmp = dir.join(format!(".{}.{}.json.tmp", session.id, nonce));
     {

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -44,6 +44,22 @@ pub fn discover_skills(cwd: &Path) -> Vec<Skill> {
                 if !skill_md.is_file() {
                     continue;
                 }
+                // Cap skill content at 1 MB. A skill is meant to be a
+                // short markdown instructions file; multi-MB skills
+                // would blow up LLM context. If users have legitimate
+                // need for larger skills, they should compress and
+                // bump this cap deliberately.
+                const SKILL_MAX_BYTES: u64 = 1024 * 1024;
+                if let Ok(meta) = std::fs::metadata(&skill_md)
+                    && meta.len() > SKILL_MAX_BYTES
+                {
+                    eprintln!(
+                        "warning: skipping skill {:?} ({} bytes > 1 MB cap)",
+                        skill_md,
+                        meta.len(),
+                    );
+                    continue;
+                }
                 if let Ok(content) = std::fs::read_to_string(&skill_md) {
                     if let Some(skill) = parse_skill(&content, &path) {
                         map.entry(skill.name.clone()).or_insert(skill);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1019,7 +1019,16 @@ pub async fn run_interactive(
                         if let Some(text) = input.handle_key(key) {
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
-                                renderer.write_line("loop active: /loop stop to cancel", c_error())?;
+                                // Queue the message instead of dropping it.
+                                // The next loop iteration's prompt-build path
+                                // already drains `interjection_queue` and
+                                // prepends queued messages, so this is the
+                                // natural place to land mid-loop user input.
+                                interjection_queue.push_back(text.to_string());
+                                renderer.write_line(
+                                    "loop active — message queued (will send after current iteration; /loop stop to cancel)",
+                                    c_agent(),
+                                )?;
                                 renderer.draw_bottom(
                                     &input,
                                     &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref()), interjection_queue.len()),
@@ -1686,8 +1695,24 @@ pub async fn run_interactive(
                                     "╭─ ⚠ AUTO-COMPACT FAILED ─────────────────────────────╮",
                                     c_error(),
                                 )?;
+                                // Cap the cause length so a sprawling
+                                // multi-line error doesn't blow out the
+                                // box's visual rhythm. The full error
+                                // is still in the agent's recovery
+                                // path; this is for the user-facing
+                                // hint only.
+                                let cause = {
+                                    let s = e.to_string().replace('\n', " ");
+                                    if s.chars().count() > 64 {
+                                        let mut out: String = s.chars().take(63).collect();
+                                        out.push('…');
+                                        out
+                                    } else {
+                                        s
+                                    }
+                                };
                                 renderer.write_line(
-                                    &format!("│ cause: {}", e),
+                                    &format!("│ cause: {}", cause),
                                     c_error(),
                                 )?;
                                 renderer.write_line(

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -1058,10 +1058,20 @@ pub async fn handle_slash(
                     // the Assistant/User pair pattern; using it here
                     // would leave a trailing System message in the
                     // session and the agent would see it on retry.
+                    //
+                    // Bound the loop at the current message count so
+                    // a corrupt session that somehow lacks user msgs
+                    // (despite the `last_user.is_some()` check above)
+                    // can't infinite-loop on `pop` returning None.
+                    let mut guard = session.messages.len();
                     while let Some(last) = session.messages.last() {
                         let was_user = last.role == MessageRole::User;
                         session.pop_last_message();
                         if was_user {
+                            break;
+                        }
+                        guard = guard.saturating_sub(1);
+                        if guard == 0 {
                             break;
                         }
                     }


### PR DESCRIPTION
Round 4 of audit fixes. Surveys provider, memory/skill/MCP, LSP/sandbox/semantic, worktree/loop/ACP/task, and UI surfaces. Fixes 11 actionable findings (3 skipped as false positives). 612 tests pass.