### PR TITLE
fix: drop .maki/skills/ (inherited from fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Minimal coding agent written in Rust, inspired by [pi](https://pi.dev/docs/lates
 - **Line-numbered read output**: `read` tool prefixes each line with right-aligned line numbers (`123: content`)
 - **Environment-aware**: system prompt includes OS, shell, working directory, and git branch for context
 - **Semantic code tools** (tree-sitter): list_symbols, get_symbol_body, find_definition, find_callers, find_callees — supports TypeScript/TSX and Python
-- **Claude-compatible skills**: discover skills from `.claude/skills/`, `.maki/skills/`, `.opencode/skills/`, `.dirge/skills/` directories. Agent can call the `skill` tool to load instructions on demand
+- **Claude-compatible skills**: discover skills from `.claude/skills/`, `.opencode/skills/`, `.dirge/skills/` directories. Agent can call the `skill` tool to load instructions on demand
 - **Bash permissions** (tree-sitter): parses shell commands to split `&&`/`;`/`|` into individual segments, detects command substitution and complex constructs
 - **Permission system**: four configurable modes with per-tool patterns, session allowlists, and external directory policies
 - **Session management**: save/load/resume sessions, auto-compaction to stay within context windows
@@ -200,7 +200,7 @@ The agent automatically loads `AGENTS.md` or `CLAUDE.md` from the project root, 
 
 ## Claude-compatible skills
 
-Place skill directories in `.claude/skills/`, `.maki/skills/`, or `.opencode/skills/` in your project or home directory. Each skill is a directory containing `SKILL.md` with optional YAML frontmatter:
+Place skill directories in `.claude/skills/`, `.opencode/skills/`, or `.dirge/skills/` in your project or home directory. Each skill is a directory containing `SKILL.md` with optional YAML frontmatter:
 
 ```markdown
 ---

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -16,7 +16,6 @@ pub fn discover_skills(cwd: &Path) -> Vec<Skill> {
     let global_dirs = dirs::home_dir().into_iter().flat_map(|home| {
         [
             home.join(".claude").join("skills"),
-            home.join(".maki").join("skills"),
             home.join(".opencode").join("skills"),
             home.join(".dirge").join("skills"),
         ]
@@ -27,7 +26,6 @@ pub fn discover_skills(cwd: &Path) -> Vec<Skill> {
         .flat_map(|ancestor| {
             [
                 ancestor.join(".claude").join("skills"),
-                ancestor.join(".maki").join("skills"),
                 ancestor.join(".opencode").join("skills"),
                 ancestor.join(".dirge").join("skills"),
             ]


### PR DESCRIPTION
Removes `.maki/skills/` from skill discovery and the two README mentions. Code already checks `.dirge/skills/` alongside `.claude/skills/` and `.opencode/skills/`. Acknowledgements + 'inspired by maki' header stay.