### PR TITLE
fix(audit r6): plan-mode apply_patch gate, prompt persistence, temp/--session/websearch fixes

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -144,7 +144,9 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     let max_turns = cli.resolve_max_agent_turns(cfg);
     builder = builder.default_max_turns(max_turns);
 
-    if let Some(temp) = cli.temperature {
+    // Temperature: CLI > config > unset. Previously only `cli.temperature`
+    // was checked, so users couldn't set a default in config.json.
+    if let Some(temp) = cli.resolve_temperature(cfg) {
         let clamped = temp.clamp(0.0, 2.0);
         builder = builder.temperature(clamped);
     }
@@ -217,6 +219,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             Box::new(tools::ApplyPatchTool::with_cache(
                 permission.clone(),
                 ask_tx.clone(),
+                plan_file.clone(),
                 cache.clone(),
             )),
         ];

--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -1,7 +1,7 @@
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path};
@@ -30,6 +30,12 @@ pub struct ApplyPatchTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    /// When active prompt is `plan`/`review`/`review-security`, writes
+    /// are restricted to this single file (typically `PLAN.md`). Any
+    /// op targeting another path is refused. Mirrors the gate on
+    /// `WriteTool` / `EditTool` so a planning-mode session can't
+    /// sneak filesystem changes through `apply_patch`.
+    plan_file: Option<PathBuf>,
 }
 
 impl ApplyPatchTool {
@@ -39,18 +45,21 @@ impl ApplyPatchTool {
             permission,
             ask_tx,
             cache: None,
+            plan_file: None,
         }
     }
 
     pub fn with_cache(
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
+        plan_file: Option<PathBuf>,
         cache: ToolCache,
     ) -> Self {
         Self {
             permission,
             ask_tx,
             cache: Some(cache),
+            plan_file,
         }
     }
 }
@@ -193,6 +202,36 @@ impl Tool for ApplyPatchTool {
         let mut results = Vec::new();
 
         for op in &args.operations {
+            // Plan-mode write restriction: when active prompt is
+            // plan/review/review-security, `plan_file` is set to
+            // PLAN.md and every op's target path must match it. This
+            // mirrors the gate on `WriteTool` + `EditTool` so plan
+            // mode actually means "no filesystem changes outside
+            // PLAN.md" — apply_patch previously bypassed it.
+            let paths_to_check: Vec<&str> = match op {
+                PatchOp::Create { path, .. }
+                | PatchOp::Update { path, .. }
+                | PatchOp::Delete { path } => vec![path.as_str()],
+                PatchOp::Rename { path, new_path } => {
+                    vec![path.as_str(), new_path.as_str()]
+                }
+            };
+            if let Some(plan) = self.plan_file.as_ref() {
+                for path in &paths_to_check {
+                    let target = Path::new(path);
+                    let target_canon = target
+                        .canonicalize()
+                        .unwrap_or_else(|_| target.to_path_buf());
+                    let plan_canon = plan.canonicalize().unwrap_or_else(|_| plan.clone());
+                    if target_canon != plan_canon {
+                        return Err(ToolError::Msg(format!(
+                            "plan mode is active — apply_patch can only target {}; got {}",
+                            plan.display(),
+                            path,
+                        )));
+                    }
+                }
+            }
             // Permission check for the target path
             match op {
                 PatchOp::Create { path, .. }

--- a/src/agent/tools/memory.rs
+++ b/src/agent/tools/memory.rs
@@ -45,7 +45,8 @@ impl Tool for MemoryTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "description": "Action: view, write, or delete"
+                        "enum": ["view", "write", "delete"],
+                        "description": "view: read one or list all; write: create/overwrite; delete: remove a memory file"
                     },
                     "path": {
                         "type": "string",

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -103,7 +103,8 @@ impl Tool for WebSearchTool {
                         "description": "The search query"
                     },
                     "num_results": {
-                        "type": "number",
+                        "type": "integer",
+                        "minimum": 1,
                         "description": "Maximum number of results (default: 10)"
                     }
                 },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,13 @@ impl Cli {
         self.max_tokens.or(cfg.max_tokens).unwrap_or(8192)
     }
 
+    /// Model temperature with CLI > config > unset precedence. Clamped
+    /// to `[0.0, 2.0]` by the caller (builder) so a typo'd config
+    /// can't push the provider into an unsupported range.
+    pub fn resolve_temperature(&self, cfg: &config::Config) -> Option<f64> {
+        self.temperature.or(cfg.temperature)
+    }
+
     pub fn resolve_max_agent_turns(&self, cfg: &config::Config) -> usize {
         self.max_agent_turns.or(cfg.max_agent_turns).unwrap_or(100)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,40 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if let Some(session_id) = &cli.session {
-        session = session::storage::load_session(session_id)?;
+        // Try exact id first; fall back to prefix match so the CLI
+        // is as forgiving as the interactive `/sessions <prefix>`
+        // command. Ambiguous prefix surfaces a list of matching ids.
+        match session::storage::load_session(session_id) {
+            Ok(s) => session = s,
+            Err(_) => {
+                let matches = session::storage::find_sessions_by_prefix(session_id)?;
+                match matches.len() {
+                    0 => anyhow::bail!("no session matching id or prefix {:?}", session_id),
+                    1 => session = matches.into_iter().next().expect("len == 1"),
+                    n => {
+                        let ids: Vec<String> =
+                            matches.iter().take(5).map(|s| s.id.to_string()).collect();
+                        anyhow::bail!(
+                            "session prefix {:?} matches {} sessions: {} — pass a longer prefix",
+                            session_id,
+                            n,
+                            ids.join(", "),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Restore the active prompt from the loaded session so resumed
+    // sessions don't silently snap back to the default `code` prompt.
+    // Default-prompt initialization above set context.current_prompt
+    // to `code`; we override it here if the session carries a name.
+    if let Some(name) = session.current_prompt_name.clone()
+        && let Some(content) = context.prompts.get(&name)
+    {
+        context.current_prompt = Some(content.clone());
+        context.current_prompt_name = Some(name);
     }
 
     let client = provider::create_client(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -164,6 +164,12 @@ pub struct Session {
     /// populates it from `messages` for legacy session files.
     #[serde(default)]
     pub message_store: HashMap<CompactString, SessionMessage>,
+    /// Active prompt name (e.g. "code", "plan", "review"). Persisted
+    /// with the session so resuming via `-c` / `/sessions <id>`
+    /// restores the same prompt the user had active. Defaulted to
+    /// `None` for backward compat with pre-feature session files.
+    #[serde(default)]
+    pub current_prompt_name: Option<String>,
 }
 
 impl Session {
@@ -194,6 +200,7 @@ impl Session {
             next_entry_seq: 0,
             tree: SessionTree::default(),
             message_store: HashMap::new(),
+            current_prompt_name: None,
         }
     }
 
@@ -504,7 +511,15 @@ impl Session {
 
     pub fn compacted_context(&self) -> (Option<&str>, usize) {
         match self.compactions.last() {
-            Some(c) => (Some(c.summary.as_str()), c.first_kept_index),
+            // Clamp `first_kept_index` to `messages.len()` defensively
+            // in case the session was edited externally or shrunk by
+            // `switch_to_leaf` / `pop_last_message` after the
+            // compaction was recorded. Without this, callers doing
+            // `messages[first_kept..]` would panic on stale indices.
+            Some(c) => (
+                Some(c.summary.as_str()),
+                c.first_kept_index.min(self.messages.len()),
+            ),
             None => (None, 0),
         }
     }

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -626,6 +626,9 @@ pub async fn handle_slash(
                 } else {
                     context.current_prompt = None;
                     context.current_prompt_name = None;
+                    // Mirror into session so `-c` / `/sessions <id>`
+                    // resumes the same prompt state next time.
+                    session.current_prompt_name = None;
                     let model = client.completion_model(session.model.to_string());
                     *agent = crate::provider::build_agent(
                         model,
@@ -652,6 +655,9 @@ pub async fn handle_slash(
                 if let Some(content) = context.prompts.get(name) {
                     context.current_prompt = Some(content.clone());
                     context.current_prompt_name = Some(name.to_string());
+                    // Mirror into the session so resuming restores the
+                    // same active prompt instead of defaulting to "code".
+                    session.current_prompt_name = Some(name.to_string());
                     let model = client.completion_model(session.model.to_string());
                     *agent = crate::provider::build_agent(
                         model,


### PR DESCRIPTION
Audit round 6: plan-mode apply_patch was bypassing the PLAN.md gate (critical), prompt name didn't persist across session resume (high), `config.temperature` silently ignored (high), `--session` didn't accept prefix (medium), websearch `num_results` was schema-typed as number (high), memory tool action gained enum constraint, compacted_context now bounds-clamps. 612 tests pass.