### PR TITLE
fix(audit r7): ACP build, diff theme, plan-gate edge case, prompt fallback warn

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -194,6 +194,23 @@ output.
 - `harness/replace-prompt`: think of it as "rewrite what the LLM sees
   this turn." Only meaningful from `on-prompt`.
 
+```janet
+# Capture the latest LLM response so the next `on-prompt` hook can
+# read it from the binding `harness-response`. The host calls
+# `(harness/store-response text)` itself after every turn, so you
+# normally don't need to invoke this directly — read `harness-response`
+# from inside `on-prompt` to inspect the previous assistant message.
+# If you DO want to fabricate a "previous response" for your own
+# state machine (e.g. seeding a test fixture), you can call it
+# explicitly.
+(harness/store-response "the previous assistant message text")
+```
+
+- `harness/store-response`: sets the `harness-response` binding so the
+  next `on-prompt` hook can react to what the LLM said last turn. The
+  host wires this automatically; plugins call it only for testing or
+  to seed a synthetic prior response.
+
 ### Tool interception
 
 These three set slots that the host inspects right after each tool hook.

--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -217,13 +217,54 @@ impl Tool for ApplyPatchTool {
                 }
             };
             if let Some(plan) = self.plan_file.as_ref() {
+                // Build a parent+filename comparison so we can match
+                // PLAN.md by name even when the file doesn't exist
+                // yet (the very first `apply_patch create PLAN.md` op
+                // in a fresh plan-mode session). Pure `canonicalize`
+                // fails on non-existent paths and the fallback
+                // `to_path_buf` would compare relative vs absolute
+                // unequal — refusing a legitimate create. Compare:
+                //   1. canonicalized full paths (works once PLAN.md
+                //      exists, and for both create and update),
+                //   2. resolved parent + same filename (works for the
+                //      first-create case before PLAN.md exists).
+                let plan_canon = plan.canonicalize().ok();
+                let plan_parent = plan
+                    .parent()
+                    .and_then(|p| p.canonicalize().ok())
+                    .or_else(|| {
+                        std::env::current_dir()
+                            .ok()
+                            .map(|cwd| plan.parent().map(|p| cwd.join(p)).unwrap_or(cwd))
+                    });
+                let plan_name = plan.file_name();
                 for path in &paths_to_check {
                     let target = Path::new(path);
-                    let target_canon = target
-                        .canonicalize()
-                        .unwrap_or_else(|_| target.to_path_buf());
-                    let plan_canon = plan.canonicalize().unwrap_or_else(|_| plan.clone());
-                    if target_canon != plan_canon {
+                    let target_canon = target.canonicalize().ok();
+                    let target_parent = target
+                        .parent()
+                        .and_then(|p| p.canonicalize().ok())
+                        .or_else(|| {
+                            std::env::current_dir().ok().map(|cwd| {
+                                target
+                                    .parent()
+                                    .filter(|p| !p.as_os_str().is_empty())
+                                    .map(|p| cwd.join(p))
+                                    .unwrap_or(cwd)
+                            })
+                        });
+                    let target_name = target.file_name();
+
+                    let matches_canonical = match (&plan_canon, &target_canon) {
+                        (Some(p), Some(t)) => p == t,
+                        _ => false,
+                    };
+                    let matches_by_parent_and_name =
+                        match (&plan_parent, &target_parent, plan_name, target_name) {
+                            (Some(pp), Some(tp), Some(pn), Some(tn)) => pp == tp && pn == tn,
+                            _ => false,
+                        };
+                    if !matches_canonical && !matches_by_parent_and_name {
                         return Err(ToolError::Msg(format!(
                             "plan mode is active — apply_patch can only target {}; got {}",
                             plan.display(),

--- a/src/agent/tools/task_status.rs
+++ b/src/agent/tools/task_status.rs
@@ -112,7 +112,10 @@ impl Tool for TaskStatusTool {
                         }
                     },
                     None => {
-                        return Err(ToolError::Msg(format!("task not found: {}", args.task_id)));
+                        return Err(ToolError::Msg(format!(
+                            "task not found: {} (either it never existed, or it was evicted from the background store after 32 newer tasks)",
+                            args.task_id
+                        )));
                     }
                 }
             }
@@ -129,7 +132,10 @@ impl Tool for TaskStatusTool {
                         args.task_id, err
                     )),
                 },
-                None => Err(ToolError::Msg(format!("task not found: {}", args.task_id))),
+                None => Err(ToolError::Msg(format!(
+                    "task not found: {} (either it never existed, or it was evicted from the background store after 32 newer tasks)",
+                    args.task_id
+                ))),
             }
         }
     }

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -247,6 +247,17 @@ async fn run_prompt(
             AgentEvent::Error(_) => {
                 break;
             }
+            // Observability markers added for the interactive UI's
+            // turn tracker + interjection queue. ACP doesn't have a
+            // mid-stream interjection concept (the client owns
+            // submission), so we treat these as no-ops.
+            AgentEvent::TurnStart { .. } | AgentEvent::TurnEnd { .. } => {}
+            AgentEvent::Interjected { .. } => {
+                // An interjected turn shouldn't reach the ACP bridge —
+                // ACP runs aren't interactive — but bail cleanly if
+                // one does rather than panic on partial state.
+                break;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,11 +282,22 @@ async fn main() -> anyhow::Result<()> {
     // sessions don't silently snap back to the default `code` prompt.
     // Default-prompt initialization above set context.current_prompt
     // to `code`; we override it here if the session carries a name.
-    if let Some(name) = session.current_prompt_name.clone()
-        && let Some(content) = context.prompts.get(&name)
-    {
-        context.current_prompt = Some(content.clone());
-        context.current_prompt_name = Some(name);
+    // If the persisted name no longer resolves (user uninstalled the
+    // prompt), warn so the silent fallback doesn't surprise them.
+    if let Some(name) = session.current_prompt_name.clone() {
+        match context.prompts.get(&name) {
+            Some(content) => {
+                context.current_prompt = Some(content.clone());
+                context.current_prompt_name = Some(name);
+            }
+            None => {
+                eprintln!(
+                    "warning: session was using prompt {:?} but it's no longer available — falling back to default ({:?}).",
+                    name,
+                    context.current_prompt_name.as_deref().unwrap_or("none"),
+                );
+            }
+        }
     }
 
     let client = provider::create_client(

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -19,6 +19,11 @@ pub struct SemanticManager {
 
 impl SemanticManager {
     pub fn new() -> Self {
+        // `mut` is conditionally needed depending on which language
+        // adapter features are active. Suppress the warning so a
+        // `semantic` build without any of the language sub-features
+        // (`semantic-ts`/`-python`/`-bash`) doesn't trip the linter.
+        #[allow(unused_mut)]
         let mut adapters: Vec<Box<dyn LanguageAdapter>> = Vec::new();
 
         #[cfg(feature = "semantic-ts")]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1536,14 +1536,23 @@ pub async fn run_interactive(
                                     for l in &lines[pre..] {
                                         let txt = sanitize_output(l).into_string();
                                         if l.starts_with("--- ") || l.starts_with("+++ ") {
+                                            // Filenames in the diff header get
+                                            // the same accent as section
+                                            // markers elsewhere in chat. Was
+                                            // hardcoded `Color::Cyan` which is
+                                            // invisible on phosphor (same hue
+                                            // as agent text).
                                             renderer.write_line(
                                                 &chamber_row(&txt, inner),
-                                                Color::Cyan,
+                                                theme::accent(),
                                             )?;
                                         } else if l.starts_with("@@") {
+                                            // Hunk position markers — use dim
+                                            // so they recede behind the +/-
+                                            // content lines below.
                                             renderer.write_line(
                                                 &chamber_row(&txt, inner),
-                                                Color::DarkCyan,
+                                                theme::dim(),
                                             )?;
                                         } else if l.starts_with('+') {
                                             renderer.write_line(


### PR DESCRIPTION
Round 7 audit fixes. ACP feature was broken (missing match arms for TurnStart/TurnEnd/Interjected — `--all-features` build failed). Plan-mode apply_patch refused legitimate first `create PLAN.md` when PLAN.md didn't exist yet. Diff header colors invisible on phosphor theme. Prompt-name resume now warns when the persisted prompt is missing. Eviction error message clarified. `harness/store-response` documented. Semantic build warning silenced. 612 tests pass across all build profiles.