### PR TITLE
chore: hide cost UI (always 0), log plugin hook errors via tracing

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -454,8 +454,29 @@ State persists for the life of the session — survives between turns.
 
 - **`harness/log`** writes to dirge's log file (not the chat). Use it
   freely.
-- **Janet errors** in a hook are caught and rendered as a chat error,
-  not a crash. The line/file should appear in the error message.
+- **Janet errors** in a hook are caught (so a broken hook can never
+  crash the host or block other plugins from dispatching), and the
+  error is emitted via the structured logger as a `warn`-level event
+  with target `dirge::plugin` so it shows up under
+  `RUST_LOG=dirge::plugin=warn dirge ...` or under the catch-all
+  `RUST_LOG=warn`. The error line/file from Janet's stack appears in
+  the message. The hook's return value is treated as `nil` (i.e. no
+  effect on the host) and dispatch continues to the next plugin.
+
+  **Why "log-and-continue" rather than "abort the turn"**: a single
+  misbehaving plugin shouldn't be able to wedge the user out of their
+  session. This matches how opencode handles plugin errors
+  (`log.error("plugin config hook failed", { error })` then
+  `Effect.ignore`). pi is a step further and emits a structured
+  `ExtensionError` event the host UI can render as a chat
+  notification — dirge stops short of that today (a plugin gets no
+  user-visible signal beyond the log) but the structured log payload
+  makes it straightforward to wire later.
+
+  **Implication for plugin authors**: if your hook isn't taking
+  effect, run dirge with `RUST_LOG=dirge::plugin=warn` and look for
+  `plugin hook errored — continuing dispatch` lines. Don't expect
+  the chat to surface plugin errors automatically.
 - **Hook didn't fire?** Double-check the function name matches the
   hook reference exactly — `on_prompt` (underscore) is a different
   symbol than `on-prompt`.

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1658,14 +1658,38 @@ impl PluginManager {
 
         let mut results = Vec::new();
         for name in &names {
-            // Wrap the call in (try ... ([err] nil)) so plugin runtime
-            // errors don't print Janet stack traces to stderr.
+            // Wrap the call so plugin runtime errors don't print
+            // Janet stack traces to stderr OR vanish silently. On
+            // error, format the message as `DIRGE_HOOK_ERR:<msg>`
+            // so the Rust side can pick it out and emit a
+            // `tracing::warn!` (visible via RUST_LOG=warn).
+            //
+            // Prior behavior: pure `(try ... ([err fib] nil))` which
+            // swallowed errors entirely. Plugin authors got no
+            // feedback on broken hooks — strictly worse than both
+            // opencode (`log.error("plugin config hook failed", …)`
+            // in `packages/opencode/src/plugin/index.ts`) and pi
+            // (which emits structured `ExtensionError` events the
+            // host UI can render — see
+            // `packages/coding-agent/src/core/extensions/runner.ts`).
+            // dirge now mirrors opencode's behavior: log structured,
+            // continue dispatch.
             let code = format!(
-                r#"(try (do (def ctx {ctx}) ({fname} ctx)) ([err fib] nil))"#,
+                r#"(try (do (def ctx {ctx}) ({fname} ctx)) ([err fib] (string "DIRGE_HOOK_ERR:" err)))"#,
                 ctx = context_janet,
                 fname = name,
             );
             if let Ok(s) = self.eval(&code) {
+                if let Some(msg) = s.strip_prefix("DIRGE_HOOK_ERR:") {
+                    tracing::warn!(
+                        target: "dirge::plugin",
+                        hook = %hook,
+                        function = %name,
+                        error = %msg,
+                        "plugin hook errored — continuing dispatch",
+                    );
+                    continue;
+                }
                 // Janet nil -> skip
                 if s != "nil" && !s.is_empty() {
                     results.push(s);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -127,6 +127,14 @@ pub struct Session {
     pub compactions: Vec<Compaction>,
     pub created_at: CompactString,
     pub updated_at: CompactString,
+    // TODO(cost-tracking): `total_tokens` and `total_cost` are placeholders.
+    // Currently `total_tokens` accumulates the same heuristic estimate that
+    // already lives in `total_estimated_tokens` (`AgentEvent::Done` emits
+    // estimated_tokens because no provider integration has been wired
+    // through rig to extract actual usage). `total_cost` is never advanced
+    // past 0.0 because no per-provider pricing table exists. Both fields
+    // serialize for forward-compat so when actual provider usage lands
+    // they can be populated without a schema bump.
     pub total_tokens: u64,
     pub total_cost: f64,
     pub total_estimated_tokens: u64,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1668,6 +1668,13 @@ pub async fn run_interactive(
                         renderer.write_line("", Color::White)?;
                         renderer.write_line("", Color::White)?;
                         session.add_message(MessageRole::Assistant, &response);
+                        // TODO(cost-tracking): `tokens` here is the heuristic
+                        // estimate (text.len()/4) and `cost` is always 0.0 —
+                        // these accumulate into placeholder fields and won't
+                        // reflect actual provider usage / billing until we
+                        // pipe rig's `FinalResponse.usage()` through into
+                        // `AgentEvent::Done`. Kept as no-op-ish additions so
+                        // the wiring is in place when real values arrive.
                         session.total_tokens = session.total_tokens.saturating_add(tokens);
                         session.total_cost += cost;
                         agent_line_started = false;
@@ -1933,6 +1940,9 @@ pub async fn run_interactive(
                         // it had said when the user spoke up.
                         if !partial_response.is_empty() {
                             session.add_message(MessageRole::Assistant, &partial_response);
+                            // TODO(cost-tracking): same caveat as the Done
+                            // branch — `tokens` is an estimate, not actual
+                            // provider usage. Wire after rig usage plumbing.
                             session.total_tokens = session.total_tokens.saturating_add(tokens);
                         }
                         agent_line_started = false;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -34,11 +34,14 @@ impl StatusLine {
         let used = session.total_estimated_tokens;
         let pct = if ctx > 0 { (used * 100) / ctx } else { 0 };
 
-        let cost_str = if session.total_cost > 0.0 {
-            format!(" ${:.4}", session.total_cost)
-        } else {
-            String::new()
-        };
+        // TODO(cost-tracking): `session.total_cost` is always 0.0
+        // because dirge doesn't yet have a per-provider pricing
+        // table — `AgentEvent::Done` emits `cost: 0.0` unconditionally
+        // (see `src/agent/runner.rs::run_stream`). Until that's wired,
+        // the cost segment is suppressed entirely to avoid showing a
+        // misleading "$0.0000". When pricing lands, restore the
+        // conditional formatter that was here previously.
+        let cost_str = String::new();
 
         let compact_badge = if session.compactions.is_empty() {
             String::new()


### PR DESCRIPTION
Two related cleanups: (1) cost/token fields are placeholders without provider usage wiring, so suppress their display + mark with TODO(cost-tracking). (2) Plugin hook errors no longer vanish silently — caught error is emitted as `tracing::warn!(target: "dirge::plugin", ...)` matching opencode's structured-log approach. PLUGINS.md now explains the model + how it compares to opencode and pi. 612 tests pass.