### PR TITLE
feat: --verbose flag + pi-style chat-visible plugin hook errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ dirge --provider deepseek  # defaults to deepseek-v4-pro
 
 export GLM_API_KEY="..."
 dirge --provider glm       # defaults to glm-4
+
+# Verbose mode — debug-level dirge logs + warn-level plugin hook
+# errors (useful when authoring a plugin or filing a bug report).
+# RUST_LOG env still takes precedence if set.
+dirge --verbose
 ```
 
 ## Slash commands

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -456,27 +456,42 @@ State persists for the life of the session — survives between turns.
   freely.
 - **Janet errors** in a hook are caught (so a broken hook can never
   crash the host or block other plugins from dispatching), and the
-  error is emitted via the structured logger as a `warn`-level event
-  with target `dirge::plugin` so it shows up under
-  `RUST_LOG=dirge::plugin=warn dirge ...` or under the catch-all
-  `RUST_LOG=warn`. The error line/file from Janet's stack appears in
-  the message. The hook's return value is treated as `nil` (i.e. no
-  effect on the host) and dispatch continues to the next plugin.
+  error surfaces in TWO places:
 
-  **Why "log-and-continue" rather than "abort the turn"**: a single
-  misbehaving plugin shouldn't be able to wedge the user out of their
-  session. This matches how opencode handles plugin errors
-  (`log.error("plugin config hook failed", { error })` then
-  `Effect.ignore`). pi is a step further and emits a structured
-  `ExtensionError` event the host UI can render as a chat
-  notification — dirge stops short of that today (a plugin gets no
-  user-visible signal beyond the log) but the structured log payload
-  makes it straightforward to wire later.
+  1. **Chat banner** — a red `[plugin] hook <hook>.<fn> errored:
+     <message>` notification appears at the next loop tick (drained
+     out of `harness-notif-list` like a regular `harness/notify`
+     `:error` call). The user sees it inline with the chat without
+     having to know about logs.
+  2. **Structured log** — a `tracing::warn!` with target
+     `dirge::plugin` and fields `hook` / `function` / `error`.
+     Visible via `dirge --verbose` (or
+     `RUST_LOG=dirge::plugin=warn`). Includes the Janet stack line
+     so you can jump straight to the offending form.
 
-  **Implication for plugin authors**: if your hook isn't taking
-  effect, run dirge with `RUST_LOG=dirge::plugin=warn` and look for
-  `plugin hook errored — continuing dispatch` lines. Don't expect
-  the chat to surface plugin errors automatically.
+  The hook's return value is treated as `nil` (no effect on the
+  host) and dispatch continues to the next plugin.
+
+  **Why "log + notify + continue" rather than "abort the turn"**: a
+  single misbehaving plugin shouldn't be able to wedge the user out
+  of their session. The two-surface approach is modeled on pi's
+  `ExtensionError` flow (see
+  `packages/coding-agent/src/core/extensions/runner.ts` —
+  `emitError` calls registered listeners, hosts wire
+  `onError: (e) => ctx.ui.notify("Compaction failed: ...", "error")`).
+  opencode logs only (`log.error("plugin config hook failed", …)`
+  in `packages/opencode/src/plugin/index.ts`); dirge does both so
+  plugin authors get the visible signal without having to enable
+  logs.
+
+  **Quick debugging recipe**:
+  - Notice the red `[plugin] hook X.Y errored: ...` in the chat?
+    Your plugin's `Y` hook threw. The message is the Janet error.
+  - Run with `dirge --verbose` for the full Rust-side log including
+    `dirge::plugin` warn events plus dirge's own debug-level traces.
+  - Use `(harness/log "...")` from inside your hook to add ad-hoc
+    breadcrumbs — these appear in the same `dirge::plugin` log
+    stream when verbose mode is on.
 - **Hook didn't fire?** Double-check the function name matches the
   hook reference exactly — `on_prompt` (underscore) is a different
   symbol than `on-prompt`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,13 @@ pub struct Cli {
     pub no_color: bool,
 
     #[arg(
+        short = 'v',
+        long = "verbose",
+        help = "Enable verbose logging (debug for dirge, warn for plugin hooks; equivalent to RUST_LOG=dirge=debug,dirge::plugin=warn). RUST_LOG env takes precedence if set."
+    )]
+    pub verbose: bool,
+
+    #[arg(
         long = "restrictive",
         short = 'R',
         help = "Default all tools to ask for approval"

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,14 +185,25 @@ fn compile_lsp_commands(cfg: &config::Config) -> std::collections::HashMap<Strin
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
+    let cli = cli::Cli::parse();
+
+    // Tracing filter precedence: RUST_LOG (always wins) > --verbose
+    // (debug for dirge + warn for plugin hooks) > default
+    // (warn, rig silenced). `--verbose` exists primarily so plugin
+    // authors can see hook-error logs without having to know the
+    // RUST_LOG syntax. Logs go to stderr; the interactive TUI
+    // captures stdout but leaves stderr passthrough.
+    let default_filter = if cli.verbose {
+        "dirge=debug,dirge::plugin=warn,rig=off"
+    } else {
+        "warn,rig=off"
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,rig=off")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_filter)),
         )
         .init();
-
-    let cli = cli::Cli::parse();
     let cfg = config::load();
     // Initialize the global UI theme before any rendering happens. The
     // theme is global state; setting it once at boot keeps every

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1337,6 +1337,38 @@ mod tests {
         assert!(out.contains(&"from-beta".to_string()));
     }
 
+    /// A hook that throws is caught: dispatch continues (no panic,
+    /// no propagated error to the caller), `nil` is the effective
+    /// return value (filtered out of the results vec), AND the
+    /// error is pushed onto `harness-notif-list` with `error`
+    /// level so the next drain surfaces a chat-visible notification
+    /// — pi-style behavior layered on top of the structured
+    /// tracing::warn already emitted on the Rust side.
+    #[test]
+    fn dispatch_chat_surfaces_hook_errors_via_notification_queue() {
+        let path = tmpfile("errored-hook", r#"(defn on-prompt [ctx] (error "boom"))"#);
+        let mut mgr = PluginManager::try_new().unwrap();
+        super::load_plugin(&mut mgr, &path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        // Dispatch must NOT propagate the error — the host should
+        // continue regardless of a broken plugin.
+        let out = mgr.dispatch("on-prompt", "@{:prompt \"x\"}").unwrap();
+        // Hook returned nil after the catch, so no results.
+        assert!(out.is_empty(), "errored hook should produce no result");
+
+        // The error landed on the notification queue and shows up
+        // in the next drain as an `error`-level entry.
+        let pending = mgr.drain_notifications();
+        assert!(
+            pending.iter().any(|(level, msg)| level == "error"
+                && msg.contains("on-prompt")
+                && msg.contains("boom")),
+            "expected an error notification mentioning on-prompt and boom; got: {:?}",
+            pending,
+        );
+    }
+
     /// A directory plugin loads every `*.janet` file inside in
     /// alphabetical order. The stem is the directory name; multi-file
     /// plugins share the same Janet env so files can collaborate.
@@ -1660,24 +1692,40 @@ impl PluginManager {
         for name in &names {
             // Wrap the call so plugin runtime errors don't print
             // Janet stack traces to stderr OR vanish silently. On
-            // error, format the message as `DIRGE_HOOK_ERR:<msg>`
-            // so the Rust side can pick it out and emit a
-            // `tracing::warn!` (visible via RUST_LOG=warn).
+            // error, the catch arm does TWO things:
+            //   1. Push an entry onto `harness-notif-list` with
+            //      `error` level so the next drain surfaces a
+            //      chat-visible "[plugin] hook X.Y errored: ..."
+            //      banner (pi-style — see
+            //      `packages/coding-agent/src/core/extensions/runner.ts`
+            //      which emits structured `ExtensionError` events
+            //      the host renders as `ctx.ui.notify("...","error")`).
+            //   2. Return `DIRGE_HOOK_ERR:<msg>` so the Rust side
+            //      can also log a structured `tracing::warn!` —
+            //      surfaces via `--verbose` or `RUST_LOG=warn`.
             //
-            // Prior behavior: pure `(try ... ([err fib] nil))` which
-            // swallowed errors entirely. Plugin authors got no
-            // feedback on broken hooks — strictly worse than both
-            // opencode (`log.error("plugin config hook failed", …)`
-            // in `packages/opencode/src/plugin/index.ts`) and pi
-            // (which emits structured `ExtensionError` events the
-            // host UI can render — see
-            // `packages/coding-agent/src/core/extensions/runner.ts`).
-            // dirge now mirrors opencode's behavior: log structured,
-            // continue dispatch.
+            // Prior behavior (now retired): pure
+            // `(try ... ([err fib] nil))` which swallowed errors
+            // entirely. Plugin authors got no feedback on broken
+            // hooks. opencode logged but didn't notify; pi notified.
+            // dirge now does both.
             let code = format!(
-                r#"(try (do (def ctx {ctx}) ({fname} ctx)) ([err fib] (string "DIRGE_HOOK_ERR:" err)))"#,
+                r#"(try (do (def ctx {ctx}) ({fname} ctx))
+                       ([err fib]
+                         (set harness-notif-list
+                              (string harness-notif-list
+                                      "error\t[plugin] hook "
+                                      {hook_lit}
+                                      "."
+                                      {fname_lit}
+                                      " errored: "
+                                      err
+                                      "\n"))
+                         (string "DIRGE_HOOK_ERR:" err)))"#,
                 ctx = context_janet,
                 fname = name,
+                hook_lit = format!("\"{}\"", escape_janet_string(hook)),
+                fname_lit = format!("\"{}\"", escape_janet_string(name)),
             );
             if let Ok(s) = self.eval(&code) {
                 if let Some(msg) = s.strip_prefix("DIRGE_HOOK_ERR:") {


### PR DESCRIPTION
Two changes so plugin authors can debug without knowing RUST_LOG: (1) `--verbose` flag flips the tracing filter to dirge=debug + plugin=warn when RUST_LOG isn't set; (2) hook errors are now also pushed onto `harness-notif-list` so a red chat banner appears next loop tick (pi-style — modeled on `packages/coding-agent/src/core/extensions/runner.ts`'s emitError flow that hosts wire to `ctx.ui.notify`). 613 tests pass, new regression test covers the chat-notification path.