### PR TITLE
fix(audit r8): allowlist isolation, pop-summary guard, rewind sync, worker timeouts, FFI logging

### DIFF
--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -262,14 +262,27 @@ impl PermissionChecker {
     }
 
     pub fn add_session_allowlist(&mut self, tool: String, pattern_str: &str) {
+        // Dedup against existing (tool, pattern.original) so
+        // repeated "allow always" picks for the same command don't
+        // accumulate identical entries. Cheap O(N) check — N here
+        // is per-session and typically dozens at most.
+        if self
+            .session_allowlist
+            .iter()
+            .any(|(t, p)| t == &tool && p.original == pattern_str)
+        {
+            return;
+        }
         let pattern = pattern_for_tool(&tool, pattern_str);
         self.session_allowlist.push((tool, pattern));
     }
 
     pub fn load_session_allowlist(&mut self, entries: &[(String, String)]) {
+        // Route through `add_session_allowlist` so the same dedup
+        // applies on load. Prevents duplicate entries either from a
+        // malformed session file or from a host that loads twice.
         for (tool, pat) in entries {
-            self.session_allowlist
-                .push((tool.clone(), pattern_for_tool(tool, pat)));
+            self.add_session_allowlist(tool.clone(), pat);
         }
     }
 
@@ -382,6 +395,57 @@ mod tests {
 
         let r2 = checker.check("bash", "cd /Users/yogthos/src/work/rigging-workshop");
         assert!(matches!(r2, CheckResult::Allowed));
+    }
+
+    // Adding the same (tool, pattern) twice must not duplicate the
+    // entry. The audit flagged that "allow always" picks for the
+    // same command repeated across a long session accumulate
+    // identical entries, wasting space and causing redundant
+    // matches on every subsequent check.
+    #[test]
+    fn add_session_allowlist_dedupes_identical_entries() {
+        let mut checker = fresh_checker();
+        checker.add_session_allowlist("bash".to_string(), "cargo *");
+        checker.add_session_allowlist("bash".to_string(), "cargo *");
+        checker.add_session_allowlist("bash".to_string(), "cargo *");
+        let entries = checker.allowlist_entries();
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected dedup; got {} entries: {:?}",
+            entries.len(),
+            entries,
+        );
+    }
+
+    // Distinct patterns for the same tool stay separate — only
+    // exact (tool, pattern) duplicates dedupe.
+    #[test]
+    fn add_session_allowlist_keeps_distinct_patterns_for_same_tool() {
+        let mut checker = fresh_checker();
+        checker.add_session_allowlist("bash".to_string(), "cargo *");
+        checker.add_session_allowlist("bash".to_string(), "git *");
+        let entries = checker.allowlist_entries();
+        assert_eq!(entries.len(), 2, "got: {:?}", entries);
+    }
+
+    // `load_session_allowlist` (called on session resume) also
+    // dedupes against existing entries. If the host calls load
+    // twice (test harness, reconnect, etc.) the entries don't
+    // double up.
+    #[test]
+    fn load_session_allowlist_dedupes_against_existing() {
+        let mut checker = fresh_checker();
+        let entries = vec![
+            ("bash".to_string(), "cargo *".to_string()),
+            ("bash".to_string(), "cargo *".to_string()),
+        ];
+        checker.load_session_allowlist(&entries);
+        // Even within a single load, dupes get collapsed.
+        assert_eq!(checker.allowlist_entries().len(), 1);
+        // Loading the same entries again should not add more.
+        checker.load_session_allowlist(&entries);
+        assert_eq!(checker.allowlist_entries().len(), 1);
     }
 
     // Path-tool patterns still get filesystem-glob semantics — adding

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -14,6 +14,35 @@ mod tests {
         assert!(PluginManager::try_new().is_ok());
     }
 
+    /// Dropping an idle worker must complete promptly (well under
+    /// the `JOIN_TIMEOUT` upper bound). This is the regression guard
+    /// for the bounded-join change in `Worker::Drop` — without the
+    /// poll loop the change would have introduced a fixed 2s delay
+    /// on every shutdown.
+    #[test]
+    fn worker_drop_completes_promptly_when_idle() {
+        let mgr = PluginManager::try_new().unwrap();
+        let start = std::time::Instant::now();
+        drop(mgr);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "idle Drop should be near-instant; took {:?}",
+            elapsed,
+        );
+    }
+
+    /// Sanity-check that `eval` still returns the worker's reply
+    /// after the switch from `recv()` to `recv_timeout(EVAL_TIMEOUT)`.
+    /// Without this, a typo in the new match arms could mask the
+    /// happy-path break by always returning the timeout error.
+    #[test]
+    fn worker_eval_still_returns_reply_after_recv_timeout_switch() {
+        let mut mgr = PluginManager::try_new().unwrap();
+        let out = mgr.eval("(+ 1 2)").unwrap();
+        assert_eq!(out, "3", "got: {out:?}");
+    }
+
     #[test]
     fn test_dispatch_returns_per_hook_results() {
         // Multiple plugins registering the same hook must each contribute

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -37,6 +37,25 @@ const INIT_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg_attr(not(feature = "plugin"), allow(dead_code))]
 const DIALOG_POLL: Duration = Duration::from_millis(50);
 
+/// Upper bound on how long a single `Worker::eval` will wait for the
+/// worker's reply. Generous (10 min) because `harness/confirm` /
+/// `harness/select` legitimately block the worker on user input — a
+/// distracted user may take minutes to answer a dialog. The point of
+/// the bound is to detect a truly wedged plugin (e.g. plugin code in
+/// `(while true)`) rather than to enforce snappy responses. When the
+/// timeout fires the caller gets a clean error instead of hanging.
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
+const EVAL_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Upper bound on how long `Worker::Drop` will wait for the worker
+/// thread to exit. Short by design: shutdown is best-effort. If the
+/// plugin is stuck in an infinite loop, the worker thread can't
+/// respond to `Cmd::Shutdown` and we'd hang the user's terminal
+/// forever on Drop. Beyond `JOIN_TIMEOUT` we leak the thread (it's
+/// reaped on process exit) and log a warn so the operator knows.
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
+const JOIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[cfg(feature = "plugin")]
 use janetrs::client::JanetClient;
 #[cfg(feature = "plugin")]
@@ -428,8 +447,22 @@ impl Worker {
                 reply,
             })
             .map_err(|_| "janet worker disconnected".to_string())?;
-        rx.recv()
-            .map_err(|_| "janet worker dropped reply channel".to_string())?
+        // Bounded wait. `recv_timeout` is functionally `recv()` for
+        // any well-behaved plugin since EVAL_TIMEOUT is 10 minutes;
+        // its purpose is to surface a clean error when a plugin
+        // is wedged in an infinite loop, rather than locking the
+        // host's event loop forever on a `recv()` that never
+        // resolves.
+        match rx.recv_timeout(EVAL_TIMEOUT) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(format!(
+                "janet worker did not reply within {}s — plugin may be stuck in an infinite loop",
+                EVAL_TIMEOUT.as_secs(),
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err("janet worker dropped reply channel".to_string())
+            }
+        }
     }
 }
 
@@ -444,7 +477,27 @@ impl Drop for Worker {
         self.shutdown.store(true, Ordering::SeqCst);
         let _ = self.cmd_tx.send(Cmd::Shutdown);
         if let Some(h) = self.join.take() {
-            let _ = h.join();
+            // Bounded join. `JoinHandle::join` has no timeout, so we
+            // poll `is_finished()` (stable since Rust 1.61) and bail
+            // after JOIN_TIMEOUT. If the worker is wedged in plugin
+            // code (e.g. Janet `(while true)`), join would otherwise
+            // hang the calling thread — usually the user's main
+            // thread on `/quit`. We leak the JoinHandle rather than
+            // pinning the process; the thread is reaped on exit.
+            let deadline = std::time::Instant::now() + JOIN_TIMEOUT;
+            while !h.is_finished() && std::time::Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            if h.is_finished() {
+                let _ = h.join();
+            } else {
+                tracing::warn!(
+                    target: "dirge::plugin",
+                    timeout_secs = JOIN_TIMEOUT.as_secs(),
+                    "janet worker thread did not exit within JOIN_TIMEOUT; leaking on shutdown",
+                );
+                std::mem::forget(h);
+            }
         }
     }
 }
@@ -539,7 +592,21 @@ unsafe extern "C-unwind" fn janet_confirm_cfn(
     }));
     match result {
         Ok(j) => j,
-        Err(_) => unsafe { janet_wrap_boolean(0) },
+        Err(payload) => {
+            // Log the panic before swallowing so the operator can
+            // see *why* harness/confirm collapsed to false. Previous
+            // behavior masked panics silently and plugin authors had
+            // no way to distinguish "user said no" from "Rust panic
+            // at FFI boundary."
+            let msg = panic_payload_to_string(&payload);
+            tracing::error!(
+                target: "dirge::plugin",
+                cfn = "harness/confirm",
+                panic = %msg,
+                "FFI panic in dialog cfn — returning safe default (false)",
+            );
+            unsafe { janet_wrap_boolean(0) }
+        }
     }
 }
 
@@ -586,7 +653,32 @@ unsafe extern "C-unwind" fn janet_select_cfn(
     }));
     match result {
         Ok(j) => j,
-        Err(_) => unsafe { janet_wrap_nil() },
+        Err(payload) => {
+            let msg = panic_payload_to_string(&payload);
+            tracing::error!(
+                target: "dirge::plugin",
+                cfn = "harness/select",
+                panic = %msg,
+                "FFI panic in dialog cfn — returning safe default (nil)",
+            );
+            unsafe { janet_wrap_nil() }
+        }
+    }
+}
+
+/// Best-effort conversion of a panic payload (`Box<dyn Any>`) to a
+/// printable string. Tries `&str` then `String` — covers the two
+/// payload shapes std and most code produce. Returns
+/// `"<non-string panic payload>"` for anything else so the log
+/// always has SOMETHING to anchor on rather than going silent again.
+#[cfg(feature = "plugin")]
+fn panic_payload_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -329,6 +329,18 @@ impl Session {
     /// always safe to remove.
     pub fn pop_last_message(&mut self) -> Option<SessionMessage> {
         self.ensure_back_compat_initialized();
+        // Refuse to pop a compaction summary. After compress, the
+        // System message at index 0 anchors all prior context for
+        // the next agent turn; removing it would silently lose the
+        // entire compressed history. Repeated `/undo` past the
+        // recent messages must stop here. The user can `/clear` to
+        // reset entirely.
+        if let Some(last) = self.messages.last()
+            && self.messages.len() == 1
+            && last.role == MessageRole::System
+        {
+            return None;
+        }
         let msg = self.messages.pop()?;
         // Pull the popped node's parent for leaf rewind. If the tree
         // somehow lacks this node (corruption / external mutation),
@@ -506,8 +518,14 @@ impl Session {
         self.total_estimated_tokens = 0;
         self.created_at = now.clone();
         self.updated_at = now;
-        // Note: model/provider/context_window/working_dir/permission_allowlist
-        // preserved so the host can keep the same agent runtime.
+        // Least privilege: clear `permission_allowlist` too. The
+        // previous "preserved across reset" behavior let "allow
+        // always" grants for one task (e.g. `bash cargo *` from a
+        // testing session) silently transfer to an unrelated fresh
+        // session. Each new session re-asks for permissions.
+        self.permission_allowlist.clear();
+        // Note: model/provider/context_window/working_dir preserved
+        // so the host can keep the same agent runtime.
     }
 
     pub fn needs_compaction(&self, reserve_tokens: u64) -> bool {
@@ -1071,6 +1089,78 @@ mod tests {
         assert_eq!(s.context_window, 200_000);
         // Lineage left blank when no parent passed.
         assert_eq!(s.name, "");
+    }
+
+    /// `reset_to_new` must clear `permission_allowlist` to avoid
+    /// leaking "allow always" decisions from a prior conversation
+    /// into an unrelated fresh session. Least-privilege: each new
+    /// task starts with no implicit grants.
+    #[test]
+    fn reset_to_new_clears_permission_allowlist() {
+        let mut s = Session::new("openai", "gpt-4", 200_000);
+        s.permission_allowlist.push(PermissionAllowEntry {
+            tool: "bash".to_string(),
+            pattern: "rm -rf /tmp/foo".to_string(),
+        });
+        assert!(!s.permission_allowlist.is_empty());
+        s.reset_to_new(None);
+        assert!(
+            s.permission_allowlist.is_empty(),
+            "allowlist must reset on new session; got {:?}",
+            s.permission_allowlist,
+        );
+    }
+
+    /// Repeated `/undo` after a compress must NOT pop the System
+    /// summary at index 0. Removing it would unanchor the compressed
+    /// context and the next agent turn would see no history.
+    #[test]
+    fn pop_last_message_refuses_to_pop_summary_at_index_zero() {
+        let mut s = Session::new("p", "m", 0);
+        s.add_message(MessageRole::User, "u1");
+        s.add_message(MessageRole::Assistant, "a1");
+        s.add_message(MessageRole::User, "u2");
+        s.add_message(MessageRole::Assistant, "a2");
+        s.compress("summary".to_string(), 4, 100);
+        // After compress: messages = [<summary at 0>, ...nothing else,
+        // since we drained 4 and kept 0 recent]. Verify the shape.
+        assert_eq!(s.messages.len(), 1, "post-compress shape");
+        assert_eq!(s.messages[0].role, MessageRole::System);
+
+        // Now /undo style pop. Must NOT remove the summary.
+        let popped = s.pop_last_message();
+        assert!(
+            popped.is_none(),
+            "pop must refuse the summary; got {:?}",
+            popped,
+        );
+        assert_eq!(s.messages.len(), 1, "summary must remain");
+        assert_eq!(s.messages[0].role, MessageRole::System);
+    }
+
+    /// Popping past the summary by depleting all recent messages
+    /// also must not remove the summary itself — the user has to
+    /// `/clear` to reset.
+    #[test]
+    fn pop_drains_recent_but_keeps_summary() {
+        let mut s = Session::new("p", "m", 0);
+        s.add_message(MessageRole::User, "u1");
+        s.add_message(MessageRole::Assistant, "a1");
+        s.compress("summary".to_string(), 2, 50);
+        // Re-add some recent messages after the compress.
+        s.add_message(MessageRole::User, "u2");
+        s.add_message(MessageRole::Assistant, "a2");
+        assert_eq!(s.messages.len(), 3); // [summary, u2, a2]
+
+        // Pop a2, then u2 — both should succeed.
+        assert!(s.pop_last_message().is_some());
+        assert!(s.pop_last_message().is_some());
+        assert_eq!(s.messages.len(), 1);
+        assert_eq!(s.messages[0].role, MessageRole::System);
+
+        // One more pop attempt → refused.
+        assert!(s.pop_last_message().is_none());
+        assert_eq!(s.messages.len(), 1);
     }
 
     /// When given a parent session id, `reset_to_new` records it

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2914,17 +2914,28 @@ pub async fn run_interactive(
 }
 
 fn suggest_pattern(tool: &str, input: &str) -> String {
+    // Refuse to suggest a catch-all wildcard for empty / whitespace-
+    // only input. A user mis-clicking "(a) allow always" on an empty
+    // invocation would otherwise pin an "allow everything for this
+    // tool forever" rule into their session. The placeholder string
+    // is intentionally not a valid glob — the UI shows it as the
+    // suggested pattern, the user edits it before confirming.
+    const PLACEHOLDER: &str = "<edit this pattern>";
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return PLACEHOLDER.to_string();
+    }
     match tool {
         "bash" => {
-            let first = input.split_whitespace().next().unwrap_or("*");
+            let first = trimmed.split_whitespace().next().unwrap_or(PLACEHOLDER);
             format!("{} *", first)
         }
         "read" | "write" | "edit" | "list_dir" => {
-            let path = std::path::Path::new(input);
+            let path = std::path::Path::new(trimmed);
             let parent = path
                 .parent()
                 .map(|p| p.to_string_lossy())
-                .unwrap_or(std::borrow::Cow::Borrowed("*"));
+                .unwrap_or(std::borrow::Cow::Borrowed(""));
             if parent.is_empty() {
                 "**".to_string()
             } else {
@@ -2932,10 +2943,12 @@ fn suggest_pattern(tool: &str, input: &str) -> String {
             }
         }
         "grep" | "find_files" => {
-            let first = input.split_whitespace().next().unwrap_or("*");
+            let first = trimmed.split_whitespace().next().unwrap_or(PLACEHOLDER);
             format!("{}*", first)
         }
-        _ => "*".to_string(),
+        // Unknown tools (MCP, semantic, etc.) — return placeholder
+        // so the user explicitly edits before allowing.
+        _ => PLACEHOLDER.to_string(),
     }
 }
 
@@ -3177,7 +3190,25 @@ fn rewind_session(
     let target = user_indices.len().saturating_sub(idx + 1);
     if let Some(&msg_idx) = user_indices.get(target) {
         let removed = session.messages.len() - msg_idx;
+        // Collect ids of the messages we're dropping BEFORE truncate
+        // so we can also prune them from `tree.entries` and
+        // `message_store`. Without this, the tree references
+        // orphaned ids (no content in store), and subsequent
+        // fork/clone/switch-to-leaf operations silently fail or
+        // corrupt the session.
+        let dropped_ids: Vec<_> = session.messages[msg_idx..]
+            .iter()
+            .map(|m| m.id.clone())
+            .collect();
         session.messages.truncate(msg_idx);
+        for id in &dropped_ids {
+            session.tree.entries.remove(id);
+            session.message_store.remove(id);
+        }
+        // Re-anchor `leaf_id` to the new tail (or None if everything
+        // was dropped). Previously the leaf was left pointing at a
+        // dropped id, which made `/tree` show a phantom branch.
+        session.tree.leaf_id = session.messages.last().map(|m| m.id.clone());
         session.total_estimated_tokens = session.messages.iter().map(|m| m.estimated_tokens).sum();
         renderer.write_line(&format!("rewound {} message(s)", removed), theme::accent())?;
     }
@@ -3312,6 +3343,109 @@ mod tests {
             !content.contains("1 tool calls ran"),
             "leaked plural for singular case: {content:?}",
         );
+    }
+
+    // Whitespace-only or empty input must NOT collapse to a "* *"
+    // / "*" wildcard pattern that matches every subsequent call.
+    // The audit flagged this as a footgun: a user accidentally
+    // hitting "(a) allow always" on an empty bash invocation would
+    // permanently auto-allow ALL bash. Now we return a literal
+    // placeholder + the user has to type the pattern themselves.
+    #[test]
+    fn suggest_pattern_refuses_wildcard_on_empty_input() {
+        // Bash: empty / whitespace input should NOT yield "* *".
+        let p = suggest_pattern("bash", "");
+        assert_ne!(p, "* *", "empty bash input must not yield catch-all");
+        assert!(
+            !p.contains('*'),
+            "empty input should not contain wildcards: {p:?}"
+        );
+
+        let p = suggest_pattern("bash", "   \t  ");
+        assert_ne!(
+            p, "* *",
+            "whitespace-only bash input must not yield catch-all"
+        );
+        assert!(
+            !p.contains('*'),
+            "ws-only input should not contain wildcards: {p:?}"
+        );
+
+        // grep / find_files: same — empty must not yield "*"
+        let p = suggest_pattern("grep", "");
+        assert!(
+            !p.contains('*'),
+            "empty grep input must not yield wildcard: {p:?}"
+        );
+
+        // Unknown tool with empty input shouldn't yield catch-all.
+        let p = suggest_pattern("mcp_tool:foo", "");
+        assert!(!p.contains('*'), "unknown tool empty input: {p:?}");
+    }
+
+    // Non-empty inputs still produce the expected suggestion.
+    #[test]
+    fn suggest_pattern_works_for_non_empty_inputs() {
+        assert_eq!(suggest_pattern("bash", "cargo test --all"), "cargo *");
+        assert_eq!(suggest_pattern("grep", "fn foo bar"), "fn*");
+    }
+
+    // Rewind must sync tree.entries + message_store + leaf_id with
+    // the truncated `messages` slice. Without this, the tree
+    // references orphaned ids that no longer have content, and the
+    // leaf_id can point past the truncation. Subsequent fork /
+    // clone / save-load operations either fail or carry stale ids.
+    #[test]
+    fn rewind_truncates_tree_and_store_in_sync_with_messages() {
+        let mut session = crate::session::Session::new("p", "m", 100_000);
+        session.add_message(crate::session::MessageRole::User, "u1");
+        session.add_message(crate::session::MessageRole::Assistant, "a1");
+        session.add_message(crate::session::MessageRole::User, "u2");
+        session.add_message(crate::session::MessageRole::Assistant, "a2");
+        let baseline_tree = session.tree.entries.len();
+        assert_eq!(baseline_tree, 4, "fixture: 4 entries");
+
+        // Rewind back to the first user message (idx=1 in the
+        // reverse-order user list means the *first* user).
+        let mut renderer = crate::ui::renderer::Renderer::new().unwrap();
+        // idx=0 = "rewind through the most recent user prompt" → cut
+        // at the position of u2 → messages become [u1, a1].
+        let _ = rewind_session(&mut session, 0, &mut renderer);
+
+        // After rewind, messages has [u1, a1]; tree must agree.
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(
+            session.tree.entries.len(),
+            session.messages.len(),
+            "tree entries must match messages count; got tree={}, msgs={}",
+            session.tree.entries.len(),
+            session.messages.len(),
+        );
+        assert_eq!(
+            session.message_store.len(),
+            session.messages.len(),
+            "store must match messages count",
+        );
+        // Leaf points to the last remaining message.
+        let last_id = session.messages.last().unwrap().id.clone();
+        assert_eq!(
+            session.tree.leaf_id,
+            Some(last_id.clone()),
+            "leaf_id must anchor to the new tail",
+        );
+        // Every remaining message id has a tree entry + store entry.
+        for m in &session.messages {
+            assert!(
+                session.tree.entries.contains_key(&m.id),
+                "missing tree entry for {}",
+                m.id,
+            );
+            assert!(
+                session.message_store.contains_key(&m.id),
+                "missing store entry for {}",
+                m.id,
+            );
+        }
     }
 
     // The token accumulator on the abort path keeps `total_tokens`


### PR DESCRIPTION
Audit round 8 batch — 3 TDD rounds covering session-tree consistency on rewind/pop, allowlist privacy/dedup, and worker thread resilience (eval timeout, bounded Drop join). 11 new tests, 633 pass total across all build profiles.