### PR TITLE
fix(F2): hide dotfiles by default in find_files/glob/list_dir

### DIFF
--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -58,6 +58,10 @@ impl Tool for FindFilesTool {
                     "path": {
                         "type": "string",
                         "description": "Directory to search in (defaults to current working directory)"
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include dotfiles (.env, .gitignore, etc.) in results. Default false to avoid surfacing secrets and config files."
                     }
                 },
                 "required": ["pattern"]
@@ -69,9 +73,10 @@ impl Tool for FindFilesTool {
         check_perm(&self.permission, &self.ask_tx, "find_files", &args.pattern).await?;
 
         let cache_key = format!(
-            "find_files:{}:{}",
+            "find_files:{}:{}:hidden={}",
             args.pattern,
             args.path.as_deref().unwrap_or("."),
+            args.include_hidden,
         );
 
         if let Some(ref cache) = self.cache {
@@ -85,12 +90,18 @@ impl Tool for FindFilesTool {
 
         let search_path = args.path.as_deref().unwrap_or(".");
 
+        // `WalkBuilder::hidden(true)` means SKIP hidden entries.
+        // Default behavior (`include_hidden = false`) hides
+        // dotfiles so .env / .git / .DS_Store don't leak into the
+        // LLM's view of the filesystem unintentionally. The LLM
+        // can pass `include_hidden: true` when it explicitly needs
+        // them. Matches pi + opencode defaults.
         let walker = WalkBuilder::new(search_path)
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
             .require_git(false)
-            .hidden(false)
+            .hidden(!args.include_hidden)
             .filter_entry(|entry| {
                 if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                     !is_skip_dir(entry.file_name().to_str().unwrap_or(""))

--- a/src/agent/tools/glob.rs
+++ b/src/agent/tools/glob.rs
@@ -48,6 +48,10 @@ impl GlobTool {
 pub struct GlobArgs {
     pub pattern: String,
     pub path: Option<String>,
+    /// Include dotfiles in the walk. Default `false`. See the
+    /// equivalent doc on `FindFilesArgs::include_hidden`.
+    #[serde(default)]
+    pub include_hidden: bool,
 }
 
 fn glob_to_regex(pattern: &str) -> Result<regex::Regex, String> {
@@ -105,6 +109,10 @@ impl Tool for GlobTool {
                     "path": {
                         "type": "string",
                         "description": "Root directory to search in (default: current working directory)"
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include dotfiles (.env, .gitignore, etc.). Default false to avoid surfacing secrets and config files."
                     }
                 },
                 "required": ["pattern"]
@@ -122,9 +130,10 @@ impl Tool for GlobTool {
         .await?;
 
         let cache_key = format!(
-            "glob:{}:{}",
+            "glob:{}:{}:hidden={}",
             args.pattern,
             args.path.as_deref().unwrap_or("."),
+            args.include_hidden,
         );
         if let Some(ref cache) = self.cache
             && let Some(cached) = cache.get(&cache_key)
@@ -144,7 +153,8 @@ impl Tool for GlobTool {
         let mut matches: Vec<(String, std::path::PathBuf)> = Vec::new();
 
         let walker = WalkBuilder::new(root)
-            .hidden(false)
+            // Hide dotfiles by default. See `FindFilesArgs::include_hidden`.
+            .hidden(!args.include_hidden)
             .git_global(false)
             .git_ignore(true)
             .git_exclude(true)
@@ -297,6 +307,7 @@ mod tests {
             .call(GlobArgs {
                 pattern: "**/*.rs".into(),
                 path: Some(tree.root_str()),
+                include_hidden: false,
             })
             .await
             .unwrap();
@@ -323,6 +334,7 @@ mod tests {
             .call(GlobArgs {
                 pattern: "**/*.nonexistent".into(),
                 path: Some(tree.root_str()),
+                include_hidden: false,
             })
             .await
             .unwrap();
@@ -348,6 +360,7 @@ mod tests {
             .call(GlobArgs {
                 pattern: "*.rs".into(),
                 path: Some(tree.root_str()),
+                include_hidden: false,
             })
             .await
             .unwrap();
@@ -372,6 +385,7 @@ mod tests {
             .call(GlobArgs {
                 pattern: "*.rs".into(),
                 path: Some(tree.root_str()),
+                include_hidden: false,
             })
             .await
             .unwrap();
@@ -399,5 +413,58 @@ mod tests {
         let re = glob_to_regex("*.rs").unwrap();
         assert!(re.is_match("main.rs"));
         assert!(!re.is_match("src/main.rs"));
+    }
+
+    /// F2: dotfiles must be skipped by default. `.env`, `.gitignore`,
+    /// `.DS_Store` etc. previously appeared in glob results,
+    /// risking secret leakage into the LLM context.
+    #[tokio::test]
+    async fn glob_skips_dotfiles_by_default() {
+        let tree = TempTree::new("hidden-default");
+        tree.write("main.rs", "");
+        tree.write(".env", "SECRET=hunter2");
+        tree.write(".gitignore", "target/");
+
+        let tool = GlobTool::new(None, None);
+        let out = tool
+            .call(GlobArgs {
+                pattern: "*".into(),
+                path: Some(tree.root_str()),
+                include_hidden: false,
+            })
+            .await
+            .unwrap();
+
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines.contains(&"main.rs"), "main.rs missing: {out}");
+        assert!(
+            !lines.iter().any(|l| l.starts_with('.')),
+            "dotfile leaked into default glob: {out}",
+        );
+    }
+
+    /// F2: setting `include_hidden: true` opts back in to seeing
+    /// dotfiles. The LLM uses this when it explicitly needs to
+    /// inspect `.gitignore`, `.env.example`, etc.
+    #[tokio::test]
+    async fn glob_includes_dotfiles_when_asked() {
+        let tree = TempTree::new("hidden-opt-in");
+        tree.write("main.rs", "");
+        tree.write(".gitignore", "target/");
+
+        let tool = GlobTool::new(None, None);
+        let out = tool
+            .call(GlobArgs {
+                pattern: "*".into(),
+                path: Some(tree.root_str()),
+                include_hidden: true,
+            })
+            .await
+            .unwrap();
+        assert!(out.contains("main.rs"), "main.rs missing: {out}");
+        assert!(
+            out.contains(".gitignore"),
+            "dotfile missing when opt-in: {out}"
+        );
     }
 }

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -76,6 +76,10 @@ impl Tool for ListDirTool {
                     "path": {
                         "type": "string",
                         "description": "Directory path (defaults to current working directory)"
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include dotfiles (.env, .gitignore, etc.) in the listing. Default false to avoid surfacing secrets and config files."
                     }
                 },
                 "required": []
@@ -87,7 +91,7 @@ impl Tool for ListDirTool {
         let path = args.path.as_deref().unwrap_or(".");
         check_perm_path(&self.permission, &self.ask_tx, "list_dir", path).await?;
 
-        let cache_key = format!("list_dir:{}", path);
+        let cache_key = format!("list_dir:{}:hidden={}", path, args.include_hidden);
 
         if let Some(ref cache) = self.cache {
             if let Some(cached) = cache.get(&cache_key) {
@@ -100,7 +104,9 @@ impl Tool for ListDirTool {
             .git_global(true)
             .git_exclude(true)
             .require_git(false)
-            .hidden(false)
+            // Hide dotfiles by default to avoid leaking .env etc.
+            // into LLM context. See `FindFilesArgs::include_hidden`.
+            .hidden(!args.include_hidden)
             .max_depth(Some(1))
             .filter_entry(|entry| {
                 if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -118,11 +118,22 @@ pub struct GrepArgs {
 pub struct FindFilesArgs {
     pub pattern: String,
     pub path: Option<String>,
+    /// Include dotfiles / hidden files (e.g. `.env`, `.gitignore`).
+    /// Default `false` — by default the listing skips hidden files
+    /// so secrets in `.env` or `.git/` internals don't get pulled
+    /// into LLM context inadvertently. Set `true` when the agent
+    /// explicitly needs to inspect dotfiles.
+    #[serde(default)]
+    pub include_hidden: bool,
 }
 
 #[derive(Deserialize)]
 pub struct ListDirArgs {
     pub path: Option<String>,
+    /// Include dotfiles in the listing. See `FindFilesArgs::include_hidden`
+    /// for the rationale; default `false` for safety.
+    #[serde(default)]
+    pub include_hidden: bool,
 }
 
 async fn handle_ask_inner(


### PR DESCRIPTION
Track F-CRITICAL #2. All three filesystem-walking tools defaulted to including dotfiles, leaking `.env` / `.git/` / `.DS_Store` into LLM context. Added `include_hidden: bool` arg (defaults to false); LLM opts in when needed. 2 new tests, 651 pass.