### PR TITLE
fix(F18): normalize relative paths in is_external_path

### DIFF
--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -332,12 +332,29 @@ impl PermissionChecker {
     }
 
     fn is_external_path(&self, path_str: &str) -> bool {
-        let p = Path::new(path_str);
+        // F18: previously `!is_absolute → return false`, which
+        // treated `../../etc/passwd` as "internal" (not external).
+        // In Accept mode that bypassed external_directory rules:
+        // a relative `../../secret` would auto-allow because it
+        // wasn't classified external. Now we resolve relative
+        // paths against the working_dir (same logic as
+        // `resolve_absolute`) before the starts_with check.
+        let resolved = resolve_absolute(path_str, &self.working_dir);
+        let p = Path::new(&resolved);
         if !p.is_absolute() {
+            // resolve_absolute fell back to lexical join and the
+            // result is still relative — usually means working_dir
+            // itself is bogus. Treat as not-external; rules will
+            // fall through to the default action.
             return false;
         }
         let cwd = Path::new(&self.working_dir);
-        !p.starts_with(cwd)
+        // Canonicalize cwd for the comparison too — if a symlinked
+        // working_dir or one with `..` segments was stored, a
+        // canonicalized `resolved` could no longer share the
+        // prefix even when it's the same directory.
+        let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+        !p.starts_with(&canonical_cwd) && !p.starts_with(cwd)
     }
 
     fn match_ext_dir(&self, path_str: &str) -> Option<Action> {

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -158,6 +158,50 @@ fn relative_path_is_not_external() {
     assert!(matches!(result, CheckResult::Allowed));
 }
 
+/// F18: a relative path with `..` traversal that escapes the
+/// working directory IS external — previously it was treated as
+/// internal because is_external_path returned false on
+/// `!is_absolute`. In Accept mode that auto-allowed `../../secret`.
+#[test]
+fn relative_path_escaping_cwd_is_external() {
+    // Build a deeper working dir so `../../../escaped` lands ABOVE
+    // the working dir but inside a still-existing ancestor.
+    let base = std::env::temp_dir().join(format!("dirge-f18-extern-{}", std::process::id()));
+    let cwd = base.join("a/b/c"); // 3 levels deep under `base`
+    let escaped_dir = base.join("escaped");
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&cwd).unwrap();
+    std::fs::create_dir_all(&escaped_dir).unwrap();
+    let escaped_file = escaped_dir.join("file.rs");
+    std::fs::write(&escaped_file, "").unwrap();
+
+    let config = PermissionConfig {
+        read: Some(ToolPerm::Simple(Action::Ask)),
+        ..PermissionConfig::default()
+    };
+    let mut checker = PermissionChecker::new(&config, SecurityMode::Accept, Some(cwd.clone()));
+
+    // In-tree relative path → still internal → auto-allow in Accept.
+    std::fs::write(cwd.join("local.rs"), "").unwrap();
+    let internal = checker.check_path("read", "local.rs");
+    assert!(
+        matches!(internal, CheckResult::Allowed),
+        "in-tree path should auto-allow in Accept: got {:?}",
+        internal,
+    );
+
+    // `../../../escaped/file.rs` escapes cwd → external → Ask
+    // (no external_directory rule configured to allow it).
+    let escape = checker.check_path("read", "../../../escaped/file.rs");
+    assert!(
+        matches!(escape, CheckResult::Ask),
+        "escape attempt must surface as Ask in Accept; got {:?}",
+        escape,
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 // --- Config-driven rules ---
 
 #[test]


### PR DESCRIPTION
Track F-MEDIUM #18. Previously `is_external_path` returned false on any non-absolute path, letting `../../escape` bypass Accept-mode external-directory rules. Now resolves via the same canonicalize logic used by check_path, comparing against both literal and canonical working_dir. 1 new test, 679 pass.