### PR TITLE
fix(ui): avatar smear, user/agent colors, chamber alignment, emoji tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-python",
  "tree-sitter-typescript",
+ "unicode-width",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ libc = "0.2"
 
 [dependencies]
 rig = { version = "0.37", features = ["rmcp"] }
+# Display-width-aware char counting for terminal layout. `chars().count()`
+# undercounts emoji (e.g. ✅ takes 2 cells in most terminals); markdown
+# tables misaligned the right border when cells contained them.
+unicode-width = "0.2"
 rmcp = { version = "1.7", optional = true, default-features = false, features = [
     "client",
     "transport-child-process",

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -75,10 +75,15 @@ fn render_table(
     max_width: usize,
     out: &mut Vec<LineEntry>,
 ) {
+    use unicode_width::UnicodeWidthStr;
     if header.is_empty() && rows.is_empty() {
         return;
     }
-    // Compute per-column max char width.
+    // Compute per-column max DISPLAY width — emoji like ✅ occupy 2
+    // terminal cells but only 1 `char`. Counting chars previously
+    // produced narrow columns and the right border slid left by one
+    // per emoji. `unicode_width::UnicodeWidthStr::width` returns the
+    // terminal-cell width.
     let ncols = header
         .len()
         .max(rows.iter().map(|r| r.len()).max().unwrap_or(0));
@@ -87,11 +92,11 @@ fn render_table(
     }
     let mut widths = vec![0usize; ncols];
     for (i, cell) in header.iter().enumerate() {
-        widths[i] = widths[i].max(cell.chars().count());
+        widths[i] = widths[i].max(cell.as_str().width());
     }
     for row in rows {
         for (i, cell) in row.iter().enumerate() {
-            widths[i] = widths[i].max(cell.chars().count());
+            widths[i] = widths[i].max(cell.as_str().width());
         }
     }
     // Minimum column width — ragged rows (one row has fewer cells
@@ -115,21 +120,32 @@ fn render_table(
         }
     }
 
+    // `fit` pads or truncates `cell` to occupy exactly `w` terminal
+    // cells. Char-based length undercounts emoji; we accumulate the
+    // per-character display width and pad with the actual cell deficit
+    // so right borders line up under cells of any width mix.
     let fit = |cell: &str, w: usize| -> String {
-        let chars: Vec<char> = cell.chars().collect();
-        if chars.len() <= w {
-            let mut s: String = chars.iter().collect();
-            for _ in chars.len()..w {
-                s.push(' ');
+        use unicode_width::UnicodeWidthChar;
+        let mut out = String::with_capacity(cell.len() + w);
+        let mut used = 0usize;
+        for c in cell.chars() {
+            let cw = c.width().unwrap_or(0);
+            // Truncate with ellipsis if the next char would overflow.
+            // The ellipsis itself is 1 cell wide.
+            if used + cw > w {
+                if w >= 1 && used + 1 <= w {
+                    out.push('…');
+                    used += 1;
+                }
+                break;
             }
-            s
-        } else if w <= 1 {
-            chars.iter().take(w).collect()
-        } else {
-            let mut s: String = chars.iter().take(w - 1).collect();
-            s.push('…');
-            s
+            out.push(c);
+            used += cw;
         }
+        for _ in used..w {
+            out.push(' ');
+        }
+        out
     };
 
     let render_row = |row: &[String], widths: &[usize]| -> String {
@@ -486,4 +502,79 @@ pub fn markdown_to_styled(text: &str, max_width: usize) -> Vec<LineEntry> {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use unicode_width::UnicodeWidthStr;
+
+    /// Each rendered row must occupy the same number of terminal
+    /// cells so the right border `│` lines up vertically.
+    fn assert_rows_same_width(rows: &[LineEntry]) {
+        let widths: Vec<usize> = rows.iter().map(|r| r.text.as_str().width()).collect();
+        if widths.is_empty() {
+            return;
+        }
+        let first = widths[0];
+        for (i, w) in widths.iter().enumerate() {
+            assert_eq!(
+                *w, first,
+                "row {i} has width {w}, expected {first} (matching first row).\nrow: {:?}",
+                rows[i].text,
+            );
+        }
+    }
+
+    /// Tables with emoji cells used to misalign the right border:
+    /// `chars().count()` undercounted emoji like ✅ (2-cell-wide)
+    /// as 1 char, leaving the right border 1 cell short.
+    #[test]
+    fn table_with_emoji_aligns_right_border() {
+        let header = vec![
+            "File".to_string(),
+            "Action".to_string(),
+            "Status".to_string(),
+        ];
+        let rows = vec![
+            vec!["a.rs".to_string(), "CREATE".to_string(), "✅".to_string()],
+            vec!["b.rs".to_string(), "MODIFY".to_string(), "✅".to_string()],
+            vec!["c.rs".to_string(), "DELETE".to_string(), "❌".to_string()],
+        ];
+        let mut out = Vec::new();
+        render_table(&header, &rows, 80, &mut out);
+        // Drop the trailing empty line; everything else must align.
+        let non_empty: Vec<&LineEntry> = out.iter().filter(|e| !e.text.is_empty()).collect();
+        let owned: Vec<LineEntry> = non_empty.into_iter().cloned().collect();
+        assert_rows_same_width(&owned);
+    }
+
+    /// Plain ASCII rows continue to align (regression guard).
+    #[test]
+    fn table_with_ascii_only_aligns() {
+        let header = vec!["a".to_string(), "bb".to_string()];
+        let rows = vec![
+            vec!["1".to_string(), "22".to_string()],
+            vec!["3".to_string(), "44".to_string()],
+        ];
+        let mut out = Vec::new();
+        render_table(&header, &rows, 80, &mut out);
+        let owned: Vec<LineEntry> = out.iter().filter(|e| !e.text.is_empty()).cloned().collect();
+        assert_rows_same_width(&owned);
+    }
+
+    /// Mixed-width column (1-cell chars + emoji) still aligns.
+    #[test]
+    fn table_with_mixed_cell_widths_aligns() {
+        let header = vec!["Name".to_string(), "Status".to_string()];
+        let rows = vec![
+            vec!["short".to_string(), "✅ OK".to_string()],
+            vec!["longer one".to_string(), "—".to_string()],
+            vec!["🚀 emoji-first".to_string(), "?".to_string()],
+        ];
+        let mut out = Vec::new();
+        render_table(&header, &rows, 80, &mut out);
+        let owned: Vec<LineEntry> = out.iter().filter(|e| !e.text.is_empty()).cloned().collect();
+        assert_rows_same_width(&owned);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1629,6 +1629,16 @@ pub async fn run_interactive(
                         let trimmed = summary
                             .strip_prefix(&format!("{} ", name))
                             .unwrap_or(&summary);
+                        // Blank line BEFORE the chamber top so the eye
+                        // has an anchor between dense prior output (a
+                        // permission alert + "allowed ..." lines) and
+                        // the new tool chamber. Without it, the
+                        // chamber's ╭─ tended to sit pressed against
+                        // the previous line and on small terminals
+                        // the ╭ row could scroll off-screen while the
+                        // chamber's content rows stayed visible —
+                        // looking like a "cut off at top" chamber.
+                        renderer.write_line("", Color::White)?;
                         let pre = format!("╭─ {} ─ {} ", upper, trimmed);
                         let pre_clean = sanitize_output(&pre).into_string();
                         let (frame_w, _) = chamber_widths(&renderer);
@@ -3080,41 +3090,23 @@ fn close_tool_chamber_if_open(
         // Abnormal close: this helper is only called when the tool's
         // chamber is closing without a `ToolResult` (permission
         // denied, interjected mid-execution, agent error, fresh tool
-        // call before the previous one finished). Surface that with
-        // a CRT-static "no signal" row so the empty chamber isn't a
-        // mute box. Two textured rows + one labelled row inside the
-        // chamber give it a distinct shape from a normal output
-        // chamber.
-        renderer.write_line(&static_row(inner, 0), theme::dim())?;
+        // call before the previous one finished). Previously we
+        // painted CRT-static dither rows here, but those used
+        // `static_row()` which was 2 chars narrower than the chamber
+        // frame so the right border never lined up, and the dithered
+        // noise was visually loud for a state the user just needs to
+        // SEE quickly. Now we emit a single centered alert row in
+        // the perm/error color (same orange tone as the permission
+        // ask), which lines up with the chamber border and reads at
+        // a glance.
         renderer.write_line(
-            &chamber_row_centered("░▒▓  NO OUTPUT  ▓▒░", inner),
-            theme::dim(),
+            &chamber_row_centered("⚠ tool denied · aborted · no result", inner),
+            theme::perm(),
         )?;
-        renderer.write_line(
-            &chamber_row_centered("tool denied · aborted · no result", inner),
-            theme::dim(),
-        )?;
-        renderer.write_line(&static_row(inner, 1), theme::dim())?;
         renderer.write_line(&chamber_bottom(frame_w), theme::dim())?;
         *last_tool_name = None;
     }
     Ok(())
-}
-
-/// Produce a "CRT signal noise" row inside a chamber: a deterministic
-/// `░▒▓` glyph mix padded to inner width. The `seed` selects between
-/// two pre-baked patterns so top vs bottom static rows differ slightly
-/// — the eye reads it as continuous noise rather than a duplicated row.
-fn static_row(inner: usize, seed: usize) -> String {
-    let glyphs = [
-        ['░', '▒', '░', '▓', '░', '▒', '▒', '░', '▓', '▒'],
-        ['▒', '░', '▓', '░', '▒', '▓', '░', '▒', '░', '▓'],
-    ];
-    let pattern = &glyphs[seed % 2];
-    // Body fills `inner` chars (the chamber inner is already the
-    // padded content width); the `│ ` and ` │` borders sit outside.
-    let body: String = (0..inner).map(|i| pattern[i % pattern.len()]).collect();
-    format!("│{}│", body)
 }
 
 /// `│   <content centered to inner>   │` — pad text on both sides so

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -603,10 +603,28 @@ impl Renderer {
             let mut stdout = io::stdout();
             let _ = stdout.execute(ScrollUp(1));
             self.lines = self.lines.saturating_sub(1);
-            for &r in &[max_content.saturating_sub(1), max_content] {
+            // After ScrollUp, the input row (with the avatar) and any
+            // continuation input rows + the status row all shifted up
+            // by 1. Their fragments now sit on `max_content - 1`
+            // through `rows - 2`. Clear EVERY row from the last chat
+            // row through the previous status row — anything else
+            // would leave avatar/status fragments visible at the
+            // wrong row, which is the symptom users see as "avatar
+            // duplicated on scroll." The bottom row (now blank from
+            // ScrollUp) doesn't need clearing.
+            let clear_start = max_content.saturating_sub(1);
+            let clear_end = rows.saturating_sub(1); // exclusive
+            for r in clear_start..clear_end {
                 let _ = stdout.execute(MoveTo(0, r));
                 let _ = write!(stdout, "{}", " ".repeat(content_cols as usize));
             }
+            // Repaint the avatar after the wipe — otherwise the
+            // avatar visibly blinks out between writes during
+            // streaming (until the next `draw_bottom` is called by
+            // the UI loop on a significant event). Cheap: one
+            // MoveTo + 5 chars at a known column.
+            let input_top = rows.saturating_sub(self.input_rows + 1);
+            let _ = self.draw_avatar(&mut stdout, input_top);
             let _ = stdout.flush();
         }
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -70,7 +70,14 @@ impl Theme {
     pub const fn phosphor() -> Self {
         Theme {
             agent: Color::Green,
-            user: Color::Green,
+            // Cyan complements phosphor green without breaking the
+            // CRT aesthetic — classic CRTs shipped with green OR
+            // cyan/amber phosphors and the cyan tone reads
+            // distinct-but-related. Before this both `user` and
+            // `agent` were `Color::Green` so user messages were
+            // visually indistinguishable from the agent's output —
+            // confusing when scrolling chat history.
+            user: Color::Cyan,
             system: Color::DarkGreen,
             tool: Color::Green,
             perm: Color::Yellow,


### PR DESCRIPTION
Five UI bugs from the ROADMAP bug-log. Avatar now redraws after each ensure_room ScrollUp; phosphor theme user color is now cyan (was indistinguishable from agent green); NO-OUTPUT chamber uses a centered alert row instead of dithered rows that misaligned right border; tool chambers preceded by blank line so top doesn't scroll off; markdown tables use display-width counting so emoji cells don't push right border left. 3 new tests, 684 pass.