### PR TITLE
feat: auto-detect provider from API key env vars (#53 rebased + test fix)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,7 @@ impl Cli {
             .as_deref()
             .or(cfg.provider.as_deref())
             .map(CompactString::new)
+            .or_else(|| crate::provider::auto_detect_provider().map(CompactString::new))
             .unwrap_or_else(|| CompactString::new("openrouter"))
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -145,22 +145,42 @@ fn provider_env_var(kind: ProviderKind) -> &'static str {
     }
 }
 
-/// Auto-detect provider from environment variables when none is explicitly configured.
-/// Returns the provider name string (e.g. "deepseek") for the first matching env var.
+/// Auto-detect provider from environment variables when none is
+/// explicitly configured. Returns the provider name string
+/// (e.g. "deepseek") for the first matching `*_API_KEY` env var
+/// with a non-empty value. Returns `None` if no known key is set.
+///
+/// Resolution order is fixed (see `PROVIDER_AUTODETECT_ORDER`).
+/// When multiple keys are present, the FIRST in that list wins so
+/// the behavior is deterministic — important for users who have
+/// several keys in their shell environment.
 pub fn auto_detect_provider() -> Option<&'static str> {
-    let candidates: &[(&str, &str)] = &[
-        ("DEEPSEEK_API_KEY", "deepseek"),
-        ("OPENAI_API_KEY", "openai"),
-        ("ANTHROPIC_API_KEY", "anthropic"),
-        ("GEMINI_API_KEY", "gemini"),
-        ("GLM_API_KEY", "glm"),
-        ("OLLAMA_API_KEY", "ollama"),
-        ("OPENROUTER_API_KEY", "openrouter"),
-    ];
-    for (env_var, provider_name) in candidates {
-        if std::env::var(env_var)
-            .map(|v| !v.is_empty())
-            .unwrap_or(false)
+    auto_detect_provider_from(|name| std::env::var(name).ok())
+}
+
+/// Provider candidate list for autodetect. Listed in priority
+/// order — first key with a non-empty value wins. Extracted as a
+/// module item so tests reference the same source of truth and
+/// adding a provider only touches one place.
+const PROVIDER_AUTODETECT_ORDER: &[(&str, &str)] = &[
+    ("DEEPSEEK_API_KEY", "deepseek"),
+    ("OPENAI_API_KEY", "openai"),
+    ("ANTHROPIC_API_KEY", "anthropic"),
+    ("GEMINI_API_KEY", "gemini"),
+    ("GLM_API_KEY", "glm"),
+    ("OLLAMA_API_KEY", "ollama"),
+    ("OPENROUTER_API_KEY", "openrouter"),
+];
+
+/// Pure helper that drives `auto_detect_provider` from a
+/// caller-supplied env lookup. Production calls
+/// `auto_detect_provider()` which passes `std::env::var`; tests
+/// pass a closure backed by a HashMap so they don't mutate
+/// process-wide env vars (which races under parallel `cargo test`).
+fn auto_detect_provider_from<F: Fn(&str) -> Option<String>>(env: F) -> Option<&'static str> {
+    for (env_var, provider_name) in PROVIDER_AUTODETECT_ORDER {
+        if let Some(v) = env(env_var)
+            && !v.is_empty()
         {
             return Some(provider_name);
         }
@@ -558,54 +578,60 @@ pub async fn build_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    fn clean_env() {
-        for var in &[
-            "DEEPSEEK_API_KEY",
-            "OPENAI_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "GEMINI_API_KEY",
-            "GLM_API_KEY",
-            "OLLAMA_API_KEY",
-            "OPENROUTER_API_KEY",
-        ] {
-            unsafe { std::env::remove_var(var) };
-        }
+    /// Build an env-lookup closure backed by a HashMap. Avoids
+    /// mutating process-wide env vars — `std::env::set_var` is
+    /// thread-unsafe and the previous test suite raced under
+    /// parallel `cargo test`, producing intermittent failures.
+    fn mock_env(vars: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let map: HashMap<String, String> = vars
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |name: &str| map.get(name).cloned()
     }
 
     #[test]
     fn auto_detect_returns_none_when_no_vars_set() {
-        clean_env();
-        assert_eq!(auto_detect_provider(), None);
+        assert_eq!(auto_detect_provider_from(mock_env(&[])), None);
     }
 
     #[test]
     fn auto_detect_finds_deepseek_when_key_set() {
-        clean_env();
-        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-test-123") };
-        assert_eq!(auto_detect_provider(), Some("deepseek"));
+        let env = mock_env(&[("DEEPSEEK_API_KEY", "sk-test-123")]);
+        assert_eq!(auto_detect_provider_from(env), Some("deepseek"));
     }
 
     #[test]
     fn auto_detect_finds_openai_when_key_set() {
-        clean_env();
-        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-456") };
-        assert_eq!(auto_detect_provider(), Some("openai"));
+        let env = mock_env(&[("OPENAI_API_KEY", "sk-test-456")]);
+        assert_eq!(auto_detect_provider_from(env), Some("openai"));
     }
 
     #[test]
     fn auto_detect_skips_empty_var() {
-        clean_env();
-        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "") };
-        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-789") };
-        assert_eq!(auto_detect_provider(), Some("openai"));
+        let env = mock_env(&[("DEEPSEEK_API_KEY", ""), ("OPENAI_API_KEY", "sk-test-789")]);
+        assert_eq!(auto_detect_provider_from(env), Some("openai"));
     }
 
     #[test]
     fn auto_detect_returns_first_match_in_order() {
-        clean_env();
-        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-ds") };
-        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-oai") };
-        assert_eq!(auto_detect_provider(), Some("deepseek"));
+        let env = mock_env(&[("DEEPSEEK_API_KEY", "sk-ds"), ("OPENAI_API_KEY", "sk-oai")]);
+        assert_eq!(auto_detect_provider_from(env), Some("deepseek"));
+    }
+
+    /// Cover every provider in the autodetect list — guards
+    /// against accidentally dropping or reordering an entry.
+    #[test]
+    fn auto_detect_each_provider_in_isolation() {
+        for &(env_var, expected) in PROVIDER_AUTODETECT_ORDER {
+            let env = mock_env(&[(env_var, "sk-x")]);
+            assert_eq!(
+                auto_detect_provider_from(env),
+                Some(expected),
+                "env_var={env_var}",
+            );
+        }
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -145,6 +145,29 @@ fn provider_env_var(kind: ProviderKind) -> &'static str {
     }
 }
 
+/// Auto-detect provider from environment variables when none is explicitly configured.
+/// Returns the provider name string (e.g. "deepseek") for the first matching env var.
+pub fn auto_detect_provider() -> Option<&'static str> {
+    let candidates: &[(&str, &str)] = &[
+        ("DEEPSEEK_API_KEY", "deepseek"),
+        ("OPENAI_API_KEY", "openai"),
+        ("ANTHROPIC_API_KEY", "anthropic"),
+        ("GEMINI_API_KEY", "gemini"),
+        ("GLM_API_KEY", "glm"),
+        ("OLLAMA_API_KEY", "ollama"),
+        ("OPENROUTER_API_KEY", "openrouter"),
+    ];
+    for (env_var, provider_name) in candidates {
+        if std::env::var(env_var)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
+            return Some(provider_name);
+        }
+    }
+    None
+}
+
 fn resolve_api_key(
     kind: ProviderKind,
     api_key_env_override: Option<&str>,
@@ -529,5 +552,60 @@ pub async fn build_agent(
         AnyModel::Glm(m) => build_inner!(m, Glm),
         AnyModel::Ollama(m) => build_inner!(m, Ollama),
         AnyModel::Custom(m) => build_inner!(m, Custom),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean_env() {
+        for var in &[
+            "DEEPSEEK_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GLM_API_KEY",
+            "OLLAMA_API_KEY",
+            "OPENROUTER_API_KEY",
+        ] {
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    #[test]
+    fn auto_detect_returns_none_when_no_vars_set() {
+        clean_env();
+        assert_eq!(auto_detect_provider(), None);
+    }
+
+    #[test]
+    fn auto_detect_finds_deepseek_when_key_set() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-test-123") };
+        assert_eq!(auto_detect_provider(), Some("deepseek"));
+    }
+
+    #[test]
+    fn auto_detect_finds_openai_when_key_set() {
+        clean_env();
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-456") };
+        assert_eq!(auto_detect_provider(), Some("openai"));
+    }
+
+    #[test]
+    fn auto_detect_skips_empty_var() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "") };
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-789") };
+        assert_eq!(auto_detect_provider(), Some("openai"));
+    }
+
+    #[test]
+    fn auto_detect_returns_first_match_in_order() {
+        clean_env();
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "sk-ds") };
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-oai") };
+        assert_eq!(auto_detect_provider(), Some("deepseek"));
     }
 }


### PR DESCRIPTION
Rebased version of @allen-munsch's #53 with the test-flakiness fix.

## Original PR

If no provider is set via CLI flag, `DIRGE_PROVIDER` env var, or config file, dirge now checks for known API key environment variables and picks the matching provider automatically.

Resolution order:
1. `--provider` CLI flag / `DIRGE_PROVIDER` env var
2. `provider` in config file
3. Auto-detect from `*_API_KEY` env vars (new!)
4. Default to `"openrouter"`

Supported vars: `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GLM_API_KEY`, `OLLAMA_API_KEY`, `OPENROUTER_API_KEY`.

## Changes on top of #53

The original tests mutated process-wide env vars via `std::env::set_var` / `remove_var`. Rust runs tests in parallel by default, so they raced under `cargo test` — 2 of 5 failed intermittently on first run locally.

Refactored to a pure helper `auto_detect_provider_from(env_lookup)` that takes an env-lookup closure. Production passes `std::env::var`; tests pass a HashMap-backed closure via `mock_env(&[...])`. No process env mutation, no race.

Also extracted the candidate list to a module-level `PROVIDER_AUTODETECT_ORDER` so tests reference the same source of truth, plus added `auto_detect_each_provider_in_isolation` that exercises every entry as a regression guard against accidental drops/reorders.

6 deterministic tests (was 5 flaky); 693 pass total.

Co-authored-by: James Munsch <james.a.munsch@gmail.com>