### PR TITLE
fix: three bugs found in PR #96 self-review

### DIFF
--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -230,12 +230,19 @@ impl Tool for EditTool {
         };
         // Mention the line delta when adding/removing lines so the
         // LLM can confirm the size of change without re-reading
-        // the diff block.
+        // the diff block. For replace_all the per-replacement
+        // delta multiplies by the number of replacements — the
+        // user wants the FILE delta, not the per-instance delta.
         let old_lines = args.old_text.lines().count();
         let new_lines = args.new_text.lines().count();
-        let delta = new_lines as i64 - old_lines as i64;
-        if delta != 0 {
-            result.push_str(&format!(" ({:+} lines)", delta));
+        let per_replacement_delta = new_lines as i64 - old_lines as i64;
+        let total_delta = if do_replace_all {
+            per_replacement_delta * (match_positions.len() as i64)
+        } else {
+            per_replacement_delta
+        };
+        if total_delta != 0 {
+            result.push_str(&format!(" ({:+} lines)", total_delta));
         }
 
         // Always emit a diff. The earlier 20-line cap was meant to

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -166,13 +166,31 @@ impl Tool for ReadTool {
         // so don't repeat it here — that was visible duplication.
         // The first line inside the chamber is now a compact metadata
         // summary, followed by a blank line and the excerpt.
-        let info = format!(
-            "({} lines total, showing lines {}-{})\n\n{}",
-            total_lines,
-            offset + 1,
-            end,
-            excerpt
-        );
+        //
+        // Edge cases:
+        // - Empty file (total_lines = 0): no useful range; just say
+        //   "(empty file)" without the showing-lines clause that
+        //   would otherwise render the nonsense "showing lines 1-0".
+        // - offset past EOF (`offset >= total_lines`): no lines
+        //   match; report that explicitly instead of showing the
+        //   backwards `X-(X-1)` range.
+        let info = if total_lines == 0 {
+            "(empty file)\n".to_string()
+        } else if offset >= total_lines {
+            format!(
+                "({} lines total; offset {} is past end of file — nothing to show)\n",
+                total_lines,
+                offset + 1,
+            )
+        } else {
+            format!(
+                "({} lines total, showing lines {}-{})\n\n{}",
+                total_lines,
+                offset + 1,
+                end,
+                excerpt
+            )
+        };
 
         if let Some(ref cache) = self.cache {
             cache.set(&cache_key, info.clone());
@@ -347,5 +365,63 @@ mod tests {
 
         // The mid-file BOM stays.
         assert!(out.contains('\u{FEFF}'));
+    }
+
+    /// Self-review bug: empty file used to render the nonsense
+    /// range `"(0 lines total, showing lines 1-0)"`. Now reports
+    /// `"(empty file)"` directly.
+    #[tokio::test]
+    async fn read_reports_empty_file_explicitly() {
+        let path = temp_path("empty");
+        std::fs::write(&path, "").unwrap();
+
+        let tool = ReadTool::new(None, None);
+        let out = tool
+            .call(ReadArgs {
+                path: path.to_string_lossy().into_owned(),
+                offset: None,
+                limit: None,
+            })
+            .await
+            .unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            out.contains("(empty file)"),
+            "expected explicit empty marker; got: {out:?}",
+        );
+        assert!(
+            !out.contains("showing lines 1-0"),
+            "must NOT show the nonsense backwards range: {out:?}",
+        );
+    }
+
+    /// Self-review bug: offset past EOF used to render
+    /// `"showing lines 100-1"` (backwards). Now reports the past-
+    /// end condition explicitly.
+    #[tokio::test]
+    async fn read_reports_offset_past_eof_explicitly() {
+        let path = temp_path("short");
+        std::fs::write(&path, "only line\n").unwrap();
+
+        let tool = ReadTool::new(None, None);
+        let out = tool
+            .call(ReadArgs {
+                path: path.to_string_lossy().into_owned(),
+                offset: Some(100),
+                limit: Some(10),
+            })
+            .await
+            .unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            out.contains("past end of file"),
+            "expected past-end marker; got: {out:?}",
+        );
+        assert!(
+            !out.contains("showing lines 100-1"),
+            "must NOT show backwards range: {out:?}",
+        );
     }
 }

--- a/src/tests/edit_tests.rs
+++ b/src/tests/edit_tests.rs
@@ -102,6 +102,32 @@ async fn test_replace_all() {
     assert!(result.contains("3 replacements"), "result: {result}");
 }
 
+/// Self-review bug: `replace_all` line-delta used to report the
+/// PER-REPLACEMENT delta, not the FILE delta. 3 replacements
+/// each adding 1 line grow the file by 3, but the summary said
+/// "(+1 lines)". Fix multiplies by replacement count.
+#[tokio::test]
+async fn test_replace_all_reports_file_delta_not_per_replacement() {
+    let tmp = TempFile::new("replace_all_delta.txt");
+    // 3 single-line occurrences; each replacement adds 1 line.
+    std::fs::write(tmp.path(), "x\nx\nx\n").unwrap();
+    let tool = EditTool::new(None, None, None);
+    let result = tool
+        .call(EditArgs {
+            path: tmp.path().into(),
+            old_text: "x".into(),
+            new_text: "x\nx".into(),
+            replace_all: Some(true),
+        })
+        .await
+        .unwrap();
+    // 3 replacements × +1 line per replacement = +3 file delta.
+    assert!(
+        result.contains("(+3 lines)"),
+        "expected total file delta, not per-replacement; got: {result}",
+    );
+}
+
 #[tokio::test]
 async fn test_multi_match_without_replace_all_returns_error() {
     let tmp = TempFile::new("multi.txt");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -376,8 +376,25 @@ fn format_tool_banner_value(name: &str, args: &serde_json::Value) -> String {
         serde_json::Value::Object(map) => map,
         _ => return String::new(),
     };
+    // `apply_patch` is structurally different: its arg is
+    // `operations: Vec<PatchOp>` (an array of ops, each with its
+    // own path), not a single string. Render "N ops" so the
+    // banner has content — degrading to bare "APPLY_PATCH" with
+    // dashes was uninformative.
+    if name == "apply_patch" {
+        let n = obj
+            .get("operations")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        return match n {
+            0 => String::new(),
+            1 => "1 op".to_string(),
+            _ => format!("{n} ops"),
+        };
+    }
     let key = match name {
-        "read" | "write" | "edit" | "list_dir" | "apply_patch" => "path",
+        "read" | "write" | "edit" | "list_dir" => "path",
         "grep" => "pattern",
         "find_files" | "glob" => "pattern",
         "bash" => "command",
@@ -3559,6 +3576,34 @@ mod tests {
         );
         assert!(header.starts_with("╭─ DONE ─"));
         assert!(header.ends_with("─╮"));
+    }
+
+    /// Self-review bug 1: `apply_patch` arg is `operations`
+    /// (array), not a single string. Previously fell through to
+    /// "path" lookup which returned empty, degrading the banner
+    /// to bare "APPLY_PATCH" with dashes. Now shows op count.
+    #[test]
+    fn banner_value_apply_patch_shows_op_count() {
+        let args = serde_json::json!({"operations": [{"action": "create", "path": "/a"}]});
+        assert_eq!(format_tool_banner_value("apply_patch", &args), "1 op");
+
+        let args = serde_json::json!({
+            "operations": [
+                {"action": "create", "path": "/a"},
+                {"action": "update", "path": "/b"},
+                {"action": "delete", "path": "/c"},
+            ],
+        });
+        assert_eq!(format_tool_banner_value("apply_patch", &args), "3 ops");
+
+        // Empty operations array → empty value (banner degrades
+        // gracefully to prefix + dashes + suffix).
+        let args = serde_json::json!({"operations": []});
+        assert_eq!(format_tool_banner_value("apply_patch", &args), "");
+
+        // Missing operations key → empty.
+        let args = serde_json::json!({});
+        assert_eq!(format_tool_banner_value("apply_patch", &args), "");
     }
 
     /// `format_tool_banner_value` picks the right key per tool.


### PR DESCRIPTION
Self-review of PR #96 found three real bugs: apply_patch banner empty (operations is an array, not a string), read.rs nonsense range on empty/past-EOF, edit.rs replace_all delta was per-replacement not file-total. 4 new tests, 702 pass.