### PR TITLE
fix(list_dir): drop duplicated path; add entry-count summary

### DIFF
--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -165,11 +165,34 @@ impl Tool for ListDirTool {
         });
 
         if entries.is_empty() {
-            return Ok(format!("Listing {}:\n(empty directory)", path));
+            // Path is in the chamber banner; no need to repeat it.
+            return Ok("(empty directory)".to_string());
         }
 
+        // Summary line for at-a-glance counts: useful when the
+        // listing is long enough to be truncated by
+        // `tool_result_max_chars` — the LLM sees the totals even
+        // if the per-entry rows get cut. The `dir(N)` markers
+        // already show nested counts per directory.
+        let dir_count = entries
+            .iter()
+            .filter(|(_, k, _)| k.starts_with("dir"))
+            .count();
+        let link_count = entries.iter().filter(|(_, k, _)| k == "link").count();
+        let file_count = entries.len() - dir_count - link_count;
+
         let max_name = entries.iter().map(|e| e.0.len()).max().unwrap_or(0);
-        let mut result = format!("Listing {}:\n", path);
+        let mut summary = format!(
+            "{} entries ({} dirs, {} files",
+            entries.len(),
+            dir_count,
+            file_count,
+        );
+        if link_count > 0 {
+            summary.push_str(&format!(", {link_count} symlinks"));
+        }
+        summary.push_str("):\n");
+        let mut result = summary;
         for (name, kind, size) in &entries {
             let padded = format!("{:width$}", name, width = max_name);
             let size_str = if size.is_empty() {


### PR DESCRIPTION
Same banner-duplication pattern as PR #96, missed on first pass. `list_dir` no longer repeats the path; first body line is `N entries (D dirs, F files):` for at-a-glance counts that survive output truncation.