### PR TITLE
fix: audit followups — UTF-8 picker, flag conflict, prompt restore, MCP timeout + rustfmt

### DIFF
--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -79,9 +79,32 @@ impl ToolDyn for McpTool {
                 .map(|a| CallToolRequestParams::new(tool_name.clone()).with_arguments(a))
                 .unwrap_or_else(|| CallToolRequestParams::new(tool_name.clone()));
 
-            let result = peer.call_tool(params).await.map_err(|e| {
-                ToolError::ToolCallError(Box::new(McpToolError(format!("MCP tool error: {e}"))))
-            })?;
+            // MCP tool calls go over JSON-RPC to a spawned server
+            // process. If the server hangs (deadlock, infinite
+            // loop, lost stdin pipe), the await never resolves and
+            // the agent turn stalls indefinitely. Cap at 120s to
+            // match `bash`'s default timeout — anything longer is
+            // clearly broken on the server side. The error message
+            // names the server + tool so the user can identify
+            // which MCP server is misbehaving.
+            const MCP_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+            let result = match tokio::time::timeout(MCP_CALL_TIMEOUT, peer.call_tool(params)).await
+            {
+                Ok(r) => r.map_err(|e| {
+                    ToolError::ToolCallError(Box::new(McpToolError(format!(
+                        "MCP tool error ({}::{}): {e}",
+                        server_name, tool_name,
+                    ))))
+                })?,
+                Err(_) => {
+                    return Err(ToolError::ToolCallError(Box::new(McpToolError(format!(
+                        "MCP tool {}::{} timed out after {}s",
+                        server_name,
+                        tool_name,
+                        MCP_CALL_TIMEOUT.as_secs(),
+                    )))));
+                }
+            };
 
             if result.is_error.unwrap_or(false) {
                 let error_msg = result

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,29 @@ struct Channels {
 }
 
 fn resolve_mode(cli: &cli::Cli, cfg: &config::Config) -> SecurityMode {
+    // Warn on conflicting CLI flags. Previously `--yolo --restrictive`
+    // silently picked yolo (the first-match in the if-else chain)
+    // without surfacing the conflict — the user thought they had
+    // restricted permissions and got the opposite. Emit a stderr
+    // warning naming the active mode so the user can correct it.
+    let cli_modes: &[(bool, &str)] = &[
+        (cli.yolo, "--yolo"),
+        (cli.accept_all, "--accept-all"),
+        (cli.restrictive, "--restrictive"),
+    ];
+    let cli_picks: Vec<&str> = cli_modes
+        .iter()
+        .filter(|(v, _)| *v)
+        .map(|(_, name)| *name)
+        .collect();
+    if cli_picks.len() > 1 {
+        eprintln!(
+            "warning: conflicting permission flags {:?}; using the most permissive ({}). \
+             Pass only one of --yolo / --accept-all / --restrictive.",
+            cli_picks, cli_picks[0],
+        );
+    }
+
     if cli.yolo || cfg.yolo.unwrap_or(false) {
         SecurityMode::Yolo
     } else if cli.accept_all || cfg.accept_all.unwrap_or(false) {

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -626,16 +626,20 @@ impl InputEditor {
                 true
             }
             KeyCode::Esc => {
-                let at_pos = self.buffer.rfind('@');
-                if let Some(at) = at_pos {
-                    let before: String = self.buffer.chars().take(at).collect();
-                    let after: String = self
-                        .buffer
-                        .chars()
-                        .skip(at + 1 + picker.query.len())
-                        .collect();
-                    self.buffer = format!("{}{}", before, after).into();
+                // Use BYTE-level slicing here, matching the Enter
+                // path above. `rfind('@')` returns a byte offset;
+                // the previous implementation used `chars().take(at)`
+                // and `chars().skip(at + ...)` which mixed byte
+                // offsets with char counts and corrupted the buffer
+                // for any input containing multi-byte UTF-8 chars
+                // before the `@` (accented letters, emoji, CJK, …).
+                if let Some(at) = self.buffer.rfind('@') {
+                    let before = &self.buffer[..at];
+                    let after_byte = at + 1 + picker.query.len();
+                    let after = self.buffer.get(after_byte..).unwrap_or("");
+                    let new_buf = format!("{}{}", before, after);
                     self.cursor = at;
+                    self.buffer = new_buf.into();
                 }
                 picker.deactivate();
                 true

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -383,9 +383,46 @@ pub async fn handle_slash(
                     if let Some(s) = sessions.into_iter().next() {
                         let msg_count = s.messages.len();
                         *session = s;
+                        // Restore the prompt that was active when the
+                        // session was saved. Without this, `/sessions
+                        // <id>` would always rebuild the agent with the
+                        // default prompt, even if the saved session
+                        // recorded `current_prompt_name = Some("plan")`.
+                        // Sets both context fields + rebuilds the agent
+                        // so the new prompt actually takes effect.
+                        let restored = session.current_prompt_name.clone();
+                        if let Some(name) = restored.as_deref()
+                            && let Some(content) = context.prompts.get(name)
+                        {
+                            context.current_prompt = Some(content.clone());
+                            context.current_prompt_name = Some(name.to_string());
+                            let model = client.completion_model(session.model.to_string());
+                            *agent = crate::provider::build_agent(
+                                model,
+                                cli,
+                                cfg,
+                                context,
+                                permission.clone(),
+                                ask_tx.clone(),
+                                None,
+                                None,
+                                bg_store.clone(),
+                                #[cfg(feature = "lsp")]
+                                None,
+                                sandbox.clone(),
+                                #[cfg(feature = "mcp")]
+                                mcp_manager,
+                                #[cfg(feature = "semantic")]
+                                semantic_manager,
+                            )
+                            .await;
+                        }
                         render_session(renderer, session, cli, cfg, context)?;
+                        let prompt_note = restored
+                            .map(|n| format!("; prompt: {}", n))
+                            .unwrap_or_default();
                         renderer.write_line(
-                            &format!("loaded session ({} msgs)", msg_count),
+                            &format!("loaded session ({} msgs{})", msg_count, prompt_note),
                             c_agent(),
                         )?;
                     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -303,7 +303,8 @@ fn load_custom_theme(name: &str) -> Result<Theme, String> {
     if !path.exists() {
         return Err(format!("no such file: {}", path.display()));
     }
-    let raw = std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let raw =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     let overrides: ThemeJson =
         serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
     // Label defaults to the filename's stem in uppercase if the JSON


### PR DESCRIPTION
Five verified bugs from the latest 6-agent code audit: (1) @-picker Esc handler mixed byte/char offsets, corrupting UTF-8 buffers; (2) `--yolo --restrictive` silently picked yolo with no warning; (3) /sessions <id> didn't restore the saved prompt; (4) MCP tool calls had no timeout (hung agent on server hangs); (5) rustfmt CI was red on a line from PR #102. False-positive findings documented in the commit body. 715 pass.