### PR TITLE
fix: audit r3 — grep hidden files, invalid include glob, chamber centering, perm mode, README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ dirge --verbose
 | `/regen-prompts` | Restore built-in prompts |
 | `/mcp` | List MCP servers and tools |
 | `/panel [on\|off\|auto]` | Toggle the right-hand info panel (cwd, MCP, LSP, todos, modified files). `auto` shows it when the terminal is at least 100 cols wide. |
+| `/allow <list\|add\|remove\|clear>` | Manage the session permission allowlist (see `/help` for argument shapes) |
 | `/quit` | Exit dirge |
 | `/retry` | Retry last prompt |
 | `/help` | Show all commands |
@@ -316,6 +317,8 @@ dirge ships with an 80s-CRT phosphor green palette by default. To opt out, set `
 ```
 
 Errors stay red and warnings stay yellow under every theme — those colors are part of the load-bearing semantic contract.
+
+For custom themes, create `~/.config/dirge/<name>.theme.json` with overrides for any subset of the palette (named colors, hex `#rrggbb`, or 256-color indices), then set `theme: "<name>"` in `config.json`. See [`docs/THEMES.md`](docs/THEMES.md) for the full schema and examples.
 
 ## Supported providers
 

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -86,6 +86,10 @@ impl Tool for GrepTool {
                     "context_lines": {
                         "type": "integer",
                         "description": "Number of context lines to show before and after each match (like grep -C)"
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include dotfiles (.env, .gitignore, etc.) in the search. Default false to avoid surfacing secrets and config files."
                     }
                 },
                 "required": ["pattern"]
@@ -97,11 +101,12 @@ impl Tool for GrepTool {
         check_perm(&self.permission, &self.ask_tx, "grep", &args.pattern).await?;
 
         let cache_key = format!(
-            "grep:{}:{}:{}:{}",
+            "grep:{}:{}:{}:{}:hidden={}",
             args.pattern,
             args.path.as_deref().unwrap_or("."),
             args.include.as_deref().unwrap_or(""),
             args.context_lines.unwrap_or(0),
+            args.include_hidden,
         );
 
         if let Some(ref cache) = self.cache {
@@ -116,17 +121,32 @@ impl Tool for GrepTool {
         let search_path = args.path.as_deref().unwrap_or(".");
         let context = args.context_lines.unwrap_or(0);
 
-        let include_re = args.include.as_ref().map(|g| {
-            let pattern = format!("^(?:{})$", Self::glob_to_regex(g));
-            Regex::new(&pattern).unwrap_or_else(|_| Regex::new(".*").unwrap())
-        });
+        // Validate the include glob and surface compile errors
+        // instead of the previous silent fallback to `.*` (match
+        // everything). A user passing `include: "[a-z("` would have
+        // silently matched every file — the include filter would
+        // appear to do nothing and they'd never know why.
+        let include_re = match args.include.as_ref() {
+            Some(g) => {
+                let pattern = format!("^(?:{})$", Self::glob_to_regex(g));
+                Some(Regex::new(&pattern).map_err(|e| {
+                    ToolError::Msg(format!(
+                        "Invalid include glob {g:?}: {e}. Use forms like \"*.rs\" or \"*.{{ts,tsx}}\"."
+                    ))
+                })?)
+            }
+            None => None,
+        };
 
         let walker = WalkBuilder::new(search_path)
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
             .require_git(false)
-            .hidden(false)
+            // F2 carryover: hide dotfiles by default so grep doesn't
+            // silently surface `.env` / `.git/` internals. Opt-in
+            // via `include_hidden: true`.
+            .hidden(!args.include_hidden)
             .filter_entry(|entry| {
                 if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                     !is_skip_dir(entry.file_name().to_str().unwrap_or(""))

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -112,6 +112,12 @@ pub struct GrepArgs {
     pub path: Option<String>,
     pub include: Option<String>,
     pub context_lines: Option<usize>,
+    /// Include dotfiles / hidden files in the search. Default
+    /// `false` — F2 carryover from find_files/glob/list_dir: grep
+    /// also walks the filesystem and should not silently surface
+    /// `.env`, `.git/` internals, etc. by default.
+    #[serde(default)]
+    pub include_hidden: bool,
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,19 @@ fn resolve_mode(cli: &cli::Cli, cfg: &config::Config) -> SecurityMode {
             "yolo" => SecurityMode::Yolo,
             "accept" => SecurityMode::Accept,
             "restrictive" => SecurityMode::Restrictive,
-            _ => SecurityMode::Standard,
+            "standard" => SecurityMode::Standard,
+            other => {
+                // Unknown value silently mapped to Standard before
+                // this — a typo like `restritctive` ended up as
+                // Standard and the user never knew. Warn explicitly
+                // and name the valid values.
+                eprintln!(
+                    "warning: unknown default_permission_mode {:?} in config; using standard. \
+                     Valid values: yolo, accept, restrictive, standard.",
+                    other,
+                );
+                SecurityMode::Standard
+            }
         }
     } else {
         SecurityMode::Standard

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3245,11 +3245,29 @@ fn close_tool_chamber_if_open(
 /// `│   <content centered to inner>   │` — pad text on both sides so
 /// it sits horizontally centered within the chamber inner width.
 fn chamber_row_centered(content: &str, inner: usize) -> String {
-    let len = content.chars().count();
-    if len + 2 >= inner {
+    // Total row width matches `chamber_row`: exactly `inner + 4`
+    // terminal cells (`│ ` (2) + inner-cell middle + ` │` (2)).
+    // The middle is `inner` cells: left_pad + content + right_pad.
+    //
+    // TWO bugs were stacked here:
+    // (1) Used `chars().count()` instead of display width — the
+    //     NO-OUTPUT chamber starts with `⚠` (2 cells / 1 char) so
+    //     centering was off by 1 cell.
+    // (2) Subtracted `len + 2` from `inner` for the pad, leaving
+    //     the row 2 cells short of `inner + 4` total — the right
+    //     `│` didn't line up under the chamber's top `╮` /
+    //     bottom `╯`. Correct: pad = inner - len (the middle is
+    //     `inner` cells wide; subtracting only `len` reserves the
+    //     rest for padding around it).
+    //
+    // Anything wider than `inner` falls back to `chamber_row`
+    // which truncates with `…` and pads to exactly `inner` cells.
+    use unicode_width::UnicodeWidthStr;
+    let len = UnicodeWidthStr::width(content);
+    if len >= inner {
         return chamber_row(content, inner);
     }
-    let pad = inner.saturating_sub(len + 2);
+    let pad = inner - len;
     let left = pad / 2;
     let right = pad - left;
     format!("│ {}{}{} │", " ".repeat(left), content, " ".repeat(right))
@@ -3668,6 +3686,29 @@ mod tests {
         );
         assert!(header.starts_with("╭─ DONE ─"));
         assert!(header.ends_with("─╮"));
+    }
+
+    /// Regression: `chamber_row_centered` must use DISPLAY width
+    /// not char count. The NO-OUTPUT chamber message starts with
+    /// `⚠` (2 cells wide, 1 char). Before this, centering was off
+    /// by 1 cell and the right `│` border misaligned with the
+    /// chamber's top/bottom borders.
+    #[test]
+    fn chamber_row_centered_handles_wide_emoji() {
+        let row = chamber_row_centered("⚠ tool denied", 40);
+        // Row must occupy exactly `inner + 4` display cells
+        // (`│ ` + content + padding + ` │` = inner + 4 = 44).
+        let row_width = UnicodeWidthStr::width(row.as_str());
+        assert_eq!(
+            row_width, 44,
+            "row must be exactly inner+4 cells wide; got {row_width} for {row:?}",
+        );
+        // Right border `│` MUST be at the very end (no trailing
+        // pad mismatch).
+        assert!(
+            row.ends_with(" │"),
+            "right border missing or padded wrong: {row:?}"
+        );
     }
 
     /// Self-review bug 1: `apply_patch` arg is `operations`


### PR DESCRIPTION
Five verified bugs from third audit pass: (1) grep walked dotfiles (F2 carryover, security), now `include_hidden: bool`; (2) grep invalid include glob silently matched everything, now surfaces error; (3) `default_permission_mode` typo silently → Standard, now warns; (4) chamber_row_centered had two bugs — char-count vs display-width AND pad off-by-2 vs other chamber helpers; (5) README missing `/allow` row + custom theme JSON note. 1 new test, 716 pass.