### PR TITLE
fix: audit r6 — plugin provider timing + MCP tool name collisions

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -326,11 +326,55 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
                 .collect_tools(permission.clone(), ask_tx.clone())
                 .await;
             if !mcp_tools.is_empty() {
-                let dyn_tools: Vec<Box<dyn rig::tool::ToolDyn>> = mcp_tools
+                // Skip MCP tools whose names collide with dirge
+                // built-ins. Without this, the MCP version would
+                // silently shadow `read`/`write`/`bash`/etc. —
+                // rig's builder takes the last-added tool when
+                // names clash, and dirge adds built-ins first.
+                // Better to warn loudly and refuse to shadow than
+                // to let an arbitrary MCP server replace core tools.
+                const BUILTIN_TOOL_NAMES: &[&str] = &[
+                    "read",
+                    "write",
+                    "edit",
+                    "bash",
+                    "grep",
+                    "find_files",
+                    "glob",
+                    "list_dir",
+                    "write_todo_list",
+                    "apply_patch",
+                    "memory",
+                    "skill",
+                    "task",
+                    "task_status",
+                    "question",
+                    "webfetch",
+                    "websearch",
+                    "lsp",
+                ];
+                let filtered: Vec<crate::extras::mcp::tool::McpTool> = mcp_tools
                     .into_iter()
-                    .map(|t| Box::new(t) as Box<dyn rig::tool::ToolDyn>)
+                    .filter(|t| {
+                        let name = t.definition.name.as_ref();
+                        if BUILTIN_TOOL_NAMES.contains(&name) {
+                            eprintln!(
+                                "warning: MCP server '{}' exports tool '{}' which collides with a dirge built-in; skipping MCP version",
+                                t.server_name, name,
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    })
                     .collect();
-                builder = builder.tools(hookify(dyn_tools));
+                if !filtered.is_empty() {
+                    let dyn_tools: Vec<Box<dyn rig::tool::ToolDyn>> = filtered
+                        .into_iter()
+                        .map(|t| Box::new(t) as Box<dyn rig::tool::ToolDyn>)
+                        .collect();
+                    builder = builder.tools(hookify(dyn_tools));
+                }
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,30 +345,12 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let client = provider::create_client(
-        &provider,
-        cli.api_key.as_deref(),
-        &cfg.custom_providers_map(),
-    )?;
-
-    #[cfg(feature = "mcp")]
-    let mcp_manager = if let Some(servers) = &cfg.mcp_servers {
-        if !cli.resolve_no_tools(&cfg) {
-            Some(extras::mcp::McpClientManager::connect_all(servers).await)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    #[cfg(feature = "semantic")]
-    let semantic_manager = if !cli.resolve_no_tools(&cfg) {
-        Some(semantic::SemanticManager::new())
-    } else {
-        None
-    };
-
+    // Plugin loading must happen BEFORE `create_client` so plugin-
+    // registered providers (via `harness/register-provider`) are
+    // installed into `PLUGIN_PROVIDERS` before
+    // `resolve_provider_info` runs. Previously plugins loaded later,
+    // so `--provider <plugin-name>` failed with "Unknown provider"
+    // even though the plugin defined it.
     #[cfg(feature = "plugin")]
     let plugin_manager = match plugin::PluginManager::try_new() {
         Ok(pm) => Some(std::sync::Arc::new(std::sync::Mutex::new(pm))),
@@ -377,7 +359,6 @@ async fn main() -> anyhow::Result<()> {
             None
         }
     };
-
     // Make the PluginManager visible to HookedToolDyn (which runs inside
     // rig's tool dispatch, where we can't easily plumb the Arc through).
     // Set once, before any tool is built or called.
@@ -385,7 +366,6 @@ async fn main() -> anyhow::Result<()> {
     if let Some(pm_arc) = plugin_manager.as_ref() {
         plugin::hook::init_global(pm_arc.clone());
     }
-
     // Pull the dialog-request receiver out of the PluginManager once,
     // here, so we can hand it to the UI loop. After this point, calling
     // take_dialog_rx again returns None — single owner by design. Always
@@ -398,7 +378,6 @@ async fn main() -> anyhow::Result<()> {
     });
     #[cfg(not(feature = "plugin"))]
     let dialog_rx: Option<tokio::sync::mpsc::UnboundedReceiver<plugin::DialogRequest>> = None;
-
     #[cfg(feature = "plugin")]
     if let Some(pm_arc) = plugin_manager.as_ref() {
         use std::path::PathBuf;
@@ -482,6 +461,30 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("  registered {} plugin provider(s)", n);
         }
     }
+
+    let client = provider::create_client(
+        &provider,
+        cli.api_key.as_deref(),
+        &cfg.custom_providers_map(),
+    )?;
+
+    #[cfg(feature = "mcp")]
+    let mcp_manager = if let Some(servers) = &cfg.mcp_servers {
+        if !cli.resolve_no_tools(&cfg) {
+            Some(extras::mcp::McpClientManager::connect_all(servers).await)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    #[cfg(feature = "semantic")]
+    let semantic_manager = if !cli.resolve_no_tools(&cfg) {
+        Some(semantic::SemanticManager::new())
+    } else {
+        None
+    };
 
     #[cfg(feature = "acp")]
     if cli.acp_enabled {


### PR DESCRIPTION
Two real bugs from sixth audit pass. (1) Plugin-registered providers (`harness/register-provider`) were installed AFTER `create_client`, so `--provider <plugin-name>` always failed with 'Unknown provider'. Moved plugin loading to run BEFORE create_client. (2) MCP tools could silently shadow dirge built-ins (read/write/bash/etc.) via name collision in rig's tool builder. Now filtered with a warning. 719 pass.