### PR TITLE
fix: audit batch 2 — docs accuracy + 2 small code touch-ups

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -63,7 +63,7 @@ Accepted top-level keys:
 | `model`                   | string  | Model name. Default: `deepseek/deepseek-v4-flash`.                                                                                                                          |
 | `max_tokens`              | integer | Maximum response tokens. Default: `8192`.                                                                                                                                   |
 | `max_agent_turns`         | integer | Maximum agent turns per response. Default: `100`.                                                                                                                           |
-| `temperature`             | number  | Model temperature value. Only configurable via the `--temperature` CLI flag (`0.0` to `2.0`). Config-file value is parsed but not currently applied.                        |
+| `temperature`             | number  | Model sampling temperature in `0.0`–`2.0`. `--temperature` CLI flag overrides this. Values outside the range are clamped with a stderr warning.                            |
 | `no_tools`                | boolean | Disable all tools. Default: `false`.                                                                                                                                        |
 | `no_context_files`        | boolean | Disable loading global/project `AGENTS.md` and `CLAUDE.md` context files. Default: `false`.                                                                                 |
 | `context_window`          | integer | Session context-window size used for status and auto-compaction. Default: `128000`.                                                                                         |
@@ -81,11 +81,10 @@ Accepted top-level keys:
 | `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
 | `tool_result_max_chars`   | integer | Maximum characters to show before truncating tool output with `[N more chars]`. Default: `500`.                                                                              |
 | `default_prompt`          | string  | Prompt name to activate on startup. Default: `code`.                                                                                                                        |
-| `theme`                   | string  | UI color theme. `phosphor` (default — 80s CRT green-on-black) or `plain` (pre-theme white/cyan). Unknown values fall back to `phosphor` with a warning.                       |
+| `theme`                   | string  | UI color theme. `phosphor` (default — 80s CRT green-on-black), `plain` (pre-theme white/cyan), or any `<name>.theme.json` file in the config dir. See [docs/THEMES.md](docs/THEMES.md). |
+| `tools`                   | object  | Optional per-tool enable map. Currently honors `tools.websearch` and `tools.webfetch` (both `bool`, default `true`); set either to `false` to drop the tool from the registered set even when its env vars are present. |
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, defaults to a single Exa Web Search server; see below.                                                   |
 | `acp_servers`             | object  | ACP server config map when compiled with the `acp` feature. See the ACP section below.                                                                                       |
-| `acp_host`                | string  | TCP bind host for ACP server mode (equivalent to `--acp-host`).                                                                                                              |
-| `acp_port`                | integer | TCP bind port for ACP server mode (equivalent to `--acp-port`, default: 7243).                                                                                               |
 
 Permission actions are lowercase strings: `allow`, `ask`, or `deny`. Each tool
 rule can be a single action or an object mapping glob-like patterns to actions.
@@ -202,8 +201,10 @@ The following config keys are available:
 | Key           | Type    | Description                                            |
 | ------------- | ------- | ------------------------------------------------------ |
 | `acp_servers` | object  | Named ACP server configurations (see below)            |
-| `acp_host`    | string  | TCP bind host for ACP server (default: stdio mode)     |
-| `acp_port`    | integer | TCP bind port for ACP server (default: 7243)           |
+
+dirge's ACP runs over stdio only; the `acp_host` / `acp_port`
+keys that earlier docs mentioned have been removed from the CLI
+and config in favor of editors driving the agent via stdio.
 
 ACP server configs (in `acp_servers`) support two transport types:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ dirge --provider glm       # defaults to glm-4
 # errors (useful when authoring a plugin or filing a bug report).
 # RUST_LOG env still takes precedence if set.
 dirge --verbose
+
+# Pass an API key inline (one-off testing, CI). Prefer env vars
+# in production — `--api-key` is visible to other processes via
+# the process list (`ps`).
+dirge --provider openai --api-key sk-...
 ```
 
 ## Slash commands
@@ -284,7 +289,7 @@ When built with `--features "semantic,semantic-ts,semantic-python"`, dirge gains
 | `list_symbols` | List functions, classes, methods, interfaces, and type aliases in a file or project. Filter by kind. |
 | `get_symbol_body` | Full source of a named symbol via precise byte-range extraction. |
 | `find_definition` | Locate where a symbol is defined across the project. |
-| `find_callers` | Find all call sites of a function/method (word-boundary regex, excludes definition site). |
+| `find_callers` | Find all call sites of a function/method via the tree-sitter symbol index (word-boundary semantics, excludes the definition site). |
 | `find_callees` | Extract all function/method calls made within a symbol's body (tree-sitter query). |
 
 Supports TypeScript/TSX and Python. Index is built lazily on first use and cached by file mtime.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -42,10 +42,24 @@ pub fn load(no_context_files: bool) -> ContextFiles {
 }
 
 fn load_file(path: &PathBuf) -> Option<String> {
-    if path.exists() {
-        std::fs::read_to_string(path).ok()
-    } else {
-        None
+    if !path.exists() {
+        return None;
+    }
+    match std::fs::read_to_string(path) {
+        Ok(content) => Some(content),
+        Err(e) => {
+            // Previously the error was silently swallowed via `.ok()`
+            // — a permission-denied AGENTS.md looked the same as a
+            // missing file. Surface the path + reason at warn so
+            // users can investigate when context they expected is
+            // missing.
+            eprintln!(
+                "warning: failed to read context file {}: {}",
+                path.display(),
+                e,
+            );
+            None
+        }
     }
 }
 

--- a/src/semantic/index.rs
+++ b/src/semantic/index.rs
@@ -161,8 +161,13 @@ impl SymbolIndex {
             .hidden(false)
             .filter_entry(|entry| {
                 if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    // Share the central skip list with find_files /
+                    // glob / list_dir / grep — the previous inline
+                    // `matches!` only listed 4 dirs and diverged
+                    // silently from the canonical set in
+                    // `agent::tools::is_skip_dir`.
                     let name = entry.file_name().to_str().unwrap_or("");
-                    !matches!(name, "node_modules" | "target" | ".git" | "__pycache__")
+                    !crate::agent::tools::is_skip_dir(name)
                 } else {
                     true
                 }


### PR DESCRIPTION
Tier-2 follow-up to PR #111. 5 docs fixes (#6 `tools`, #12 temperature, #13 --api-key, #14 acp_host/port, #21 find_callers) + 2 code fixes (#16 share is_skip_dir between semantic + tools, #18 context::load_file error context). 725/599 pass.