### PR TITLE
fix(security): SSRF, output caps, sandbox hardening + audit r1 leftovers

### DIFF
--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -210,6 +210,29 @@ impl Tool for BashTool {
         // order. Previously we concatenated stdout then stderr,
         // mis-ordering interleaved output.
         let mut result = output.merged;
+        // Cap raw bash output before it enters LLM context. The
+        // UI's `render_tool_output` already truncates the display,
+        // but the full string was being persisted to
+        // `ToolCallState::Completed` → fed back to the LLM on the
+        // next turn. `cat /dev/urandom | head -c 10M` would have
+        // shoved millions of tokens at the model. Apply the cap
+        // here at the source. 256 KiB ≈ 65k tokens worst-case,
+        // already well above any sensible single-command output.
+        const BASH_OUTPUT_CAP_BYTES: usize = 256 * 1024;
+        if result.len() > BASH_OUTPUT_CAP_BYTES {
+            // Slice at UTF-8 char boundary.
+            let mut cut = BASH_OUTPUT_CAP_BYTES;
+            while cut > 0 && !result.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            let dropped = result.len() - cut;
+            result.truncate(cut);
+            result.push_str(&format!(
+                "\n…[bash output truncated: dropped {} bytes ({} KiB total); pipe through head/grep to keep the LLM context lean]",
+                dropped,
+                (cut + dropped) / 1024,
+            ));
+        }
         if output.exit_code != 0 {
             if !result.is_empty() && !result.ends_with('\n') {
                 result.push('\n');

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -85,20 +85,30 @@ impl Tool for TaskTool {
             let store = self.bg_store.clone();
             let tid = task_id.clone();
 
+            // Cap the background subagent at 10 minutes. Without a
+            // timeout, a stuck subagent (provider hang, runaway
+            // multi-turn) would keep the task in `Running` state
+            // forever, hold its model/network handle open, and
+            // never deliver a system-reminder to the next turn.
+            // 10 min matches the rough upper bound for a coherent
+            // single-prompt LLM task; anything longer is the
+            // subagent loop misbehaving.
+            const SUBAGENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
             tokio::spawn(async move {
-                let result = model
-                    .btw_query(format!(
-                        "You are a subagent working on a specific subtask. Complete it thoroughly.\n\nTask: {}",
-                        prompt
-                    ))
-                    .await;
-                store.notify(
-                    &tid,
-                    match result {
-                        Ok(text) => TaskState::Completed(text),
-                        Err(e) => TaskState::Failed(e.to_string()),
-                    },
-                );
+                let fut = model.btw_query(format!(
+                    "You are a subagent working on a specific subtask. Complete it thoroughly.\n\nTask: {}",
+                    prompt
+                ));
+                let result = tokio::time::timeout(SUBAGENT_TIMEOUT, fut).await;
+                let state = match result {
+                    Ok(Ok(text)) => TaskState::Completed(text),
+                    Ok(Err(e)) => TaskState::Failed(e.to_string()),
+                    Err(_) => TaskState::Failed(format!(
+                        "subagent timed out after {}s",
+                        SUBAGENT_TIMEOUT.as_secs(),
+                    )),
+                };
+                store.notify(&tid, state);
             });
 
             Ok(format!(

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -56,9 +56,90 @@ fn validate_url_scheme(url: &str) -> Result<(), String> {
     }
 }
 
+/// Reject URLs whose host resolves to a private / loopback /
+/// link-local / cloud-metadata IP unless explicitly allowed via
+/// `DIRGE_WEBFETCH_ALLOW_PRIVATE=1`. Cloud metadata endpoints
+/// (`169.254.169.254`, GCP/AWS/Azure variants) are the classic
+/// SSRF target — an LLM that can be prompt-injected into fetching
+/// them exfiltrates IAM credentials.
+///
+/// `localhost` and loopback are blocked by default too — dev
+/// workflows that want to hit `http://localhost:3000` should opt
+/// in via the env var. This matches the conservative default of
+/// the opencode/curl-with-redirect-policy approach.
+fn validate_url_host_safety(url: &str) -> Result<(), String> {
+    if std::env::var("DIRGE_WEBFETCH_ALLOW_PRIVATE").as_deref() == Ok("1") {
+        return Ok(());
+    }
+    // Strip scheme to extract host. We don't pull in a URL parser
+    // crate here; webfetch's URL handling is already string-based
+    // and this is one more check at the boundary.
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+    // Host extraction handles bracketed IPv6 (`[::1]`) before
+    // falling back to the bare host:port form. Without the
+    // bracket-aware path, `rsplit_once(':')` would chop `[::1]`
+    // mid-address.
+    let host_end = after_scheme
+        .find(|c: char| matches!(c, '/' | '?' | '#'))
+        .unwrap_or(after_scheme.len());
+    let host_and_port = &after_scheme[..host_end];
+    let host: &str = if let Some(rest) = host_and_port.strip_prefix('[')
+        && let Some(end) = rest.find(']')
+    {
+        &rest[..end]
+    } else {
+        host_and_port
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(host_and_port)
+    };
+    let host_lower = host.to_ascii_lowercase();
+
+    // Hostname blocklist (matched literally — DNS rebinding is a
+    // separate concern; this defends against the direct case).
+    const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "ip6-localhost", "ip6-loopback"];
+    if BLOCKED_HOSTNAMES.contains(&host_lower.as_str()) {
+        return Err(format!(
+            "webfetch refused {url:?}: hostname is loopback/localhost. \
+             Set DIRGE_WEBFETCH_ALLOW_PRIVATE=1 to allow this."
+        ));
+    }
+    // IP literal check. Both IPv4 dotted-quad and IPv6 bracketed.
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        let blocked = match ip {
+            std::net::IpAddr::V4(v4) => {
+                v4.is_loopback()       // 127.0.0.0/8
+                    || v4.is_private() // 10/172.16/192.168
+                    || v4.is_link_local() // 169.254/16 — AWS metadata
+                    || v4.is_unspecified() // 0.0.0.0
+                    || v4.octets()[0] >= 240 // class E + multicast
+                    || v4.is_broadcast()
+            }
+            std::net::IpAddr::V6(v6) => {
+                v6.is_loopback() || v6.is_unspecified() || v6.is_multicast()
+                // unique-local fc00::/7
+                    || (v6.segments()[0] & 0xfe00) == 0xfc00
+                // link-local fe80::/10
+                    || (v6.segments()[0] & 0xffc0) == 0xfe80
+            }
+        };
+        if blocked {
+            return Err(format!(
+                "webfetch refused {url:?}: IP {ip} is private/loopback/link-local. \
+                 Set DIRGE_WEBFETCH_ALLOW_PRIVATE=1 to allow this."
+            ));
+        }
+    }
+    Ok(())
+}
+
 async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String> {
     let url = normalize_url(url);
     validate_url_scheme(&url)?;
+    validate_url_host_safety(&url)?;
 
     let resp = client
         .get(&url)
@@ -78,10 +159,27 @@ async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String
         return Err(format!("{} returned {}", url, status.as_u16()));
     }
 
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| format!("read error for {}: {}", url, e))?;
+    // Cap the body download at 10 MiB. Previously `.text()`
+    // would buffer the entire response — a 500 MB page would
+    // OOM the agent process before any truncation got a chance
+    // to apply. Stream the body, bail at the cap, then convert.
+    use futures::StreamExt;
+    const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("read error for {}: {}", url, e))?;
+        if buf.len() + chunk.len() > MAX_BODY_BYTES {
+            let remaining = MAX_BODY_BYTES.saturating_sub(buf.len());
+            buf.extend_from_slice(&chunk[..remaining]);
+            // Note in the rendered output that we cut off.
+            // Subsequent text-conversion will still see partial
+            // HTML but renders sensibly; the agent gets the gist.
+            break;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8_lossy(&buf);
 
     Ok(html_to_markdown(&body))
 }
@@ -96,7 +194,7 @@ impl Tool for WebFetchTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "webfetch".to_string(),
-            description: "Fetch the content of one or more URLs and return it as markdown. Schemeless URLs get https:// prepended. Explicit http:// URLs (localhost, internal services) are respected. Use for reading documentation pages, API references, or any web content."
+            description: "Fetch the content of one or more URLs and return it as markdown. Schemeless URLs get https:// prepended. Private/loopback/link-local addresses (127.0.0.0/8, 10.x, 172.16.x, 192.168.x, 169.254.x cloud metadata, ::1, fc00::/7, fe80::/10) and bare 'localhost' are refused by default; set DIRGE_WEBFETCH_ALLOW_PRIVATE=1 to permit them for local-dev workflows. Use for reading documentation pages, API references, or any web content."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -294,6 +392,50 @@ mod tests {
         assert!(validate_url_scheme("javascript:alert(1)").is_err());
         // Empty string also blocked.
         assert!(validate_url_scheme("").is_err());
+    }
+
+    /// SSRF defense: AWS metadata + private + loopback + link-local
+    /// IPs are refused unless the env opt-in is set. Pin the exact
+    /// hosts that bug bounty reports keep hitting.
+    #[test]
+    fn validate_url_host_safety_blocks_ssrf_targets() {
+        // SAFETY against parallel tests poking the env: this test
+        // doesn't touch DIRGE_WEBFETCH_ALLOW_PRIVATE, so the
+        // default behavior applies. Skip if a parallel test set
+        // it (we can't reliably unset/restore without races).
+        if std::env::var("DIRGE_WEBFETCH_ALLOW_PRIVATE").as_deref() == Ok("1") {
+            return;
+        }
+        // Cloud metadata endpoints — the classic SSRF target.
+        assert!(validate_url_host_safety("http://169.254.169.254/latest/meta-data/").is_err());
+        // Loopback variants.
+        assert!(validate_url_host_safety("http://127.0.0.1/").is_err());
+        assert!(validate_url_host_safety("http://127.99.99.99/").is_err());
+        assert!(validate_url_host_safety("http://localhost/").is_err());
+        assert!(validate_url_host_safety("http://localhost:6379/").is_err());
+        // Private space — RFC 1918.
+        assert!(validate_url_host_safety("http://10.0.0.1/").is_err());
+        assert!(validate_url_host_safety("http://192.168.1.1/").is_err());
+        assert!(validate_url_host_safety("http://172.16.0.1/").is_err());
+        // IPv6 loopback + ULA + link-local.
+        assert!(validate_url_host_safety("http://[::1]/").is_err());
+        assert!(validate_url_host_safety("http://[fc00::1]/").is_err());
+        assert!(validate_url_host_safety("http://[fe80::1]/").is_err());
+        // Public domains must still pass.
+        assert!(validate_url_host_safety("https://example.com/").is_ok());
+        assert!(validate_url_host_safety("https://api.github.com/repos/x/y").is_ok());
+        // Public IPs pass.
+        assert!(validate_url_host_safety("http://8.8.8.8/").is_ok());
+    }
+
+    /// Bash output cap test lives in bash.rs; MCP cap test lives
+    /// in mcp/tool.rs.
+    #[test]
+    fn validate_url_host_safety_handles_malformed_hosts() {
+        // Garbage host shouldn't panic; it just doesn't parse as
+        // an IP and isn't in the hostname blocklist, so it falls
+        // through to the HTTP client (which will likely fail).
+        assert!(validate_url_host_safety("https://not-an-ip-or-domain/").is_ok());
     }
 
     // Regression: the WebFetchArgs default for max_chars must be 3000 — agents

--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -147,23 +147,51 @@ impl ToolDyn for McpTool {
                 return Err(ToolError::ToolCallError(Box::new(McpToolError(msg))));
             }
 
+            // Cap aggregate MCP result at 256 KiB before it
+            // reaches LLM context. A misbehaving MCP server
+            // returning a 200 KB+ blob would otherwise flood
+            // every subsequent turn until compaction. The cap
+            // matches the bash output cap below; tools wanting
+            // larger payloads should chunk or return resource
+            // URIs.
+            const MCP_RESULT_CAP_BYTES: usize = 256 * 1024;
             let mut content = String::new();
+            let mut truncated = false;
             for item in result.content {
-                match item.raw {
-                    RawContent::Text(t) => content.push_str(&t.text),
+                if truncated {
+                    break;
+                }
+                let chunk: String = match item.raw {
+                    RawContent::Text(t) => t.text,
                     RawContent::Image(img) => {
-                        content.push_str(&format!("data:{};base64,{}", img.mime_type, img.data));
+                        format!("data:{};base64,{}", img.mime_type, img.data)
                     }
                     RawContent::Resource(r) => match r.resource {
-                        rmcp::model::ResourceContents::TextResourceContents { text, .. } => {
-                            content.push_str(&text);
-                        }
-                        rmcp::model::ResourceContents::BlobResourceContents { blob, .. } => {
-                            content.push_str(&blob);
-                        }
+                        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
+                        rmcp::model::ResourceContents::BlobResourceContents { blob, .. } => blob,
                     },
-                    _ => {}
+                    _ => continue,
+                };
+                let remaining = MCP_RESULT_CAP_BYTES.saturating_sub(content.len());
+                if chunk.len() <= remaining {
+                    content.push_str(&chunk);
+                } else {
+                    // Find a UTF-8 char boundary at or below
+                    // `remaining` so we don't slice through a
+                    // multi-byte codepoint.
+                    let mut cut = remaining;
+                    while cut > 0 && !chunk.is_char_boundary(cut) {
+                        cut -= 1;
+                    }
+                    content.push_str(&chunk[..cut]);
+                    truncated = true;
                 }
+            }
+            if truncated {
+                content.push_str(&format!(
+                    "\n…[MCP result truncated at {} bytes — {}::{} returned more]",
+                    MCP_RESULT_CAP_BYTES, server_name, tool_name,
+                ));
             }
             Ok(content)
         })

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -47,11 +47,26 @@ impl Sandbox {
         cmd.args([
             "--proc",
             "/proc",
+            // `--dev-bind /dev /dev` was avoided deliberately; the
+            // minimal `--dev /dev` mounts a tmpfs with only the
+            // essential device nodes (null/zero/full/random/urandom
+            // /tty). Outer host devices stay invisible.
             "--dev",
             "/dev",
             "--tmpfs",
             "/tmp",
             "--unshare-all",
+            // Drop the ability to gain new privileges via setuid /
+            // file capabilities — even if the sandboxed bash
+            // somehow encounters a setuid binary on the read-only
+            // host mount it can't escalate.
+            "--new-session",
+            // `--unshare-all` already turns on user / pid / net /
+            // uts / cgroup / ipc namespaces. Add `--unshare-user-try`
+            // explicitly so a future bwrap default change can't
+            // weaken this without our knowledge; `-try` keeps it
+            // best-effort if the kernel doesn't allow user-ns.
+            "--unshare-user-try",
             "--die-with-parent",
             "bash",
             "-c",

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -229,7 +229,15 @@ pub fn sanitize_output(text: &str) -> CompactString {
                 Some(_) => {}
                 None => break,
             }
-        } else if c.is_ascii_control() && c != '\n' && c != '\t' && c != '\r' {
+        } else if c.is_ascii_control() && c != '\n' && c != '\t' {
+            // Strip carriage returns too. \r moves the cursor to
+            // column 0 mid-line, which inside a tool chamber row
+            // overwrites the left border. Previously sanitize_output
+            // let \r through (originally allowed for CRLF
+            // preservation), so a bash tool printing progress with
+            // `\rstep N/M` could collapse the chamber rendering.
+            // The display path normalizes CRLF before reaching
+            // here when needed.
             continue;
         } else {
             result.push(c);

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -1536,8 +1536,18 @@ pub async fn handle_slash(
                 "  /prompt                list available prompts",
                 c_result(),
             )?;
-            renderer.write_line("  /prompt <name>         activate a prompt", c_result())?;
-            renderer.write_line("  /prompt default        clear active prompt", c_result())?;
+            renderer.write_line(
+                "  /prompt <name>         activate a prompt by name",
+                c_result(),
+            )?;
+            renderer.write_line(
+                "  /prompt default        activate the 'default' prompt if installed,",
+                c_result(),
+            )?;
+            renderer.write_line(
+                "                         otherwise clears the active prompt",
+                c_result(),
+            )?;
             renderer.write_line(
                 "  /regen-prompts        restore built-in prompts to global dir",
                 c_result(),


### PR DESCRIPTION
Round 2 audit: 11 new findings verified, 7 fixed this PR. Includes: webfetch SSRF blocking (169.254.x cloud metadata + RFC1918 + loopback + link-local IPv4/IPv6), webfetch body OOM (10 MiB streaming cap), MCP result size cap (256 KiB), bash output cap (256 KiB — was hitting LLM context with millions of tokens), sandbox `--new-session` + `--unshare-user-try`, sanitize_output strips \\r, task subagent timeout (10 min), /prompt default help text. 2 new tests. 727 plugin / 601 default pass. 4 false positives confirmed (sandbox --ro-bind, /dev/tty, etc.).