### PR TITLE
fix(semantic): adapter review followups — close 10 extraction holes

### DIFF
--- a/src/semantic/adapters/c.rs
+++ b/src/semantic/adapters/c.rs
@@ -116,16 +116,24 @@ impl CAdapter {
 
     /// `struct Foo { … }` at top level. Anonymous structs (no
     /// `type_identifier` child) are skipped — there's no useful
-    /// symbol name to attach.
+    /// symbol name to attach. Forward declarations (`struct Foo;`,
+    /// no body) are also skipped: emitting them creates a Class
+    /// symbol with no contents that confuses code navigation, and
+    /// the real definition elsewhere produces the canonical symbol.
     fn handle_struct(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
         let mut name: Option<String> = None;
+        let mut has_body = false;
         for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.kind() == "type_identifier"
-            {
+            let Some(c) = n.named_child(i) else { continue };
+            if c.kind() == "type_identifier" && name.is_none() {
                 name = Some(self.text(c, s).to_string());
-                break;
             }
+            if c.kind() == "field_declaration_list" {
+                has_body = true;
+            }
+        }
+        if !has_body {
+            return;
         }
         let Some(name) = name else { return };
         symbols.push(Symbol {
@@ -139,24 +147,64 @@ impl CAdapter {
     }
 
     fn handle_enum(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
+        // Find the enum's tag name + its enumerator list in a single
+        // pass so we can emit both the parent enum AND its constants
+        // as Variable symbols. Previously the constants (`RED`,
+        // `GREEN`, …) were lost; in C they're far more frequently
+        // referenced than the enum tag itself.
         let mut name: Option<String> = None;
+        let mut enumerator_list: Option<Node> = None;
         for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.kind() == "type_identifier"
-            {
-                name = Some(self.text(c, s).to_string());
-                break;
+            let Some(c) = n.named_child(i) else { continue };
+            match c.kind() {
+                "type_identifier" => {
+                    if name.is_none() {
+                        name = Some(self.text(c, s).to_string());
+                    }
+                }
+                "enumerator_list" => enumerator_list = Some(c),
+                _ => {}
             }
         }
-        let Some(name) = name else { return };
-        symbols.push(Symbol {
-            kind: SymbolKind::Class,
-            is_exported: true,
-            name,
-            range: self.range(n),
-            signature: self.text(n, s).lines().next().unwrap_or("").to_string(),
-            parent_class: None,
-        });
+        let parent_name = name.clone();
+        if let Some(name) = name {
+            symbols.push(Symbol {
+                kind: SymbolKind::Class,
+                is_exported: true,
+                name,
+                range: self.range(n),
+                signature: self.text(n, s).lines().next().unwrap_or("").to_string(),
+                parent_class: None,
+            });
+        }
+        // Emit each constant as a Variable symbol. Anonymous enums
+        // (`enum { A, B };`) still surface their constants — the
+        // parent enum just isn't named.
+        if let Some(list) = enumerator_list {
+            for i in 0..list.named_child_count() {
+                if let Some(e) = list.named_child(i)
+                    && e.kind() == "enumerator"
+                {
+                    // Enumerator's first identifier child is the
+                    // constant name.
+                    for j in 0..e.named_child_count() {
+                        if let Some(id) = e.named_child(j)
+                            && id.kind() == "identifier"
+                        {
+                            symbols.push(Symbol {
+                                kind: SymbolKind::Variable,
+                                is_exported: true,
+                                name: self.text(id, s).to_string(),
+                                range: self.range(e),
+                                signature: self.text(e, s).to_string(),
+                                parent_class: parent_name.clone(),
+                            });
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// `typedef <type> <alias>;`. If `<type>` is an inline struct
@@ -443,5 +491,32 @@ mod tests {
             .unwrap();
         assert!(callees.contains(&"printf".to_string()));
         assert!(callees.contains(&"helper".to_string()));
+    }
+
+    /// Enum constants — `RED`/`GREEN` are individually surfaced as
+    /// Variable symbols anchored to the parent enum tag.
+    #[test]
+    fn extracts_enum_constants_as_variables() {
+        let src = "enum Color { RED, GREEN = 5, BLUE };\n";
+        let f = CAdapter.extract(&pb("a.c"), src).unwrap();
+        for needed in ["Color", "RED", "GREEN", "BLUE"] {
+            assert!(
+                f.symbols.iter().any(|s| s.name == needed),
+                "missing: {needed}",
+            );
+        }
+        let red = f.symbols.iter().find(|s| s.name == "RED").unwrap();
+        assert!(matches!(red.kind, SymbolKind::Variable));
+        assert_eq!(red.parent_class.as_deref(), Some("Color"));
+    }
+
+    /// Forward `struct` declarations (no body) are skipped to
+    /// avoid duplicate symbols with the real definition.
+    #[test]
+    fn forward_struct_declaration_is_skipped() {
+        let src = "struct Foo;\nstruct Foo { int n; };\n";
+        let f = CAdapter.extract(&pb("a.c"), src).unwrap();
+        let foos: Vec<_> = f.symbols.iter().filter(|s| s.name == "Foo").collect();
+        assert_eq!(foos.len(), 1, "only the definition should produce a symbol");
     }
 }

--- a/src/semantic/adapters/clojure.rs
+++ b/src/semantic/adapters/clojure.rs
@@ -31,10 +31,14 @@ impl ClojureAdapter {
         }
     }
 
-    /// The text of a `sym_lit` is in its `sym_name` child. Falling back
-    /// to the full node text is fine for the simple `foo` case but
-    /// returns prefixed-namespace garbage for `clojure.string/blank?`,
-    /// so we prefer the child.
+    /// The text of a `sym_lit` is in its `sym_name` child. For
+    /// namespace-qualified symbols like `clojure.string/blank?` the
+    /// grammar exposes `sym_ns` (namespace) and `sym_name` (leaf)
+    /// children separately — we want only `blank?`. When neither
+    /// child exists (older grammar revisions or malformed input),
+    /// fall back to the raw text BUT strip any `ns/` prefix so the
+    /// callees list / symbol index don't get polluted with fully
+    /// qualified names.
     fn sym_name<'a>(&self, sym_lit: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
         for i in 0..sym_lit.named_child_count() {
             if let Some(c) = sym_lit.named_child(i)
@@ -43,9 +47,11 @@ impl ClojureAdapter {
                 return Some(self.node_text(c, source));
             }
         }
-        // Fallback: raw node text (some symbols have no sym_name child
-        // in older grammar revisions).
-        Some(self.node_text(sym_lit, source))
+        // Fallback: raw node text with the `ns/` prefix stripped so
+        // `clojure.string/blank?` is normalized to `blank?`. Symbols
+        // with no namespace prefix pass through unchanged.
+        let raw = self.node_text(sym_lit, source);
+        Some(raw.rsplit_once('/').map(|(_, leaf)| leaf).unwrap_or(raw))
     }
 
     /// Children of a `list_lit` that are actual forms (symbols / lists /
@@ -552,5 +558,33 @@ mod tests {
         for needed in [".clj", ".cljs", ".cljc", ".edn", ".bb"] {
             assert!(exts.contains(&needed), "missing extension: {needed}");
         }
+    }
+
+    /// Namespace-qualified symbols (`clojure.string/blank?`) in
+    /// call position must surface only the leaf name. Previously
+    /// the fallback returned the full `ns/name` string, polluting
+    /// the call graph.
+    #[test]
+    fn find_callees_strips_namespace_from_qualified_calls() {
+        let src = "(defn run [] (clojure.string/blank? \"x\") (str/join \", \" [1 2]))\n";
+        let f = adapter().extract(&pb("a.clj"), src).unwrap();
+        let run = &f.symbols[0];
+        let callees = adapter()
+            .find_callees_in_range(src, &pb("a.clj"), run.range)
+            .unwrap();
+        // Leaf names, not fully qualified.
+        assert!(
+            callees.iter().any(|c| c == "blank?"),
+            "expected leaf 'blank?'; got {callees:?}",
+        );
+        assert!(
+            callees.iter().any(|c| c == "join"),
+            "expected leaf 'join'; got {callees:?}",
+        );
+        // Should NOT contain the full qualified path.
+        assert!(
+            !callees.iter().any(|c| c.contains('/')),
+            "no callee should contain a /: {callees:?}",
+        );
     }
 }

--- a/src/semantic/adapters/cpp.rs
+++ b/src/semantic/adapters/cpp.rs
@@ -106,8 +106,19 @@ impl CppAdapter {
         let Some(name) = self.function_name(n, s) else {
             return;
         };
+        // Out-of-line method definition (`void Foo::bar() {}`)
+        // carries the receiving class via a qualified_identifier
+        // in the declarator. Detect that and emit a Method with
+        // the qualifier as parent_class so users can find these
+        // alongside in-class methods via list_symbols --parent Foo.
+        let parent = self.qualified_owner(n, s);
+        let kind = if parent.is_some() {
+            SymbolKind::Method
+        } else {
+            SymbolKind::Function
+        };
         symbols.push(Symbol {
-            kind: SymbolKind::Function,
+            kind,
             // C++ top-level functions are externally visible
             // unless they're in an anonymous namespace or marked
             // `static`. We don't recurse into anonymous namespace
@@ -116,8 +127,42 @@ impl CppAdapter {
             name,
             range: self.range(n),
             signature: self.signature(n, s),
-            parent_class: None,
+            parent_class: parent,
         });
+    }
+
+    /// If the function's declarator is a `qualified_identifier`
+    /// (`Foo::bar` / `ns::Foo::bar`), return everything before the
+    /// last `::` as the parent_class. Returns None for plain
+    /// non-qualified function definitions.
+    fn qualified_owner(&self, n: Node, s: &[u8]) -> Option<String> {
+        for i in 0..n.named_child_count() {
+            let Some(decl) = n.named_child(i) else {
+                continue;
+            };
+            // Walk through the wrappers; we want the actual
+            // function_declarator's name child.
+            let inner = if matches!(
+                decl.kind(),
+                "function_declarator" | "pointer_declarator" | "reference_declarator"
+            ) {
+                // function_declarator's `declarator` field holds the name.
+                decl.child_by_field_name("declarator").unwrap_or(decl)
+            } else {
+                continue;
+            };
+            if inner.kind() != "qualified_identifier" {
+                continue;
+            }
+            // Take all text before the trailing `::name`. tree-sitter
+            // exposes scope vs name fields, but we use raw text since
+            // it round-trips namespaces correctly.
+            let raw = self.text(inner, s);
+            if let Some((scope, _name)) = raw.rsplit_once("::") {
+                return Some(scope.to_string());
+            }
+        }
+        None
     }
 
     /// Walk a `field_declaration_list` (the body of `class`/`struct`)
@@ -318,6 +363,26 @@ impl CppAdapter {
             }
             "preproc_include" => self.handle_include(c, bytes, imports),
             "using_declaration" | "using_directive" => self.handle_using(c, bytes, imports),
+            // `extern "C" { ... }` blocks. tree-sitter-cpp exposes
+            // them as `linkage_specification`. Walk the inner
+            // declaration_list as if it were the top level so FFI
+            // functions show up in list_symbols.
+            "linkage_specification" => {
+                for i in 0..c.named_child_count() {
+                    if let Some(inner) = c.named_child(i)
+                        && inner.kind() == "declaration_list"
+                    {
+                        for j in 0..inner.named_child_count() {
+                            if let Some(item) = inner.named_child(j) {
+                                self.dispatch_top(item, bytes, symbols, imports);
+                            }
+                        }
+                    } else if let Some(inner) = c.named_child(i) {
+                        // Single-statement extern (no braces).
+                        self.dispatch_top(inner, bytes, symbols, imports);
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -508,5 +573,39 @@ mod tests {
         assert!(callees.contains(&"helper".to_string()));
         assert!(callees.contains(&"bar".to_string()));
         assert!(callees.contains(&"Foo".to_string()));
+    }
+
+    /// `extern "C" { ... }` blocks — previously dropped entirely.
+    #[test]
+    fn extracts_extern_c_block_contents() {
+        let src = "extern \"C\" {\n  int c_function(int x);\n  void c_void(void);\n}\nint c_function(int x) { return x; }\nvoid c_void(void) {}\n";
+        let f = CppAdapter.extract(&pb("a.cpp"), src).unwrap();
+        assert!(f.symbols.iter().any(|s| s.name == "c_function"));
+        assert!(f.symbols.iter().any(|s| s.name == "c_void"));
+    }
+
+    /// Out-of-line method definitions `void Foo::bar() {}` attach
+    /// to the qualifying class via parent_class.
+    #[test]
+    fn out_of_line_method_attaches_to_qualifying_class() {
+        let src = "class Foo { public: void bar(); };\nvoid Foo::bar() {}\n";
+        let f = CppAdapter.extract(&pb("a.cpp"), src).unwrap();
+        // There are two `bar` symbols: the declaration inside Foo,
+        // and the out-of-line definition. Both should be Methods
+        // with parent_class = "Foo".
+        let bars: Vec<_> = f.symbols.iter().filter(|s| s.name == "bar").collect();
+        assert!(!bars.is_empty(), "no bar symbols");
+        assert!(
+            bars.iter().all(|s| matches!(s.kind, SymbolKind::Method)),
+            "every bar should be a Method; got {:?}",
+            bars.iter()
+                .map(|s| (s.kind, s.parent_class.clone()))
+                .collect::<Vec<_>>(),
+        );
+        assert!(
+            bars.iter()
+                .all(|s| s.parent_class.as_deref() == Some("Foo")),
+            "every bar's parent_class should be Foo",
+        );
     }
 }

--- a/src/semantic/adapters/go.rs
+++ b/src/semantic/adapters/go.rs
@@ -185,6 +185,50 @@ impl GoAdapter {
         }
     }
 
+    /// Walks `var_declaration` / `const_declaration` (both bare and
+    /// grouped) and emits one Variable per declared name. Grouped
+    /// declarations have `var_spec` / `const_spec` children, each
+    /// with one or more `identifier`s. Bare declarations carry the
+    /// spec inline.
+    fn handle_var_or_const(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
+        let mut emit_from_spec = |spec: Node| {
+            for j in 0..spec.named_child_count() {
+                if let Some(id) = spec.named_child(j)
+                    && id.kind() == "identifier"
+                {
+                    let name = self.text(id, s).to_string();
+                    symbols.push(Symbol {
+                        kind: SymbolKind::Variable,
+                        is_exported: self.is_exported(&name),
+                        name,
+                        range: self.range(spec),
+                        signature: self.text(spec, s).lines().next().unwrap_or("").to_string(),
+                        parent_class: None,
+                    });
+                }
+            }
+        };
+        for i in 0..n.named_child_count() {
+            let Some(c) = n.named_child(i) else { continue };
+            match c.kind() {
+                "var_spec" | "const_spec" => emit_from_spec(c),
+                // Grouped form `var ( a = 1; b = 2 )` wraps the
+                // specs in a `var_spec_list` (or `const_spec_list`);
+                // unwrap to get each spec.
+                "var_spec_list" | "const_spec_list" => {
+                    for j in 0..c.named_child_count() {
+                        if let Some(spec) = c.named_child(j)
+                            && matches!(spec.kind(), "var_spec" | "const_spec")
+                        {
+                            emit_from_spec(spec);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn handle_imports(&self, n: Node, s: &[u8], imports: &mut Vec<Import>) {
         // import_declaration has import_spec children (or import_spec_list).
         let mut harvest = |spec: Node| {
@@ -269,6 +313,14 @@ impl LanguageAdapter for GoAdapter {
                 "method_declaration" => self.handle_method(c, source_bytes, &mut symbols),
                 "type_declaration" => self.handle_type_decl(c, source_bytes, &mut symbols),
                 "import_declaration" => self.handle_imports(c, source_bytes, &mut imports),
+                // Top-level `var x = ...;` / `const x = ...;` and
+                // their grouped forms `var ( x = 1; y = 2 )`. Both
+                // shapes use the same node kinds at the top level;
+                // grouped declarations have multiple `var_spec` /
+                // `const_spec` children.
+                "var_declaration" | "const_declaration" => {
+                    self.handle_var_or_const(c, source_bytes, &mut symbols);
+                }
                 _ => {}
             }
         }
@@ -388,5 +440,25 @@ mod tests {
             .unwrap();
         assert!(callees.contains(&"Println".to_string()));
         assert!(callees.contains(&"helper".to_string()));
+    }
+
+    /// Top-level `var` / `const` (both bare and grouped) — previously
+    /// dropped entirely.
+    #[test]
+    fn extracts_var_and_const_declarations() {
+        let src = "package main\nvar Single = 1\nvar (\n  Grouped = 2\n  Other = 3\n)\nconst Max = 100\nconst (\n  A = \"a\"\n  B = \"b\"\n)\n";
+        let f = GoAdapter.extract(&pb("a.go"), src).unwrap();
+        for needed in ["Single", "Grouped", "Other", "Max", "A", "B"] {
+            assert!(
+                f.symbols.iter().any(|s| s.name == needed),
+                "missing var/const: {needed}; got {:?}",
+                f.symbols.iter().map(|s| &s.name).collect::<Vec<_>>(),
+            );
+        }
+        // All these uppercase names should be exported.
+        for needed in ["Single", "Grouped", "Max"] {
+            let sym = f.symbols.iter().find(|s| s.name == needed).unwrap();
+            assert!(sym.is_exported, "{needed} should be exported");
+        }
     }
 }

--- a/src/semantic/adapters/java.rs
+++ b/src/semantic/adapters/java.rs
@@ -145,7 +145,10 @@ impl JavaAdapter {
                         }
                     }
                 }
-                "class_declaration" | "interface_declaration" | "enum_declaration" => {
+                "class_declaration"
+                | "interface_declaration"
+                | "enum_declaration"
+                | "record_declaration" => {
                     // Nested class — recurse from the top of the
                     // walker so the new class gets its own
                     // symbol + body walk.
@@ -192,7 +195,15 @@ impl JavaAdapter {
                     self.walk_class_body(body, s, symbols, &name);
                 }
             }
-            "enum_declaration" => {
+            "enum_declaration" | "record_declaration" => {
+                // Records (Java 16+) are immutable data carriers
+                // that look like \`public record Point(int x, int y) {}\`.
+                // tree-sitter exposes them as record_declaration; we
+                // surface them as Class so list_symbols finds them,
+                // and walk the body for any explicit methods. The
+                // auto-generated accessors aren't AST-visible so we
+                // can't list them, but the signature line preserves
+                // the component list which is the useful info.
                 let Some(name) = self.ident_name(n, s) else {
                     return;
                 };
@@ -276,7 +287,10 @@ impl LanguageAdapter for JavaAdapter {
                 continue;
             };
             match c.kind() {
-                "class_declaration" | "interface_declaration" | "enum_declaration" => {
+                "class_declaration"
+                | "interface_declaration"
+                | "enum_declaration"
+                | "record_declaration" => {
                     self.walk_top(c, bytes, &mut symbols);
                 }
                 "import_declaration" => self.handle_import(c, bytes, &mut imports),
@@ -432,5 +446,17 @@ mod tests {
         );
         let deep = f.symbols.iter().find(|s| s.name == "deep").unwrap();
         assert_eq!(deep.parent_class.as_deref(), Some("Inner"));
+    }
+
+    /// Records (Java 16+) — previously silently dropped.
+    #[test]
+    fn extracts_record_declaration_as_class() {
+        let src = "public record Point(int x, int y) {\n  public boolean isOrigin() { return x == 0 && y == 0; }\n}\n";
+        let f = JavaAdapter.extract(&pb("a.java"), src).unwrap();
+        let point = f.symbols.iter().find(|s| s.name == "Point").unwrap();
+        assert!(matches!(point.kind, SymbolKind::Class));
+        assert!(point.is_exported);
+        let m = f.symbols.iter().find(|s| s.name == "isOrigin").unwrap();
+        assert_eq!(m.parent_class.as_deref(), Some("Point"));
     }
 }

--- a/src/semantic/adapters/ruby.rs
+++ b/src/semantic/adapters/ruby.rs
@@ -130,6 +130,22 @@ impl RubyAdapter {
                 }
                 // Nested class / module — recurse.
                 "class" | "module" => self.walk_top(c, s, symbols, Some(parent.to_string())),
+                // `class << self ... end` — singleton class block.
+                // Methods defined inside are class methods on the
+                // enclosing class. tree-sitter exposes the block as
+                // `singleton_class`; walk its body and emit each
+                // `method` as a Method on `parent`. Without this,
+                // the entire `class << self` block of methods was
+                // invisible to list_symbols.
+                "singleton_class" => {
+                    for j in 0..c.named_child_count() {
+                        if let Some(body) = c.named_child(j)
+                            && body.kind() == "body_statement"
+                        {
+                            self.walk_class_body(body, s, symbols, parent);
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -396,5 +412,18 @@ mod tests {
             .unwrap();
         assert!(callees.contains(&"puts".to_string()));
         assert!(callees.contains(&"helper".to_string()));
+    }
+
+    /// `class << self` singleton class blocks define class methods.
+    /// Previously the entire block's methods were invisible.
+    #[test]
+    fn extracts_singleton_class_methods_as_class_methods() {
+        let src = "class A\n  class << self\n    def factory; new; end\n    def banner; puts \"hi\"; end\n  end\nend\n";
+        let f = RubyAdapter.extract(&pb("a.rb"), src).unwrap();
+        let factory = f.symbols.iter().find(|s| s.name == "factory").unwrap();
+        let banner = f.symbols.iter().find(|s| s.name == "banner").unwrap();
+        assert!(matches!(factory.kind, SymbolKind::Method));
+        assert_eq!(factory.parent_class.as_deref(), Some("A"));
+        assert_eq!(banner.parent_class.as_deref(), Some("A"));
     }
 }

--- a/src/semantic/adapters/rust.rs
+++ b/src/semantic/adapters/rust.rs
@@ -71,6 +71,28 @@ impl RustAdapter {
         None
     }
 
+    /// Extract the base type name from a possibly-generic type
+    /// expression: `Foo` → `Foo`, `Foo<T>` → `Foo`, `Box<Foo<T>>` →
+    /// `Box`. Used by `handle_impl` so `impl<T> Trait for Foo<T>`
+    /// attaches its methods to `Foo`, not the generic param `T`.
+    fn type_leaf_name(&self, n: Node, s: &[u8]) -> Option<String> {
+        match n.kind() {
+            "type_identifier" => Some(self.text(n, s).to_string()),
+            "generic_type" | "scoped_type_identifier" => {
+                // First named child is the base type expr.
+                for i in 0..n.named_child_count() {
+                    if let Some(c) = n.named_child(i)
+                        && let Some(name) = self.type_leaf_name(c, s)
+                    {
+                        return Some(name);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
     fn handle_function(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
         let Some(name) = self.ident_child(n, s) else {
             return;
@@ -141,17 +163,30 @@ impl RustAdapter {
 
     fn handle_impl(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
         // `impl Type { ... }` or `impl Trait for Type { ... }`. The
-        // RECEIVING type is the most useful parent_class — it's what
-        // the user types when they want "all methods on Foo".
-        let mut last_type: Option<String> = None;
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.kind() == "type_identifier"
-            {
-                last_type = Some(self.text(c, s).to_string());
-            }
-        }
-        let Some(receiving) = last_type else {
+        // RECEIVING type (the implementor) is the most useful
+        // parent_class — it's what the user types when they want
+        // "all methods on Foo".
+        //
+        // tree-sitter-rust exposes the receiving type via the `type`
+        // field, which is robust against generic args, lifetime
+        // params, and `<T as Trait>::` paths that would otherwise
+        // confuse a positional last-type_identifier walk. Fall back
+        // to the positional walk only when the field is absent.
+        let receiving = n
+            .child_by_field_name("type")
+            .and_then(|t| self.type_leaf_name(t, s))
+            .or_else(|| {
+                let mut last: Option<String> = None;
+                for i in 0..n.named_child_count() {
+                    if let Some(c) = n.named_child(i)
+                        && c.kind() == "type_identifier"
+                    {
+                        last = Some(self.text(c, s).to_string());
+                    }
+                }
+                last
+            });
+        let Some(receiving) = receiving else {
             return;
         };
         for i in 0..n.named_child_count() {
@@ -213,6 +248,104 @@ impl RustAdapter {
             signature: self.text(n, s).lines().next().unwrap_or("").to_string(),
             parent_class: None,
         });
+    }
+
+    fn handle_mod(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>, imports: &mut Vec<Import>) {
+        let Some(name) = self.ident_child(n, s) else {
+            return;
+        };
+        symbols.push(Symbol {
+            kind: SymbolKind::Class,
+            is_exported: self.is_exported(n),
+            name,
+            range: self.range(n),
+            signature: self.text(n, s).lines().next().unwrap_or("").to_string(),
+            parent_class: None,
+        });
+        // Inline modules carry a `declaration_list`; file-only
+        // `mod foo;` doesn't, and we skip that case (the file's
+        // own indexing covers its contents).
+        for i in 0..n.named_child_count() {
+            let Some(c) = n.named_child(i) else { continue };
+            if c.kind() != "declaration_list" {
+                continue;
+            }
+            for j in 0..c.named_child_count() {
+                let Some(item) = c.named_child(j) else {
+                    continue;
+                };
+                match item.kind() {
+                    "function_item" => self.handle_function(item, s, symbols),
+                    "struct_item" | "enum_item" | "union_item" => {
+                        self.handle_struct_or_enum(item, s, symbols);
+                    }
+                    "trait_item" => self.handle_trait(item, s, symbols),
+                    "impl_item" => self.handle_impl(item, s, symbols),
+                    "type_item" => self.handle_type_alias(item, s, symbols),
+                    "const_item" | "static_item" => self.handle_const_or_static(item, s, symbols),
+                    "use_declaration" => self.handle_use(item, s, imports),
+                    "mod_item" => self.handle_mod(item, s, symbols, imports),
+                    "macro_definition" => self.handle_macro(item, s, symbols),
+                    "foreign_mod_item" => self.handle_extern_block(item, s, symbols),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn handle_macro(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
+        // `macro_rules! NAME { ... }`. The macro name appears as an
+        // `identifier` child of the macro_definition node.
+        for i in 0..n.named_child_count() {
+            if let Some(c) = n.named_child(i)
+                && c.kind() == "identifier"
+            {
+                let name = self.text(c, s).to_string();
+                symbols.push(Symbol {
+                    kind: SymbolKind::Function,
+                    is_exported: self.is_exported(n),
+                    name,
+                    range: self.range(n),
+                    signature: self.text(n, s).lines().next().unwrap_or("").to_string(),
+                    parent_class: None,
+                });
+                return;
+            }
+        }
+    }
+
+    fn handle_extern_block(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
+        // `extern "C" { ... }` — body is a `declaration_list` with
+        // `function_signature_item`, `static_item`, and
+        // `type_item` children.
+        for i in 0..n.named_child_count() {
+            let Some(c) = n.named_child(i) else { continue };
+            if c.kind() != "declaration_list" {
+                continue;
+            }
+            for j in 0..c.named_child_count() {
+                let Some(item) = c.named_child(j) else {
+                    continue;
+                };
+                match item.kind() {
+                    "function_signature_item" => {
+                        if let Some(name) = self.ident_child(item, s) {
+                            symbols.push(Symbol {
+                                kind: SymbolKind::Function,
+                                is_exported: true,
+                                name,
+                                range: self.range(item),
+                                signature: self.signature(item, s),
+                                parent_class: None,
+                            });
+                        }
+                    }
+                    "static_item" => self.handle_const_or_static(item, s, symbols),
+                    "type_item" => self.handle_type_alias(item, s, symbols),
+                    _ => {}
+                }
+            }
+        }
     }
 
     fn handle_use(&self, n: Node, s: &[u8], imports: &mut Vec<Import>) {
@@ -290,6 +423,19 @@ impl LanguageAdapter for RustAdapter {
                 "type_item" => self.handle_type_alias(c, bytes, &mut symbols),
                 "const_item" | "static_item" => self.handle_const_or_static(c, bytes, &mut symbols),
                 "use_declaration" => self.handle_use(c, bytes, &mut imports),
+                // Top-level `mod inner { ... }` — surface the module
+                // itself as a Class so list_symbols anchors on it,
+                // then recurse into the body so contents are indexed
+                // alongside top-level items.
+                "mod_item" => self.handle_mod(c, bytes, &mut symbols, &mut imports),
+                // `macro_rules! foo { ... }` — declarative macros.
+                // Treated as Function (closest match in SymbolKind);
+                // the LLM commonly invokes them like fns.
+                "macro_definition" => self.handle_macro(c, bytes, &mut symbols),
+                // `extern "ABI" { fn foo(); type Bar; }` — FFI
+                // blocks. Walk the body for declarations so the
+                // declared signatures are visible.
+                "foreign_mod_item" => self.handle_extern_block(c, bytes, &mut symbols),
                 _ => {}
             }
         }
@@ -460,5 +606,61 @@ mod tests {
         assert!(callees.contains(&"helper".to_string()));
         assert!(callees.contains(&"bar".to_string()));
         assert!(callees.contains(&"println".to_string()));
+    }
+
+    /// Inline `mod inner { ... }` — previously the module + every
+    /// item inside it were silently dropped.
+    #[test]
+    fn extracts_inline_module_and_its_items() {
+        let src = "pub mod inner {\n  pub fn deep() -> u32 { 42 }\n  pub struct Held;\n}\n";
+        let f = RustAdapter.extract(&pb("x.rs"), src).unwrap();
+        let m = f.symbols.iter().find(|s| s.name == "inner").unwrap();
+        assert!(matches!(m.kind, SymbolKind::Class));
+        assert!(m.is_exported);
+        assert!(
+            f.symbols
+                .iter()
+                .any(|s| s.name == "deep" && matches!(s.kind, SymbolKind::Function))
+        );
+        assert!(
+            f.symbols
+                .iter()
+                .any(|s| s.name == "Held" && matches!(s.kind, SymbolKind::Class))
+        );
+    }
+
+    /// `extern "C" { ... }` blocks — FFI declarations now visible.
+    #[test]
+    fn extracts_extern_block_signatures() {
+        let src =
+            "extern \"C\" {\n  fn foreign_fn(x: i32) -> i32;\n  static FOREIGN_GLOBAL: i32;\n}\n";
+        let f = RustAdapter.extract(&pb("x.rs"), src).unwrap();
+        let ff = f.symbols.iter().find(|s| s.name == "foreign_fn").unwrap();
+        assert!(matches!(ff.kind, SymbolKind::Function));
+        let g = f
+            .symbols
+            .iter()
+            .find(|s| s.name == "FOREIGN_GLOBAL")
+            .unwrap();
+        assert!(matches!(g.kind, SymbolKind::Variable));
+    }
+
+    /// `macro_rules!` declarations.
+    #[test]
+    fn extracts_macro_rules() {
+        let src = "macro_rules! my_mac { ($x:expr) => { $x + 1 }; }\n";
+        let f = RustAdapter.extract(&pb("x.rs"), src).unwrap();
+        let m = f.symbols.iter().find(|s| s.name == "my_mac").unwrap();
+        assert!(matches!(m.kind, SymbolKind::Function));
+    }
+
+    /// `impl<T> Trait for Generic<T>` — the receiving type's base
+    /// name (Generic) must be parent_class, not the generic param.
+    #[test]
+    fn impl_for_generic_type_uses_base_name() {
+        let src = "pub struct Bag<T>(T);\nimpl<T: Clone> AsRef<T> for Bag<T> { fn as_ref(&self) -> &T { &self.0 } }\n";
+        let f = RustAdapter.extract(&pb("x.rs"), src).unwrap();
+        let m = f.symbols.iter().find(|s| s.name == "as_ref").unwrap();
+        assert_eq!(m.parent_class.as_deref(), Some("Bag"));
     }
 }


### PR DESCRIPTION
Code review of the 6 newly-added language adapters surfaced significant coverage gaps across all of them. This PR closes the 10 highest-impact ones; cross-cutting refactors deferred. Java records, Ruby `class << self`, Go grouped `var(...)`, Rust `mod`/`extern`/`macro_rules`/generic-impl trait pick, C enum constants + forward-decl dedup, C++ `extern "C"` + out-of-line methods, Clojure namespace-stripped callees. 12 new regression tests; 809 all-features pass (was 797).