### PR TITLE
refactor(semantic): shared helpers, ImportKind, UTF-8 trace, populated exports

### DIFF
--- a/src/semantic/adapters/c.rs
+++ b/src/semantic/adapters/c.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_up_to_body};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for C.
 ///
@@ -20,31 +21,13 @@ pub struct CAdapter;
 
 impl CAdapter {
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        if let Some(body) = n.child_by_field_name("body") {
-            return String::from_utf8_lossy(&s[n.start_byte()..body.start_byte()])
-                .trim()
-                .to_string();
-        }
-        let first = self.text(n, s).lines().next().unwrap_or("");
-        if first.chars().count() > 80 {
-            let p: String = first.chars().take(80).collect();
-            format!("{p}…")
-        } else {
-            first.to_string()
-        }
+        signature_up_to_body(n, s)
     }
 
     /// Direct child `storage_class_specifier` with text "static"
@@ -269,6 +252,7 @@ impl CAdapter {
                     imports.push(Import {
                         names: vec![path.clone()],
                         source: path,
+                        kind: ImportKind::Header,
                     });
                     return;
                 }
@@ -281,6 +265,7 @@ impl CAdapter {
                             imports.push(Import {
                                 names: vec![path.clone()],
                                 source: path,
+                                kind: ImportKind::Header,
                             });
                             return;
                         }
@@ -289,22 +274,6 @@ impl CAdapter {
                 _ => {}
             }
         }
-    }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
     }
 }
 
@@ -327,7 +296,6 @@ impl LanguageAdapter for CAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
         if root.has_error() {
             warnings.push("tree-sitter reported syntax errors".to_string());
@@ -368,6 +336,12 @@ impl LanguageAdapter for CAdapter {
             }
         }
 
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
+
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
             symbols,
@@ -393,8 +367,7 @@ impl LanguageAdapter for CAdapter {
         let root = tree.root_node();
         let bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // `call_expression > identifier` for `foo()`. Member access

--- a/src/semantic/adapters/clojure.rs
+++ b/src/semantic/adapters/clojure.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for Clojure / ClojureScript / cljc / edn / bb.
 /// Uses `tree-sitter-clojure` (sogaiu's grammar, packaged on crates.io).
@@ -18,17 +19,15 @@ use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKin
 pub struct ClojureAdapter;
 
 impl ClojureAdapter {
-    fn node_text<'a>(&self, node: Node<'a>, source: &'a [u8]) -> &'a str {
-        node.utf8_text(source).unwrap_or("")
+    // `node_text` and `make_range` previously lived here; now from
+    // `crate::semantic::common`. The local wrapper functions are
+    // kept as thin shims so the rest of this adapter reads
+    // unchanged — `self.node_text(n, s)` etc.
+    fn node_text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
+        node_text(n, s)
     }
-
-    fn make_range(&self, node: Node) -> ByteRange {
-        ByteRange {
-            start_byte: node.start_byte(),
-            end_byte: node.end_byte(),
-            start_line: node.start_position().row + 1,
-            end_line: node.end_position().row + 1,
-        }
+    fn make_range(&self, n: Node) -> ByteRange {
+        ByteRange::from(n)
     }
 
     /// The text of a `sym_lit` is in its `sym_name` child. For
@@ -254,6 +253,7 @@ impl ClojureAdapter {
                                     imports.push(Import {
                                         names: vec![name.to_string()],
                                         source: name.to_string(),
+                                        kind: ImportKind::Module,
                                     });
                                 }
                             }
@@ -268,6 +268,7 @@ impl ClojureAdapter {
                                         imports.push(Import {
                                             names: vec![name.to_string()],
                                             source: name.to_string(),
+                                            kind: ImportKind::Module,
                                         });
                                         break;
                                     }
@@ -288,22 +289,6 @@ impl ClojureAdapter {
                 let _ = exports;
             }
         }
-    }
-
-    fn find_node_at_range<'a>(&self, node: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if node.start_byte() == start && node.end_byte() == end {
-            return Some(node);
-        }
-        for i in 0..node.named_child_count() {
-            if let Some(child) = node.named_child(i)
-                && child.start_byte() <= start
-                && child.end_byte() >= end
-                && let Some(found) = self.find_node_at_range(child, start, end)
-            {
-                return Some(found);
-            }
-        }
-        None
     }
 }
 
@@ -348,6 +333,20 @@ impl LanguageAdapter for ClojureAdapter {
             }
         }
 
+        // Backfill exports from is_exported symbols. Adapters that
+        // have an explicit export list (TS index re-exports, etc.)
+        // populate `exports` directly; for everything else, the
+        // is_exported flag on each symbol is authoritative and we
+        // mirror it here so consumers don't have to re-iterate.
+        if exports.is_empty() {
+            exports.extend(
+                symbols
+                    .iter()
+                    .filter(|s| s.is_exported)
+                    .map(|s| s.name.clone()),
+            );
+        }
+
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
             symbols,
@@ -373,8 +372,7 @@ impl LanguageAdapter for ClojureAdapter {
         let root = tree.root_node();
         let source_bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // Match every `list_lit` and pull its leading symbol — the
@@ -586,5 +584,28 @@ mod tests {
             !callees.iter().any(|c| c.contains('/')),
             "no callee should contain a /: {callees:?}",
         );
+    }
+
+    /// Imports are tagged with `ImportKind::Module` (Clojure
+    /// namespaces look like single dotted tokens, not the scoped
+    /// `Foo::Bar` syntax used by Rust/Java).
+    #[test]
+    fn imports_are_tagged_module_kind() {
+        let src = "(ns app (:require [clojure.string :as str]))\n";
+        let f = adapter().extract(&pb("a.clj"), src).unwrap();
+        assert!(!f.imports.is_empty());
+        for imp in &f.imports {
+            assert_eq!(imp.kind, ImportKind::Module);
+        }
+    }
+
+    /// Exports are populated from `is_exported=true` symbols.
+    /// `defn` is exported; `defn-` private.
+    #[test]
+    fn exports_mirror_is_exported_symbols() {
+        let src = "(defn public-thing [] :ok)\n(defn- private-thing [] :no)\n";
+        let f = adapter().extract(&pb("a.clj"), src).unwrap();
+        assert!(f.exports.iter().any(|n| n == "public-thing"));
+        assert!(!f.exports.iter().any(|n| n == "private-thing"));
     }
 }

--- a/src/semantic/adapters/cpp.rs
+++ b/src/semantic/adapters/cpp.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_up_to_body};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for C++.
 ///
@@ -24,31 +25,13 @@ pub struct CppAdapter;
 
 impl CppAdapter {
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        if let Some(body) = n.child_by_field_name("body") {
-            return String::from_utf8_lossy(&s[n.start_byte()..body.start_byte()])
-                .trim()
-                .to_string();
-        }
-        let first = self.text(n, s).lines().next().unwrap_or("");
-        if first.chars().count() > 80 {
-            let p: String = first.chars().take(80).collect();
-            format!("{p}…")
-        } else {
-            first.to_string()
-        }
+        signature_up_to_body(n, s)
     }
 
     /// Recursive declarator walk shared with C — finds the
@@ -301,6 +284,7 @@ impl CppAdapter {
                 imports.push(Import {
                     names: vec![path.clone()],
                     source: path,
+                    kind: ImportKind::Qualified,
                 });
                 return;
             }
@@ -319,6 +303,7 @@ impl CppAdapter {
                     imports.push(Import {
                         names: vec![path.clone()],
                         source: path,
+                        kind: ImportKind::Header,
                     });
                     return;
                 }
@@ -331,6 +316,7 @@ impl CppAdapter {
                             imports.push(Import {
                                 names: vec![path.clone()],
                                 source: path,
+                                kind: ImportKind::Header,
                             });
                             return;
                         }
@@ -386,22 +372,6 @@ impl CppAdapter {
             _ => {}
         }
     }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
-    }
 }
 
 impl LanguageAdapter for CppAdapter {
@@ -428,7 +398,6 @@ impl LanguageAdapter for CppAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
         if root.has_error() {
             warnings.push("tree-sitter reported syntax errors".to_string());
@@ -439,6 +408,12 @@ impl LanguageAdapter for CppAdapter {
                 self.dispatch_top(c, bytes, &mut symbols, &mut imports);
             }
         }
+
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
 
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
@@ -464,8 +439,7 @@ impl LanguageAdapter for CppAdapter {
         let tree = parser.parse(source, None).ok_or("Failed to parse source")?;
         let root = tree.root_node();
         let bytes = source.as_bytes();
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // Direct calls + member calls. Constructor calls

--- a/src/semantic/adapters/go.rs
+++ b/src/semantic/adapters/go.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_up_to_body};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for Go. Uses the Go convention that
 /// uppercase-first-letter names are exported. Methods are attached
@@ -13,27 +14,19 @@ use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKin
 pub struct GoAdapter;
 
 impl GoAdapter {
+    // Thin wrappers around the shared helpers in
+    // `crate::semantic::common`. Method-shape preserved so the
+    // bulk of this adapter reads unchanged.
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
     /// Signature is the prefix up to the function body's opening
     /// brace. `func Foo(x int) int { ... }` → `func Foo(x int) int`.
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        let body = n.child_by_field_name("body");
-        let end = body.map(|b| b.start_byte()).unwrap_or(n.end_byte());
-        String::from_utf8_lossy(&s[n.start_byte()..end])
-            .trim()
-            .to_string()
+        signature_up_to_body(n, s)
     }
 
     /// True if the name starts with an uppercase ASCII letter —
@@ -241,6 +234,7 @@ impl GoAdapter {
                     imports.push(Import {
                         names: vec![path.clone()],
                         source: path,
+                        kind: ImportKind::Module,
                     });
                 }
             }
@@ -262,22 +256,6 @@ impl GoAdapter {
             }
         }
     }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
-    }
 }
 
 impl LanguageAdapter for GoAdapter {
@@ -297,7 +275,6 @@ impl LanguageAdapter for GoAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
 
         if root.has_error() {
@@ -325,6 +302,16 @@ impl LanguageAdapter for GoAdapter {
             }
         }
 
+        // Populate `exports` from is_exported symbols so consumers
+        // get a quick "what does this file export?" view without
+        // re-iterating the symbol vec. Matches the pattern used by
+        // every other adapter.
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
+
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
             symbols,
@@ -350,8 +337,7 @@ impl LanguageAdapter for GoAdapter {
         let root = tree.root_node();
         let source_bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // Direct calls: `foo(...)`. Method calls: `obj.bar(...)` —

--- a/src/semantic/adapters/java.rs
+++ b/src/semantic/adapters/java.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_first_line};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for Java.
 ///
@@ -20,29 +21,22 @@ pub struct JavaAdapter;
 
 impl JavaAdapter {
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        // Use prefix up to the body (block / class_body / interface_body)
-        // when available; otherwise first line.
-        for field in ["body"] {
-            if let Some(body) = n.child_by_field_name(field) {
-                return String::from_utf8_lossy(&s[n.start_byte()..body.start_byte()])
-                    .trim()
-                    .to_string();
-            }
+        // Prefer the body field (set by tree-sitter-java for
+        // class/interface/method bodies); fall back to walking
+        // children for any *_body node (covers enum_body which
+        // doesn't always expose the field); finally a first-line
+        // cap as the universal fallback.
+        if let Some(body) = n.child_by_field_name("body") {
+            return String::from_utf8_lossy(&s[n.start_byte()..body.start_byte()])
+                .trim()
+                .to_string();
         }
-        // Fall back to walking children for any *_body node.
         for i in 0..n.named_child_count() {
             if let Some(c) = n.named_child(i)
                 && (c.kind().ends_with("_body") || c.kind() == "block")
@@ -52,13 +46,7 @@ impl JavaAdapter {
                     .to_string();
             }
         }
-        let first = self.text(n, s).lines().next().unwrap_or("");
-        if first.chars().count() > 80 {
-            let p: String = first.chars().take(80).collect();
-            format!("{p}…")
-        } else {
-            first.to_string()
-        }
+        signature_first_line(n, s)
     }
 
     /// Examines the `modifiers` child (if any) for the literal token
@@ -236,26 +224,11 @@ impl JavaAdapter {
                 imports.push(Import {
                     names: vec![path.clone()],
                     source: path,
+                    kind: ImportKind::Qualified,
                 });
                 return;
             }
         }
-    }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
     }
 }
 
@@ -276,7 +249,6 @@ impl LanguageAdapter for JavaAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
         if root.has_error() {
             warnings.push("tree-sitter reported syntax errors".to_string());
@@ -297,6 +269,12 @@ impl LanguageAdapter for JavaAdapter {
                 _ => {}
             }
         }
+
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
 
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
@@ -323,8 +301,7 @@ impl LanguageAdapter for JavaAdapter {
         let root = tree.root_node();
         let bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // `method_invocation` covers both bare `foo()` and `obj.foo()`.

--- a/src/semantic/adapters/python.rs
+++ b/src/semantic/adapters/python.rs
@@ -4,22 +4,17 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 pub struct PythonAdapter;
 
 impl PythonAdapter {
-    fn node_text<'a>(&self, node: Node<'a>, source: &'a [u8]) -> &'a str {
-        node.utf8_text(source).unwrap_or("")
+    fn node_text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
+        node_text(n, s)
     }
-
-    fn make_range(&self, node: Node) -> ByteRange {
-        ByteRange {
-            start_byte: node.start_byte(),
-            end_byte: node.end_byte(),
-            start_line: node.start_position().row + 1,
-            end_line: node.end_position().row + 1,
-        }
+    fn make_range(&self, n: Node) -> ByteRange {
+        ByteRange::from(n)
     }
 
     fn signature_from_node(&self, node: Node, source: &[u8]) -> String {
@@ -131,6 +126,7 @@ impl PythonAdapter {
                     imports.push(Import {
                         names,
                         source: module,
+                        kind: ImportKind::Module,
                     });
                 }
                 "import_from_statement" => {
@@ -155,6 +151,7 @@ impl PythonAdapter {
                     imports.push(Import {
                         names,
                         source: module,
+                        kind: ImportKind::Module,
                     });
                 }
                 "function_definition" | "decorated_definition" => {
@@ -210,22 +207,6 @@ impl PythonAdapter {
             }
         }
     }
-
-    fn find_node_at_range<'a>(&self, node: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if node.start_byte() == start && node.end_byte() == end {
-            return Some(node);
-        }
-        for i in 0..node.named_child_count() {
-            if let Some(child) = node.named_child(i) {
-                if child.start_byte() <= start && child.end_byte() >= end {
-                    if let Some(found) = self.find_node_at_range(child, start, end) {
-                        return Some(found);
-                    }
-                }
-            }
-        }
-        None
-    }
 }
 
 impl LanguageAdapter for PythonAdapter {
@@ -256,6 +237,15 @@ impl LanguageAdapter for PythonAdapter {
 
         self.walk_top_level(root, source_bytes, &mut symbols, &mut imports, &mut exports);
 
+        if exports.is_empty() {
+            exports.extend(
+                symbols
+                    .iter()
+                    .filter(|s| s.is_exported)
+                    .map(|s| s.name.clone()),
+            );
+        }
+
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
             symbols,
@@ -283,8 +273,7 @@ impl LanguageAdapter for PythonAdapter {
         let root = tree.root_node();
         let source_bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         let query_str = "(call function: (identifier) @callee)";

--- a/src/semantic/adapters/ruby.rs
+++ b/src/semantic/adapters/ruby.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_first_line};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for Ruby.
 ///
@@ -23,27 +24,13 @@ pub struct RubyAdapter;
 
 impl RubyAdapter {
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
-    /// First line of the node's text, capped at 80 chars.
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        let first = self.text(n, s).lines().next().unwrap_or("");
-        if first.chars().count() > 80 {
-            let p: String = first.chars().take(80).collect();
-            format!("{p}…")
-        } else {
-            first.to_string()
-        }
+        signature_first_line(n, s)
     }
 
     fn method_name<'a>(&self, n: Node<'a>, s: &'a [u8]) -> Option<String> {
@@ -250,26 +237,11 @@ impl RubyAdapter {
                     imports.push(Import {
                         names: vec![path.clone()],
                         source: path,
+                        kind: ImportKind::Module,
                     });
                 }
             }
         }
-    }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
     }
 }
 
@@ -290,7 +262,6 @@ impl LanguageAdapter for RubyAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
 
         if root.has_error() {
@@ -304,6 +275,12 @@ impl LanguageAdapter for RubyAdapter {
             self.walk_top(c, bytes, &mut symbols, None);
             self.maybe_import(c, bytes, &mut imports);
         }
+
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
 
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
@@ -330,8 +307,7 @@ impl LanguageAdapter for RubyAdapter {
         let root = tree.root_node();
         let bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // `(call method: (identifier) @callee)` catches `obj.foo`

--- a/src/semantic/adapters/rust.rs
+++ b/src/semantic/adapters/rust.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text, signature_up_to_body};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 /// Tree-sitter adapter for Rust. dirge itself is written in Rust;
 /// this was a glaring gap — list_symbols / find_callers worked for
@@ -18,33 +19,13 @@ pub struct RustAdapter;
 
 impl RustAdapter {
     fn text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
-        n.utf8_text(s).unwrap_or("")
+        node_text(n, s)
     }
-
     fn range(&self, n: Node) -> ByteRange {
-        ByteRange {
-            start_byte: n.start_byte(),
-            end_byte: n.end_byte(),
-            start_line: n.start_position().row + 1,
-            end_line: n.end_position().row + 1,
-        }
+        ByteRange::from(n)
     }
-
     fn signature(&self, n: Node, s: &[u8]) -> String {
-        // Function signature is everything up to the body's `{`.
-        if let Some(body) = n.child_by_field_name("body") {
-            return String::from_utf8_lossy(&s[n.start_byte()..body.start_byte()])
-                .trim()
-                .to_string();
-        }
-        // Fall back to first line capped at 80.
-        let first = self.text(n, s).lines().next().unwrap_or("");
-        if first.chars().count() > 80 {
-            let p: String = first.chars().take(80).collect();
-            format!("{p}…")
-        } else {
-            first.to_string()
-        }
+        signature_up_to_body(n, s)
     }
 
     /// True if any direct child is a `visibility_modifier`.
@@ -360,28 +341,13 @@ impl RustAdapter {
                     imports.push(Import {
                         names: vec![path.clone()],
                         source: path,
+                        kind: ImportKind::Qualified,
                     });
                     break;
                 }
                 _ => {}
             }
         }
-    }
-
-    fn find_node_at_range<'a>(&self, n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if n.start_byte() == start && n.end_byte() == end {
-            return Some(n);
-        }
-        for i in 0..n.named_child_count() {
-            if let Some(c) = n.named_child(i)
-                && c.start_byte() <= start
-                && c.end_byte() >= end
-                && let Some(f) = self.find_node_at_range(c, start, end)
-            {
-                return Some(f);
-            }
-        }
-        None
     }
 }
 
@@ -402,7 +368,6 @@ impl LanguageAdapter for RustAdapter {
 
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
-        let exports = Vec::new();
         let mut warnings = Vec::new();
 
         if root.has_error() {
@@ -440,6 +405,14 @@ impl LanguageAdapter for RustAdapter {
             }
         }
 
+        // Populate `exports` from is_exported symbols (each adapter
+        // does this so consumers don't re-iterate the symbol vec).
+        let exports: Vec<String> = symbols
+            .iter()
+            .filter(|s| s.is_exported)
+            .map(|s| s.name.clone())
+            .collect();
+
         Ok(ExtractedFile {
             file_path: file_path.to_path_buf(),
             symbols,
@@ -465,8 +438,7 @@ impl LanguageAdapter for RustAdapter {
         let root = tree.root_node();
         let bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         // Direct call: `foo(...)`. Method call: `obj.bar(...)` —

--- a/src/semantic/adapters/typescript.rs
+++ b/src/semantic/adapters/typescript.rs
@@ -4,7 +4,8 @@ use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query};
 
 use crate::semantic::adapter::LanguageAdapter;
-use crate::semantic::types::{ByteRange, ExtractedFile, Import, Symbol, SymbolKind};
+use crate::semantic::common::{find_node_at_range, node_text};
+use crate::semantic::types::{ByteRange, ExtractedFile, Import, ImportKind, Symbol, SymbolKind};
 
 pub struct TypescriptAdapter;
 
@@ -20,17 +21,11 @@ impl TypescriptAdapter {
         }
     }
 
-    fn node_text<'a>(&self, node: Node<'a>, source: &'a [u8]) -> &'a str {
-        node.utf8_text(source).unwrap_or("")
+    fn node_text<'a>(&self, n: Node<'a>, s: &'a [u8]) -> &'a str {
+        node_text(n, s)
     }
-
-    fn make_range(&self, node: Node) -> ByteRange {
-        ByteRange {
-            start_byte: node.start_byte(),
-            end_byte: node.end_byte(),
-            start_line: node.start_position().row + 1,
-            end_line: node.end_position().row + 1,
-        }
+    fn make_range(&self, n: Node) -> ByteRange {
+        ByteRange::from(n)
     }
 
     fn signature_from_node(&self, node: Node, source: &[u8]) -> String {
@@ -71,6 +66,7 @@ impl TypescriptAdapter {
         Some(Import {
             names,
             source: module_path,
+            kind: ImportKind::Qualified,
         })
     }
 
@@ -328,22 +324,6 @@ impl TypescriptAdapter {
             _ => {}
         }
     }
-
-    fn find_node_at_range<'a>(&self, node: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
-        if node.start_byte() == start && node.end_byte() == end {
-            return Some(node);
-        }
-        for i in 0..node.named_child_count() {
-            if let Some(child) = node.named_child(i) {
-                if child.start_byte() <= start && child.end_byte() >= end {
-                    if let Some(found) = self.find_node_at_range(child, start, end) {
-                        return Some(found);
-                    }
-                }
-            }
-        }
-        None
-    }
 }
 
 impl LanguageAdapter for TypescriptAdapter {
@@ -408,8 +388,7 @@ impl LanguageAdapter for TypescriptAdapter {
         let root = tree.root_node();
         let source_bytes = source.as_bytes();
 
-        let target = self
-            .find_node_at_range(root, range.start_byte, range.end_byte)
+        let target = find_node_at_range(root, range.start_byte, range.end_byte)
             .ok_or("Could not find node at given range")?;
 
         let query_str = "(call_expression function: (identifier) @callee)";

--- a/src/semantic/common.rs
+++ b/src/semantic/common.rs
@@ -1,0 +1,127 @@
+//! Shared helpers used by every `LanguageAdapter` impl.
+//!
+//! Each adapter previously defined its own `text()`, `range()`,
+//! `signature_line()`, and `find_node_at_range()` — 7 copies of the
+//! same 4 functions with mild drift between them. This module is the
+//! one place all adapters call into.
+
+use tree_sitter::Node;
+
+/// Decode a node's source text. Falls back to `""` on UTF-8 errors
+/// (rare in practice — tree-sitter parses bytes, but the source
+/// could contain malformed sequences if a file slipped through the
+/// binary-detection guard).
+///
+/// The fallback is logged at `debug` so users running with
+/// `--verbose` (which enables `dirge=debug`) see them, while
+/// default-log users don't get flooded by them. UTF-8 failures
+/// here aren't load-bearing: an empty symbol name is filtered out
+/// downstream; this log line exists purely so the issue surfaces
+/// when someone is investigating "why is this symbol missing".
+pub fn node_text<'a>(node: Node<'a>, source: &'a [u8]) -> &'a str {
+    match node.utf8_text(source) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(
+                start = node.start_byte(),
+                end = node.end_byte(),
+                kind = node.kind(),
+                error = %e,
+                "semantic: utf8_text failed; falling back to empty string",
+            );
+            ""
+        }
+    }
+}
+
+/// Walk a node's descendants looking for one whose byte range
+/// exactly matches `[start, end)`. Used by `find_callees_in_range`
+/// to re-find the target after a fresh parse. Returns `None` if no
+/// match exists.
+///
+/// **Note on ambiguity:** if multiple nested nodes span the same
+/// range (e.g., a `function_item` and its inner `block`), this
+/// returns the OUTER node (first match in depth-first order). That
+/// matches what callers want: a query over the function body is
+/// rooted at the function node, not at its inner block — the query
+/// itself filters to the relevant constructs.
+pub fn find_node_at_range<'a>(n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
+    if n.start_byte() == start && n.end_byte() == end {
+        return Some(n);
+    }
+    for i in 0..n.named_child_count() {
+        if let Some(c) = n.named_child(i)
+            && c.start_byte() <= start
+            && c.end_byte() >= end
+            && let Some(f) = find_node_at_range(c, start, end)
+        {
+            return Some(f);
+        }
+    }
+    None
+}
+
+/// First line of `node`'s text, capped at 80 display chars (with an
+/// ellipsis if longer). Used for symbol signatures — long
+/// signatures clutter the list_symbols output and don't help the
+/// LLM understand the symbol.
+///
+/// Note: counts CHARS not bytes (UTF-8-safe), but doesn't account
+/// for display width (emoji / CJK). Source code is overwhelmingly
+/// ASCII so the simpler char-count is fine.
+pub fn signature_first_line(node: Node, source: &[u8]) -> String {
+    let text = node_text(node, source);
+    let first = text.lines().next().unwrap_or(text);
+    if first.chars().count() > 80 {
+        let prefix: String = first.chars().take(80).collect();
+        format!("{prefix}…")
+    } else {
+        first.to_string()
+    }
+}
+
+/// Build a signature from the node's leading prefix up to its body.
+/// For function-shaped nodes (`function_definition`, `function_item`,
+/// `method_declaration`, …) the body is exposed via a `body` field
+/// name; this returns everything before it, trimmed. Falls back to
+/// the first-line-capped form when no `body` field exists. Used by
+/// adapters whose signature concept is "the declarator + return
+/// type, minus the body" — Go, Java, C, C++, Rust.
+pub fn signature_up_to_body(node: Node, source: &[u8]) -> String {
+    if let Some(body) = node.child_by_field_name("body") {
+        return String::from_utf8_lossy(&source[node.start_byte()..body.start_byte()])
+            .trim()
+            .to_string();
+    }
+    signature_first_line(node, source)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::semantic::types::ByteRange;
+    use tree_sitter::Parser;
+
+    /// `ByteRange::from(Node)` produces the right line numbers
+    /// (1-based) and byte offsets. Sanity check the shared
+    /// converter that replaces 7 copies of the same body.
+    #[test]
+    fn byte_range_from_node_uses_1_based_lines() {
+        // Use any registered grammar; clojure is always built in
+        // the test feature set.
+        #[cfg(feature = "semantic-clojure")]
+        {
+            let mut p = Parser::new();
+            let lang: tree_sitter::Language = tree_sitter_clojure::LANGUAGE.into();
+            p.set_language(&lang).unwrap();
+            let src = "\n(defn foo [] :ok)\n";
+            let t = p.parse(src, None).unwrap();
+            // First named child of `source` is the defn list_lit.
+            let list_lit = t.root_node().named_child(0).unwrap();
+            let range = ByteRange::from(list_lit);
+            // defn is on line 2 (1-based) after the leading \n.
+            assert_eq!(range.start_line, 2);
+            assert_eq!(range.end_line, 2);
+            assert_eq!(range.start_byte, 1);
+        }
+    }
+}

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -1,5 +1,6 @@
 mod adapter;
 pub mod adapters;
+pub(crate) mod common;
 mod index;
 pub mod types;
 

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -32,6 +32,18 @@ pub struct ByteRange {
     pub end_line: usize,
 }
 
+#[cfg(feature = "semantic")]
+impl From<tree_sitter::Node<'_>> for ByteRange {
+    fn from(n: tree_sitter::Node) -> Self {
+        ByteRange {
+            start_byte: n.start_byte(),
+            end_byte: n.end_byte(),
+            start_line: n.start_position().row + 1,
+            end_line: n.end_position().row + 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Symbol {
     pub kind: SymbolKind,
@@ -42,11 +54,32 @@ pub struct Symbol {
     pub parent_class: Option<String>,
 }
 
+/// What kind of import path this entry carries. Different
+/// languages express imports in incompatible textual forms
+/// (`stdio.h`, `clojure.string`, `std::sync::Arc`, …); the
+/// `kind` lets cross-language queries (e.g., "what files import
+/// this module?") normalize without re-parsing the string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum ImportKind {
+    /// C / C++ preprocessor `#include` — local or system header.
+    Header,
+    /// Single-token module names: Go's `"fmt"`, Python's
+    /// `os.path`, Ruby's `'json'`, Clojure's `clojure.string`.
+    /// Hierarchy is segment-based (dot or `/`).
+    Module,
+    /// Fully-qualified names with explicit scoping syntax:
+    /// Java's `java.util.List`, Rust's `std::sync::Arc`,
+    /// TypeScript's relative-path-style imports.
+    Qualified,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Import {
     pub names: Vec<String>,
     pub source: String,
+    pub kind: ImportKind,
 }
 
 #[derive(Debug, Clone)]
@@ -55,6 +88,10 @@ pub struct ExtractedFile {
     pub file_path: PathBuf,
     pub symbols: Vec<Symbol>,
     pub imports: Vec<Import>,
+    /// Names exported from this file. Derived from the symbol
+    /// list: every symbol with `is_exported=true` contributes its
+    /// `name`. Pre-computed at extract time so consumers don't
+    /// have to re-iterate the symbol vec.
     pub exports: Vec<String>,
     pub warnings: Vec<String>,
     pub mtime: std::time::SystemTime,


### PR DESCRIPTION
Four cross-cutting cleanups across all 9 semantic adapters. (1) Shared `common.rs` for `node_text` / `find_node_at_range` / signature builders — ~150 lines of duplication gone; `ByteRange::from(Node)` replaces 7 hand-written constructors. (2) `ImportKind` enum (Header/Module/Qualified) so cross-language import queries can normalize. (3) UTF-8 fallback now logs at `debug` (visible under `--verbose`). (4) `exports` field populated from `is_exported` symbols. 3 new regression tests. 812 all-features pass (was 809).