### PR TITLE
fix(lsp): didClose on shutdown + extensions config override (C7, H8)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,16 @@ pub struct LspServerConfig {
     pub disabled: Option<bool>,
 }
 
+#[cfg(feature = "lsp")]
+impl crate::lsp::server::AsExtensionOverride for LspServerConfig {
+    fn extensions(&self) -> Option<&[String]> {
+        self.extensions.as_deref()
+    }
+    fn disabled(&self) -> bool {
+        self.disabled.unwrap_or(false)
+    }
+}
+
 /// `lsp = true`  → enable built-in servers with default commands.
 /// `lsp = false` → disable LSP entirely.
 /// `lsp = { server-id = { … } }` → enable defaults, overriding the named

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -178,6 +178,55 @@ impl LspClient {
         Ok(version)
     }
 
+    /// Send `textDocument/didClose` for one file and drop the
+    /// associated server-side state on our end (version, push +
+    /// pull diagnostics, last-push timestamp). Per the LSP spec
+    /// the server is free to discard its parse-tree / cached
+    /// analyses once it receives this notification — without it
+    /// servers retain everything we've ever opened, growing
+    /// unbounded over a long session.
+    ///
+    /// Returns Ok even if the file wasn't open; sending a stray
+    /// didClose is harmless per the spec.
+    pub async fn notify_close(&self, path: &Path) -> Result<(), LspError> {
+        let abs = match tokio::fs::canonicalize(path).await {
+            Ok(p) => p,
+            Err(_) => path.to_path_buf(),
+        };
+        let was_open;
+        {
+            let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            was_open = state.files.remove(&abs).is_some();
+            state.push.remove(&abs);
+            state.pull.remove(&abs);
+            state.last_push_at.remove(&abs);
+        }
+        if was_open {
+            let uri = path_to_file_uri_string(&abs);
+            self.rpc
+                .notify(
+                    "textDocument/didClose",
+                    json!({ "textDocument": { "uri": uri } }),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Close every file currently tracked by this client. Used at
+    /// session shutdown to release server-side per-file state
+    /// before the process exits. Failures are swallowed: shutdown
+    /// is best-effort.
+    pub async fn close_all(&self) {
+        let paths: Vec<PathBuf> = {
+            let state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            state.files.keys().cloned().collect()
+        };
+        for p in paths {
+            let _ = self.notify_close(&p).await;
+        }
+    }
+
     /// Merged + deduplicated diagnostics for a single file. Combines push
     /// (server-volunteered) and pull (server requested explicitly) state.
     pub fn diagnostics_for(&self, path: &Path) -> Vec<Diagnostic> {
@@ -416,6 +465,49 @@ mod tests {
         let frame = from_client.recv().await.unwrap();
         assert_eq!(frame["params"]["textDocument"]["text"], "hello world\n");
         std::fs::remove_file(&path).ok();
+    }
+
+    /// Regression: `notify_close` emits `textDocument/didClose` and
+    /// removes the per-file state so a subsequent `notify_open`
+    /// starts a fresh didOpen (version 0) rather than a didChange.
+    #[tokio::test]
+    async fn notify_close_emits_did_close_and_clears_state() {
+        let (client, mut from_client, _to) = pair().await;
+        let path = tempfile_with("close-flow", "fn main() {}\n");
+        client.notify_open(&path).await.unwrap();
+        let _open_frame = from_client.recv().await.unwrap();
+
+        client.notify_close(&path).await.unwrap();
+        let close_frame = from_client.recv().await.unwrap();
+        assert_eq!(close_frame["method"], "textDocument/didClose");
+        // Re-open after close must send a fresh didOpen (not didChange)
+        // because the file state was dropped.
+        client.notify_open(&path).await.unwrap();
+        let reopen_frame = from_client.recv().await.unwrap();
+        assert_eq!(reopen_frame["method"], "textDocument/didOpen");
+        assert_eq!(reopen_frame["params"]["textDocument"]["version"], 0);
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// `close_all` sends didClose for every tracked file.
+    #[tokio::test]
+    async fn close_all_emits_did_close_for_every_open_file() {
+        let (client, mut from_client, _to) = pair().await;
+        let p1 = tempfile_with("close-all-a", "a\n");
+        let p2 = tempfile_with("close-all-b", "b\n");
+        client.notify_open(&p1).await.unwrap();
+        client.notify_open(&p2).await.unwrap();
+        // Drain the didOpens.
+        let _ = from_client.recv().await.unwrap();
+        let _ = from_client.recv().await.unwrap();
+
+        client.close_all().await;
+        let f1 = from_client.recv().await.unwrap();
+        let f2 = from_client.recv().await.unwrap();
+        assert_eq!(f1["method"], "textDocument/didClose");
+        assert_eq!(f2["method"], "textDocument/didClose");
+        std::fs::remove_file(&p1).ok();
+        std::fs::remove_file(&p2).ok();
     }
 
     // Push diagnostic flow: server fires a textDocument/publishDiagnostics

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -168,11 +168,23 @@ pub struct LspManager {
 
 impl LspManager {
     pub fn new(spawner: Arc<dyn Spawner>, worktree: impl Into<PathBuf>) -> Self {
+        Self::with_servers(spawner, worktree, server::builtin_servers())
+    }
+
+    /// Construct an `LspManager` with an explicit server set —
+    /// the host calls this when the user has per-server config
+    /// overrides (extensions, disabled, etc.). The default `new`
+    /// just delegates here with the unmodified builtin list.
+    pub fn with_servers(
+        spawner: Arc<dyn Spawner>,
+        worktree: impl Into<PathBuf>,
+        servers: Vec<ServerInfo>,
+    ) -> Self {
         Self {
             spawner,
             worktree: worktree.into(),
             state: Arc::new(Mutex::new(ManagerState::default())),
-            servers: Arc::new(server::builtin_servers()),
+            servers: Arc::new(servers),
         }
     }
 
@@ -438,6 +450,26 @@ impl LspManager {
             .filter(|(_, s)| s.still_cooling())
             .map(|((root, id), _)| (id.clone(), root.clone()))
             .collect()
+    }
+
+    /// Fan-out `textDocument/didClose` across every attached
+    /// client for every file each one has open. Called once at
+    /// session shutdown so LSP servers can release per-file
+    /// state — without this, a long session that touches dozens
+    /// of files leaks server-side parse trees / diagnostic caches
+    /// for the lifetime of the server process.
+    ///
+    /// Best-effort: a server that's already gone won't be
+    /// re-contacted, and individual `notify_close` failures are
+    /// swallowed inside the client.
+    pub async fn close_all_files(&self) {
+        let entries: Vec<_> = {
+            let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.clients.values().cloned().collect()
+        };
+        for entry in entries {
+            entry.client.close_all().await;
+        }
     }
 
     /// Aggregated diagnostics across all attached clients. Same key/dedupe

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -11,7 +11,11 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct ServerInfo {
     pub id: &'static str,
-    pub extensions: &'static [&'static str],
+    /// Extensions claimed by this server. Owned `Vec<String>` (not
+    /// `&'static [&'static str]`) so user config can extend or
+    /// override the builtin list — see
+    /// `apply_extension_overrides`.
+    pub extensions: Vec<String>,
     /// Walks up from `file` (bounded by `stop_at`) to locate the workspace
     /// root. Returns `None` when no plausible root exists (signals "don't
     /// attach this server to this file").
@@ -149,28 +153,165 @@ fn clojure_root(file: &Path, stop_at: &Path) -> Option<PathBuf> {
 /// breaking when an extension is claimed by more than one server — earlier
 /// entries are tried first.
 pub fn builtin_servers() -> Vec<ServerInfo> {
+    let owned = |xs: &[&str]| xs.iter().map(|s| s.to_string()).collect::<Vec<_>>();
     vec![
         ServerInfo {
             id: "rust",
-            extensions: &["rs"],
+            extensions: owned(&["rs"]),
             root: rust_workspace_root,
         },
         ServerInfo {
             id: "typescript",
-            extensions: &["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+            extensions: owned(&["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]),
             root: typescript_root,
         },
         ServerInfo {
             id: "pyright",
-            extensions: &["py", "pyi"],
+            extensions: owned(&["py", "pyi"]),
             root: pyright_root,
         },
         ServerInfo {
             id: "clojure-lsp",
-            extensions: &["clj", "cljs", "cljc", "edn", "bb"],
+            extensions: owned(&["clj", "cljs", "cljc", "edn", "bb"]),
             root: clojure_root,
         },
     ]
+}
+
+/// Apply config-time per-server overrides. For each `(server_id,
+/// override)` in `overrides`, if `override.extensions` is set,
+/// REPLACE the builtin's claimed extensions (matches the
+/// principle-of-least-surprise: a user-listed extension list is
+/// the full list they want, not an additive one). Skips overrides
+/// for unknown server ids — those are silently ignored today
+/// since we have no out-of-tree server registry. `disabled` is
+/// honored by removing the entry entirely (matches the spawn
+/// path's `disabled: true` semantics).
+///
+/// Lowercases user-supplied extensions to match the
+/// `servers_for_extension` lookup, which also lowercases input.
+pub fn apply_extension_overrides<C>(
+    servers: &mut Vec<ServerInfo>,
+    overrides: &std::collections::HashMap<String, C>,
+) where
+    C: AsExtensionOverride,
+{
+    let mut to_remove: Vec<String> = Vec::new();
+    for (id, ovr) in overrides {
+        if ovr.disabled() {
+            to_remove.push(id.clone());
+            continue;
+        }
+        if let Some(exts) = ovr.extensions() {
+            let normalized: Vec<String> = exts
+                .iter()
+                .map(|e| e.trim_start_matches('.').to_lowercase())
+                .collect();
+            if let Some(s) = servers.iter_mut().find(|s| s.id == id) {
+                s.extensions = normalized;
+            }
+        }
+    }
+    servers.retain(|s| !to_remove.contains(&s.id.to_string()));
+}
+
+/// Shim trait so `apply_extension_overrides` works against the
+/// real `LspServerConfig` (in `config/mod.rs`) AND against test
+/// fixtures without dragging the config module into here.
+pub trait AsExtensionOverride {
+    fn extensions(&self) -> Option<&[String]>;
+    fn disabled(&self) -> bool;
+}
+
+#[cfg(test)]
+mod override_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct StubOverride {
+        extensions: Option<Vec<String>>,
+        disabled: bool,
+    }
+    impl AsExtensionOverride for StubOverride {
+        fn extensions(&self) -> Option<&[String]> {
+            self.extensions.as_deref()
+        }
+        fn disabled(&self) -> bool {
+            self.disabled
+        }
+    }
+
+    /// Regression: `apply_extension_overrides` actually replaces a
+    /// server's claimed extensions when the user config specifies
+    /// `extensions: [...]`. Previously this field was parsed but
+    /// silently ignored.
+    #[test]
+    fn extensions_override_replaces_builtin_list() {
+        let mut servers = builtin_servers();
+        let mut overrides: HashMap<String, StubOverride> = HashMap::new();
+        overrides.insert(
+            "rust".to_string(),
+            StubOverride {
+                extensions: Some(vec!["rs".to_string(), "rlib".to_string()]),
+                disabled: false,
+            },
+        );
+        apply_extension_overrides(&mut servers, &overrides);
+        let rust = servers.iter().find(|s| s.id == "rust").unwrap();
+        assert_eq!(rust.extensions, vec!["rs".to_string(), "rlib".to_string()]);
+    }
+
+    /// `disabled: true` removes the entry entirely (matches spawn-command path).
+    #[test]
+    fn disabled_override_removes_server() {
+        let mut servers = builtin_servers();
+        let mut overrides: HashMap<String, StubOverride> = HashMap::new();
+        overrides.insert(
+            "rust".to_string(),
+            StubOverride {
+                extensions: None,
+                disabled: true,
+            },
+        );
+        apply_extension_overrides(&mut servers, &overrides);
+        assert!(servers.iter().all(|s| s.id != "rust"));
+    }
+
+    /// Unknown server ids are silently ignored — there's no
+    /// out-of-tree server registry yet.
+    #[test]
+    fn unknown_server_override_is_silently_ignored() {
+        let mut servers = builtin_servers();
+        let original_len = servers.len();
+        let mut overrides: HashMap<String, StubOverride> = HashMap::new();
+        overrides.insert(
+            "kotlin-lsp".to_string(),
+            StubOverride {
+                extensions: Some(vec!["kt".to_string()]),
+                disabled: false,
+            },
+        );
+        apply_extension_overrides(&mut servers, &overrides);
+        assert_eq!(servers.len(), original_len);
+    }
+
+    /// User-supplied extensions are normalized (leading-dot
+    /// stripped, lowercased) to match `servers_for_extension`.
+    #[test]
+    fn override_extensions_are_normalized() {
+        let mut servers = builtin_servers();
+        let mut overrides: HashMap<String, StubOverride> = HashMap::new();
+        overrides.insert(
+            "rust".to_string(),
+            StubOverride {
+                extensions: Some(vec![".RS".to_string(), "Rlib".to_string()]),
+                disabled: false,
+            },
+        );
+        apply_extension_overrides(&mut servers, &overrides);
+        let rust = servers.iter().find(|s| s.id == "rust").unwrap();
+        assert_eq!(rust.extensions, vec!["rs".to_string(), "rlib".to_string()]);
+    }
 }
 
 /// Returns the descriptors claiming the given file extension (no leading dot,
@@ -179,7 +320,7 @@ pub fn servers_for_extension(ext: &str) -> Vec<ServerInfo> {
     let ext = ext.trim_start_matches('.').to_lowercase();
     builtin_servers()
         .into_iter()
-        .filter(|s| s.extensions.iter().any(|e| *e == ext))
+        .filter(|s| s.extensions.iter().any(|e| e == &ext))
         .collect()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,18 @@ fn build_channels(cli: &cli::Cli, cfg: &config::Config) -> Channels {
         let worktree = std::env::current_dir().unwrap_or_else(|_| ".".into());
         let commands = compile_lsp_commands(cfg);
         let spawner = std::sync::Arc::new(ProcessSpawner::new(commands));
-        Some(std::sync::Arc::new(LspManager::new(spawner, worktree)))
+        // Apply per-server config overrides (extensions, disabled).
+        // Without this, user config like
+        //   "lsp": { "rust": { "extensions": ["rs", "rlib"] } }
+        // was silently ignored — the manager always used the
+        // builtin list.
+        let mut servers = crate::lsp::server::builtin_servers();
+        if let Some(lsp_cfg) = &cfg.lsp {
+            crate::lsp::server::apply_extension_overrides(&mut servers, lsp_cfg.server_overrides());
+        }
+        Some(std::sync::Arc::new(LspManager::with_servers(
+            spawner, worktree, servers,
+        )))
     } else {
         None
     };
@@ -159,11 +170,9 @@ fn build_channels(cli: &cli::Cli, cfg: &config::Config) -> Channels {
 /// and applying per-server overrides from user config. A `disabled = true`
 /// override removes the entry; any non-empty `command` replaces the default.
 ///
-/// Known limitation: `extensions` on the override is currently ignored. The
-/// claimed-extensions list lives in the static `builtin_servers()` registry
-/// (`lsp/server.rs`) — making it instance-overridable requires plumbing a
-/// per-session server set down through `LspManager`. Follow-up; users who
-/// need new extensions today must edit `server.rs`.
+/// Extensions overrides are applied separately in `build_channels` via
+/// `lsp::server::apply_extension_overrides` since they live on the
+/// per-session `ServerInfo` registry, not on the spawn-command map.
 #[cfg(feature = "lsp")]
 fn compile_lsp_commands(cfg: &config::Config) -> std::collections::HashMap<String, ProcessCommand> {
     let mut commands = ProcessSpawner::default_commands();
@@ -628,6 +637,12 @@ async fn main() -> anyhow::Result<()> {
         if !initial_msg.is_empty() {
             session.add_message(MessageRole::User, &initial_msg);
         }
+        // Clone the LSP manager Arc so we can call didClose
+        // cleanup after `run_interactive` has consumed its handle.
+        // The Arc is cheap to clone; both copies point at the same
+        // manager state, which is what we need for shutdown.
+        #[cfg(feature = "lsp")]
+        let lsp_manager_for_shutdown = lsp_manager.clone();
         ui::run_interactive(
             client,
             agent,
@@ -656,6 +671,18 @@ async fn main() -> anyhow::Result<()> {
             dialog_rx,
         )
         .await?;
+
+        // Best-effort `textDocument/didClose` for every file each
+        // LSP server saw this session. Servers retain parse trees
+        // + diagnostic caches keyed on open files; without this
+        // cleanup a long session leaves them holding all that
+        // state for the lifetime of their process. The notify is
+        // fire-and-forget; individual failures are swallowed
+        // inside `close_all_files`.
+        #[cfg(feature = "lsp")]
+        if let Some(mgr) = lsp_manager_for_shutdown.as_ref() {
+            mgr.close_all_files().await;
+        }
     }
 
     #[cfg(feature = "mcp")]


### PR DESCRIPTION
Closes the two remaining audit items. (C7) Added `notify_close` + `close_all` on LspClient; `LspManager::close_all_files` fans across attached clients on session shutdown — fixes unbounded server-side state retention. (H8) `LspServerConfig.extensions` now actually wired through: `ServerInfo.extensions` is owned Vec<String>; new `apply_extension_overrides` replaces builtin lists, removes `disabled: true` servers, normalizes input. 6 new tests, 736 plugin / 610 default pass.