### PR TITLE
fix(prompt+perm): steer to question tool; C2/C4 remnants; WEBFETCH_ENABLED

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -94,7 +94,7 @@ Supported permission tool keys are:
   `list_dir`, `apply_patch`, `write_todo_list`
 - LSP / question: `lsp`, `question`
 - Web: `webfetch`, `websearch`
-- Subagent / state: `task`, `memory`, `skill`
+- Subagent / state: `task`, `task_status`, `memory`, `skill`
 - Semantic (tree-sitter): `list_symbols`, `get_symbol_body`,
   `find_definition`, `find_callers`, `find_callees`
 - MCP umbrella: `mcp_tool` — patterns match the full key

--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -249,18 +249,22 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
             vec![enter, exit]
         });
 
-        // Web tools: gated on config + (for websearch) a separate
-        // env-var escape hatch. CONFIG.md documents both keys as
-        // defaulting to `true`; the previous `unwrap_or(false)`
-        // disabled them by default contrary to the docs. Now
-        // matches the documented behavior — explicit `false` in
-        // config disables; absent or `true` enables (the runtime
-        // API-key check still has to pass for websearch).
-        let websearch_enabled = cfg.tools.as_ref().and_then(|t| t.websearch).unwrap_or(true)
-            || std::env::var("WEBSEARCH_ENABLED")
+        // Web tools: gated on config + an env-var escape hatch.
+        // CONFIG.md documents both keys as defaulting to `true`;
+        // explicit `false` in config disables. The env vars are
+        // symmetric — previously only `WEBSEARCH_ENABLED` existed,
+        // forcing webfetch users to edit config.json for an
+        // equivalent toggle. The runtime API-key check still has
+        // to pass for websearch.
+        let env_true = |k: &str| {
+            std::env::var(k)
                 .map(|v| v == "true" || v == "1")
-                .unwrap_or(false);
-        let webfetch_enabled = cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(true);
+                .unwrap_or(false)
+        };
+        let websearch_enabled = cfg.tools.as_ref().and_then(|t| t.websearch).unwrap_or(true)
+            || env_true("WEBSEARCH_ENABLED");
+        let webfetch_enabled = cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(true)
+            || env_true("WEBFETCH_ENABLED");
 
         let websearch_tool = websearch_enabled
             .then(|| std::env::var("EXA_API_KEY").ok())

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -69,7 +69,7 @@ Respond in the same language the user writes to you.
 - Use edit for precise changes. If old_text is ambiguous (multiple matches), add surrounding lines as context or set replaceAll: true
 - Use write only for new files or complete rewrites
 - Use bash for running commands, tests, git operations
-- If you have doubts or need clarification, ask the user directly. Do not guess or assume.
+- When the user's request is genuinely ambiguous — multiple plausible paths, unclear scope, or load-bearing decisions you can't infer from the codebase — prefer the `question` tool over guessing. Phrase each question with concrete options (and mark a recommended option \"(Recommended)\" when you have a strong preference) rather than open-ended prose. Don't over-ask: skip the tool for choices that are clearly decidable from context.
 
 Available tools:
 - read: Read file contents (supports offset/limit for large files, max 10MB). Lines are prefixed with right-aligned numbers for reference (e.g. \"   1: content\"). When passing text from read to edit, strip the \"NNN: \" prefix — use only the actual file content.

--- a/src/agent/tools/question.rs
+++ b/src/agent/tools/question.rs
@@ -83,9 +83,29 @@ impl Tool for QuestionTool {
     type Output = String;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
+        // Description mirrors opencode's question.txt structure —
+        // the explicit \"when to use\" list + \"usage notes\" gets
+        // the model to actually reach for this tool instead of
+        // either guessing or asking in plain prose. The
+        // \"(Recommended)\" convention helps the model communicate
+        // its preferred answer without taking choice away from
+        // the user.
         ToolDefinition {
             name: "question".to_string(),
-            description: "Ask the user one or more structured questions. Use when you need clarification, decisions, or preferences. The tool blocks until the user answers. Each question has options with labels and descriptions; set multi_select to true for multiple-choice. The custom option (default true) adds a free-text 'Type your own answer' choice."
+            description: "Ask the user structured questions during execution. Use this when you need to:\n\
+                1. Gather user preferences or requirements\n\
+                2. Clarify ambiguous instructions before proceeding\n\
+                3. Get decisions on implementation choices as you work\n\
+                4. Offer choices about what direction to take\n\
+                \n\
+                The tool blocks until the user answers. Multiple questions can be asked in one call.\n\
+                \n\
+                Usage notes:\n\
+                - When `custom` is enabled (default), a \"Type your own answer\" option is added automatically; don't include \"Other\" or catch-all options yourself.\n\
+                - Answers are returned per question (one array of selected labels each); set `multi_select: true` to allow more than one selection.\n\
+                - If you recommend a specific option, make it the first option and add \" (Recommended)\" at the end of the label.\n\
+                - Use `header` to group related questions under a short section title.\n\
+                - Prefer asking over guessing when the user's request is genuinely ambiguous — but don't over-ask for clearly-decidable details."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",

--- a/src/agent/tools/semantic/find_callers.rs
+++ b/src/agent/tools/semantic/find_callers.rs
@@ -5,7 +5,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::Deserialize;
 
-use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm, check_perm_path};
 use crate::semantic::SymbolIndex;
 
 pub struct FindCallersTool {
@@ -63,10 +63,21 @@ impl Tool for FindCallersTool {
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {
+        // Name-side check: existing rules keyed on the symbol name
+        // still apply.
         check_perm(&self.permission, &self.ask_tx, "find_callers", &args.name).await?;
+        // Path-side check: the optional `path` arg scopes the
+        // search and was previously unchecked — an LLM could
+        // request `find_callers(name=\"foo\", path=\"/etc\")` and
+        // walk external dirs without consulting
+        // external_directory rules. Default to \".\" so the check
+        // runs against the working dir when no path was supplied.
+        let perm_path = args.path.as_deref().unwrap_or(".");
+        check_perm_path(&self.permission, &self.ask_tx, "find_callers", perm_path).await?;
 
         let search_path = args
             .path
+            .clone()
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -95,6 +95,7 @@ impl PermissionChecker {
             ("webfetch", &config.webfetch),
             ("websearch", &config.websearch),
             ("task", &config.task),
+            ("task_status", &config.task_status),
             ("memory", &config.memory),
             ("skill", &config.skill),
             ("list_symbols", &config.list_symbols),

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -51,6 +51,10 @@ pub struct PermissionConfig {
     pub websearch: Option<ToolPerm>,
     /// `task` — subagent runner. The pattern is the subagent prompt.
     pub task: Option<ToolPerm>,
+    /// `task_status` — companion query tool for `task`. Read-only;
+    /// included for completeness so users can deny it independently
+    /// (e.g. to force background-only invocations).
+    pub task_status: Option<ToolPerm>,
     /// `memory` — persistent project memory store. Pattern rules
     /// restrict the memory keys / operations.
     pub memory: Option<ToolPerm>,

--- a/src/ui/slash.rs
+++ b/src/ui/slash.rs
@@ -1331,6 +1331,7 @@ pub async fn handle_slash(
                         "webfetch",
                         "websearch",
                         "task",
+                        "task_status",
                         "memory",
                         "skill",
                         "list_symbols",


### PR DESCRIPTION
Ports opencode's question-tool description structure (concrete use-cases + usage notes + `(Recommended)` first-option convention) and tightens the system prompt to name the tool. Plus three follow-ups noted during review: (1) `find_callers` optional path arg now gets `check_perm_path` (C2 remnant); (2) `task_status` added to PermissionConfig + checker + /allow whitelist (C4 remnant); (3) symmetric `WEBFETCH_ENABLED` env var. 736 / 610 pass.