### PR TITLE
fix(acp): add missing ContextOverflow match arm

### DIFF
--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -260,6 +260,12 @@ async fn run_prompt(
                 // one does rather than panic on partial state.
                 break;
             }
+            AgentEvent::ContextOverflow { .. } => {
+                // ACP client is expected to set a generous context
+                // window; overflow here means the session is
+                // unsuitable for ACP use. Bail without retrying.
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Upstream/main added `AgentEvent::ContextOverflow` in audit H17 (auto-compact on context-length errors), but the ACP bridge match block in `src/extras/acp/mod.rs` wasn't updated. Compiling with `--features acp` fails with:

```
error[E0004]: non-exhaustive patterns: `AgentEvent::ContextOverflow { .. }` not covered
```

The ACP bridge treats `ContextOverflow` as terminal (bail, same as `Error` / `Interjected`) since there's no interactive user to compact the session.