### PR TITLE
feat(agent): phase 1 — storm breaker / repeat-loop detection

### DIFF
--- a/src/agent/agent_loop/mod.rs
+++ b/src/agent/agent_loop/mod.rs
@@ -39,6 +39,7 @@ pub mod rig_stream_factory;
 pub mod rig_tool;
 pub mod run;
 pub mod steering;
+pub mod storm;
 pub mod stream;
 pub mod tool;
 pub mod tool_input_repair;

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -47,6 +47,7 @@ use tokio::sync::mpsc;
 use super::message::{
     AssistantMessage, ContentBlock, LoopEvent, LoopMessage, StopReason, ToolResultMessage,
 };
+use super::storm::{StormBreaker, StormReport};
 use super::stream::{StreamFn, stream_assistant_response};
 use super::tool::AbortSignal;
 use super::tools::execute_tool_calls;
@@ -187,6 +188,11 @@ pub async fn run_loop(
 ) -> Vec<LoopMessage> {
     let mut first_turn = true;
 
+    // Storm breaker: tracks (tool_name, args) repeats to detect
+    // stuck-in-a-loop behavior. Reset each new user turn.
+    // Port of Reasonix `repair/index.ts:38-46` + `loop.ts:621`.
+    let mut storm = StormBreaker::default();
+
     // Pi line 167: initial steering poll.
     let mut pending_messages: Vec<LoopMessage> = match &config.get_steering_messages {
         Some(get) => get().await,
@@ -194,6 +200,10 @@ pub async fn run_loop(
     };
 
     'outer: loop {
+        // Storm: fresh intent on each new user turn.
+        // Port of Reasonix loop.ts:621 `this.repair.resetStorm()`.
+        storm.reset();
+        let mut turn_self_corrected = false;
         let mut has_more_tool_calls = true;
 
         // Pi line 174: INNER LOOP.
@@ -261,14 +271,63 @@ pub async fn run_loop(
             let mut tool_results: Vec<ToolResultMessage> = Vec::new();
             has_more_tool_calls = false;
             if !tool_calls.is_empty() {
-                let batch =
-                    execute_tool_calls(&current_context, &assistant_msg, &config, &signal, emit)
-                        .await;
-                tool_results = batch.messages;
-                has_more_tool_calls = !batch.terminate;
-                for result in &tool_results {
-                    current_context.messages.push(tool_result_to_value(result));
-                    new_messages.push(LoopMessage::ToolResult(result.clone()));
+                let original_count = tool_calls.len();
+                let (surviving_calls, storm_report) = storm.filter_calls(&tool_calls);
+                let all_suppressed = storm_report.all_suppressed(original_count);
+
+                // Port of Reasonix loop.ts:935-956 — first-time
+                // all-suppressed: self-correction. Stub tool
+                // results with a guard message and give the model
+                // one shot to self-correct before the loud-warning
+                // path.
+                if all_suppressed && !turn_self_corrected {
+                    turn_self_corrected = true;
+                    let guard_text = "[repeat-loop guard] this call was suppressed because it was identical to a previous call in this turn. Earlier results for it are above — try a meaningfully different approach, or stop and answer if you have enough.";
+                    let guard_blocks = vec![ContentBlock::Text {
+                        text: guard_text.to_string(),
+                    }];
+                    for call in &tool_calls {
+                        let tr = ToolResultMessage {
+                            tool_call_id: call.id.clone(),
+                            tool_name: call.name.clone(),
+                            content: guard_blocks.clone(),
+                            details: Value::Null,
+                            is_error: false,
+                        };
+                        current_context.messages.push(tool_result_to_value(&tr));
+                        new_messages.push(LoopMessage::ToolResult(tr.clone()));
+                        tool_results.push(tr);
+                    }
+                    // Surface the self-correction as a tool result
+                    // with a guard text — the model sees it as
+                    // output for its suppressed tool calls.
+                    has_more_tool_calls = true;
+                } else if storm_report.storms_broken > 0 && surviving_calls.is_empty() {
+                    // Port of Reasonix loop.ts:975-982:
+                    // no calls left, all suppressed and already
+                    // self-corrected. Model is stuck — no more
+                    // tool calls to dispatch, exit the inner
+                    // loop.
+                    has_more_tool_calls = false;
+                }
+
+                // Dispatch surviving calls.
+                if !surviving_calls.is_empty() {
+                    let batch = execute_tool_calls_with(
+                        &current_context,
+                        &assistant_msg,
+                        &surviving_calls,
+                        &config,
+                        &signal,
+                        emit,
+                    )
+                    .await;
+                    tool_results.extend(batch.messages.clone());
+                    has_more_tool_calls = !batch.terminate;
+                    for result in &batch.messages {
+                        current_context.messages.push(tool_result_to_value(result));
+                        new_messages.push(LoopMessage::ToolResult(result.clone()));
+                    }
                 }
             }
 
@@ -378,6 +437,50 @@ pub async fn run_loop(
 /// inline so `run.rs` doesn't reach into `tools` for tiny helpers.
 fn extract_tool_calls_from(msg: &AssistantMessage) -> Vec<super::tools::ToolCall> {
     super::tools::extract_tool_calls(msg)
+}
+
+/// Dispatch pre-filtered tool calls (after storm breaker has
+/// removed suppressed calls). Mirrors the dispatch logic in
+/// `execute_tool_calls` but takes the calls directly instead of
+/// extracting from the assistant message.
+async fn execute_tool_calls_with(
+    context: &Context,
+    assistant_message: &AssistantMessage,
+    tool_calls: &[super::tools::ToolCall],
+    config: &LoopConfig,
+    signal: &AbortSignal,
+    emit: &mpsc::Sender<LoopEvent>,
+) -> super::tools::ExecutedToolCallBatch {
+    use super::ExecutedToolCallBatch;
+    let has_sequential = tool_calls.iter().any(|tc| {
+        context
+            .tools
+            .iter()
+            .find(|t| t.name() == tc.name)
+            .and_then(|t| t.execution_mode())
+            == Some(super::ToolExecutionMode::Sequential)
+    });
+    if config.tool_execution == super::ToolExecutionMode::Sequential || has_sequential {
+        super::tools::execute_tool_calls_sequential(
+            context,
+            assistant_message,
+            tool_calls,
+            config,
+            signal,
+            emit,
+        )
+        .await
+    } else {
+        super::tools::execute_tool_calls_parallel(
+            context,
+            assistant_message,
+            tool_calls,
+            config,
+            signal,
+            emit,
+        )
+        .await
+    }
 }
 
 /// Convert a `LoopMessage` to the placeholder `Value` shape used

--- a/src/agent/agent_loop/storm.rs
+++ b/src/agent/agent_loop/storm.rs
@@ -1,0 +1,360 @@
+//! Storm breaker — repeat-loop detection for tool calls.
+//!
+//! Faithful port of `DeepSeek-Reasonix/src/repair/storm.ts` (66 lines).
+//!
+//! Tracks (tool_name, args) tuples in a sliding window. When the same
+//! call appears `threshold` times within `window_size` entries, the
+//! call is suppressed (the model is stuck in a loop).
+//!
+//! Mutating calls (write, edit, bash) clear prior read-only entries
+//! from the window so a post-edit verify-read isn't flagged as a
+//! repeat. Mutators still count amongst themselves — three identical
+//! edits in a row IS a storm.
+//!
+//! Storm-exempt tools (cheap inspectors like `list_dir`) never trip
+//! the guard regardless of repetition count.
+
+use super::tools::ToolCall;
+
+/// Outcome of `StormBreaker::inspect`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StormVerdict {
+    pub suppress: bool,
+    pub reason: Option<String>,
+}
+
+impl StormVerdict {
+    fn pass() -> Self {
+        Self {
+            suppress: false,
+            reason: None,
+        }
+    }
+
+    fn suppress(name: &str, count: usize) -> Self {
+        Self {
+            suppress: true,
+            reason: Some(format!(
+                "{name} called with identical args {count} times — repeat-loop guard tripped"
+            )),
+        }
+    }
+}
+
+/// Summary of what the storm breaker did to a batch of tool calls.
+#[derive(Debug, Clone, Default)]
+pub struct StormReport {
+    /// How many calls were suppressed.
+    pub storms_broken: usize,
+    /// Per-suppression reasons for diagnostics.
+    pub notes: Vec<String>,
+}
+
+impl StormReport {
+    /// True when every call was suppressed and there was at least one.
+    pub fn all_suppressed(&self, original_count: usize) -> bool {
+        self.storms_broken > 0 && self.storms_broken == original_count && original_count > 0
+    }
+}
+
+struct RecentEntry {
+    name: String,
+    args: String,
+    read_only: bool,
+}
+
+/// Tracks (name, args) repeats in a sliding window.
+///
+/// Mutating calls clear prior read-only entries while still
+/// counting amongst themselves. Storm-exempt calls never trigger.
+pub struct StormBreaker {
+    window_size: usize,
+    threshold: usize,
+    is_mutating: Option<Box<dyn Fn(&ToolCall) -> bool + Send + Sync>>,
+    is_storm_exempt: Option<Box<dyn Fn(&ToolCall) -> bool + Send + Sync>>,
+    recent: Vec<RecentEntry>,
+}
+
+impl StormBreaker {
+    pub fn new(
+        window_size: usize,
+        threshold: usize,
+        is_mutating: Option<Box<dyn Fn(&ToolCall) -> bool + Send + Sync>>,
+        is_storm_exempt: Option<Box<dyn Fn(&ToolCall) -> bool + Send + Sync>>,
+    ) -> Self {
+        Self {
+            window_size,
+            threshold,
+            is_mutating,
+            is_storm_exempt,
+            recent: Vec::with_capacity(window_size),
+        }
+    }
+
+    pub fn inspect(&mut self, call: &ToolCall) -> StormVerdict {
+        let name = &call.name;
+        if name.is_empty() {
+            return StormVerdict::pass();
+        }
+        if let Some(ref exempt) = self.is_storm_exempt {
+            if exempt(call) {
+                return StormVerdict::pass();
+            }
+        }
+        let args = serde_json::to_string(&call.arguments).unwrap_or_default();
+
+        let mutating = self.is_mutating.as_ref().map(|f| f(call)).unwrap_or(false);
+        let read_only = !mutating;
+
+        if mutating {
+            // Drop prior read-only entries — the file/shell state just
+            // changed, so a verify-read after this should start with a
+            // clean slate. Keep mutator entries: 3 identical edits in
+            // a row is still a storm (model in a loop).
+            // Iterate in reverse so removals don't shift indices.
+            let mut i = self.recent.len();
+            while i > 0 {
+                i -= 1;
+                if self.recent[i].read_only {
+                    self.recent.remove(i);
+                }
+            }
+        }
+
+        let count = self
+            .recent
+            .iter()
+            .filter(|e| e.name == *name && e.args == args)
+            .count();
+
+        if count >= self.threshold.saturating_sub(1) {
+            return StormVerdict::suppress(name, count + 1);
+        }
+
+        self.recent.push(RecentEntry {
+            name: name.clone(),
+            args,
+            read_only,
+        });
+        while self.recent.len() > self.window_size {
+            self.recent.remove(0);
+        }
+
+        StormVerdict::pass()
+    }
+
+    pub fn reset(&mut self) {
+        self.recent.clear();
+    }
+
+    /// Filter a batch of tool calls through the storm breaker.
+    /// Returns surviving calls and a report of what was suppressed.
+    /// Port of `ToolCallRepair.process()` storm phase
+    /// (repair/index.ts:111-121).
+    pub fn filter_calls(&mut self, calls: &[ToolCall]) -> (Vec<ToolCall>, StormReport) {
+        let mut surviving: Vec<ToolCall> = Vec::with_capacity(calls.len());
+        let mut report = StormReport::default();
+
+        for call in calls {
+            let verdict = self.inspect(call);
+            if verdict.suppress {
+                report.storms_broken += 1;
+                if let Some(reason) = verdict.reason {
+                    report.notes.push(reason);
+                }
+            } else {
+                surviving.push(call.clone());
+            }
+        }
+
+        (surviving, report)
+    }
+}
+
+impl Default for StormBreaker {
+    fn default() -> Self {
+        Self::new(6, 3, None, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn call(name: &str, args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            name: name.to_string(),
+            arguments: args,
+        }
+    }
+
+    fn call_json(name: &str, args_json: &str) -> ToolCall {
+        call(
+            name,
+            serde_json::from_str::<serde_json::Value>(args_json).unwrap_or(json!({})),
+        )
+    }
+
+    #[test]
+    fn passes_through_below_threshold() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        assert!(!sb.inspect(&call_json("x", "{}")).suppress);
+        assert!(!sb.inspect(&call_json("x", "{}")).suppress);
+    }
+
+    #[test]
+    fn suppresses_on_threshold_reached() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        sb.inspect(&call_json("x", "{}"));
+        sb.inspect(&call_json("x", "{}"));
+        let verdict = sb.inspect(&call_json("x", "{}"));
+        assert!(verdict.suppress);
+        assert!(verdict.reason.unwrap().contains("repeat-loop guard"));
+    }
+
+    #[test]
+    fn distinguishes_different_args_as_different_calls() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        sb.inspect(&call_json("x", r#"{"a":1}"#));
+        sb.inspect(&call_json("x", r#"{"a":2}"#));
+        sb.inspect(&call_json("x", r#"{"a":3}"#));
+        let verdict = sb.inspect(&call_json("x", r#"{"a":4}"#));
+        assert!(!verdict.suppress);
+    }
+
+    #[test]
+    fn forgets_old_calls_beyond_window() {
+        let mut sb = StormBreaker::new(3, 3, None, None);
+        sb.inspect(&call_json("x", "{}"));
+        sb.inspect(&call_json("x", "{}"));
+        sb.inspect(&call_json("y", "{}"));
+        sb.inspect(&call_json("z", "{}"));
+        sb.inspect(&call_json("w", "{}"));
+        // Only the most recent 3 are in the window now, none of which
+        // is "x", so a single new "x" should not suppress.
+        assert!(!sb.inspect(&call_json("x", "{}")).suppress);
+    }
+
+    #[test]
+    fn intervening_mutating_call_resets_window_for_rerereads() {
+        let mutators: Box<dyn Fn(&ToolCall) -> bool + Send + Sync> =
+            Box::new(|c| matches!(c.name.as_str(), "edit_file" | "write_file"));
+        let mut sb = StormBreaker::new(6, 3, Some(mutators), None);
+        let args = r#"{"path":"src/env.ts"}"#;
+        assert!(!sb.inspect(&call_json("read_file", args)).suppress);
+        assert!(
+            !sb.inspect(&call_json(
+                "edit_file",
+                r#"{"path":"src/env.ts","new_text":"x"}"#,
+            ))
+            .suppress
+        );
+        assert!(!sb.inspect(&call_json("read_file", args)).suppress);
+        assert!(
+            !sb.inspect(&call_json(
+                "edit_file",
+                r#"{"path":"src/env.ts","new_text":"y"}"#,
+            ))
+            .suppress
+        );
+        // 3rd read_file with identical args — would trip the breaker
+        // pre-fix, but each edit_file legitimately changed the file in
+        // between.
+        assert!(!sb.inspect(&call_json("read_file", args)).suppress);
+    }
+
+    #[test]
+    fn predicate_flagged_write_file_resets_the_window() {
+        let mutators: Box<dyn Fn(&ToolCall) -> bool + Send + Sync> =
+            Box::new(|c| c.name == "write_file");
+        let mut sb = StormBreaker::new(6, 3, Some(mutators), None);
+        assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
+        assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
+        assert!(!sb.inspect(&call_json("write_file", "{}")).suppress);
+        // Buffer cleared by write_file — a fresh pair of reads is now safe.
+        assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
+        assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
+    }
+
+    #[test]
+    fn with_no_predicate_every_tool_counts() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        sb.inspect(&call_json("edit_file", "{}"));
+        sb.inspect(&call_json("edit_file", "{}"));
+        assert!(sb.inspect(&call_json("edit_file", "{}")).suppress);
+    }
+
+    mod storm_exempt {
+        use super::*;
+
+        #[test]
+        fn exempt_tools_never_trip_the_storm_guard() {
+            let exempt: Box<dyn Fn(&ToolCall) -> bool + Send + Sync> =
+                Box::new(|c| matches!(c.name.as_str(), "read_file" | "list_jobs"));
+            let mut sb = StormBreaker::new(6, 3, None, Some(exempt));
+            for _ in 0..10 {
+                assert!(
+                    !sb.inspect(&call_json("read_file", r#"{"path":"/foo"}"#))
+                        .suppress
+                );
+            }
+        }
+
+        #[test]
+        fn non_exempt_tools_still_trip_after_exempt_reads() {
+            let exempt: Box<dyn Fn(&ToolCall) -> bool + Send + Sync> =
+                Box::new(|c| c.name == "read_file");
+            let mut sb = StormBreaker::new(3, 3, None, Some(exempt));
+            sb.inspect(&call_json("edit_file", "{}"));
+            sb.inspect(&call_json("edit_file", "{}"));
+            sb.inspect(&call_json("read_file", "{}"));
+            sb.inspect(&call_json("read_file", "{}"));
+            sb.inspect(&call_json("read_file", "{}"));
+            assert!(sb.inspect(&call_json("edit_file", "{}")).suppress);
+        }
+    }
+
+    #[test]
+    fn filter_calls_passes_through_below_threshold() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        let calls = vec![call_json("x", "{}"), call_json("x", "{}")];
+        let (surviving, report) = sb.filter_calls(&calls);
+        assert_eq!(surviving.len(), 2);
+        assert_eq!(report.storms_broken, 0);
+    }
+
+    #[test]
+    fn filter_calls_suppresses_at_threshold() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        let calls = vec![
+            call_json("x", "{}"),
+            call_json("x", "{}"),
+            call_json("x", "{}"),
+        ];
+        let (surviving, report) = sb.filter_calls(&calls);
+        // First two pass, third is suppressed.
+        assert_eq!(surviving.len(), 2);
+        assert_eq!(report.storms_broken, 1);
+        // Not all-suppressed — 2 calls survived.
+        assert!(!report.all_suppressed(3));
+    }
+
+    #[test]
+    fn filter_calls_all_suppressed_on_second_batch() {
+        let mut sb = StormBreaker::new(6, 3, None, None);
+        // First batch: 3 calls, 3rd suppressed
+        let calls1: Vec<ToolCall> = (0..3).map(|_| call_json("x", "{}")).collect();
+        let (surviving1, _) = sb.filter_calls(&calls1);
+        assert_eq!(surviving1.len(), 2);
+
+        // Second batch: same 3 calls again — all suppressed now
+        // because there are already 2 in the window.
+        let calls2: Vec<ToolCall> = (0..3).map(|_| call_json("x", "{}")).collect();
+        let (surviving2, report2) = sb.filter_calls(&calls2);
+        assert_eq!(surviving2.len(), 0);
+        assert_eq!(report2.storms_broken, 3);
+        assert!(report2.all_suppressed(3));
+    }
+}


### PR DESCRIPTION
Faithful port of DeepSeek-Reasonix src/repair/storm.ts (66 LOC).

StormBreaker tracks (tool_name, args) tuples in a sliding window (default window=6, threshold=3). When the same call appears threshold times, the call is suppressed.

- Mutating calls (write, edit, bash) clear prior read-only entries so a post-edit verify-read isn't flagged as a repeat.
- Storm-exempt tools (cheap inspectors) never trip the guard.
- First-time all-suppressed: self-correction — the model gets one shot to self-correct with guard messages injected as tool results.
- Second-time all-suppressed: inner loop exits (model is stuck).

Tests: 12 tests ported from Reasonix tests/repair/storm.test.ts. All 14 existing agent_loop::run loop tests still pass. Build + fmt clean.