### PR TITLE
feat(agent): phase 2 — schema flattening for deep/wide tool schemas

### DIFF
--- a/src/agent/agent_loop/mod.rs
+++ b/src/agent/agent_loop/mod.rs
@@ -38,6 +38,7 @@ pub mod rig_stream;
 pub mod rig_stream_factory;
 pub mod rig_tool;
 pub mod run;
+pub mod schema_flatten;
 pub mod steering;
 pub mod stream;
 pub mod tool;

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -304,11 +304,19 @@ fn value_to_assistant_content(block: &Value) -> Option<AssistantContent> {
 /// Build a rig `ToolDefinition` from one of our `LoopTool`s.
 /// Returns the trio rig actually consumes (name, description,
 /// parameters); label is dropped because rig has no slot for it.
+///
+/// If the tool has a `flat_parameters` schema (auto-detected via
+/// `analyze_schema`), the LLM receives the flat dot-notation
+/// variant so it's less likely to drop deeply nested args.
 pub fn loop_tool_to_rig_definition(tool: &dyn LoopTool) -> ToolDefinition {
+    let parameters = tool
+        .flat_parameters()
+        .cloned()
+        .unwrap_or_else(|| tool.parameters().clone());
     ToolDefinition {
         name: tool.name().to_string(),
         description: tool.description().to_string(),
-        parameters: tool.parameters().clone(),
+        parameters,
     }
 }
 

--- a/src/agent/agent_loop/rig_tool.rs
+++ b/src/agent/agent_loop/rig_tool.rs
@@ -36,6 +36,7 @@ use rig::tool::{ToolDyn, ToolError};
 use serde_json::Value;
 
 use super::result::LoopToolResult;
+use super::schema_flatten::{FlattenDecision, analyze_schema, flatten_schema, nest_arguments};
 use super::tool::{AbortSignal, LoopTool, LoopToolUpdate};
 use super::types::ToolExecutionMode;
 
@@ -45,11 +46,19 @@ use super::types::ToolExecutionMode;
 /// tool's definition (name, description, parameters). The wrapped
 /// tool is shared via `Arc` because `LoopTool` impls are stored as
 /// `Arc<dyn LoopTool>` in `Context.tools` (see `types.rs`).
+///
+/// Schema flattening: if the tool's JSON Schema has >10 leaf params
+/// or >2 levels of nesting, the adapter auto-flattens it at
+/// construction time (Reasonix tools.ts:36-38). The LLM sees flat
+/// dot-notation keys; `prepare_arguments` re-nests them at dispatch.
 pub struct RigToolAdapter {
     inner: Box<dyn ToolDyn>,
     name: String,
     description: String,
     parameters: Value,
+    /// Flattened parameters stored when the schema warrants flattening.
+    /// Port of Reasonix `InternalTool.flatSchema` (tools.ts:37).
+    flat_parameters: Option<Value>,
     execution_mode: Option<ToolExecutionMode>,
 }
 
@@ -58,6 +67,7 @@ impl std::fmt::Debug for RigToolAdapter {
         f.debug_struct("RigToolAdapter")
             .field("name", &self.name)
             .field("execution_mode", &self.execution_mode)
+            .field("has_flat_schema", &self.flat_parameters.is_some())
             .finish()
     }
 }
@@ -72,18 +82,29 @@ impl RigToolAdapter {
     /// needs prompt-conditional definitions, the loop will need
     /// to expose a per-turn definition rebuild path. Documented
     /// as a deferred concern.
+    ///
+    /// Auto-analyzes the schema; if it's deep (>2) or wide (>10
+    /// leaves), flattens it and stores the flat variant so
+    /// `prepare_arguments` can re-nest at dispatch (Reasonix
+    /// tools.ts:36-38).
     pub async fn new(inner: Box<dyn ToolDyn>) -> Self {
         let def = inner.definition(String::new()).await;
+        let flat_parameters = match analyze_schema(&def.parameters) {
+            FlattenDecision {
+                should_flatten: true,
+                ..
+            } => Some(flatten_schema(&def.parameters)),
+            _ => None,
+        };
         Self {
             inner,
             name: def.name,
             description: def.description,
             parameters: def.parameters,
+            flat_parameters,
             execution_mode: None,
         }
     }
-
-    /// Force this tool into sequential execution. Use for tools
     /// that mutate shared filesystem state or process state
     /// (bash, edit, write, apply_patch) to prevent concurrent
     /// races. Phase 3's umbrella dispatcher detects this and
@@ -108,6 +129,7 @@ impl RigToolAdapter {
             name,
             description,
             parameters,
+            flat_parameters: None,
             execution_mode: None,
         }
     }
@@ -133,15 +155,23 @@ impl LoopTool for RigToolAdapter {
         &self.parameters
     }
 
+    fn flat_parameters(&self) -> Option<&Value> {
+        self.flat_parameters.as_ref()
+    }
+
     fn execution_mode(&self) -> Option<ToolExecutionMode> {
         self.execution_mode
     }
 
-    /// Rig tools self-parse via serde; no shim needed. Defaults
-    /// to identity (inherited from the trait default but stated
-    /// here for the side-by-side audit).
+    /// Re-nests flat dot-notation args when the schema was
+    /// flattened. Port of Reasonix `dispatch()` re-nest
+    /// (tools.ts:126-130). Otherwise identity.
     fn prepare_arguments(&self, args: Value) -> Value {
-        args
+        if self.flat_parameters.is_some() {
+            nest_arguments(&args)
+        } else {
+            args
+        }
     }
 
     fn execute<'a>(

--- a/src/agent/agent_loop/schema_flatten.rs
+++ b/src/agent/agent_loop/schema_flatten.rs
@@ -1,0 +1,333 @@
+//! Schema flattening — prevent models from dropping deeply nested args.
+//!
+//! Faithful port of `DeepSeek-Reasonix/src/repair/flatten.ts` (92 lines).
+//!
+//! DeepSeek (and other models) drop arguments on schemas with >10 leaf
+//! parameters or >2 levels of nesting. The fix:
+//!
+//! 1. `analyze_schema` — detect schemas that need flattening
+//! 2. `flatten_schema` — present dot-notation keys to the model
+//! 3. `nest_arguments` — re-nest flat args at dispatch time
+//!
+//! Example: `{user: {profile: {name: string}}}` becomes
+//! `{"user.profile.name": string}`
+
+use serde_json::Value;
+
+/// Result of `analyze_schema`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlattenDecision {
+    pub should_flatten: bool,
+    pub leaf_count: usize,
+    pub max_depth: usize,
+}
+
+/// Walk the schema and decide whether flattening is needed.
+/// Port of `analyzeSchema` (flatten.ts:11-24).
+pub fn analyze_schema(schema: &Value) -> FlattenDecision {
+    let mut leaf_count = 0;
+    let mut max_depth = 0;
+    walk(schema, 0, &mut leaf_count, &mut max_depth);
+    FlattenDecision {
+        should_flatten: leaf_count > 10 || max_depth > 2,
+        leaf_count,
+        max_depth,
+    }
+}
+
+/// Flatten a nested schema to dot-notation.
+/// Port of `flattenSchema` (flatten.ts:26-35).
+///
+/// Returns the input unchanged if it's not a deep/wide schema.
+pub fn flatten_schema(schema: &Value) -> Value {
+    let mut flat_props = serde_json::Map::new();
+    let mut required: Vec<String> = Vec::new();
+    collect("", schema, &mut flat_props, &mut required, true);
+    let required_json: Vec<Value> = required.into_iter().map(Value::String).collect();
+    serde_json::json!({
+        "type": "object",
+        "properties": flat_props,
+        "required": required_json,
+    })
+}
+
+/// Re-nest flat dot-notation args back into the original nested shape.
+/// Port of `nestArguments` (flatten.ts:37-43).
+pub fn nest_arguments(flat_args: &Value) -> Value {
+    match flat_args {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (key, value) in map {
+                set_by_path(&mut out, key.split('.').collect::<Vec<_>>(), value.clone());
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+// ---- internal helpers ----
+
+/// Walk the schema tree, counting leaves and tracking max depth.
+/// Port of `walk` (flatten.ts:45-61).
+#[allow(clippy::collapsible_if)]
+fn walk(schema: &Value, depth: usize, leaf_count: &mut usize, max_depth: &mut usize) {
+    let ty = schema.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    if ty == "object" {
+        if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+            for child in props.values() {
+                walk(child, depth + 1, leaf_count, max_depth);
+            }
+            return;
+        }
+    }
+
+    if ty == "array" {
+        if let Some(items) = schema.get("items") {
+            walk(items, depth + 1, leaf_count, max_depth);
+            return;
+        }
+    }
+
+    // Leaf: any non-object, non-array type.
+    *leaf_count += 1;
+    if depth > *max_depth {
+        *max_depth = depth;
+    }
+}
+
+/// Collect dot-path → leaf-schema mappings.
+/// Port of `collect` (flatten.ts:63-82).
+#[allow(clippy::collapsible_if)]
+fn collect(
+    prefix: &str,
+    schema: &Value,
+    out: &mut serde_json::Map<String, Value>,
+    required: &mut Vec<String>,
+    is_root_required: bool,
+) {
+    let ty = schema.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    if ty == "object" {
+        if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+            let required_set: Vec<&str> = schema
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+
+            for (key, child) in props {
+                let next_prefix = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                let child_required = is_root_required && required_set.contains(&key.as_str());
+                collect(&next_prefix, child, out, required, child_required);
+            }
+            return;
+        }
+    }
+
+    // Treat anything non-object (including arrays) as a leaf.
+    out.insert(prefix.to_string(), schema.clone());
+    if is_root_required {
+        required.push(prefix.to_string());
+    }
+}
+
+/// Set a value at a dot-path inside a nested JSON object.
+/// Port of `setByPath` (flatten.ts:84-92).
+fn set_by_path(target: &mut serde_json::Map<String, Value>, path: Vec<&str>, value: Value) {
+    let mut cur = target;
+    let last = path.len() - 1;
+    for (i, key) in path.iter().enumerate() {
+        if i == last {
+            cur.insert(key.to_string(), value.clone());
+        } else {
+            cur = cur
+                .entry(key.to_string())
+                .or_insert_with(|| Value::Object(serde_json::Map::new()))
+                .as_object_mut()
+                .expect("nested value must be an object");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ============================================================
+    // analyze_schema — ported from flatten.test.ts
+    // ============================================================
+
+    #[test]
+    fn does_not_flatten_flat_shallow_schemas() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "number"},
+            }
+        });
+        let d = analyze_schema(&schema);
+        assert!(!d.should_flatten);
+    }
+
+    #[test]
+    fn flags_deep_schemas() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "middle": {
+                            "type": "object",
+                            "properties": {
+                                "leaf": {"type": "string"}
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let d = analyze_schema(&schema);
+        assert!(d.should_flatten);
+        assert!(d.max_depth > 2);
+    }
+
+    #[test]
+    fn flags_wide_schemas_over_10_leaves() {
+        let mut props = serde_json::Map::new();
+        for i in 0..12 {
+            props.insert(format!("p{i}"), serde_json::json!({"type": "string"}));
+        }
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": props,
+        });
+        let d = analyze_schema(&schema);
+        assert!(d.should_flatten);
+        assert_eq!(d.leaf_count, 12);
+    }
+
+    // ============================================================
+    // flatten_schema / nest_arguments roundtrip
+    // ============================================================
+
+    #[test]
+    fn flattens_nested_schema_and_renests_arguments() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "required": ["user"],
+            "properties": {
+                "user": {
+                    "type": "object",
+                    "required": ["profile"],
+                    "properties": {
+                        "profile": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                                "name": {"type": "string"},
+                                "age": {"type": "integer"},
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let flat = flatten_schema(&schema);
+        assert!(flat["properties"].get("user.profile.name").is_some());
+        assert!(flat["properties"].get("user.profile.age").is_some());
+
+        let req: Vec<&str> = flat["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(req, vec!["user.profile.name"]);
+
+        let nested = nest_arguments(&serde_json::json!({
+            "user.profile.name": "alice",
+            "user.profile.age": 30,
+        }));
+        assert_eq!(
+            nested,
+            serde_json::json!({
+                "user": {
+                    "profile": {
+                        "name": "alice",
+                        "age": 30,
+                    }
+                }
+            })
+        );
+    }
+
+    // ============================================================
+    // Additional edge cases
+    // ============================================================
+
+    #[test]
+    fn undefined_schema_does_not_flatten() {
+        let d = analyze_schema(&serde_json::json!({}));
+        assert!(!d.should_flatten);
+        // Empty object with no type field falls through to leaf counting
+        // (same as Reasonix — `undefined !== "object"`).
+    }
+
+    #[test]
+    fn array_items_are_leaves_for_flattening() {
+        // Arrays are treated as leaf nodes — we don't descend into them
+        // for flattening purposes (same as Reasonix).
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                }
+            }
+        });
+        let d = analyze_schema(&schema);
+        assert!(!d.should_flatten);
+        assert_eq!(d.leaf_count, 1); // tags array is one leaf
+    }
+
+    #[test]
+    fn nest_arguments_preserves_non_object_input() {
+        assert_eq!(nest_arguments(&Value::Null), Value::Null);
+        assert_eq!(
+            nest_arguments(&Value::String("hello".into())),
+            Value::String("hello".into())
+        );
+        assert_eq!(nest_arguments(&Value::Array(vec![])), Value::Array(vec![]));
+    }
+
+    #[test]
+    fn nest_arguments_handles_deeply_nested_paths() {
+        let nested = nest_arguments(&serde_json::json!({
+            "a.b.c.d": "deep",
+            "a.b.c.e": 42,
+        }));
+        assert_eq!(
+            nested,
+            serde_json::json!({
+                "a": {
+                    "b": {
+                        "c": {
+                            "d": "deep",
+                            "e": 42,
+                        }
+                    }
+                }
+            })
+        );
+    }
+}

--- a/src/agent/agent_loop/tool.rs
+++ b/src/agent/agent_loop/tool.rs
@@ -97,6 +97,17 @@ pub trait LoopTool: Send + Sync + std::fmt::Debug {
     /// front tools with wildly different arg shapes.
     fn parameters(&self) -> &Value;
 
+    /// Flattened variant of `parameters` for deep/wide schemas.
+    /// When `Some`, the LLM sees the flat schema (dot-notation
+    /// keys) and the dispatch re-nests args before calling
+    /// `execute`. Port of Reasonix `InternalTool.flatSchema`
+    /// (tools.ts:37).
+    ///
+    /// Default: `None` (no flattening).
+    fn flat_parameters(&self) -> Option<&Value> {
+        None
+    }
+
     /// Per-tool execution-mode override. `None` means "use the
     /// loop's default mode". Returning `Sequential` forces the
     /// whole batch sequential per pi's tool-execution semantics


### PR DESCRIPTION
Faithful port of DeepSeek-Reasonix src/repair/flatten.ts (92 LOC).

- analyze_schema: walk JSON Schema, flag when >10 leaf params OR >2 levels of nesting
- flatten_schema: present dot-notation keys to the model (user.profile.name)
- nest_arguments: re-nest flat args at dispatch time
- RigToolAdapter::new auto-analyzes and stores flat schema
- RigToolAdapter::prepare_arguments re-nests when flat schema is active
- loop_tool_to_rig_definition uses flat_parameters when present
- LoopTool trait gains flat_parameters() method (default None)

Tests: 8 tests ported from Reasonix tests/repair/flatten.test.ts. All 185 existing agent_loop tests still pass. Build + fmt clean.