### PR TITLE
feat: Shift+Y yolo shortcut, /mode mid-run, interjection fix

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1249,28 +1249,7 @@ pub async fn run_interactive(
                                 // matches alone; if there's an
                                 // argument, treat as potentially
                                 // mutating and gate.
-                                let head = text.split_whitespace().next().unwrap_or("");
-                                let args = text
-                                    .split_whitespace()
-                                    .nth(1)
-                                    .map(|s| s.to_string());
-                                let always_safe = matches!(
-                                    head,
-                                    "/quit" | "/help" | "/reasoning" | "/tasks"
-                                );
-                                let safe_when_no_arg = matches!(
-                                    head,
-                                    "/sessions"
-                                        | "/tree"
-                                        | "/model"
-                                        | "/prompt"
-                                ) && args.is_none();
-                                let safe_when_list = matches!(
-                                    (head, args.as_deref()),
-                                    ("/memory", Some("list")) | ("/skill", Some("list"))
-                                );
-                                let safe_during_agent =
-                                    always_safe || safe_when_no_arg || safe_when_list;
+                                let safe_during_agent = is_safe_during_agent(&text);
                                 if is_running && !safe_during_agent {
                                     write_outside_chamber(
                                         &mut renderer,
@@ -1278,7 +1257,7 @@ pub async fn run_interactive(
                                         &mut tool_chamber_open,
                                     &mut chamber_top_start,
                                     &mut chamber_top_end,
-                                        "agent is busy — wait, interrupt (Ctrl+C), or use /quit. (/tasks /help /sessions /tree /model /prompt run during agent activity.)",
+                                        "agent is busy — wait, interrupt (Ctrl+C), or use /quit. (/mode /tasks /help /sessions /tree /model /prompt run during agent activity.)",
                                         c_error(),
                                     )?;
                                     renderer.draw_bottom(
@@ -1437,6 +1416,12 @@ pub async fn run_interactive(
                                 // the steering queue at turn boundaries and injects
                                 // it as mid-turn guidance within the same run.
                                 interjection_queue.lock().unwrap().push_back(text.to_string());
+                                // Signal the agent to stop at the next tool-result
+                                // boundary so the queued message is injected as a new
+                                // user turn rather than waiting for the run to complete.
+                                if let Some(tx) = agent_interject.as_ref() {
+                                    let _ = tx.try_send(());
+                                }
                                 for line in text.lines() {
                                     let safe_line = sanitize_output(line);
                                     renderer.write_line(
@@ -3531,6 +3516,21 @@ pub async fn run_interactive(
     }
 
     Ok(())
+}
+
+/// Whether a slash command is safe to run while the agent is active.
+/// Read-only inspection commands don't need the agent idle.
+fn is_safe_during_agent(text: &str) -> bool {
+    let head = text.split_whitespace().next().unwrap_or("");
+    let args = text.split_whitespace().nth(1).map(|s| s.to_string());
+    let always_safe = matches!(head, "/quit" | "/help" | "/reasoning" | "/tasks" | "/mode");
+    let safe_when_no_arg =
+        matches!(head, "/sessions" | "/tree" | "/model" | "/prompt") && args.is_none();
+    let safe_when_list = matches!(
+        (head, args.as_deref()),
+        ("/memory", Some("list")) | ("/skill", Some("list"))
+    );
+    always_safe || safe_when_no_arg || safe_when_list
 }
 
 #[cfg(test)]

--- a/src/ui/mod_tests.rs
+++ b/src/ui/mod_tests.rs
@@ -566,3 +566,57 @@ fn chat_index_next_prev_one_chat_is_noop() {
     assert_eq!((0 + 1) % count, 0);
     assert_eq!((0 + count - 1) % count, 0);
 }
+
+// ============================================================
+// safe_during_agent — slash commands allowed while agent runs
+// ============================================================
+
+#[test]
+fn mode_is_safe_during_agent() {
+    assert!(is_safe_during_agent("/mode"));
+    assert!(is_safe_during_agent("/mode yolo"));
+    assert!(is_safe_during_agent("/mode standard"));
+    assert!(is_safe_during_agent("/mode accept"));
+    assert!(is_safe_during_agent("/mode restrictive"));
+}
+
+#[test]
+fn quit_help_reasoning_tasks_always_safe_during_agent() {
+    assert!(is_safe_during_agent("/quit"));
+    assert!(is_safe_during_agent("/help"));
+    assert!(is_safe_during_agent("/reasoning"));
+    assert!(is_safe_during_agent("/tasks"));
+    assert!(is_safe_during_agent("/tasks list"));
+}
+
+#[test]
+fn sessions_tree_model_prompt_safe_only_without_args() {
+    assert!(is_safe_during_agent("/sessions"));
+    assert!(is_safe_during_agent("/tree"));
+    assert!(is_safe_during_agent("/model"));
+    assert!(is_safe_during_agent("/prompt"));
+    assert!(!is_safe_during_agent("/sessions 42"));
+    assert!(!is_safe_during_agent("/model gpt-4"));
+    assert!(!is_safe_during_agent("/prompt my-prompt"));
+}
+
+#[test]
+fn mutating_commands_are_not_safe_during_agent() {
+    assert!(!is_safe_during_agent("/cd /tmp"));
+    assert!(!is_safe_during_agent("/clear"));
+    assert!(!is_safe_during_agent("/compress"));
+    assert!(!is_safe_during_agent("/clone"));
+    assert!(!is_safe_during_agent("/fork"));
+    assert!(!is_safe_during_agent("/compact"));
+    assert!(!is_safe_during_agent("/undo"));
+    assert!(!is_safe_during_agent("/retry"));
+    assert!(!is_safe_during_agent("/allow bash rm *"));
+}
+
+#[test]
+fn memory_skill_list_safe_during_agent() {
+    assert!(is_safe_during_agent("/memory list"));
+    assert!(is_safe_during_agent("/skill list"));
+    assert!(!is_safe_during_agent("/memory add key value"));
+    assert!(!is_safe_during_agent("/skill load foo"));
+}


### PR DESCRIPTION
Three changes to make yolo mode more accessible:

## 1. Permission prompt `[Y]` yolo mode shortcut (Shift+Y)

Pressing `Y` in the permission dialog sets `SecurityMode::Yolo` and auto-approves the current tool call. All subsequent calls skip permission prompts. The status line reflects the mode change immediately.

<img width="600" alt="permission prompt showing yolo shortcut" src="https://github.com/user-attachments/assets/placeholder">

## 2. `/mode` slash command allowed during agent runs

Added `/mode` to the `always_safe` set in `is_safe_during_agent()`. Previously you had to wait for the agent to finish before switching to yolo mode. Now `/mode yolo` works mid-run — subsequent tool calls are auto-approved.

## 3. Interjection fix for non-loop agent runs

When the user types during a non-loop agent run, the text was queued but the agent was never signaled to stop. Added `agent_interject.try_send(())` after queueing so the agent stops at the next tool-result boundary and injects the queued message as a new user turn.

## Refactoring

Extracted `is_safe_during_agent()` into a reusable function (previously inline logic) and added 5 unit tests covering all edge cases.

## Test results

- 39 ui::tests — all pass
- 8 slash — all pass
- 20 checker — all pass
- 51 permission — all pass
- Zero regressions