### PR TITLE
feat(dirge-a6bv): MEMORY_GUIDANCE + SESSION_SEARCH_GUIDANCE in system prompt

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -3,7 +3,8 @@ use rig::completion::CompletionModel;
 use std::sync::Arc;
 
 use crate::agent::prompt::{
-    PROJECT_SKILLS_PREAMBLE, SKILLS_GUIDANCE, SYSTEM_PROMPT, TODO_TOOLS_PROMPT,
+    MEMORY_GUIDANCE, PROJECT_SKILLS_PREAMBLE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    SYSTEM_PROMPT, TODO_TOOLS_PROMPT,
 };
 use crate::agent::tools;
 use crate::agent::tools::ToolCache;
@@ -33,7 +34,14 @@ pub(crate) fn assemble_base_preamble() -> String {
     let mut p = SYSTEM_PROMPT.to_string();
     p.push('\n');
     p.push_str(TODO_TOOLS_PROMPT);
+    // dirge-xxun: skills self-improvement nudge (hermes SKILLS_GUIDANCE).
     p.push_str(SKILLS_GUIDANCE);
+    // dirge-a6bv: memory + past-session recall guidance (hermes
+    // MEMORY_GUIDANCE + SESSION_SEARCH_GUIDANCE). Both tools are always
+    // present in dirge's registry, so we inject unconditionally rather
+    // than tool-gating like hermes does on `valid_tool_names`.
+    p.push_str(MEMORY_GUIDANCE);
+    p.push_str(SESSION_SEARCH_GUIDANCE);
     p
 }
 
@@ -1202,6 +1210,44 @@ mod reminder_tests {
         assert!(
             p.contains("## Skill creation and maintenance"),
             "missing heading"
+        );
+    }
+
+    /// dirge-a6bv — assembled preamble carries hermes's MEMORY_GUIDANCE
+    /// and SESSION_SEARCH_GUIDANCE blocks: when to save vs not save,
+    /// declarative-fact phrasing, and the past-session-recall nudge.
+    #[test]
+    fn base_preamble_includes_memory_and_search_guidance() {
+        let p = assemble_base_preamble();
+
+        // MEMORY_GUIDANCE — must include the do/don't-save rules and the
+        // declarative-vs-imperative example pair.
+        assert!(p.contains("persistent memory"), "missing memory-tool intro");
+        assert!(
+            p.contains("Do NOT save task progress"),
+            "missing do-not-save rule"
+        );
+        assert!(
+            p.contains("PR numbers"),
+            "missing example list of stale artifacts"
+        );
+        assert!(
+            p.contains("declarative facts"),
+            "missing declarative-fact framing"
+        );
+        assert!(
+            p.contains("Procedures and workflows belong in skills"),
+            "missing memory-vs-skills boundary"
+        );
+
+        // SESSION_SEARCH_GUIDANCE — must name the trigger.
+        assert!(
+            p.contains("session_search"),
+            "missing session_search tool name"
+        );
+        assert!(
+            p.contains("before asking them to repeat"),
+            "missing past-session-recall nudge"
         );
     }
 

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -114,6 +114,46 @@ pub const SKILLS_GUIDANCE: &str = "\n\n## Skill creation and maintenance\n\n\
      patch it immediately with `skill(action='patch', ...)` — don't wait to \
      be asked. Skills that aren't maintained become liabilities.";
 
+/// In-session guidance for the per-project `memory` tool. Ported from
+/// hermes-agent (`agent/prompt_builder.py:150-171`, `MEMORY_GUIDANCE`).
+/// Hermes uses a single global memory; dirge memory is per-project
+/// (see `~/.claude/projects/<slug>/memory/MEMORY.md` analogue at
+/// `extras::memory_store::MemoryToolStore`). The advice on what to
+/// save / not save and the declarative-fact phrasing applies equally
+/// to both. See dirge-a6bv.
+pub const MEMORY_GUIDANCE: &str = "\n\n## Memory usage\n\n\
+     You have persistent memory across sessions on this project. Save \
+     durable facts using the `memory` tool: user preferences, environment \
+     details, tool quirks, and stable conventions. Memory is injected into \
+     every turn, so keep it compact and focused on facts that will still \
+     matter later.\n\
+     Prioritize what reduces future user steering — the most valuable \
+     memory is one that prevents the user from having to correct or remind \
+     you again. User preferences and recurring corrections matter more \
+     than procedural task details.\n\
+     Do NOT save task progress, session outcomes, completed-work logs, or \
+     temporary TODO state to memory; use `session_search` to recall those \
+     from past transcripts. Specifically: do not record PR numbers, issue \
+     numbers, commit SHAs, 'fixed bug X', 'submitted PR Y', 'Phase N done', \
+     file counts, or any artifact that will be stale in 7 days. If a fact \
+     will be stale in a week, it does not belong in memory. If you've \
+     discovered a new way to do something, or solved a problem that could \
+     be necessary later, save it as a skill with the `skill` tool.\n\
+     Write memories as declarative facts, not instructions to yourself. \
+     'User prefers concise responses' ✓ — 'Always respond concisely' ✗. \
+     'Project uses pytest with xdist' ✓ — 'Run tests with pytest -n 4' ✗. \
+     Imperative phrasing gets re-read as a directive in later sessions \
+     and can cause repeated work or override the user's current request. \
+     Procedures and workflows belong in skills, not memory.";
+
+/// In-session guidance for `session_search`. Ported verbatim from
+/// hermes-agent (`agent/prompt_builder.py:173-177`,
+/// `SESSION_SEARCH_GUIDANCE`). See dirge-a6bv.
+pub const SESSION_SEARCH_GUIDANCE: &str = "\n\n## Past-session recall\n\n\
+     When the user references something from a past conversation or you \
+     suspect relevant cross-session context exists, use `session_search` \
+     to recall it before asking them to repeat themselves.";
+
 /// Phase-3 — appended to the system prompt when
 /// `dynamic_tool_search` is on. Tells the model only a small
 /// always-on set of tools ships every turn and the rest must be


### PR DESCRIPTION
## Summary
Ports hermes-agent's `MEMORY_GUIDANCE` (`agent/prompt_builder.py:150-171`) and `SESSION_SEARCH_GUIDANCE` (`173-177`) into dirge's always-on base preamble.

Before this PR the model had no in-session signal for **when** to persist durable facts (or what NOT to record) and no nudge to recall past sessions before asking the user to repeat themselves. Both signals lived only in the post-session background-review prompt.

- Add `MEMORY_GUIDANCE` + `SESSION_SEARCH_GUIDANCE` consts in `src/agent/prompt.rs`. Hermes uses a single global memory; dirge memory is per-project but the do/don't-save rules and declarative-fact phrasing apply equally.
- Wire both into `assemble_base_preamble` after `SKILLS_GUIDANCE` (both tools are unconditionally registered in dirge, so no tool-gate).
- TDD: assembled preamble carries the do/don't-save rules ("Do NOT save task progress", "PR numbers"), the declarative-fact framing, the memory-vs-skills boundary, and the past-session-recall trigger.

## Test plan
- [x] `cargo test --bin dirge agent::builder`
- [x] `cargo test --bin dirge agent::prompt`
- [x] `cargo build --bin dirge`