### PR TITLE
chore: zero-warning build across all feature combinations

### DIFF
--- a/.dirge/skills/.usage.json
+++ b/.dirge/skills/.usage.json
@@ -1,84 +1,84 @@
 {
-  "steering-pipeline-debug": {
+  "session-db-migration": {
     "use_count": 0,
-    "view_count": 8,
+    "view_count": 12,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.661555+00:00",
-    "created_at": "2026-05-28T03:16:51.647294+00:00",
+    "last_viewed_at": "2026-05-28T04:30:20.150456+00:00",
+    "created_at": "2026-05-28T03:16:51.642338+00:00",
     "state": "active",
     "pinned": false
   },
   "dead-code-cleanup": {
     "use_count": 1,
-    "view_count": 9,
+    "view_count": 13,
     "patch_count": 0,
     "last_used_at": "2026-05-26T19:34:56.640777+00:00",
-    "last_viewed_at": "2026-05-28T04:16:15.572275+00:00",
+    "last_viewed_at": "2026-05-28T04:30:20.097589+00:00",
     "created_at": "2026-05-26T19:34:56.627150+00:00",
     "state": "active",
     "pinned": false
   },
-  "per-turn-session-db-writes": {
+  "steering-pipeline-debug": {
     "use_count": 0,
-    "view_count": 8,
+    "view_count": 12,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.614866+00:00",
-    "created_at": "2026-05-28T03:16:51.632047+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "flaky-test-env-var-fix": {
-    "use_count": 0,
-    "view_count": 8,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.577254+00:00",
-    "created_at": "2026-05-28T03:16:51.606580+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "security-guard-regex-upgrade": {
-    "use_count": 0,
-    "view_count": 8,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.640384+00:00",
-    "created_at": "2026-05-28T03:16:51.637220+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "add-agent-event-variant": {
-    "use_count": 0,
-    "view_count": 8,
-    "patch_count": 1,
-    "last_viewed_at": "2026-05-28T04:16:15.564975+00:00",
-    "last_patched_at": "2026-05-27T00:12:48.865965+00:00",
-    "created_at": "2026-05-27T00:12:48.865953+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "parallel-subagent-implementation": {
-    "use_count": 0,
-    "view_count": 8,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.602425+00:00",
-    "created_at": "2026-05-28T03:16:51.626955+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "session-db-migration": {
-    "use_count": 0,
-    "view_count": 8,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.655176+00:00",
-    "created_at": "2026-05-28T03:16:51.642338+00:00",
+    "last_viewed_at": "2026-05-28T04:30:20.162500+00:00",
+    "created_at": "2026-05-28T03:16:51.647294+00:00",
     "state": "active",
     "pinned": false
   },
   "hermes-porting-methodology": {
     "use_count": 0,
-    "view_count": 8,
+    "view_count": 12,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:16:15.591896+00:00",
+    "last_viewed_at": "2026-05-28T04:30:20.113335+00:00",
     "created_at": "2026-05-28T03:16:51.616889+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "flaky-test-env-var-fix": {
+    "use_count": 0,
+    "view_count": 12,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T04:30:20.104150+00:00",
+    "created_at": "2026-05-28T03:16:51.606580+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "add-agent-event-variant": {
+    "use_count": 0,
+    "view_count": 12,
+    "patch_count": 1,
+    "last_viewed_at": "2026-05-28T04:30:20.070681+00:00",
+    "last_patched_at": "2026-05-27T00:12:48.865965+00:00",
+    "created_at": "2026-05-27T00:12:48.865953+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "per-turn-session-db-writes": {
+    "use_count": 0,
+    "view_count": 12,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T04:30:20.131572+00:00",
+    "created_at": "2026-05-28T03:16:51.632047+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "security-guard-regex-upgrade": {
+    "use_count": 0,
+    "view_count": 12,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T04:30:20.137795+00:00",
+    "created_at": "2026-05-28T03:16:51.637220+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "parallel-subagent-implementation": {
+    "use_count": 0,
+    "view_count": 12,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T04:30:20.125351+00:00",
+    "created_at": "2026-05-28T03:16:51.626955+00:00",
     "state": "active",
     "pinned": false
   }

--- a/src/agent/agent_loop/plugin_hooks_tests.rs
+++ b/src/agent/agent_loop/plugin_hooks_tests.rs
@@ -258,6 +258,7 @@ async fn ywj_before_tool_call_block_prevents_invocation() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
     drop(tx);
@@ -322,6 +323,7 @@ async fn ywj_before_tool_call_mutation_threads_through() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
 
@@ -374,6 +376,7 @@ async fn ywj_after_tool_call_replaces_result_content() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
     drop(tx);
@@ -463,6 +466,7 @@ async fn ywj_prepare_next_turn_returns_turn_update() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
 
@@ -534,6 +538,7 @@ async fn ywj_should_stop_after_turn_terminates_loop() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
     drop(tx);
@@ -585,6 +590,7 @@ async fn ywj_get_steering_messages_injects_user_message_at_boundary() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
 
@@ -650,6 +656,7 @@ async fn ywj_get_followup_messages_reenters_outer_loop() {
         &tx,
         &factory,
         None,
+        None, // memory_provider — test default
     )
     .await;
 

--- a/src/agent/tools/session_search.rs
+++ b/src/agent/tools/session_search.rs
@@ -35,7 +35,11 @@ impl SessionSearchTool {
 
     /// Test/diagnostic accessor — the live session id this tool excludes
     /// from its results. `None` means no exclusion (a bug at the
-    /// builder layer; see dirge-502b).
+    /// builder layer; see dirge-502b). Gated `#[cfg(test)]` because
+    /// production code reads the id only through the
+    /// `SessionSearch::with_current_session` builder call.
+    #[cfg(test)]
+    #[allow(dead_code)]
     pub fn current_session_id(&self) -> Option<&str> {
         self.current_session_id.as_deref()
     }

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -197,6 +197,11 @@ async fn run_prompt(
         None::<&crate::extras::mcp::McpClientManager>,
         #[cfg(feature = "semantic")]
         None::<&crate::semantic::SemanticManager>,
+        // dirge-502b: ACP sessions identify themselves via the ACP
+        // protocol's own SessionId. Pass it through so the
+        // SessionSearchTool excludes the live session from its
+        // own search results.
+        Some(session_id.to_string()),
     )
     .await;
 

--- a/src/extras/memory_provider.rs
+++ b/src/extras/memory_provider.rs
@@ -26,7 +26,6 @@
 //! See dirge-bov5.
 
 use serde_json::Value;
-use std::sync::Arc;
 
 /// Pluggable backend for the `memory` tool. Implementors are stored
 /// behind `Arc<dyn MemoryProvider>` so the tool layer can hold a
@@ -159,11 +158,6 @@ impl MemoryProvider for super::memory_store::MemoryToolStore {
         super::memory_store::MemoryToolStore::remove(self, target, old_text)
     }
 }
-
-/// Boxed-provider alias used by the tool layer. Consumers hold an
-/// `Arc<dyn MemoryProvider>` so the concrete backend can be swapped
-/// at agent construction time without churning the call sites.
-pub type DynMemoryProvider = Arc<dyn MemoryProvider>;
 
 #[cfg(test)]
 mod tests {

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -386,6 +386,11 @@ impl PermissionChecker {
     /// the only behavioural difference is the post-step that converts
     /// `Ask → Allowed`. Mode coercions, prompt-level deny lists, and
     /// the session allowlist all run through unchanged.
+    ///
+    /// Gated on `feature = "semantic-bash"` to match the only call
+    /// site in `agent::tools::bash` — without that feature the
+    /// method is dead code.
+    #[cfg(feature = "semantic-bash")]
     pub fn check_bash_dev_null_softallow(&mut self, input: &str) -> CheckResult {
         match self.check("bash", input) {
             CheckResult::Ask => CheckResult::Allowed,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -726,10 +726,11 @@ impl AnyModel {
     }
 }
 
-/// dirge-yai1 — pure-function tool-name filter shared between the
-/// review and curator runner code paths. Pulled out so unit tests
-/// can exercise the filter shape without constructing a full
-/// `AnyAgent` with mock `LoopTool` instances.
+/// dirge-yai1 — pure-function tool-name filter used by tests to
+/// exercise the filter shape `spawn_filtered_runner_with_cache`
+/// applies internally. Gated `#[cfg(test)]` because production
+/// code uses the inline filter directly.
+#[cfg(test)]
 pub(crate) fn filter_tool_names<'a>(
     all: impl Iterator<Item = &'a str>,
     allowed: &[&str],
@@ -1157,6 +1158,7 @@ impl AnyAgent {
     /// `spawn_runner` later forwards to the agent loop as
     /// `LoopSpawnConfig::system_prompt`, so an end-to-end test can
     /// assert that the guidance blocks reach the model verbatim.
+    #[cfg(test)]
     pub fn preamble(&self) -> &str {
         &self.preamble
     }
@@ -1337,6 +1339,7 @@ impl AnyAgent {
     /// tool names that would survive the filter, in registration
     /// order. Lets the curator + review tests assert the filter
     /// shape without spawning a real runner.
+    #[cfg(test)]
     pub fn filtered_tool_names(&self, allowed_tools: &[&str]) -> Vec<String> {
         filter_tool_names(self.loop_tools.iter().map(|t| t.name()), allowed_tools)
     }

--- a/src/semantic/common.rs
+++ b/src/semantic/common.rs
@@ -18,6 +18,7 @@ use tree_sitter::Node;
 /// here aren't load-bearing: an empty symbol name is filtered out
 /// downstream; this log line exists purely so the issue surfaces
 /// when someone is investigating "why is this symbol missing".
+#[allow(dead_code)] // unused with `semantic-bash` alone; consumed by every other language adapter
 pub fn node_text<'a>(node: Node<'a>, source: &'a [u8]) -> &'a str {
     match node.utf8_text(source) {
         Ok(s) => s,
@@ -45,6 +46,7 @@ pub fn node_text<'a>(node: Node<'a>, source: &'a [u8]) -> &'a str {
 /// matches what callers want: a query over the function body is
 /// rooted at the function node, not at its inner block — the query
 /// itself filters to the relevant constructs.
+#[allow(dead_code)] // unused with `semantic-bash` alone; consumed by every other language adapter
 pub fn find_node_at_range<'a>(n: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
     if n.start_byte() == start && n.end_byte() == end {
         return Some(n);
@@ -69,6 +71,7 @@ pub fn find_node_at_range<'a>(n: Node<'a>, start: usize, end: usize) -> Option<N
 /// Note: counts CHARS not bytes (UTF-8-safe), but doesn't account
 /// for display width (emoji / CJK). Source code is overwhelmingly
 /// ASCII so the simpler char-count is fine.
+#[allow(dead_code)] // unused with `semantic-bash` alone; consumed by every other language adapter
 pub fn signature_first_line(node: Node, source: &[u8]) -> String {
     let text = node_text(node, source);
     let first = text.lines().next().unwrap_or(text);


### PR DESCRIPTION
## Summary
Fix three classes of build noise:

1. **ACP build broken (`feature = \"acp\"`)** — `extras/acp/mod.rs:183` was missing the `session_id` arg added in dirge-502b. Default feature set didn't include acp so it slipped through. Pass `Some(session_id.to_string())` — the ACP protocol's own SessionId.

2. **plugin-feature test sites broken** — `plugin_hooks_tests.rs` (7 sites) was missing the `memory_provider` arg added in dirge-h5tv. Default test build excludes `feature=plugin` so it slipped through.

3. **cfg-only dead code warnings:**
   - `SessionSearchTool::current_session_id` (test accessor) → `#[cfg(test)]`
   - `AnyAgent::preamble` + `filtered_tool_names` (test accessors) → `#[cfg(test)]`
   - `filter_tool_names` (test-only helper) → `#[cfg(test)]`
   - `PermissionChecker::check_bash_dev_null_softallow` (only used under `feature = \"semantic-bash\"`) → gated to match
   - `DynMemoryProvider` type alias (never used; removed)
   - `semantic::common` helpers (used by every `semantic-*` feature except `semantic-bash`) → `#[allow(dead_code)]` with comment

## Test plan
Verified zero warnings across:
- [x] `cargo build` (default)
- [x] `cargo build --features plugin`
- [x] `cargo build --features semantic-bash`
- [x] `cargo build --all-features`
- [x] `cargo test` (1598 tests)
- [x] `cargo test --features plugin` (1821 tests)
- [x] `cargo test --all-features` (1967 tests)