### PR TITLE
fix(ci): clear all warnings exposed by RUSTFLAGS=-D warnings

### DIFF
--- a/.dirge/skills/.usage.json
+++ b/.dirge/skills/.usage.json
@@ -1,84 +1,84 @@
 {
+  "flaky-test-env-var-fix": {
+    "use_count": 0,
+    "view_count": 16,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T05:18:24.954816+00:00",
+    "created_at": "2026-05-28T03:16:51.606580+00:00",
+    "state": "active",
+    "pinned": false
+  },
   "add-agent-event-variant": {
     "use_count": 0,
-    "view_count": 13,
+    "view_count": 16,
     "patch_count": 1,
-    "last_viewed_at": "2026-05-28T04:50:43.186107+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.921535+00:00",
     "last_patched_at": "2026-05-27T00:12:48.865965+00:00",
     "created_at": "2026-05-27T00:12:48.865953+00:00",
     "state": "active",
     "pinned": false
   },
+  "session-db-migration": {
+    "use_count": 0,
+    "view_count": 16,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T05:18:24.991211+00:00",
+    "created_at": "2026-05-28T03:16:51.642338+00:00",
+    "state": "active",
+    "pinned": false
+  },
   "security-guard-regex-upgrade": {
     "use_count": 0,
-    "view_count": 13,
+    "view_count": 16,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.286832+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.985228+00:00",
     "created_at": "2026-05-28T03:16:51.637220+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "flaky-test-env-var-fix": {
-    "use_count": 0,
-    "view_count": 13,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.232974+00:00",
-    "created_at": "2026-05-28T03:16:51.606580+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "per-turn-session-db-writes": {
-    "use_count": 0,
-    "view_count": 13,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.275954+00:00",
-    "created_at": "2026-05-28T03:16:51.632047+00:00",
     "state": "active",
     "pinned": false
   },
   "dead-code-cleanup": {
     "use_count": 1,
-    "view_count": 14,
+    "view_count": 17,
     "patch_count": 0,
     "last_used_at": "2026-05-26T19:34:56.640777+00:00",
-    "last_viewed_at": "2026-05-28T04:50:43.217277+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.948829+00:00",
     "created_at": "2026-05-26T19:34:56.627150+00:00",
-    "state": "active",
-    "pinned": false
-  },
-  "steering-pipeline-debug": {
-    "use_count": 0,
-    "view_count": 13,
-    "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.297780+00:00",
-    "created_at": "2026-05-28T03:16:51.647294+00:00",
     "state": "active",
     "pinned": false
   },
   "parallel-subagent-implementation": {
     "use_count": 0,
-    "view_count": 13,
+    "view_count": 16,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.265851+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.973191+00:00",
     "created_at": "2026-05-28T03:16:51.626955+00:00",
+    "state": "active",
+    "pinned": false
+  },
+  "steering-pipeline-debug": {
+    "use_count": 0,
+    "view_count": 16,
+    "patch_count": 0,
+    "last_viewed_at": "2026-05-28T05:18:24.997480+00:00",
+    "created_at": "2026-05-28T03:16:51.647294+00:00",
     "state": "active",
     "pinned": false
   },
   "hermes-porting-methodology": {
     "use_count": 0,
-    "view_count": 13,
+    "view_count": 16,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.244458+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.961850+00:00",
     "created_at": "2026-05-28T03:16:51.616889+00:00",
     "state": "active",
     "pinned": false
   },
-  "session-db-migration": {
+  "per-turn-session-db-writes": {
     "use_count": 0,
-    "view_count": 13,
+    "view_count": 16,
     "patch_count": 0,
-    "last_viewed_at": "2026-05-28T04:50:43.292934+00:00",
-    "created_at": "2026-05-28T03:16:51.642338+00:00",
+    "last_viewed_at": "2026-05-28T05:18:24.979056+00:00",
+    "created_at": "2026-05-28T03:16:51.632047+00:00",
     "state": "active",
     "pinned": false
   }

--- a/src/agent/tools/lsp.rs
+++ b/src/agent/tools/lsp.rs
@@ -364,6 +364,7 @@ mod tests {
                 response: std::sync::Mutex::new(response),
             }
         }
+        #[allow(dead_code)] // helper retained for future tests that need to assert dispatch order
         fn seen_methods(&self) -> Vec<String> {
             self.seen_methods.lock().unwrap().clone()
         }

--- a/src/plugin/hook.rs
+++ b/src/plugin/hook.rs
@@ -66,7 +66,7 @@ impl HookedToolDyn {
 
     /// Wrap with an explicit manager, bypassing the global. Used by tests
     /// and by callers that hold their own PluginManager.
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)] // retained for future callers; tests stopped using it
     pub fn with_manager(inner: Box<dyn ToolDyn>, pm: Option<Arc<Mutex<PluginManager>>>) -> Self {
         HookedToolDyn { inner, pm }
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1153,16 +1153,6 @@ impl AnyAgent {
     ///
     /// Returns immediately with `AgentRunner`; the loop runs on
     /// a spawned tokio task.
-    /// dirge-1ati — test accessor for the assembled system prompt
-    /// that `build_agent_inner` produced. Returns the same string
-    /// `spawn_runner` later forwards to the agent loop as
-    /// `LoopSpawnConfig::system_prompt`, so an end-to-end test can
-    /// assert that the guidance blocks reach the model verbatim.
-    #[cfg(test)]
-    pub fn preamble(&self) -> &str {
-        &self.preamble
-    }
-
     /// Return the provider name as a static string (matches the
     /// CLI / config naming: "openai", "anthropic", ..., "glm",
     /// "ollama", "openrouter", "custom"). Used to populate
@@ -1332,16 +1322,6 @@ impl AnyAgent {
         let (runner, _isolated_cache) =
             self.spawn_filtered_runner_with_cache(prompt, transcript, ToolCache::new(), &["skill"]);
         runner
-    }
-
-    /// dirge-yai1 — test/diagnostic accessor for the tool allow-list
-    /// applied by `spawn_filtered_runner_with_cache`. Returns the
-    /// tool names that would survive the filter, in registration
-    /// order. Lets the curator + review tests assert the filter
-    /// shape without spawning a real runner.
-    #[cfg(test)]
-    pub fn filtered_tool_names(&self, allowed_tools: &[&str]) -> Vec<String> {
-        filter_tool_names(self.loop_tools.iter().map(|t| t.name()), allowed_tools)
     }
 
     /// Internal review-runner constructor with an explicit

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -550,7 +550,7 @@ mod tests {
     /// Compaction records persist through save/load.
     #[test]
     fn roundtrip_compaction_persists() {
-        use crate::session::{Compaction, MessageRole, Session};
+        use crate::session::{MessageRole, Session};
         let id = unique_test_id("roundtrip-compact");
         let mut s = Session::new("p", "m", 100_000);
         s.id = compact_str::CompactString::from(id.clone());

--- a/src/tests/semantic_tests.rs
+++ b/src/tests/semantic_tests.rs
@@ -36,7 +36,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-ts")]
     fn find_callers_respects_word_boundaries() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         let _file = fixtures_dir().join("callers_test.ts");
 
@@ -67,7 +67,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-ts")]
     fn find_callees_works_on_tsx() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         let file = fixtures_dir().join("component.tsx");
 
@@ -85,7 +85,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-ts")]
     fn ts_extract_does_not_panic_on_imports() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         let file = fixtures_dir().join("component.tsx");
 
@@ -109,7 +109,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-python")]
     fn python_extracts_decorated_functions() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         let file = fixtures_dir().join("decorated.py");
 
@@ -139,7 +139,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-ts")]
     fn cold_cache_auto_initializes() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         // Cache is cold but find_definition auto-initializes from cwd.
         // Verify it doesn't error — it may find symbols or return empty.
@@ -152,7 +152,7 @@ mod semantic_tests {
     #[cfg(feature = "semantic-ts")]
     fn ensure_file_skips_binary_gracefully() {
         let registry = mk_registry();
-        let mut index = SymbolIndex::new(registry);
+        let index = SymbolIndex::new(registry);
 
         let bin_path = fixtures_dir().join("not_a_ts_file.bin");
         std::fs::write(&bin_path, b"\x00\x01\x02").unwrap();

--- a/src/ui/buffer.rs
+++ b/src/ui/buffer.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::ui::renderer::{VisualRow, display_col_to_char_index, wrap_editor, wrap_input};
+    use crate::ui::renderer::{display_col_to_char_index, wrap_editor, wrap_input};
 
     /// wrap_editor: empty buffer → one empty row, cursor at (0, 0).
     #[test]

--- a/src/ui/mod_tests.rs
+++ b/src/ui/mod_tests.rs
@@ -8,7 +8,6 @@
 
 use super::*;
 use crate::ui::search_rewind::update_search;
-use unicode_width::UnicodeWidthStr;
 
 // ============================================================
 // apply_subagent_panel_event — left-panel cleanup

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -15,7 +15,12 @@ use crossterm::terminal::{Clear, ClearType};
 /// fd 1 — see `TerminalGuard`'s fd redirection); falls back to
 /// stdout when there's no controlling terminal (CI tests).
 pub enum BackendWriter {
+    // In test builds the constructor is stubbed (cfg(test) at the
+    // factory below returns None), so the variants are never
+    // constructed — but the `impl Write` arms still need them.
+    #[cfg_attr(test, allow(dead_code))]
     Tty(std::fs::File),
+    #[cfg_attr(test, allow(dead_code))]
     Stdout(std::io::Stdout),
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -454,6 +454,7 @@ mod tests {
         assert!(is_bright(Color::AnsiValue(255)));
     }
 
+    #[test]
     fn presets_are_distinct() {
         assert_ne!(Theme::phosphor().agent, Theme::plain().agent);
         assert_ne!(Theme::phosphor().accent, Theme::plain().accent);


### PR DESCRIPTION
## Summary
CI matrix at PR #174 promoted warnings to errors via `RUSTFLAGS=-D warnings`, exposing 8 pre-existing dead-code / unused-import items that the local default-build never caught.

Fixed at the right layer in each case:

**Truly dead — deleted:**
- `AnyAgent::preamble` accessor (e2e test reads rig's `Agent.preamble` field directly)
- `AnyAgent::filtered_tool_names` (tests use the pure `filter_tool_names` function)

**Stale test-module imports — removed:**
- `Compaction` in `session/storage.rs:553`
- `VisualRow` in `ui/buffer.rs:9`
- `UnicodeWidthStr` in `ui/mod_tests.rs:11` (local re-imports inside test fns cover real usage)

**Test-only helpers retained — `#[allow(dead_code)]`:**
- `ScriptedSpawner::seen_methods` (LSP test mock)
- `HookedToolDyn::with_manager` (plugin-test bypass)
- `BackendWriter::Tty` / `Stdout` (built only in non-test cfg; `impl Write` arms need them; `cfg_attr(test, allow)`)

**Test bugs — fixed:**
- `ui::theme::presets_are_distinct` missing `#[test]` attribute (silently never ran)
- 6 `let mut` bindings in `semantic_tests.rs` no longer needed (`SymbolIndex` methods take `&self`)

## Test plan
Verified `RUSTFLAGS=-D warnings` clean across all 8 matrix variants and `cargo test` on default/plugin/all-features (1608 / 1831 / 1977 tests).