### PR TITLE
feat(memory): LLM consolidation pass for memory curator (dirge-mo0w PR-2)

### DIFF
--- a/src/agent/review.rs
+++ b/src/agent/review.rs
@@ -335,6 +335,131 @@ pub fn spawn_curator_review(
     });
 }
 
+/// dirge-mo0w PR-2: spawn the memory curator's LLM
+/// consolidation pass. Fire-and-forget. Mirror of
+/// `spawn_curator_review` but routes through
+/// `spawn_memory_curator_runner` (memory-only allow-list) so
+/// the model literally cannot write skills even if the prompt
+/// guard slips.
+///
+/// Skips entirely when `report.stale_candidates` is empty — no
+/// LLM call when there's nothing to consolidate. The mechanical
+/// pass still produced an audit report in PR-1; the LLM is only
+/// useful when there are decisions to make.
+///
+/// Writes its own `LLM_REPORT.md` under
+/// `.dirge/memory/.curator_reports/{ts}/` so the audit trail is
+/// preserved separately from the mechanical pass.
+pub fn spawn_memory_curator_review(
+    agent: AnyAgent,
+    paths: crate::extras::dirge_paths::ProjectPaths,
+    report: crate::extras::memory_curator::MechanicalReport,
+) {
+    if report.stale_candidates.is_empty() {
+        tracing::debug!(
+            target: "dirge::memory_curator",
+            "Skipping LLM consolidation pass — no stale candidates",
+        );
+        return;
+    }
+
+    // Read current MEMORY.md / PITFALLS.md verbatim. These are
+    // the inputs the LLM sees alongside the stale candidate
+    // table.
+    let memory_md = std::fs::read_to_string(paths.memory_file("MEMORY.md")).unwrap_or_default();
+    let pitfalls_md = std::fs::read_to_string(paths.memory_file("PITFALLS.md")).unwrap_or_default();
+    let input =
+        crate::extras::memory_curator::render_curator_input(&report, &memory_md, &pitfalls_md);
+    let prompt = format!(
+        "{}\n\n{}",
+        crate::extras::memory_curator::MEMORY_CURATOR_PROMPT,
+        input
+    );
+
+    let started = std::time::SystemTime::now();
+    let started_iso = chrono::Utc::now().to_rfc3339();
+    let started_filename = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let report_for_writer = report.clone();
+
+    tokio::spawn(async move {
+        // Memory-only runner — same forked-runner pattern as
+        // `spawn_curator_runner` but inverse allow-list.
+        let runner = agent.spawn_memory_curator_runner(prompt, String::new());
+        let mut rx = runner.event_rx;
+        let mut tool_actions: Vec<String> = Vec::new();
+        let mut error_msg: Option<String> = None;
+        while let Some(event) = rx.recv().await {
+            use crate::event::AgentEvent;
+            match event {
+                AgentEvent::Error(msg) => {
+                    tracing::warn!(
+                        target: "dirge::memory_curator",
+                        error = %msg,
+                        "Memory curator LLM pass encountered an error",
+                    );
+                    error_msg.get_or_insert_with(|| msg.to_string());
+                }
+                AgentEvent::ToolCall { name, .. } => {
+                    tool_actions.push(name.to_string());
+                }
+                AgentEvent::Done { .. } => break,
+                _ => {}
+            }
+        }
+
+        let elapsed_secs = started.elapsed().map(|d| d.as_secs_f64()).unwrap_or(0.0);
+        if error_msg.is_none() {
+            let summary = if tool_actions.is_empty() {
+                "no-op".to_string()
+            } else {
+                tool_actions
+                    .iter()
+                    .fold(Vec::<&str>::new(), |mut acc, a| {
+                        if !acc.contains(&a.as_str()) {
+                            acc.push(a.as_str());
+                        }
+                        acc
+                    })
+                    .join(" · ")
+            };
+            tracing::info!(
+                target: "dirge::memory_curator",
+                actions = %summary,
+                elapsed = %elapsed_secs,
+                "🗂  Memory curator LLM pass: {summary}",
+            );
+        }
+
+        let llm_report = crate::extras::memory_curator::LlmCuratorReport {
+            started_at_iso: started_iso,
+            elapsed_secs,
+            stale_candidates: report_for_writer.stale_candidates,
+            tool_actions,
+            error: error_msg,
+        };
+        let report_dir = paths
+            .memory_dir()
+            .join(".curator_reports")
+            .join(&started_filename);
+        if let Err(e) = std::fs::create_dir_all(&report_dir) {
+            tracing::warn!(
+                target: "dirge::memory_curator",
+                error = %e,
+                "Failed to create LLM report directory",
+            );
+            return;
+        }
+        let report_path = report_dir.join("LLM_REPORT.md");
+        if let Err(e) = std::fs::write(&report_path, llm_report.to_markdown()) {
+            tracing::warn!(
+                target: "dirge::memory_curator",
+                error = %e,
+                "Failed to write LLM report",
+            );
+        }
+    });
+}
+
 /// dirge-5cm9 / dirge-5gn6 / dirge-bx4g — fire the provider's
 /// `on_session_end` hook when a memory provider is attached. The
 /// hook receives the full transcript built from `session.messages`

--- a/src/extras/memory_curator.rs
+++ b/src/extras/memory_curator.rs
@@ -1,27 +1,31 @@
 //! Memory entry lifecycle curator. Periodic background pass that
 //! tracks MEMORY.md / PITFALLS.md entries via the usage sidecar,
-//! identifies stale candidates, and writes an audit report.
+//! identifies stale candidates, runs an LLM consolidation pass
+//! over them, and writes audit reports for both stages.
 //!
-//! dirge-mo0w (audit finding B), PR-1 of 2: mechanical pass only.
-//! No LLM call yet — that lands in the follow-up PR with the
-//! `MEMORY_CURATOR_PROMPT` analog of `dirge-odv3`. This PR builds
-//! the infrastructure (state, telemetry reconciliation, audit
-//! report, trigger gate) so the LLM pass has somewhere to plug
-//! into.
+//! dirge-mo0w (audit finding B). Closed across two PRs:
+//! - PR-1: mechanical pass — telemetry + state + stale-candidate
+//!   identification + `REPORT.md` writer.
+//! - PR-2: LLM consolidation pass — `MEMORY_CURATOR_PROMPT`
+//!   + memory-only forked runner via
+//!   `AnyAgent::spawn_memory_curator_runner` + `LLM_REPORT.md`
+//!   writer.
 //!
 //! Parallel structure to `extras::skills::curator`:
 //! - `.dirge/memory/.curator_state` — scheduler state
-//! - `.dirge/memory/.curator_reports/{YYYYMMDD-HHMMSS}/REPORT.md`
+//! - `.dirge/memory/.curator_reports/{ts}/REPORT.md` — mechanical
+//! - `.dirge/memory/.curator_reports/{ts}/LLM_REPORT.md` — LLM
 //! - 7-day interval gate, first-run defer
 //! - 30-day stale, 90-day archive-candidate thresholds
 //!
 //! Differences from the skills curator:
 //! - Entries aren't named — they're keyed by FNV-1a hash of
 //!   content via `memory_usage::MemoryUsageStore`.
-//! - PR-1 only IDENTIFIES archive candidates; it doesn't move
-//!   them. Actual archival waits for the LLM consolidation pass
-//!   in PR-2, where the model can judge whether stale entries
-//!   are also obsolete (some old facts are still load-bearing).
+//! - LLM pass biases toward KEEPING (skill curator biases toward
+//!   restructuring into umbrella classes); a 90-day-old fact may
+//!   still be load-bearing.
+//! - LLM pass uses a memory-only allow-list — model literally
+//!   cannot reach skill-write tools even if its prompt slips.
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -29,6 +33,54 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::extras::dirge_paths::ProjectPaths;
 use crate::extras::memory_usage::{MemoryUsageStore, ReconcileReport, entry_id};
+
+/// dirge-mo0w PR-2: prompt for the memory curator's LLM
+/// consolidation pass. Analog of `skills/curator::CURATOR_PROMPT`
+/// (dirge-odv3) but adapted for memory entries — the model has
+/// only the `memory` tool available (enforced at the registry
+/// level via `spawn_memory_curator_runner`'s `&["memory"]`
+/// allow-list, not just the prompt).
+///
+/// Differences from the skills prompt:
+/// - Memory entries are facts/pitfalls, not procedural skills.
+///   The right action is usually merge (consolidate overlapping
+///   facts) or remove (obsolete), not "create umbrella class".
+/// - Bias is toward KEEPING entries. A 90-day-old fact may
+///   still be load-bearing; the model must show its work for
+///   removals.
+/// - No `pinned` concept yet — every entry is in scope.
+pub const MEMORY_CURATOR_PROMPT: &str = "You are running as dirge's background memory CURATOR. Your job is to consolidate \
+the project's MEMORY.md and PITFALLS.md so they stay accurate and compact, NOT to add new facts. \
+You have ONLY the `memory` tool available — no read/write/edit/bash/skill tools are loaded. \
+\n\n\
+The mechanical pass below identified stale candidates: entries first observed ≥ 30 days ago. \
+Stale ≠ obsolete; many old facts are still load-bearing. Read each candidate carefully against \
+the rest of the memory store before acting. \
+\n\n\
+Preference order — prefer the earliest that fits:\n\
+  1. KEEP. Most entries should be kept untouched. \"Old\" is not a reason to act.\n\
+  2. CONSOLIDATE. If two or more entries cover the same fact, merge them into one \
+clearer entry using `memory(action='replace', ...)` then `memory(action='remove', ...)` for \
+the redundant copies.\n\
+  3. RESTRUCTURE. If one entry mixed unrelated concerns, split it via \
+`memory(action='replace', ...)` to the cleaner of the two facts, then `memory(action='add', ...)` \
+the other. This is rare — only do it when the entry is genuinely two facts wearing one coat.\n\
+  4. REMOVE. Only if the entry is clearly obsolete (refers to a deleted file, a renamed binary, \
+a long-superseded approach the project no longer uses). Show your reasoning in your thinking before \
+removing.\n\
+\n\
+Do NOT:\n\
+  • Add new facts. The curator is for consolidation, not capture. Background review handles capture.\n\
+  • Reword for style. Only change wording when consolidating duplicates or fixing a fact that's \
+now wrong.\n\
+  • Remove pitfalls eagerly. A pitfall surviving 90 days probably caught someone.\n\
+\n\
+Target shape: the memory file at the end of your pass should have STRICTLY FEWER OR EQUAL entries \
+to the start, each one carrying a fact that's still true. \"Nothing to consolidate.\" is a valid \
+outcome and is often the right answer.\n\
+\n\
+Below is the current memory store and the stale candidates the mechanical pass flagged. \
+Operate on these only.";
 
 /// Days since `first_seen_at` before an entry counts as stale.
 const STALE_AFTER_DAYS: u64 = 30;
@@ -295,6 +347,131 @@ impl MechanicalReport {
     }
 }
 
+/// dirge-mo0w PR-2: per-LLM-pass audit record. Parallel to
+/// `skills::curator::CuratorReport`. The mechanical pass returns
+/// `MechanicalReport`; the LLM pass returns this one. They're
+/// written to disk separately so the operator can see which
+/// stage produced which change.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LlmCuratorReport {
+    pub started_at_iso: String,
+    pub elapsed_secs: f64,
+    /// Stale candidates the mechanical pass handed to the LLM.
+    /// Same data as `MechanicalReport.stale_candidates` for the
+    /// run; copied here so a single report file fully describes
+    /// the LLM session.
+    pub stale_candidates: Vec<StaleCandidate>,
+    /// Sequence of memory-tool actions the LLM fired. Duplicates
+    /// preserved.
+    pub tool_actions: Vec<String>,
+    /// Captured error message if the agent stream surfaced one.
+    pub error: Option<String>,
+}
+
+impl LlmCuratorReport {
+    pub fn to_markdown(&self) -> String {
+        use std::collections::BTreeMap;
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        let _ = writeln!(out, "# Memory curator — LLM consolidation pass\n");
+        let _ = writeln!(out, "- Started: {}", self.started_at_iso);
+        let _ = writeln!(out, "- Elapsed: {:.2}s", self.elapsed_secs);
+        let _ = writeln!(
+            out,
+            "- Outcome: {}",
+            if self.error.is_some() {
+                "error"
+            } else if self.tool_actions.is_empty() {
+                "no-op (LLM chose to keep all candidates)"
+            } else {
+                "modified memory entries"
+            }
+        );
+        if let Some(err) = &self.error {
+            let _ = writeln!(out, "- Error: `{err}`");
+        }
+
+        let mut histogram: BTreeMap<&str, usize> = BTreeMap::new();
+        for action in &self.tool_actions {
+            *histogram.entry(action.as_str()).or_insert(0) += 1;
+        }
+        if !histogram.is_empty() {
+            let _ = writeln!(out, "\n## Tool calls\n");
+            for (name, count) in &histogram {
+                let _ = writeln!(out, "- `{name}` × {count}");
+            }
+        }
+
+        if !self.stale_candidates.is_empty() {
+            let _ = writeln!(out, "\n## Stale candidates given to the LLM\n");
+            let _ = writeln!(out, "| Target | Age (days) | Entry ID | Preview |");
+            let _ = writeln!(out, "|---|---|---|---|");
+            for c in &self.stale_candidates {
+                let _ = writeln!(
+                    out,
+                    "| `{}` | {} | `{}` | {} |",
+                    c.target,
+                    c.age_days,
+                    c.entry_id,
+                    c.preview.replace('|', "\\|"),
+                );
+            }
+        }
+
+        out
+    }
+}
+
+/// Render the input the LLM curator sees: current MEMORY.md /
+/// PITFALLS.md (full text) followed by the stale-candidate
+/// table from the mechanical pass. This is concatenated AFTER
+/// `MEMORY_CURATOR_PROMPT` and handed to the runner.
+pub fn render_curator_input(
+    report: &MechanicalReport,
+    memory_md: &str,
+    pitfalls_md: &str,
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "\n## Current MEMORY.md\n");
+    if memory_md.trim().is_empty() {
+        let _ = writeln!(out, "_(empty)_");
+    } else {
+        let _ = writeln!(out, "{}", memory_md.trim_end());
+    }
+    let _ = writeln!(out, "\n## Current PITFALLS.md\n");
+    if pitfalls_md.trim().is_empty() {
+        let _ = writeln!(out, "_(empty)_");
+    } else {
+        let _ = writeln!(out, "{}", pitfalls_md.trim_end());
+    }
+    let _ = writeln!(
+        out,
+        "\n## Stale candidates flagged by mechanical pass ({})\n",
+        report.stale_candidates.len(),
+    );
+    if report.stale_candidates.is_empty() {
+        let _ = writeln!(
+            out,
+            "_None. The mechanical pass found no entries ≥ {STALE_AFTER_DAYS} days old._"
+        );
+    } else {
+        let _ = writeln!(out, "| Target | Age (days) | Entry ID | Preview |");
+        let _ = writeln!(out, "|---|---|---|---|");
+        for c in &report.stale_candidates {
+            let _ = writeln!(
+                out,
+                "| `{}` | {} | `{}` | {} |",
+                c.target,
+                c.age_days,
+                c.entry_id,
+                c.preview.replace('|', "\\|"),
+            );
+        }
+    }
+    out
+}
+
 // ── Helpers ───────────────────────────────────────────
 
 fn now_secs() -> u64 {
@@ -531,6 +708,108 @@ mod tests {
             md.contains("no entries archived"),
             "PR-1 must disclaim mechanical-only scope: {md}",
         );
+    }
+
+    // ── PR-2: render_curator_input + LlmCuratorReport ──
+
+    fn make_report(stale: Vec<StaleCandidate>) -> MechanicalReport {
+        MechanicalReport {
+            started_at_iso: "2026-05-28T12:00:00Z".to_string(),
+            total_entries: stale.len(),
+            reconcile: ReconcileReport::default(),
+            stale_candidates: stale,
+        }
+    }
+
+    /// Render shows current memory + pitfalls verbatim, then a
+    /// table of stale candidates. The LLM sees this and decides
+    /// what to consolidate / remove.
+    #[test]
+    fn render_curator_input_includes_memory_pitfalls_and_stale_table() {
+        let report = make_report(vec![StaleCandidate {
+            target: "memory".to_string(),
+            entry_id: "abc123".to_string(),
+            preview: "old fact".to_string(),
+            age_days: 45,
+        }]);
+        let out = render_curator_input(&report, "fact A\n§\nfact B", "pitfall X");
+        assert!(out.contains("## Current MEMORY.md"));
+        assert!(out.contains("fact A"));
+        assert!(out.contains("## Current PITFALLS.md"));
+        assert!(out.contains("pitfall X"));
+        assert!(out.contains("## Stale candidates"));
+        assert!(out.contains("abc123"));
+        assert!(out.contains("old fact"));
+        assert!(out.contains("45"));
+    }
+
+    /// Empty memory store renders the `_(empty)_` sentinel
+    /// instead of leaving the section blank — keeps the prompt
+    /// readable when the project hasn't accumulated facts yet.
+    #[test]
+    fn render_curator_input_marks_empty_stores_explicitly() {
+        let report = make_report(vec![]);
+        let out = render_curator_input(&report, "", "");
+        assert!(out.contains("## Current MEMORY.md"));
+        assert!(out.contains("_(empty)_"));
+        assert!(out.contains("## Current PITFALLS.md"));
+        assert!(out.contains("None. The mechanical pass found no entries"));
+    }
+
+    /// LLM report markdown captures elapsed, tool actions
+    /// histogram, and the stale candidate table the LLM was
+    /// given.
+    #[test]
+    fn llm_curator_report_markdown_includes_actions_and_candidates() {
+        let r = LlmCuratorReport {
+            started_at_iso: "2026-05-28T12:00:00Z".to_string(),
+            elapsed_secs: 4.2,
+            stale_candidates: vec![StaleCandidate {
+                target: "pitfalls".to_string(),
+                entry_id: "deadbeef00000000".to_string(),
+                preview: "stale pitfall".to_string(),
+                age_days: 100,
+            }],
+            tool_actions: vec!["memory".to_string(), "memory".to_string()],
+            error: None,
+        };
+        let md = r.to_markdown();
+        assert!(md.contains("# Memory curator — LLM consolidation pass"));
+        assert!(md.contains("Outcome: modified memory entries"));
+        assert!(md.contains("`memory` × 2"));
+        assert!(md.contains("deadbeef00000000"));
+        assert!(md.contains("stale pitfall"));
+    }
+
+    /// LLM report flags no-op runs distinctly so the operator
+    /// can tell "LLM chose to keep everything" from "LLM crashed."
+    #[test]
+    fn llm_curator_report_markdown_flags_noop_outcome() {
+        let r = LlmCuratorReport {
+            started_at_iso: "2026-05-28T12:00:00Z".to_string(),
+            elapsed_secs: 0.5,
+            stale_candidates: vec![],
+            tool_actions: vec![],
+            error: None,
+        };
+        let md = r.to_markdown();
+        assert!(md.contains("no-op (LLM chose to keep all candidates)"));
+    }
+
+    /// LLM report markdown surfaces error messages so failures
+    /// are visible in the audit trail without scraping logs.
+    #[test]
+    fn llm_curator_report_markdown_surfaces_errors() {
+        let r = LlmCuratorReport {
+            started_at_iso: "2026-05-28T12:00:00Z".to_string(),
+            elapsed_secs: 0.1,
+            stale_candidates: vec![],
+            tool_actions: vec![],
+            error: Some("model timed out".to_string()),
+        };
+        let md = r.to_markdown();
+        assert!(md.contains("Outcome: error"));
+        assert!(md.contains("model timed out"));
     }
 
     /// Preview helper: short entries pass through verbatim;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1324,6 +1324,27 @@ impl AnyAgent {
         runner
     }
 
+    /// dirge-mo0w PR-2: memory-only forked runner for the memory
+    /// curator's LLM consolidation pass. Inverse of
+    /// `spawn_curator_runner` — same forked-runner pattern, but
+    /// the tool allow-list is `&["memory"]` so the consolidation
+    /// pass can ONLY add/replace/remove memory entries, not write
+    /// skills. The model literally cannot reach skill-write tools
+    /// even if the prompt-level guard slips.
+    pub fn spawn_memory_curator_runner(
+        &self,
+        prompt: String,
+        transcript: String,
+    ) -> crate::agent::runner::AgentRunner {
+        let (runner, _isolated_cache) = self.spawn_filtered_runner_with_cache(
+            prompt,
+            transcript,
+            ToolCache::new(),
+            &["memory"],
+        );
+        runner
+    }
+
     /// Internal review-runner constructor with an explicit
     /// caller-supplied cache. Returns the cache alongside the
     /// runner so tests can assert cache isolation via

--- a/src/ui/run_handlers/done.rs
+++ b/src/ui/run_handlers/done.rs
@@ -565,58 +565,70 @@ pub(crate) async fn handle_done(
             }
         });
 
-        // dirge-mo0w PR-1: memory curator mechanical pass.
-        // Parallel to the skills curator above — same 7-day gate,
-        // same fire-and-forget pattern. Reconciles the
-        // .dirge/memory/.usage.json sidecar against current
-        // MEMORY.md / PITFALLS.md entries, identifies stale
-        // candidates (≥30 days), writes an audit report under
-        // .dirge/memory/.curator_reports/. Does NOT archive
-        // anything in PR-1 — that waits for the LLM
-        // consolidation pass in PR-2 where the model can judge
-        // whether stale entries are also obsolete.
+        // dirge-mo0w: memory curator. PR-1 added the mechanical
+        // pass; PR-2 adds the LLM consolidation pass that fires
+        // when the mechanical pass surfaces stale candidates.
+        // Same fire-and-forget pattern as the skills curator
+        // above. The mechanical pass is fast (disk IO + hash);
+        // the LLM pass is gated on `!report.stale_candidates.is_empty()`
+        // so a session with nothing stale doesn't pay for an
+        // LLM call.
         let memory_curator_paths = paths.clone();
+        let memory_curator_agent = agent.clone();
         tokio::spawn(async move {
-            tokio::task::spawn_blocking(move || {
-                let mut curator = match crate::extras::memory_curator::MemoryCurator::new(
-                    &memory_curator_paths,
-                ) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        tracing::debug!(
-                            target: "dirge::memory_curator",
-                            error = %e,
-                            "Failed to construct memory curator — skipping run",
-                        );
-                        return;
+            let mechanical_report = tokio::task::spawn_blocking({
+                let paths = memory_curator_paths.clone();
+                move || {
+                    let mut curator =
+                        match crate::extras::memory_curator::MemoryCurator::new(&paths) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                tracing::debug!(
+                                    target: "dirge::memory_curator",
+                                    error = %e,
+                                    "Failed to construct memory curator — skipping run",
+                                );
+                                return None;
+                            }
+                        };
+                    if !curator.should_run_now() {
+                        return None;
                     }
-                };
-                if !curator.should_run_now() {
-                    return;
-                }
-                match curator.run_mechanical_pass() {
-                    Ok(report) => {
-                        tracing::info!(
-                            target: "dirge::memory_curator",
-                            total = %report.total_entries,
-                            added = %report.reconcile.added,
-                            retained = %report.reconcile.retained,
-                            dropped = %report.reconcile.dropped,
-                            stale = %report.stale_candidates.len(),
-                            "memory curator mechanical pass complete",
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "dirge::memory_curator",
-                            error = %e,
-                            "memory curator mechanical pass failed",
-                        );
+                    match curator.run_mechanical_pass() {
+                        Ok(report) => {
+                            tracing::info!(
+                                target: "dirge::memory_curator",
+                                total = %report.total_entries,
+                                added = %report.reconcile.added,
+                                retained = %report.reconcile.retained,
+                                dropped = %report.reconcile.dropped,
+                                stale = %report.stale_candidates.len(),
+                                "memory curator mechanical pass complete",
+                            );
+                            Some(report)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "dirge::memory_curator",
+                                error = %e,
+                                "memory curator mechanical pass failed",
+                            );
+                            None
+                        }
                     }
                 }
             })
             .await
-            .ok();
+            .ok()
+            .flatten();
+
+            if let Some(report) = mechanical_report {
+                crate::agent::review::spawn_memory_curator_review(
+                    memory_curator_agent,
+                    memory_curator_paths,
+                    report,
+                );
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

PR-2 of 2 closing audit finding B. PR-1 (#183) added the mechanical pass. This PR adds the LLM consolidation pass that judges whether stale entries are obsolete and applies add/replace/remove changes via the `memory` tool.

## What's new

**`MEMORY_CURATOR_PROMPT`** — analog of `skills::curator::CURATOR_PROMPT` (`dirge-odv3`) but adapted for memory entries. Bias toward KEEPING. Preference order: KEEP → CONSOLIDATE → RESTRUCTURE → REMOVE. Explicit "Nothing to consolidate." is a valid outcome.

**`AnyAgent::spawn_memory_curator_runner`** — mirror of `spawn_curator_runner` but with `&["memory"]` tool allow-list. Forked runner literally cannot reach skill-write tools (defense in depth beyond the prompt guard).

**`agent::review::spawn_memory_curator_review`** — fire-and-forget task that reads MEMORY.md + PITFALLS.md, renders the LLM input via `render_curator_input`, concatenates with the prompt, fires the runner, captures tool actions, writes `LLM_REPORT.md`. Skips entirely when `stale_candidates.is_empty()`.

**Wiring update** — `ui/run_handlers/done.rs` now invokes `spawn_memory_curator_review` from the same tokio task that ran the mechanical pass; the `MechanicalReport` flows from one to the other.

## Reports

| File | Written by | Contains |
|---|---|---|
| `.dirge/memory/.curator_reports/{ts}/REPORT.md` | Mechanical pass (PR-1) | scan stats, reconcile (added/retained/dropped), stale candidates |
| `.dirge/memory/.curator_reports/{ts}/LLM_REPORT.md` | LLM pass (PR-2) | elapsed, tool action histogram, stale candidates given to the LLM, error if any |

Two reports, intentionally separate — operator can see "mechanical pass flagged X, then LLM decided Y" without conflating the stages.

## Test plan

- [x] `cargo build --bin dirge` clean
- [x] `cargo fmt --all` clean
- [x] `RUSTFLAGS="-D warnings" cargo test --bin dirge` — 1677 passed (+5 new)
- [x] 5 new tests covering `render_curator_input` (with + without stale candidates, empty stores) and `LlmCuratorReport::to_markdown` (modified / no-op / error outcomes)
- [x] `spawn_memory_curator_review` is integration-tested through real LLM runs (no unit-level mock), same pattern as skills' `spawn_curator_review`
- [ ] CI matrix green