### PR TITLE
test(agent-loop): scavenge provider-coverage matrix (dirge-ets0)

### DIFF
--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -857,6 +857,421 @@ mod tests {
         assert_eq!(dones, 0);
     }
 
+    // ── dirge-ets0: Scavenge provider-coverage matrix ────────────
+    //
+    // Pillar 2 audit found that scavenge only reads
+    // ContentBlock::Thinking. The end-to-end claim is that ALL
+    // three reasoning surfaces (DeepSeek reasoning_content, OpenAI
+    // o1 summary, Anthropic extended thinking) route through rig
+    // into Thinking, so tool-call JSON the model forgot to put in
+    // the structured tool_calls field gets recovered.
+    //
+    // These tests drive the full pipeline:
+    // 1. Construct the rig-level streaming events for each
+    //    provider shape.
+    // 2. Run them through `wrap_streamed_assistant`.
+    // 3. Extract the final AssistantMessage's Thinking content
+    //    (the same surface run.rs:558-566 reads).
+    // 4. Feed it to `scavenge_tool_calls`.
+    // 5. Assert the orphan tool call was recovered.
+
+    use crate::agent::agent_loop::scavenge::scavenge_tool_calls;
+    use std::collections::HashSet;
+
+    /// Extract the same `reasoning_text` string `run.rs:558-566`
+    /// constructs from an AssistantMessage. Centralized helper
+    /// so the test matrix mirrors the production reasoning-text
+    /// shape verbatim — if run.rs ever changes how it joins
+    /// Thinking blocks, these tests must change with it.
+    fn reasoning_text_of(message: &AssistantMessage) -> String {
+        message
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Thinking { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn allowed_set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// DeepSeek pattern: provider streams the `reasoning_content`
+    /// field as chunked `ReasoningDelta` events. The chunks may
+    /// straddle JSON tokens. End-to-end: a model that forgot to
+    /// emit the call in `tool_calls` but described it in
+    /// reasoning must be recovered by scavenge.
+    #[tokio::test]
+    async fn provider_coverage_deepseek_reasoning_delta_chunks() {
+        // Three chunks with the orphan tool-call JSON straddling
+        // chunk boundaries — the worst case for naive joiners.
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: "I should call ".to_string(),
+            }),
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: r#"{"name": "get_weather", "arguments""#.to_string(),
+            }),
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: r#": {"city": "SF"}}"#.to_string(),
+            }),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        // Verify the Thinking block was assembled correctly from
+        // the chunks before scavenge runs against it.
+        let reasoning = reasoning_text_of(&message);
+        assert!(
+            reasoning.contains(r#"{"name": "get_weather", "arguments": {"city": "SF"}}"#),
+            "chunks must reassemble into the full JSON: {reasoning:?}",
+        );
+        // End-to-end scavenge.
+        let allowed = allowed_set(&["get_weather"]);
+        let result = scavenge_tool_calls(Some(&reasoning), &allowed, 4);
+        assert_eq!(
+            result.calls.len(),
+            1,
+            "scavenge must recover the orphan call from DeepSeek-style \
+             reasoning_content chunks: {result:?}",
+        );
+        assert_eq!(result.calls[0].name, "get_weather");
+        assert_eq!(result.calls[0].arguments["city"], "SF");
+    }
+
+    /// OpenAI o1 pattern: provider emits a single complete
+    /// Reasoning event with `ReasoningContent::Summary`. The
+    /// summary is a redacted overview of the model's internal
+    /// thinking — but if a tool-call JSON shows up in it (rare
+    /// but observed), scavenge must still recover it.
+    #[tokio::test]
+    async fn provider_coverage_openai_o1_summary_reasoning() {
+        let mut reasoning = Reasoning::new("");
+        // Public constructor builds an empty Reasoning; mutate
+        // its content via the same path the provider takes.
+        reasoning.content = vec![ReasoningContent::Summary(
+            r#"Plan: {"name": "search", "arguments": {"q": "rust async"}}"#.to_string(),
+        )];
+        let raw = raw_stream(vec![Ok(StreamedAssistantContent::Reasoning(reasoning))]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        let reasoning_text = reasoning_text_of(&message);
+        let allowed = allowed_set(&["search"]);
+        let result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert_eq!(
+            result.calls.len(),
+            1,
+            "scavenge must recover orphan call from o1 Summary: \
+             reasoning={reasoning_text:?}, result={result:?}",
+        );
+        assert_eq!(result.calls[0].name, "search");
+        assert_eq!(result.calls[0].arguments["q"], "rust async");
+    }
+
+    /// Anthropic extended-thinking pattern: provider emits a
+    /// complete Reasoning event with one or more
+    /// `ReasoningContent::Text` entries. End-to-end recovery
+    /// must work identically to the o1 case.
+    #[tokio::test]
+    async fn provider_coverage_anthropic_extended_thinking_text() {
+        let mut reasoning = Reasoning::new("");
+        reasoning.content = vec![
+            ReasoningContent::Text {
+                text: "Let me look this up.".to_string(),
+                signature: None,
+            },
+            ReasoningContent::Text {
+                text: r#"I'll dispatch: {"name": "search", "arguments": {"q": "anthropic"}}"#
+                    .to_string(),
+                signature: None,
+            },
+        ];
+        let raw = raw_stream(vec![Ok(StreamedAssistantContent::Reasoning(reasoning))]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        let reasoning_text = reasoning_text_of(&message);
+        let allowed = allowed_set(&["search"]);
+        let result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert_eq!(
+            result.calls.len(),
+            1,
+            "scavenge must recover orphan call from Anthropic-style \
+             multi-text reasoning: {result:?}",
+        );
+        assert_eq!(result.calls[0].name, "search");
+        assert_eq!(result.calls[0].arguments["q"], "anthropic");
+    }
+
+    /// Anthropic-specific edge: `ReasoningContent::Encrypted` and
+    /// `Redacted` payloads. These are opaque (the model never
+    /// emits them as scavengeable text) — they MUST be dropped
+    /// without panicking and without producing a Thinking block
+    /// with garbled bytes. Documents the intentional gap so a
+    /// future change that *does* surface them is conscious.
+    #[tokio::test]
+    async fn provider_coverage_anthropic_encrypted_thinking_is_dropped_silently() {
+        // Use the rig API directly so we don't depend on whether
+        // these variants are constructible from public APIs.
+        let mut reasoning = Reasoning::new("");
+        reasoning.content = vec![
+            ReasoningContent::Text {
+                text: "visible reasoning".to_string(),
+                signature: None,
+            },
+            ReasoningContent::Encrypted("OPAQUE_BYTES".to_string()),
+        ];
+        let raw = raw_stream(vec![Ok(StreamedAssistantContent::Reasoning(reasoning))]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        let reasoning_text = reasoning_text_of(&message);
+        // Visible text survives.
+        assert!(
+            reasoning_text.contains("visible reasoning"),
+            "Text content must survive: {reasoning_text:?}",
+        );
+        // Encrypted payload does NOT leak into the reasoning
+        // surface — scavenge would otherwise try to parse opaque
+        // bytes as JSON and could produce spurious notes.
+        assert!(
+            !reasoning_text.contains("OPAQUE_BYTES"),
+            "encrypted payload must be dropped, not appended: {reasoning_text:?}",
+        );
+        // Scavenge on the remaining text finds nothing actionable
+        // (no JSON in the visible portion). Important: it must
+        // not crash on the encrypted-was-dropped path.
+        let allowed = allowed_set(&["search"]);
+        let result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert!(
+            result.calls.is_empty(),
+            "no orphan call in visible text; scavenge must return empty",
+        );
+    }
+
+    /// Cross-provider negative: an orphan call to a tool the
+    /// model isn't allowed to call must be ignored regardless of
+    /// which reasoning surface surfaced it. Defense against the
+    /// failure mode where the model hallucinates a `rm -rf /`
+    /// tool in reasoning and scavenge would otherwise dispatch it.
+    #[tokio::test]
+    async fn provider_coverage_orphan_call_to_disallowed_tool_is_ignored() {
+        let raw = raw_stream(vec![Ok(StreamedAssistantContent::ReasoningDelta {
+            id: None,
+            reasoning: r#"{"name": "rm_rf_slash", "arguments": {}}"#.to_string(),
+        })]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        let reasoning_text = reasoning_text_of(&message);
+        // Only "search" is allowed; "rm_rf_slash" is not.
+        let allowed = allowed_set(&["search"]);
+        let result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert!(
+            result.calls.is_empty(),
+            "scavenge must skip disallowed tools regardless of reasoning surface",
+        );
+    }
+
+    /// Multiple Thinking blocks (interleaved with text content)
+    /// MUST all be joined the same way `run.rs:558-566` does so
+    /// a tool call that straddles a text→thinking→text boundary
+    /// gets recovered. Catches a regression where some future
+    /// refactor might forget to concat all Thinking blocks.
+    #[tokio::test]
+    async fn provider_coverage_multiple_thinking_blocks_all_scavenged() {
+        let mut r1 = Reasoning::new("");
+        r1.content = vec![ReasoningContent::Text {
+            text: r#"first: {"name": "get_weather", "arguments": {"city": "SF"}}"#.to_string(),
+            signature: None,
+        }];
+        let mut r2 = Reasoning::new("");
+        r2.content = vec![ReasoningContent::Text {
+            text: r#"second: {"name": "search", "arguments": {"q": "x"}}"#.to_string(),
+            signature: None,
+        }];
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::Reasoning(r1)),
+            Ok(StreamedAssistantContent::Text(Text {
+                text: "between".to_string(),
+            })),
+            Ok(StreamedAssistantContent::Reasoning(r2)),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+        let reasoning_text = reasoning_text_of(&message);
+        let allowed = allowed_set(&["get_weather", "search"]);
+        let result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert_eq!(
+            result.calls.len(),
+            2,
+            "both Thinking blocks must contribute to scavenge: {result:?}",
+        );
+        let names: Vec<&str> = result.calls.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"get_weather"));
+        assert!(names.contains(&"search"));
+    }
+
+    /// dirge-ets0 end-to-end: full chain stream → assistant
+    /// message → scavenge → dedupe → tool_calls. Mirrors the
+    /// integration in `run.rs:558-636` to prove the wiring works
+    /// across the boundary, not just at the surface points the
+    /// per-provider tests check.
+    ///
+    /// Scenario: model emits ONE structured tool call AND a
+    /// reasoning block containing the SAME call (provider double-
+    /// emit, e.g. R1 leaking the call into reasoning_content) PLUS
+    /// a NEW orphan call. After integration:
+    /// - the structured call stays exactly once (dedupe wins)
+    /// - the orphan call is appended (novel signature)
+    /// - no third copy of the structured call shows up
+    #[tokio::test]
+    async fn provider_coverage_end_to_end_scavenge_dedupe_chain() {
+        use rig::completion::message::{ToolCall as RigToolCall, ToolFunction as RigToolFunction};
+
+        // Stream: structured tool call + reasoning describing
+        // the same call AND a new one.
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: format!(
+                    "Plan: call get_weather. {} Then maybe also {}",
+                    r#"{"name": "get_weather", "arguments": {"city": "SF"}}"#,
+                    r#"{"name": "search", "arguments": {"q": "tide"}}"#,
+                ),
+            }),
+            Ok(StreamedAssistantContent::ToolCall {
+                tool_call: RigToolCall {
+                    id: "call-1".to_string(),
+                    function: RigToolFunction {
+                        name: "get_weather".to_string(),
+                        arguments: serde_json::json!({"city": "SF"}),
+                    },
+                    call_id: None,
+                    signature: None,
+                    additional_params: None,
+                },
+                internal_call_id: "internal-1".to_string(),
+            }),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let message = match events.last() {
+            Some(StreamEvent::Done { message, .. }) => message.clone(),
+            _ => panic!("expected Done"),
+        };
+
+        // Mirror run.rs:535-554 — collect structured tool calls.
+        let mut tool_calls: Vec<crate::agent::agent_loop::tools::ToolCall> = message
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                } => Some(crate::agent::agent_loop::tools::ToolCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: arguments.clone(),
+                }),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "structured tool call must be extracted exactly once"
+        );
+
+        // Mirror run.rs:558-636 — scavenge + dedupe.
+        let reasoning_text = reasoning_text_of(&message);
+        let allowed = allowed_set(&["get_weather", "search"]);
+        let scavenge_result = scavenge_tool_calls(Some(&reasoning_text), &allowed, 4);
+        assert_eq!(
+            scavenge_result.calls.len(),
+            2,
+            "scavenge must find both reasoning-embedded calls",
+        );
+
+        // Same canonical-JSON dedupe shape as run.rs.
+        fn canonical(v: &serde_json::Value) -> String {
+            match v {
+                serde_json::Value::Object(m) => {
+                    let mut keys: Vec<&String> = m.keys().collect();
+                    keys.sort();
+                    let mut s = String::from("{");
+                    for (i, k) in keys.iter().enumerate() {
+                        if i > 0 {
+                            s.push(',');
+                        }
+                        s.push_str(&serde_json::to_string(k).unwrap_or_default());
+                        s.push(':');
+                        s.push_str(&canonical(&m[*k]));
+                    }
+                    s.push('}');
+                    s
+                }
+                serde_json::Value::Array(a) => {
+                    let mut s = String::from("[");
+                    for (i, e) in a.iter().enumerate() {
+                        if i > 0 {
+                            s.push(',');
+                        }
+                        s.push_str(&canonical(e));
+                    }
+                    s.push(']');
+                    s
+                }
+                other => serde_json::to_string(other).unwrap_or_default(),
+            }
+        }
+        let seen: HashSet<String> = tool_calls
+            .iter()
+            .map(|tc| format!("{}::{}", tc.name, canonical(&tc.arguments)))
+            .collect();
+        for sc in &scavenge_result.calls {
+            let sig = format!("{}::{}", sc.name, canonical(&sc.arguments));
+            if !seen.contains(&sig) {
+                tool_calls.push(sc.clone());
+            }
+        }
+
+        // Final assertion: structured call preserved, orphan
+        // added, no double-count.
+        assert_eq!(
+            tool_calls.len(),
+            2,
+            "expected 2 calls (1 structured + 1 novel scavenged); got: {:?}",
+            tool_calls.iter().map(|t| &t.name).collect::<Vec<_>>(),
+        );
+        let names: Vec<&str> = tool_calls.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["get_weather", "search"]);
+        // Structured call's id is preserved (the reasoning copy
+        // had no id and would have been ignored only if dedupe
+        // hit — which it must).
+        assert_eq!(tool_calls[0].id, "call-1");
+    }
+
     /// Mixed content: text → reasoning → text produces 3 blocks
     /// because the reasoning resets the text-block index.
     #[tokio::test]


### PR DESCRIPTION
## Summary

Lands the Pillar 2 Phase 2 scavenge provider-coverage test matrix that the stale **PR #178** carried but never merged. (The `dirge-ets0` bead was mistakenly closed as "merged via #178" earlier — its commit was never on main. This re-lands the actual work clean off current main, dropping #178's stray `spikes/` + `.usage.json` churn.)

Adds 7 provider-coverage tests to `rig_stream.rs` exercising the scavenge → truncate → storm pipeline across provider stream shapes:
- DeepSeek reasoning-delta chunks
- OpenAI o1 summary reasoning
- multiple thinking blocks all scavenged
- orphan call to a disallowed tool ignored
- end-to-end scavenge + dedupe chain

Purely additive (no production code change). Compiles + passes against current main, which has since gained the Phase 2.5/3/4 scavenge/truncation/cap work.

## Test plan
- [x] `cargo build --bin dirge` clean
- [x] `RUSTFLAGS="-D warnings" cargo test --bin dirge` — 1705 pass
- [x] 7 new `provider_coverage_*` tests in `rig_stream::tests`
- [ ] CI matrix green

Supersedes #178 (which will be closed).