### PR TITLE
fix(perm/ux): skill transparency + traversal hardening, avatar reset, sticky-allow normalization

### DIFF
--- a/src/extras/skills/manager.rs
+++ b/src/extras/skills/manager.rs
@@ -81,6 +81,12 @@ impl SkillManager {
             .ok_or_else(|| "Invalid skill format: must have YAML frontmatter (--- ... ---) followed by markdown body".to_string())?;
         // Use the parsed name from frontmatter if it differs from dir name.
         let actual_name = spec.name;
+        // SECURITY: the on-disk directory is built from the FRONTMATTER
+        // name, not the (already-validated) `name` argument. Re-validate
+        // so a crafted frontmatter `name: ../../escape` can't write a
+        // SKILL.md outside `.dirge/skills/`. Skill writes are
+        // auto-allowed (no permission prompt) so this is the boundary.
+        format::validate_name(&actual_name)?;
 
         self.ensure_dir()?;
         let skill_dir = self.skills_dir.join(&actual_name);
@@ -98,12 +104,14 @@ impl SkillManager {
 
     /// Edit an existing skill from raw SKILL.md content. The skill must exist.
     pub fn edit_from_content(&self, name: &str, content: &str) -> Result<(), String> {
+        // SECURITY: validate before building the path (uniform with the
+        // other mutators; writes are auto-allowed so this is the guard).
+        format::validate_name(name)?;
         let skill_dir = self.skills_dir.join(name);
         if !skill_dir.is_dir() {
             return Err(format!("Skill '{}' not found", name));
         }
 
-        format::validate_name(name)?;
         format::validate_content_size(content)?;
         guard::scan_skill_content(content)?;
 
@@ -119,6 +127,9 @@ impl SkillManager {
     /// replaces only the first. If matches with different text,
     /// returns an error.
     pub fn patch(&self, name: &str, old_text: &str, new_text: &str) -> Result<(), String> {
+        // SECURITY: reject traversal names before building any path
+        // (writes are auto-allowed; the manager is the only boundary).
+        format::validate_name(name)?;
         let skill_dir = self.skills_dir.join(name);
         let skill_path = skill_dir.join("SKILL.md");
 
@@ -171,6 +182,11 @@ impl SkillManager {
     /// Delete a skill directory and its contents. Destructive —
     /// consider archiving instead for production use.
     pub fn delete(&self, name: &str) -> Result<(), String> {
+        // SECURITY: reject traversal names before `remove_dir_all` —
+        // a name like `../../foo` would otherwise delete a directory
+        // outside `.dirge/skills/`. Writes are auto-allowed, so this
+        // validation (not a permission prompt) is the only guard.
+        format::validate_name(name)?;
         let skill_dir = self.skills_dir.join(name);
         if !skill_dir.is_dir() {
             return Err(format!("Skill '{}' not found", name));
@@ -218,6 +234,8 @@ impl SkillManager {
     /// Archive a skill — move to `.archive/`. Does not delete.
     #[allow(dead_code)]
     pub fn archive(&self, name: &str) -> Result<(), String> {
+        // SECURITY: reject traversal names before moving directories.
+        format::validate_name(name)?;
         let src = self.skills_dir.join(name);
         if !src.is_dir() {
             return Err(format!("Skill '{}' does not exist", name));
@@ -473,5 +491,62 @@ mod tests {
         let big = "x".repeat(100_001);
         let err = mgr.create("big", "", &big, &[]).unwrap_err();
         assert!(err.contains("too large"), "got: {err}");
+    }
+
+    // ── path-traversal hardening ───────────────────────
+    //
+    // Skill writes are auto-allowed in Standard/Accept mode (no
+    // permission prompt), so the manager — not the prompt — is the
+    // only boundary keeping skill mutations inside `.dirge/skills/`.
+    // Every mutating method must reject names that could escape it.
+
+    /// `create_from_content` builds the on-disk dir from the
+    /// frontmatter `name:`, NOT the validated `name` argument. A
+    /// crafted frontmatter name with `..`/separators must be rejected
+    /// before any directory is created outside the skills dir.
+    #[test]
+    fn create_from_content_rejects_frontmatter_name_traversal() {
+        let (mgr, dir) = temp_manager();
+        let sentinel = dir.join("escaped-skill");
+        let _ = std::fs::remove_dir_all(&sentinel);
+        // skills_dir = dir/.dirge/skills → `../../escaped-skill` = dir/escaped-skill.
+        let content =
+            "---\nname: ../../escaped-skill\ndescription: x\n---\n\nbody content\n".to_string();
+        let err = mgr.create_from_content("safe", &content).unwrap_err();
+        assert!(
+            err.contains("Skill name"),
+            "frontmatter-name traversal must be rejected by validate_name; got: {err}",
+        );
+        assert!(
+            !sentinel.exists(),
+            "no directory may be created outside the skills dir",
+        );
+    }
+
+    #[test]
+    fn patch_rejects_name_traversal() {
+        let (mgr, _dir) = temp_manager();
+        let err = mgr.patch("../../etc/passwd", "a", "b").unwrap_err();
+        assert!(
+            err.contains("Skill name"),
+            "patch must reject traversal names before touching the path; got: {err}",
+        );
+    }
+
+    #[test]
+    fn delete_rejects_name_traversal() {
+        let (mgr, dir) = temp_manager();
+        let sentinel = dir.join("sentinel-keep");
+        std::fs::create_dir_all(&sentinel).unwrap();
+        // `../../sentinel-keep` from dir/.dirge/skills resolves to dir/sentinel-keep.
+        let err = mgr.delete("../../sentinel-keep").unwrap_err();
+        assert!(
+            err.contains("Skill name"),
+            "delete must reject traversal names before remove_dir_all; got: {err}",
+        );
+        assert!(
+            sentinel.exists(),
+            "delete must not remove directories outside the skills dir via traversal",
+        );
     }
 }

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -167,6 +167,15 @@ impl PermissionChecker {
             // in the mode switch below — its contract is "every
             // action confirms".
             "memory",
+            // skill follows the same contract as memory: its actions
+            // (load/list/create/edit/patch) operate only on the
+            // agent's own scoped skills directory, not arbitrary
+            // filesystem paths. Prompting per action is friction with
+            // no security value in Standard/Accept. Restrictive still
+            // demotes the WRITE actions (create/edit/patch) back to
+            // Ask in the mode switch below; the read actions
+            // (load/list) pass through.
+            "skill",
         ] {
             rules
                 .entry(tool.to_string())
@@ -470,8 +479,14 @@ impl PermissionChecker {
                 // "no rule matched but default is Allow" also
                 // demotes. Explicit user `deny` still denies.
                 let memory_write = tool == "memory" && input != "view" && base != Action::Deny;
+                // skill read actions arrive as the bare keywords
+                // `load`/`list`; write actions (create/edit/patch)
+                // arrive as `{action}:{name}`. Demote only the writes
+                // — same posture as memory's view-vs-mutate split.
+                let skill_write =
+                    tool == "skill" && input != "load" && input != "list" && base != Action::Deny;
                 let bare_default = matched.is_empty() && self.default_action == Action::Allow;
-                if memory_write || bare_default {
+                if memory_write || skill_write || bare_default {
                     Action::Ask
                 } else {
                     base
@@ -1020,6 +1035,36 @@ fn canonicalize_path_pattern(pattern_str: &str, working_dir: &str) -> Option<Str
     };
     if head_trimmed.is_empty() {
         return None;
+    }
+    // RELATIVE-HEAD ANCHORING (re-prompt bug): `suggest_pattern`
+    // derives a path-tool pattern from the parent of the LLM's input.
+    // When the LLM sends a relative path (e.g. `src/main.rs`), the
+    // stored pattern is the RELATIVE glob `src/**`, which compiles to
+    // `^src(?:/.*)?$`. But `check_path` always matches against the
+    // canonical ABSOLUTE form via `resolve_absolute`, so the next call
+    // (especially when the LLM sends an absolute path, or the same
+    // file resolved through the cwd) never matches the relative
+    // pattern and the user is re-prompted despite "allow always".
+    //
+    // The canonical twin must be anchored at the CHECKER's
+    // `working_dir`, not the process cwd. A bare `std::fs::canonicalize`
+    // on a relative head resolves against `std::env::current_dir()`,
+    // which can differ from the checker's working_dir (the agent may
+    // have `cd`'d via `set_working_dir`). For relative heads, anchor at
+    // `working_dir` first; this keeps the boundary tight — the twin can
+    // only point inside `working_dir` (or wherever the symlink-followed
+    // canonical path lands), never escaping to an arbitrary absolute
+    // location chosen by the LLM.
+    if !std::path::Path::new(head_trimmed).is_absolute() {
+        let resolved = resolve_absolute(head_trimmed, working_dir);
+        if resolved != head_trimmed {
+            let mut out = resolved;
+            if had_trailing_slash {
+                out.push('/');
+            }
+            out.push_str(tail);
+            return Some(out);
+        }
     }
     let canonical_head = std::fs::canonicalize(head_trimmed)
         .ok()

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -94,6 +94,9 @@ fn m4_defaults_allow_safe_ask_dangerous() {
         // dirge-sm9w: memory is auto-allowed in Standard/Accept
         // (scoped to ~/.dirge/memories/, no arbitrary FS access).
         "memory",
+        // skill is auto-allowed on the same rationale (scoped to the
+        // agent's skills dir; Restrictive still demotes its writes).
+        "skill",
     ] {
         let result = checker.check_path(tool, "/tmp/anything.rs");
         assert!(
@@ -110,7 +113,6 @@ fn m4_defaults_allow_safe_ask_dangerous() {
         "webfetch",
         "websearch",
         "task",
-        "skill",
     ] {
         // Path is OUTSIDE working_dir (/tmp) so the CWD-scoped
         // allow installer does not apply.
@@ -1215,4 +1217,146 @@ fn allow_always_folder_resolves_through_symlinks() {
     );
 
     let _ = std::fs::remove_dir_all(&root);
+}
+
+// ============================================================
+// Regression coverage for the 6 reported permission/UX issues.
+// Triage (2026-05) found 5 already fixed on main (write /dev/null,
+// memory transparency, in-cwd read/write, the escape-cwd security
+// boundary, bash sticky-allow); only `skill` transparency was a
+// genuine gap. These tests lock in all six so none regress.
+// ============================================================
+mod reported_permission_ux_regressions {
+    use super::*;
+
+    fn checker_in(dir: &str) -> PermissionChecker {
+        PermissionChecker::new(
+            &PermissionConfig::default(),
+            SecurityMode::Standard,
+            Some(std::path::PathBuf::from(dir)),
+        )
+    }
+
+    // Issue #1: write to /dev/null should not prompt.
+    #[test]
+    fn probe_write_dev_null_allowed() {
+        let mut c = checker_in("/tmp");
+        assert!(
+            matches!(c.check_path("write", "/dev/null"), CheckResult::Allowed),
+            "write /dev/null should be Allowed, got {:?}",
+            c.check_path("write", "/dev/null")
+        );
+    }
+
+    // Issue #2: memory operations should not prompt.
+    #[test]
+    fn probe_memory_actions_allowed() {
+        for action in ["view", "add", "replace", "remove"] {
+            let mut c = checker_in("/tmp");
+            assert!(
+                matches!(c.check("memory", action), CheckResult::Allowed),
+                "memory {action} should be Allowed, got {:?}",
+                c.check("memory", action)
+            );
+        }
+    }
+
+    // Issue #4: skill operations should not prompt in Standard mode.
+    // Read keywords arrive bare (load/list); write actions arrive as
+    // `{action}:{name}` (create/edit/patch).
+    #[test]
+    fn probe_skill_actions_allowed() {
+        for action in ["load", "list", "create:foo", "edit:foo", "patch:foo"] {
+            let mut c = checker_in("/tmp");
+            assert!(
+                matches!(c.check("skill", action), CheckResult::Allowed),
+                "skill {action} should be Allowed, got {:?}",
+                c.check("skill", action)
+            );
+        }
+    }
+
+    // Restrictive mode keeps its "every write confirms" contract:
+    // skill read actions stay transparent, but create/edit/patch
+    // demote back to Ask (mirrors memory's view-vs-mutate split).
+    #[test]
+    fn probe_skill_restrictive_demotes_writes_not_reads() {
+        let mk = || {
+            PermissionChecker::new(
+                &PermissionConfig::default(),
+                SecurityMode::Restrictive,
+                Some(std::path::PathBuf::from("/tmp")),
+            )
+        };
+        for read in ["load", "list"] {
+            assert!(
+                matches!(mk().check("skill", read), CheckResult::Allowed),
+                "skill {read} must stay Allowed under Restrictive, got {:?}",
+                mk().check("skill", read)
+            );
+        }
+        for write in ["create:foo", "edit:foo", "patch:foo", "delete:foo"] {
+            assert!(
+                matches!(mk().check("skill", write), CheckResult::Ask),
+                "skill {write} must demote to Ask under Restrictive, got {:?}",
+                mk().check("skill", write)
+            );
+        }
+    }
+
+    // Issue #5a: reads inside the project folder should not prompt.
+    #[test]
+    fn probe_read_inside_cwd_allowed() {
+        let mut c = checker_in("/tmp/proj");
+        assert!(
+            matches!(
+                c.check_path("read", "/tmp/proj/src/main.rs"),
+                CheckResult::Allowed
+            ),
+            "read inside cwd should be Allowed"
+        );
+    }
+
+    // Issue #5b: writes inside the project folder should not prompt.
+    #[test]
+    fn probe_write_inside_cwd_allowed() {
+        let mut c = checker_in("/tmp/proj");
+        let r = c.check_path("write", "/tmp/proj/src/main.rs");
+        assert!(
+            matches!(r, CheckResult::Allowed),
+            "write inside cwd should be Allowed, got {:?}",
+            r
+        );
+    }
+
+    // SECURITY BOUNDARY: writes OUTSIDE cwd must still prompt.
+    #[test]
+    fn probe_write_outside_cwd_still_asks() {
+        let mut c = checker_in("/tmp/proj");
+        let r = c.check_path("write", "/etc/evil.conf");
+        assert!(
+            matches!(r, CheckResult::Ask),
+            "write OUTSIDE cwd must still Ask, got {:?}",
+            r
+        );
+    }
+
+    // Issue #6: sticky-allow — after always-allowing `cargo *`,
+    // a similar cargo command should not re-prompt.
+    #[test]
+    fn probe_sticky_allow_bash_similar_command() {
+        let mut c = checker_in("/tmp");
+        c.add_session_allowlist("bash".to_string(), "cargo *");
+        assert!(
+            matches!(
+                c.check("bash", "cargo test --bin dirge"),
+                CheckResult::Allowed
+            ),
+            "sticky-allow cargo * should match cargo test --bin dirge"
+        );
+        assert!(
+            matches!(c.check("bash", "cargo build"), CheckResult::Allowed),
+            "sticky-allow cargo * should match cargo build"
+        );
+    }
 }

--- a/src/permission/path.rs
+++ b/src/permission/path.rs
@@ -117,12 +117,53 @@ pub(crate) fn resolve_absolute(path: &str, working_dir: &str) -> String {
     match std::fs::canonicalize(&joined) {
         Ok(canonical) => canonical.to_string_lossy().to_string(),
         Err(_) => {
-            if let (Some(parent), Some(name)) = (joined.parent(), joined.file_name())
-                && let Ok(canonical_parent) = std::fs::canonicalize(parent)
-            {
-                return canonical_parent.join(name).to_string_lossy().to_string();
+            // The full path doesn't exist on disk (e.g. a write to a
+            // brand-new file, possibly in a brand-new nested dir).
+            // Canonicalize the DEEPEST existing ancestor so any
+            // symlink in the existing prefix is resolved to its
+            // realpath, then re-attach the still-nonexistent tail.
+            //
+            // Why the deepest ancestor and not just the immediate
+            // parent: when the agent writes to `new_a/new_b/file.rs`
+            // inside a symlinked cwd, neither `file.rs`'s parent
+            // (`new_b`) nor its grandparent (`new_a`) exist, so the
+            // old single-level parent canonicalize failed and we fell
+            // through to a purely lexical result that kept the SYMLINK
+            // form of the cwd. That form never matches the CWD-allow
+            // rule (built from the canonical cwd), so in-project writes
+            // re-prompted. Walking to the nearest existing ancestor
+            // fixes that while staying inside the project subtree.
+            //
+            // The tail is lexically normalized FIRST (resolving `.` /
+            // `..` without touching disk) so an attacker can't smuggle
+            // an escape through `existing_dir/../../etc/passwd`: the
+            // `..` are collapsed against the lexical components, and
+            // any that climb above the existing ancestor are preserved
+            // as `..` (see `lexical_normalize`), so the result escapes
+            // the cwd subtree and is correctly classified external.
+            let normalized = lexical_normalize(&joined);
+            let mut ancestor = normalized.as_path();
+            let mut tail: Vec<std::ffi::OsString> = Vec::new();
+            loop {
+                if let Ok(canonical_ancestor) = std::fs::canonicalize(ancestor) {
+                    let mut out = canonical_ancestor;
+                    for seg in tail.iter().rev() {
+                        out.push(seg);
+                    }
+                    return out.to_string_lossy().to_string();
+                }
+                match (ancestor.parent(), ancestor.file_name()) {
+                    (Some(parent), Some(name)) => {
+                        tail.push(name.to_os_string());
+                        ancestor = parent;
+                    }
+                    // Reached the root with nothing canonicalizable
+                    // (e.g. a fully bogus working_dir). Fall back to
+                    // the lexical form so the literal-prefix checks in
+                    // `is_external_path` still have something to match.
+                    _ => return normalized.to_string_lossy().to_string(),
+                }
             }
-            lexical_normalize(&joined).to_string_lossy().to_string()
         }
     }
 }
@@ -228,6 +269,72 @@ mod tests {
         assert_eq!(resolved, expected, "symlink should resolve to its target",);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression: a write to a brand-new file in a brand-new
+    /// NESTED directory inside a symlinked cwd must resolve through
+    /// the symlink to the real path. The immediate parent doesn't
+    /// exist (so single-level parent canonicalize fails); the fix
+    /// walks up to the deepest existing ancestor, canonicalizes
+    /// that (resolving the symlinked cwd), and re-attaches the
+    /// nonexistent tail. Without this the result kept the symlink
+    /// form, the CWD-allow rule (built from the canonical cwd) never
+    /// matched, and in-project writes re-prompted.
+    #[test]
+    fn resolve_absolute_walks_to_deepest_existing_ancestor_through_symlink() {
+        let base = std::env::temp_dir().join(format!("dirge-deepancestor-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let real = base.join("real_proj");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = base.join("link_proj");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // newdir/sub do NOT exist yet; only `link_proj` (→ real_proj) does.
+        let target = link.join("newdir/sub/file.rs");
+        let resolved = resolve_absolute(target.to_str().unwrap(), link.to_str().unwrap());
+
+        let expected = std::fs::canonicalize(&real)
+            .unwrap()
+            .join("newdir/sub/file.rs")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            resolved, expected,
+            "deep new path under symlinked cwd must resolve to realpath form",
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Security: the deepest-ancestor walk must NOT let a `..`
+    /// traversal disguise an escape as internal. `..` is lexically
+    /// collapsed BEFORE the ancestor canonicalize, so a path that
+    /// climbs out of the (symlinked) cwd resolves outside the
+    /// subtree and is classified external (→ prompt), not allowed.
+    #[test]
+    fn resolve_absolute_dotdot_escape_through_symlinked_cwd_still_escapes() {
+        let base = std::env::temp_dir().join(format!("dirge-escape-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let real = base.join("real_proj");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = base.join("link_proj");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let cwd = link.to_string_lossy().into_owned();
+        // newdir doesn't exist; the `..` chain climbs above the project.
+        let traversal = "newdir/../../../../../../etc/passwd";
+        let resolved = resolve_absolute(traversal, &cwd);
+
+        let cwd_canonical = std::fs::canonicalize(&real).unwrap();
+        let resolved_path = std::path::PathBuf::from(&resolved);
+        assert!(
+            !resolved_path.starts_with(&cwd_canonical),
+            "escape via .. must resolve outside the cwd subtree; got {resolved:?}",
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// F7: nonexistent paths (writes to new files) must still

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -353,6 +353,67 @@ fn session_allowlist_takes_effect_for_path_tool_on_next_check() {
     );
 }
 
+/// Re-prompt bug: when the user "allow always"es a path tool while the
+/// LLM sent a RELATIVE path, `suggest_pattern` stores a relative glob
+/// (e.g. `sub/**`). The next check_path always matches against the
+/// canonical ABSOLUTE form (via resolve_absolute), so the relative
+/// pattern never matched and the user got re-prompted. The fix anchors
+/// the canonical-variant twin at the checker's working_dir.
+#[test]
+fn session_allowlist_relative_pattern_matches_absolute_check_inside_cwd() {
+    // Real on-disk working dir so resolve_absolute / canonicalize work.
+    let proj = std::env::temp_dir().join(format!(
+        "dirge-relpat-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let sub = proj.join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+
+    let mut checker = PermissionChecker::new(
+        &PermissionConfig::default(),
+        // Restrictive so the in-cwd write isn't auto-allowed by the
+        // CWD-scoped builtin rule — forces the test through the
+        // session-allowlist path we actually care about.
+        SecurityMode::Restrictive,
+        Some(proj.clone()),
+    );
+    checker.set_working_dir(proj.to_str().unwrap());
+
+    // Simulate "allow always" with the RELATIVE pattern that
+    // suggest_pattern("write", "sub/file.rs") would produce.
+    checker.add_session_allowlist("write".to_string(), "sub/**");
+
+    // Subsequent call arrives as an ABSOLUTE path to a DIFFERENT file
+    // in the same subtree (the realistic LLM behavior). Must be allowed
+    // without re-prompting.
+    let abs = sub.join("other.rs");
+    let result = checker.check_path("write", abs.to_str().unwrap());
+    assert!(
+        matches!(result, CheckResult::Allowed),
+        "absolute write to {abs:?} must be Allowed after relative `sub/**` allow-always; got {result:?}",
+    );
+
+    // Security boundary: a path OUTSIDE the working directory entirely
+    // must still prompt — anchoring the relative `sub/**` pattern at
+    // working_dir must not over-allow arbitrary absolute paths.
+    let outside = if cfg!(windows) {
+        "C:\\Windows\\Temp\\sub\\evil.txt".to_string()
+    } else {
+        "/tmp/sub/evil.txt".to_string()
+    };
+    let outside_result = checker.check_path("write", &outside);
+    assert!(
+        matches!(outside_result, CheckResult::Ask),
+        "write outside the working dir must still Ask; the relative `sub/**` allow must anchor at cwd, not match any `/.../sub/*`; got {outside_result:?}",
+    );
+
+    let _ = std::fs::remove_dir_all(&proj);
+}
+
 // --- Config-driven rules ---
 
 #[test]

--- a/src/ui/avatar.rs
+++ b/src/ui/avatar.rs
@@ -165,4 +165,52 @@ mod tests {
             AvatarState::Reading
         );
     }
+
+    /// Regression guard for the "avatar stuck on (O_O) Alert after a
+    /// permission dialog resolves" bug. When the user lets a tool
+    /// proceed, the UI loop resets the avatar via
+    /// `from_tool_name(&ask_req.tool)`. That reset must always land on
+    /// a working face — never on `Alert` (the prompt-time face) and
+    /// never on `Done`/`Error`/`Idle` — for every tool that can ever
+    /// be gated behind a permission prompt.
+    #[test]
+    fn permission_allow_reset_never_lands_on_alert() {
+        let gated_tools = [
+            "read",
+            "grep",
+            "find_files",
+            "list_dir",
+            "lsp",
+            "semantic",
+            "write",
+            "edit",
+            "apply_patch",
+            "write_todo_list",
+            "bash",
+            "shell",
+            "memory",
+            "skill",
+            "webfetch",
+            "task",
+            "mcp_tool:server:name",
+        ];
+        for tool in gated_tools {
+            let state = AvatarState::from_tool_name(tool);
+            assert!(
+                matches!(
+                    state,
+                    AvatarState::Reading | AvatarState::Writing | AvatarState::Bash
+                ),
+                "tool {:?} reset to non-working avatar state {:?}",
+                tool,
+                state,
+            );
+            assert_ne!(
+                state,
+                AvatarState::Alert,
+                "tool {:?} must not reset to the Alert face",
+                tool,
+            );
+        }
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2682,6 +2682,20 @@ pub async fn run_interactive(
                 renderer.clear_alert_overlay();
                 let _ = ask_req.reply.send(decision);
 
+                // Avatar bugfix: when the user lets the tool proceed
+                // (Allow / AllowAlways), the avatar is still stuck on
+                // the Alert face `(O_O)` that was set at prompt time
+                // (see set_avatar_state(Alert) above). Reset it to the
+                // tool's working face (Reading/Writing/Bash) so the
+                // bottom-row avatar matches the tool that's now
+                // running again. The deny path intentionally leaves
+                // this alone — the tool isn't going to run, and the
+                // turn's own Done/Error/Idle handlers own the next
+                // transition.
+                if !was_denied {
+                    renderer.set_avatar_state(avatar::AvatarState::from_tool_name(&ask_req.tool));
+                }
+
                 // Audit H10: cascading reject. When the user denies
                 // one tool, any other tool requests already queued
                 // in `ask_rx` belong to the same agent run and the


### PR DESCRIPTION
## Summary

Addresses 6 reported permission/UX issues. Triage found **4 already fixed on main** (write `/dev/null`, memory transparency, in-cwd read/write with the escape-cwd boundary, bash sticky-allow) — the user was likely on a stale binary for those. This branch closes the remaining gaps and adds a regression suite locking in **all six** so none regress.

| # | Issue | Status |
|---|-------|--------|
| 1 | write to `/dev/null` prompts | already on main (`install_dev_null_allow`) — regression test added |
| 2 | memory ops prompt | already on main (`dirge-sm9w`) — regression test added |
| 3 | avatar stuck on `(O_O)` after a prompt | **fixed** (reset on allow-continuation) |
| 4 | memory/skill ops should be transparent | **fixed** — `skill` now auto-allowed like `memory` |
| 5 | in-folder read/write prompts; escaping cwd must still prompt | already on main + **deepest-ancestor symlink fix**; boundary test added |
| 6 | sticky-allow doesn't match similar commands | already on main + **relative-pattern anchoring**; boundary test added |

## Changes

- **skill auto-allow** (`checker.rs`): `skill` joins `memory` in the builtin-allow list (Standard/Accept → Allow). Restrictive still demotes the write actions (`create`/`edit`/`patch`/`delete`) to Ask; reads (`load`/`list`) pass through.
- **skill manager traversal hardening** (`extras/skills/manager.rs`): auto-allowing skill writes removes the permission prompt, so the manager — not the prompt — is the only boundary keeping writes inside `.dirge/skills/`. Added `validate_name` to **every** mutator, including the FRONTMATTER-derived name in `create_from_content` (the real attack vector) and the previously-unguarded `delete`/`patch`/`archive`. Closes a path traversal where `create` with frontmatter `name: ../../escape` wrote a `SKILL.md` outside the skills dir, and an unguarded `delete ../../foo` `remove_dir_all`.
- **avatar reset** (`ui/mod.rs`, `ui/avatar.rs`): on the permission-allow continuation, reset the `(O_O)` Alert face to the tool's working face (was stuck until the next unrelated event). Deny path intentionally left to the turn's Done/Error/Idle handlers.
- **path normalization** (`permission/path.rs`, `tests/checker_tests.rs`): resolve writes to brand-new nested dirs inside a symlinked cwd via the deepest existing ancestor; anchor relative allow-always patterns at the checker's `working_dir`. Both with `..`-escape tests proving the cwd boundary still holds.

## Security

Adversarially reviewed. `validate_name` rejects `/`, `\`, control chars, and leading `.` (so bare `..` is rejected). Confirmed no remaining skill write/delete vector escapes `.dirge/skills/`; `read_content`/`exists`/`restore` lack the guard but take no attacker-controlled input (and `restore` is unwired dead code). The escape-cwd boundary holds in every mode — relative patterns anchor at cwd and don't over-allow arbitrary absolute paths.

## Tests

Full suite green: **1720 default / 1950 plugin**, `RUSTFLAGS="-D warnings"`. Added: 8-case regression suite for all 6 issues, 3 skill traversal tests, symlink/relative path-resolution tests, avatar reset guard.