### PR TITLE
fix(perm): re-anchor checker working_dir on worktree switch (in-folder writes keep prompting)

### DIFF
--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -135,8 +135,10 @@ impl PermissionChecker {
         //   - `/tmp/safe.txt` → only `**` matches → builtin allow ✓
         //
         // Tools NOT in this list (write/edit/apply_patch/bash/webfetch/
-        // websearch/task/skill/memory) fall to the global default Ask
-        // unless the user installs explicit rules.
+        // websearch/task) fall to the global default Ask unless the
+        // user installs explicit rules. NOTE: `memory` and `skill` ARE
+        // in this list (added below, per dirge-sm9w) — auto-allowed in
+        // Standard/Accept and demoted to Ask only in Restrictive.
         //
         // Adapts maki's `BUILTIN_ALLOW_RULES`
         // (`maki-agent/src/permissions.rs:16-24`) for dirge's tool set.

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -1304,6 +1304,44 @@ mod reported_permission_ux_regressions {
         }
     }
 
+    // Issue #5 (ROOT CAUSE): git worktrees are created as SIBLINGS
+    // (`../name`, see git_worktree::create), OUTSIDE the original
+    // repo. When dirge switches into a worktree it MUST call
+    // set_working_dir, or the in-cwd write-allow glob stays anchored
+    // to the original repo and EVERY write inside the worktree is
+    // classified external -> prompts on every edit. This pins the
+    // re-anchoring contract the worktree cwd-change sites must honor
+    // (cmd_worktree create, wt-exit, and merge-return in done.rs).
+    #[test]
+    fn probe_worktree_sibling_switch_reanchors_cwd_allow() {
+        let mut c = checker_in("/repo/main");
+        // Before the switch: a write in the sibling worktree is external.
+        assert!(
+            matches!(
+                c.check_path("write", "/repo/wt/src/foo.rs"),
+                CheckResult::Ask
+            ),
+            "pre-switch: sibling-worktree write should be external/Ask",
+        );
+        // Switching into the worktree (what the fixed UI must do).
+        c.set_working_dir("/repo/wt");
+        assert!(
+            matches!(
+                c.check_path("write", "/repo/wt/src/foo.rs"),
+                CheckResult::Allowed
+            ),
+            "post-switch: in-worktree write must be auto-allowed",
+        );
+        // And the old repo is now external — no privilege carry-over.
+        assert!(
+            matches!(
+                c.check_path("write", "/repo/main/src/x.rs"),
+                CheckResult::Ask
+            ),
+            "post-switch: old-repo write should now be external/Ask",
+        );
+    }
+
     // Issue #5a: reads inside the project folder should not prompt.
     #[test]
     fn probe_read_inside_cwd_allowed() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1441,6 +1441,16 @@ pub async fn run_interactive(
                                             std::env::set_current_dir(main_path)
                                                 .map_err(|e| anyhow::anyhow!("failed to change directory: {}", e))?;
                                             session.working_dir = compact_str::CompactString::new(main_path);
+                                            // Re-anchor the permission checker to the main
+                                            // repo on worktree exit, else the CWD write-allow
+                                            // stays pointed at the (now-removed) worktree and
+                                            // writes in the main repo prompt. Same contract as
+                                            // /cd (cmd_misc.rs) and worktree create.
+                                            if let Some(perm) = &permission
+                                                && let Ok(mut guard) = perm.lock()
+                                            {
+                                                guard.set_working_dir(&session.working_dir);
+                                            }
                                             context.reload();
                                             let model = client.completion_model(session.model.to_string());
                                             agent = crate::provider::build_agent(

--- a/src/ui/run_handlers/done.rs
+++ b/src/ui/run_handlers/done.rs
@@ -573,6 +573,15 @@ pub(crate) async fn handle_done(
         match std::env::set_current_dir(&main_path) {
             Ok(()) => {
                 ctx.session.working_dir = compact_str::CompactString::new(&main_path);
+                // Re-anchor the permission checker to the main repo after
+                // merging back from the worktree, else the CWD write-allow
+                // stays pointed at the removed worktree and main-repo writes
+                // prompt. Same contract as /cd and worktree create/exit.
+                if let Some(perm) = permission
+                    && let Ok(mut guard) = perm.lock()
+                {
+                    guard.set_working_dir(&ctx.session.working_dir);
+                }
                 context.reload();
                 let model = client.completion_model(ctx.session.model.to_string());
                 *agent = crate::provider::build_agent(

--- a/src/ui/slash/cmd_worktree.rs
+++ b/src/ui/slash/cmd_worktree.rs
@@ -44,6 +44,17 @@ pub(super) async fn cmd_worktree(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyh
             std::env::set_current_dir(&path)
                 .map_err(|e| anyhow::anyhow!("failed to change directory: {}", e))?;
             ctx.session.working_dir = compact_str::CompactString::new(path.to_string_lossy());
+            // Re-anchor the permission checker's CWD-scoped write-allow
+            // to the worktree. Worktrees are created as siblings
+            // (`../name`, OUTSIDE the original repo), so without this the
+            // in-cwd allow glob keeps pointing at the old repo and every
+            // write inside the worktree is treated as external -> prompts.
+            // Mirrors the `/cd` handler in cmd_misc.rs.
+            if let Some(perm) = ctx.permission
+                && let Ok(mut guard) = perm.lock()
+            {
+                guard.set_working_dir(&ctx.session.working_dir);
+            }
             ctx.context.reload();
             let model = ctx.client.completion_model(ctx.session.model.to_string());
             *ctx.agent = crate::provider::build_agent(


### PR DESCRIPTION
## Root cause

You were right to push back — the issues weren't all "already fixed / stale binary." After an end-to-end runtime trace (unit probes all passed, so the bug had to be in a layer the unit tests don't exercise), the real cause of **"permission dialog keeps popping up for writes inside the project folder"** is a **working_dir desync on git-worktree switches**:

- `git_worktree::create` makes worktrees as **siblings** (`../{name}`) — *outside* the original repo.
- The in-cwd write-allow glob is `{repo}/**`, built from the checker's `working_dir`.
- Of the **four** process-cwd-change sites, only `/cd` (cmd_misc.rs) calls `PermissionChecker::set_working_dir`. The **three worktree paths** updated `session.working_dir` but never re-anchored the checker:
  - `/worktree` create (cmd_worktree.rs:44)
  - `/wt-exit` (ui/mod.rs DEFER_WT_EXIT)
  - worktree merge-return (run_handlers/done.rs:573)
- Result: after switching into a worktree, the checker still thinks the project is the *original* repo. Every write inside the worktree resolves as an **external** path → demoted to Ask in Standard mode → **a prompt on every edit**.

This is live in your binary: `build.sh` enables `git-worktree`, and this project's agent flow uses worktrees heavily. Reads were unaffected (globally allowed); only `write`/`edit`/`apply_patch` gate on the CWD glob.

## Fix

All three worktree cwd-change sites now mirror the `/cd` contract — lock the checker and call `set_working_dir(&session.working_dir)` right after `set_current_dir`. `set_working_dir` already rebuilds the CWD-allow glob and clears stale doom-loop/allowlist state, so re-anchoring is a one-liner per site.

Also corrected a stale doc comment in checker.rs (listed `memory`/`skill` as *not* auto-allowed when they are — surfaced by the trace, no behavior change).

## Why unit tests missed it

The bug is a **missing call** in the UI layer; the checker itself is correct. Added a checker-level regression test (`probe_worktree_sibling_switch_reanchors_cwd_allow`) pinning the sibling-worktree re-anchoring contract: pre-switch sibling write is external/Ask → `set_working_dir` → in-worktree write Allowed, old repo now external.

## What the trace ruled OUT (verified, not bugs)

A 4-tracer + adversarial-verify pass refuted the other hypotheses: the avatar **allow-path** repaints correctly (`tui_redraw` is unconditional at mod.rs:2832-2833); memory has a single gate with no second path; resume intentionally doesn't chdir; bash command-verb vs write-target are deliberately separate allowlist axes. One **plausible** separate UX issue remains noted below.

## Follow-up (not in this PR)

**Cascading parallel-tool permissions** (medium-confidence): with default parallel tool execution, multiple permission prompts queue; after allowing the first, the next queued Ask immediately re-shows the `(O_O)` Alert face — which *looks* like the avatar is stuck. The allow path has no coalescing (only the deny path drains the queue at mod.rs:2707). Worth a separate fix (re-evaluate queued asks against the freshly-added allowlist, or coalesce same-tool prompts).

## Tests

Full suite green: **2069** tests with the complete `build.sh` feature set, `RUSTFLAGS="-D warnings"`.