### PR TITLE
fix(perm/ui): coalesce parallel-tool prompts (avatar 'stuck on (O_O)' after allow)

### DIFF
--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -690,6 +690,30 @@ impl PermissionChecker {
         allowlist::is_allowed(&self.session_allowlist, tool, input)
     }
 
+    /// Side-effect-free re-check of ONLY the session allowlist (the
+    /// state a fresh "allow always" mutates) for a pending request.
+    /// Unlike [`Self::check`] / [`Self::check_path`] it does NOT touch
+    /// the doom-loop counters or apply mode coercion — it answers the
+    /// narrow question "would the current session allowlist allow this
+    /// right now?".
+    ///
+    /// Used by the UI to coalesce parallel-tool permission prompts:
+    /// when the agent fires several tool calls at once, each that needs
+    /// permission queues its own request. If the user picks "allow
+    /// always" on the first, the queued siblings that the new pattern
+    /// now covers should be auto-allowed instead of re-prompting (and
+    /// re-flashing the Alert avatar). Mirrors the raw-vs-path dispatch
+    /// and the resolve-both-forms logic of the real checks so a
+    /// relative allow-always pattern matches an absolute probe.
+    pub fn session_allows_now(&self, tool: &str, input: &str) -> bool {
+        if is_path_tool_name(tool) {
+            let abs = resolve_absolute(input, &self.working_dir);
+            self.is_session_allowed(tool, input) || self.is_session_allowed(tool, &abs)
+        } else {
+            self.is_session_allowed(tool, input)
+        }
+    }
+
     pub fn add_session_allowlist(&mut self, tool: String, pattern_str: &str) {
         // dirge-yevn fix #1: register the pattern AND a
         // canonicalized variant for path-tool entries so the check

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -1397,4 +1397,54 @@ mod reported_permission_ux_regressions {
             "sticky-allow cargo * should match cargo build"
         );
     }
+
+    // Issue #3 (real cause): parallel-tool prompt coalescing. After
+    // the user "allow always"-es one queued tool call, the sibling
+    // calls already parked on a permission decision should be
+    // auto-resolved against the new allowlist instead of re-flashing
+    // the Alert avatar. `session_allows_now` is the side-effect-free
+    // probe the UI uses for that — it must match the same raw-vs-path
+    // and relative-vs-absolute forms the real checks accept.
+    #[test]
+    fn probe_session_allows_now_coalesces_after_allow_always() {
+        // Raw tool (bash): a `cargo *` allow-always covers a queued
+        // sibling `cargo build`, but not an unrelated `git status`.
+        let mut c = checker_in("/tmp");
+        assert!(
+            !c.session_allows_now("bash", "cargo build"),
+            "nothing allowed yet"
+        );
+        c.add_session_allowlist("bash".to_string(), "cargo *");
+        assert!(
+            c.session_allows_now("bash", "cargo build"),
+            "queued cargo sibling must be coalesced after allow-always",
+        );
+        assert!(
+            !c.session_allows_now("bash", "git status"),
+            "unrelated queued command must still prompt",
+        );
+
+        // Path tool: a relative `sub/**` allow-always must match an
+        // absolute probe to a sibling file in the same subtree, while
+        // a path outside the working dir must NOT be coalesced.
+        let proj = std::env::temp_dir().join(format!("dirge-coalesce-{}", std::process::id()));
+        std::fs::create_dir_all(proj.join("sub")).unwrap();
+        let mut pc = PermissionChecker::new(
+            &PermissionConfig::default(),
+            SecurityMode::Standard,
+            Some(proj.clone()),
+        );
+        pc.set_working_dir(proj.to_str().unwrap());
+        pc.add_session_allowlist("write".to_string(), "sub/**");
+        let abs = proj.join("sub/other.rs");
+        assert!(
+            pc.session_allows_now("write", abs.to_str().unwrap()),
+            "absolute sibling write must be coalesced by relative allow-always",
+        );
+        assert!(
+            !pc.session_allows_now("write", "/etc/evil.conf"),
+            "path outside the working dir must not be coalesced",
+        );
+        let _ = std::fs::remove_dir_all(&proj);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2414,6 +2414,27 @@ pub async fn run_interactive(
                     std::future::pending().await
                 }
             } => {
+                // Coalesce parallel-tool prompts. When the agent fires
+                // several tool calls at once, each that needs permission
+                // queues its own AskRequest. If the user picked "allow
+                // always" on an earlier one in the batch, the session
+                // allowlist now covers the queued siblings — auto-allow
+                // them here instead of re-flashing the (O_O) Alert for
+                // something the user just blanket-approved. The
+                // allow-always handler below installs the pattern into
+                // the live checker synchronously, so by the time the next
+                // queued ask is pulled this probe sees it. Side-effect-
+                // free (no doom-loop tracking), and only ever resolves to
+                // Allow when the user already consented to the pattern.
+                if permission.as_ref().is_some_and(|perm| {
+                    perm.lock()
+                        .map(|g| g.session_allows_now(&ask_req.tool, &ask_req.input))
+                        .unwrap_or(false)
+                }) {
+                    let _ = ask_req.reply.send(UserDecision::AllowOnce);
+                    continue;
+                }
+
                 was_reasoning = false;
                 if agent_line_started {
                     renderer.write_line("", Color::White)?;
@@ -2772,6 +2793,19 @@ pub async fn run_interactive(
                         tool: ask_req.tool.clone(),
                         pattern: pattern.clone(),
                     });
+                    // Install into the LIVE checker now, synchronously,
+                    // so queued sibling asks from the same parallel batch
+                    // see it on the next loop iteration and get coalesced
+                    // (see the auto-allow fast-path at the top of this
+                    // arm). The tool-side handler also adds it on reply
+                    // receipt, but that runs asynchronously and would
+                    // race the next queued ask; add::dedup makes the
+                    // double-add a no-op.
+                    if let Some(perm) = &permission
+                        && let Ok(mut guard) = perm.lock()
+                    {
+                        guard.add_session_allowlist(ask_req.tool.clone(), &pattern);
+                    }
                     if !cli.no_session
                         && let Err(e) = crate::session::storage::save_session(session) {
                             renderer.write_line(


### PR DESCRIPTION
## The real cause of "avatar stays on (O_O) after a permission check"

Follow-up to the e2e trace. The avatar **allow-path repaints correctly** (verified — `tui_redraw` is unconditional after the reset), so the stuck-Alert symptom isn't a missing repaint. The actual cause is **parallel tool execution**:

- dirge runs tool calls in parallel by default, and the system prompt encourages the model to batch independent calls.
- Each parallel tool that needs permission calls `enforce` → on `Ask`, queues its own `AskRequest` on `ask_rx` and parks on the reply. The UI shows them one at a time.
- When you pick **"allow always"** on the first, that adds a session-allowlist pattern — but the already-queued siblings were *already* checked (returned `Ask`) before the entry existed, and are parked waiting for a decision. The allow path had **no coalescing** (only the deny path drains the queue, at mod.rs:2707).
- So the UI immediately re-prompts and **re-flashes the `(O_O)` Alert** for each queued sibling — indistinguishable from "my allow didn't work / the avatar is stuck."

## Fix

When an `AskRequest` is pulled, first re-check it against the session allowlist (which "allow always" just populated) and auto-allow if it now matches, instead of re-prompting:

- **checker**: new side-effect-free `session_allows_now(tool, input)` — mirrors `check`/`check_path`'s raw-vs-path and relative-vs-absolute form matching, but touches no doom-loop or mode state.
- **ui/mod.rs**: a fast-path at the top of the ask arm auto-allows covered queued requests (`AllowOnce` + `continue`); and the allow-always handler now installs the pattern into the **live** checker **synchronously** — before the next queued ask is pulled from the single-threaded `select!` loop — closing the race with the async tool-side add (idempotent via allowlist dedup).

## Safety

Only ever auto-allows patterns the user **explicitly "allow always"-ed** (the session allowlist's only writers are the two allow-always handlers). Consistent with the existing precedence: the session allowlist already short-circuits to `Allowed` *before* deny-rule evaluation in `check`/`check_path`, so this is not a new deny bypass. Adversarially reviewed across security / correctness / race / UI-state — no over-allow (the write→edit alias gap is benign because `add_session_allowlist` mirrors the pattern to all three tools), forms match `check_path` exactly, no orphaned chamber.

## Tests

New regression test pins raw (`cargo *`) + path (`sub/**` → absolute) coalescing and the out-of-cwd / unrelated-command boundaries. Full suite green: **2070** tests with the complete `build.sh` feature set, `RUSTFLAGS="-D warnings"`.