### PR TITLE
feat(perm): route the live chokepoint through the engine (Phase 2b/4)

### DIFF
--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -59,7 +59,7 @@ use std::io;
 use serde::Deserialize;
 
 use crate::permission::ask::{AskRequest, AskSender, UserDecision};
-use crate::permission::checker::{CheckResult, PermCheck};
+use crate::permission::checker::PermCheck;
 
 pub const MAX_GREP_RESULTS: usize = 200;
 pub const MAX_FIND_RESULTS: usize = 200;
@@ -294,62 +294,35 @@ pub async fn enforce(
         return Ok(raw_scope.to_string());
     };
 
-    // Inner pure-lookup helper. Reads the checker, returns
-    // (CheckResult, resolved-path). Doesn't touch the ask flow —
-    // that's separate so the F2 alias check can MERGE results
-    // before any prompting fires.
-    fn inner_check(
-        guard: &mut crate::permission::checker::PermissionChecker,
-        tool: &str,
-        scope: &Scope<'_>,
-    ) -> (CheckResult, String) {
-        match scope {
-            Scope::Raw(key) => (guard.check(tool, key), (*key).to_string()),
-            Scope::Path(path) => (guard.check_path(tool, path), (*path).to_string()),
-            Scope::PathResolve(path) => {
-                let resolved = guard.resolve_path_for_tool(path);
-                let r = guard.check_path(tool, path);
-                (r, resolved)
-            }
-        }
-    }
-
-    // F2 (dirge-jlj): write / apply_patch alias to the `edit`
-    // permission. Mirrors opencode's `EDIT_TOOLS` aliasing
-    // (`permission/index.ts:291-301`): a user writing
-    // `edit: { "**": "deny" }` blocks all three uniformly.
-    //
-    // Strategy: take the MOST RESTRICTIVE outcome between the
-    // tool's own rules and the edit rules. Deny > Ask > Allow.
-    // If the tool's specific rule allows but `edit` denies, the
-    // edit deny wins — broader deny-list semantics. If both Ask,
-    // we prompt ONCE (avoids double-prompting).
-    let (result, resolved) = {
+    // M-engine (Phase 2b): route the decision through the unified
+    // authorization engine. The old per-tool F2 write↔edit↔apply_patch
+    // aliasing is gone — those tools normalize to `Operation::Edit`,
+    // so one rule governs the trio by construction. Path-vs-raw is a
+    // property of the resource (built in `authorize_scope`), so there
+    // is no Scope-dispatched `check`/`check_path` split here.
+    let is_path = matches!(scope, Scope::Path(_) | Scope::PathResolve(_));
+    let (effect, reason, resolved) = {
         let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-        let primary = inner_check(&mut guard, tool, &scope);
-        if matches!(tool, "write" | "apply_patch") {
-            let alias = inner_check(&mut guard, "edit", &scope);
-            // Combine: most restrictive wins. Use primary's
-            // resolved-path (the tool's own canonicalization
-            // anchored to its rule set, not edit's).
-            let combined = match (&primary.0, &alias.0) {
-                (CheckResult::Denied(reason), _) => CheckResult::Denied(reason.clone()),
-                (_, CheckResult::Denied(reason)) => CheckResult::Denied(reason.clone()),
-                (CheckResult::Ask, _) | (_, CheckResult::Ask) => CheckResult::Ask,
-                _ => CheckResult::Allowed,
-            };
-            (combined, primary.1)
-        } else {
-            primary
-        }
+        let decision = guard.authorize_scope(tool, raw_scope, is_path);
+        // Only PathResolve callers want the canonicalized path back
+        // (to pin the file across the check→open window); Raw/Path
+        // callers echo their input, matching the legacy contract.
+        let resolved = match scope {
+            Scope::PathResolve(_) => decision
+                .resolved_paths
+                .first()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| raw_scope.to_string()),
+            _ => raw_scope.to_string(),
+        };
+        (decision.effect, decision.reason(), resolved)
     };
 
-    match result {
-        CheckResult::Allowed => Ok(resolved),
-        CheckResult::Denied(reason) => {
-            Err(ToolError::Msg(format!("Permission denied: {}", reason)))
-        }
-        CheckResult::Ask => {
+    use crate::permission::engine::types::Effect;
+    match effect {
+        Effect::Allow => Ok(resolved),
+        Effect::Deny => Err(ToolError::Msg(format!("Permission denied: {reason}"))),
+        Effect::Ask => {
             let Some(tx) = ask_tx else {
                 return Err(ToolError::Msg(
                     "Permission denied (non-interactive mode)".to_string(),
@@ -495,14 +468,15 @@ mod tests {
         .await;
         assert!(matches!(result, Err(_)));
 
-        // `/tmp/x.rs`: write allows (`**`), edit's `/etc/**`
-        // doesn't match → edit lookup = Ask (default), write = Allow.
-        // Combined: Ask (more restrictive). No ask_tx → "non-interactive
-        // mode" deny.
+        // `/tmp/x.rs`: write/edit/apply_patch now share Operation::Edit,
+        // so both rules live in ONE ruleset, last-match-wins. The
+        // `write: { "**": allow }` rule (added before the edit deny)
+        // matches `/tmp/x.rs`; the `/etc/**` deny does not → Allow.
+        // This is the F2 dissolution: "allow all writes except /etc".
         let result = enforce(&Some(perm), &None, "write", Scope::PathResolve("/tmp/x.rs")).await;
         assert!(
-            matches!(result, Err(_)),
-            "/tmp/x.rs: write Allow + edit Ask → combined Ask → non-interactive deny; got {result:?}",
+            result.is_ok(),
+            "/tmp/x.rs: `write **: allow` governs (edit `/etc/**` deny doesn't match) → Allow; got {result:?}",
         );
     }
 

--- a/src/permission/allowlist.rs
+++ b/src/permission/allowlist.rs
@@ -8,6 +8,7 @@
 use crate::permission::engine;
 use crate::permission::pattern::Pattern;
 
+#[allow(dead_code)] // Phase 4: legacy session-allowlist match
 pub(crate) fn is_allowed(allowlist: &[(String, Pattern)], tool: &str, input: &str) -> bool {
     allowlist
         .iter()

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -1,3 +1,11 @@
+// Phase 2b routes runtime decisions through the engine; the legacy
+// `check`/`check_path` facade + their private helpers and rule fields
+// remain only for the `/allow` display surface, the `semantic-bash`
+// dev-null soft-allow, and the test oracle. They are bin-unused in the
+// default build. Phase 4 deletes this legacy decision code wholesale,
+// at which point this allow goes too.
+#![allow(dead_code)]
+
 use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -15,6 +23,17 @@ pub enum CheckResult {
     Allowed,
     Ask,
     Denied(String),
+}
+
+/// Map an engine [`Decision`](engine::types::Decision) onto the legacy
+/// `CheckResult` returned by the `check`/`check_path` facade.
+fn effect_to_result(decision: engine::types::Decision) -> CheckResult {
+    use engine::types::Effect;
+    match decision.effect {
+        Effect::Allow => CheckResult::Allowed,
+        Effect::Ask => CheckResult::Ask,
+        Effect::Deny => CheckResult::Denied(decision.reason()),
+    }
 }
 
 pub struct PermissionChecker {
@@ -63,6 +82,14 @@ pub struct PermissionChecker {
     /// when no prompt is active or the active prompt has no
     /// frontmatter.
     prompt_deny_tools: Vec<String>,
+    /// The unified authorization engine. Phase 2b routes the live
+    /// `enforce` chokepoint through this (via `authorize_scope`); the
+    /// legacy `rules`/`check`/`check_path` fields above remain only for
+    /// the `/allow` display surface and the old test suite, and are
+    /// deleted in Phase 4. The engine is the source of truth for
+    /// runtime decisions; the session allowlist + prompt-deny are kept
+    /// in sync with it on every write so the two views never diverge.
+    engine: engine::Engine,
 }
 
 /// Tools that execute external code with broad effects. Accept mode
@@ -342,6 +369,10 @@ impl PermissionChecker {
         // by the CWD-scoped builtin allow installer above).
         let working_dir_canonical = canonicalize_for_cache(&working_dir);
 
+        // The unified engine, built from the same config. Runtime
+        // decisions (the `enforce` chokepoint) flow through this.
+        let engine = engine::Engine::from_config(config);
+
         PermissionChecker {
             rules,
             default_action,
@@ -355,6 +386,68 @@ impl PermissionChecker {
             repeat_counts: HashMap::new(),
             mode,
             prompt_deny_tools: Vec::new(),
+            engine,
+        }
+    }
+
+    /// Engine-backed decision for the `enforce` chokepoint. Normalizes
+    /// a single (tool, input) into an [`engine::types::AccessRequest`],
+    /// authorizes it, commits (loop-guard accounting), and returns the
+    /// [`engine::types::Decision`]. `is_path` selects path-resource
+    /// classification (resolved + in_cwd + dev_null) vs a raw resource.
+    pub fn authorize_scope(
+        &mut self,
+        tool: &str,
+        input: &str,
+        is_path: bool,
+    ) -> engine::types::Decision {
+        let req = self.build_request(tool, input, is_path);
+        let decision = self.engine.authorize(&req);
+        self.engine.commit(&req, &decision);
+        decision
+    }
+
+    /// Normalize a (tool, input) pair into a one-resource request. The
+    /// raw-resource variant picks the resource type from the tool:
+    /// shell → Command, mcp_tool → Mcp, webfetch/websearch → Url,
+    /// everything else → Bareword (memory/skill action, grep pattern…).
+    fn build_request(
+        &self,
+        tool: &str,
+        input: &str,
+        is_path: bool,
+    ) -> engine::types::AccessRequest {
+        use engine::types::Resource;
+        let resource = if is_path {
+            engine::classify_path(input, &self.working_dir)
+        } else {
+            match tool {
+                "bash" | "shell" => Resource::Command {
+                    raw: input.to_string(),
+                    head: input.split_whitespace().next().unwrap_or("").to_string(),
+                },
+                "mcp_tool" => {
+                    // input shape: "mcp_tool:<server>:<name>"
+                    let mut parts = input.splitn(3, ':');
+                    let _umbrella = parts.next();
+                    let server = parts.next().unwrap_or("").to_string();
+                    let name = parts.next().unwrap_or("").to_string();
+                    Resource::Mcp {
+                        server,
+                        name,
+                        raw: input.to_string(),
+                    }
+                }
+                "webfetch" | "websearch" => Resource::Url(input.to_string()),
+                _ => Resource::Bareword(input.to_string()),
+            }
+        };
+        engine::types::AccessRequest {
+            op: engine::tool_operation(tool),
+            tool: tool.to_string(),
+            resources: vec![resource],
+            mode: self.mode,
+            display_input: input.to_string(),
         }
     }
 
@@ -362,6 +455,7 @@ impl PermissionChecker {
     /// active prompt changes (startup, session load, `/prompt
     /// <name>`); pass an empty vec to clear.
     pub fn set_prompt_deny_tools(&mut self, denied: Vec<String>) {
+        self.engine.ctx_mut().prompt_deny = denied.clone();
         self.prompt_deny_tools = denied;
     }
 
@@ -409,281 +503,24 @@ impl PermissionChecker {
         }
     }
 
+    /// Decision for a non-path tool input (bash command, mcp id,
+    /// memory/skill action, grep pattern…). Delegates to the unified
+    /// engine. Retained as a convenience wrapper for the `/allow`
+    /// surface, `check_bash_dev_null_softallow`, and the test suite;
+    /// the engine is the single source of truth.
     pub fn check(&mut self, tool: &str, input: &str) -> CheckResult {
-        // Prompt-level deny list runs BEFORE every other gate,
-        // including Yolo mode's blanket allow. This is the
-        // permission-layer enforcement of plan/review/etc. modes:
-        // the prompt's frontmatter declares which tools that mode
-        // CANNOT use (e.g. plan mode denies edit/write/apply_patch/
-        // bash), and the LLM gets a hard refusal instead of relying
-        // on the prompt prose to dissuade it from calling. Yolo is
-        // still "no rule-set, all calls allowed" but a prompt's
-        // deny-list is a stronger contract — the user opted into
-        // this mode, so we honor it even under Yolo.
-        if self.is_prompt_denied(tool) {
-            return CheckResult::Denied(format!(
-                "Tool {tool:?} is denied by the active prompt's `deny_tools` frontmatter. Switch with `/prompt <other>` to use it."
-            ));
-        }
-        // PERM-7: MCP tools route through `check_perm("mcp_tool", input)`
-        // with input shaped `mcp_tool:<server>:<name>`. The umbrella
-        // tool name `"mcp_tool"` won't match a deny-list entry like
-        // `edit` even if the MCP server exports an `edit` tool. Probe
-        // the concrete tool name (the part after the second `:`) so
-        // a prompt's `deny_tools: [edit]` denies an MCP-exported
-        // `edit` too. Centralized here so any caller (not just the
-        // McpTool wrapper) gets the defense; the wrapper's explicit
-        // `any_prompt_denied` probe becomes redundant but harmless.
-        if tool == "mcp_tool"
-            && let Some(rest) = input.strip_prefix("mcp_tool:")
-            && let Some((_server, concrete)) = rest.split_once(':')
-            && self.is_prompt_denied(concrete)
-        {
-            return CheckResult::Denied(format!(
-                "MCP tool {concrete:?} is denied by the active prompt's `deny_tools` frontmatter. Switch with `/prompt <other>` to use it."
-            ));
-        }
-        if self.mode == SecurityMode::Yolo {
-            return CheckResult::Allowed;
-        }
-
-        if self.is_session_allowed(tool, input) {
-            return CheckResult::Allowed;
-        }
-
-        // Track both the action AND the matching pattern so denial
-        // messages can name which rule blocked the call (was just
-        // "Blocked by permission rules", giving the user no way to
-        // identify and edit the offending rule).
-        let mut matched: Vec<(Action, String)> = Vec::new();
-        if let Some(rules) = self.rules.get(tool) {
-            for (pattern, action) in rules {
-                if pattern.matches(input) {
-                    matched.push((*action, pattern.original.clone()));
-                }
-            }
-        }
-
-        let base = matched
-            .last()
-            .map(|(a, _)| *a)
-            .unwrap_or(self.default_action);
-        let last_pat = matched.last().map(|(_, p)| p.clone());
-        let action = match self.mode {
-            SecurityMode::Restrictive => {
-                // Restrictive contract: every WRITE action confirms.
-                // Read-only builtins (read, grep, list_symbols, …)
-                // pass through as Allow — the user opted into
-                // restrictive to gate side effects, not to gate
-                // observation. For `memory`, only the read action
-                // (`view`) follows the same rule; the write actions
-                // (`add`/`replace`/`remove`) demote to Ask. Generic
-                // "no rule matched but default is Allow" also
-                // demotes. Explicit user `deny` still denies.
-                let memory_write = tool == "memory" && input != "view" && base != Action::Deny;
-                // skill read actions arrive as the bare keywords
-                // `load`/`list`; write actions (create/edit/patch)
-                // arrive as `{action}:{name}`. Demote only the writes
-                // — same posture as memory's view-vs-mutate split.
-                let skill_write =
-                    tool == "skill" && input != "load" && input != "list" && base != Action::Deny;
-                let bare_default = matched.is_empty() && self.default_action == Action::Allow;
-                if memory_write || skill_write || bare_default {
-                    Action::Ask
-                } else {
-                    base
-                }
-            }
-            SecurityMode::Accept => match base {
-                Action::Ask => {
-                    if self.is_path_tool(tool) && self.is_external_path(input) {
-                        self.match_ext_dir(input).unwrap_or(Action::Ask)
-                    } else if is_high_risk_non_path_tool(tool) {
-                        // Accept mode coerces Ask → Allow for non-path
-                        // tools on the assumption that "trust the
-                        // agent inside cwd" generalizes. That breaks
-                        // for tools that execute external code with
-                        // arbitrary effects: MCP servers run third-
-                        // party code; `bash` runs shell. Keep the Ask
-                        // for these specifically. Review #1.
-                        Action::Ask
-                    } else {
-                        Action::Allow
-                    }
-                }
-                other => other,
-            },
-            SecurityMode::Standard => base,
-            SecurityMode::Yolo => unreachable!(),
-        };
-
-        if action != Action::Deny {
-            // PERM-2: check doom-loop BEFORE tracking the current
-            // call. The counter reflects previous identical calls
-            // only — the current call doesn't count itself.
-            if self.is_doom_loop(tool, input) {
-                match self.doom_loop_action {
-                    Action::Deny => {
-                        let preview: String = input.chars().take(60).collect();
-                        return CheckResult::Denied(format!(
-                            "Doom loop: repeated identical {} call ({}{})",
-                            tool,
-                            preview,
-                            if input.chars().count() > 60 {
-                                "…"
-                            } else {
-                                ""
-                            },
-                        ));
-                    }
-                    Action::Ask => return CheckResult::Ask,
-                    Action::Allow => {}
-                }
-            }
-            self.track_doom_loop(tool, input);
-        }
-
-        match action {
-            Action::Allow => CheckResult::Allowed,
-            Action::Ask => CheckResult::Ask,
-            Action::Deny => CheckResult::Denied(match last_pat {
-                Some(pat) => format!("Blocked by rule: {tool} {pat:?} → deny"),
-                None => format!("Blocked: {tool} denied by default action"),
-            }),
-        }
+        effect_to_result(self.authorize_scope(tool, input, false))
     }
 
+    /// Decision for a filesystem-path tool input. Path classification
+    /// (resolved / in_cwd / dev_null) happens inside `authorize_scope`.
     pub fn check_path(&mut self, tool: &str, path: &str) -> CheckResult {
-        // Reject paths that are clearly LLM hallucinations
-        // (e.g. "1", "a", "xy") before they trigger permission
-        // dialogs for non-existent files.  Absolute paths and
-        // relative paths with directory components or file
-        // extensions pass through to the normal check.
+        // Reject obvious LLM hallucinations ("1", "a") before the
+        // engine — preserves the old `validate_path` guard.
         if let Err(reason) = path::validate_path(path) {
             return CheckResult::Denied(reason);
         }
-
-        // Prompt deny-list runs first, same reasoning as `check`.
-        if self.is_prompt_denied(tool) {
-            return CheckResult::Denied(format!(
-                "Tool {tool:?} is denied by the active prompt's `deny_tools` frontmatter. Switch with `/prompt <other>` to use it."
-            ));
-        }
-        if self.mode == SecurityMode::Yolo {
-            return CheckResult::Allowed;
-        }
-
-        // Resolve BEFORE the allowlist check so we can test both the
-        // raw path and the absolute form. Without this, a user who
-        // granted AllowAlways for a relative path (e.g. src/main.rs)
-        // gets re-prompted when the LLM sends an absolute path for
-        // the same file.
-        let abs_path = resolve_absolute(path, &self.working_dir);
-
-        if self.is_session_allowed(tool, path) || self.is_session_allowed(tool, &abs_path) {
-            return CheckResult::Allowed;
-        }
-
-        let mut matched: Vec<(Action, String)> = Vec::new();
-        if let Some(rules) = self.rules.get(tool) {
-            for (pattern, action) in rules {
-                if pattern.matches(&abs_path) || pattern.matches(path) {
-                    matched.push((*action, pattern.original.clone()));
-                }
-            }
-        }
-
-        let base = matched
-            .last()
-            .map(|(a, _)| *a)
-            .unwrap_or(self.default_action);
-        let last_pat = matched.last().map(|(_, p)| p.clone());
-
-        // Audit H9: `external_directory` rules used to fire only in
-        // `SecurityMode::Accept`. A user who configured
-        // `external_directory = { "/external/safe/**" = "allow" }`
-        // saw the rule silently ignored under Standard/Restrictive.
-        // Pre-compute the overlay so each mode can opt into it
-        // uniformly.
-        let is_external = self.is_external_path(&abs_path);
-        let ext_dir_action = if is_external {
-            self.match_ext_dir(&abs_path)
-        } else {
-            None
-        };
-
-        let action = match self.mode {
-            SecurityMode::Restrictive => {
-                if let Some(a) = ext_dir_action {
-                    a
-                } else if matched.is_empty() && self.default_action == Action::Allow {
-                    Action::Ask
-                } else {
-                    base
-                }
-            }
-            SecurityMode::Accept => match base {
-                Action::Ask => {
-                    if is_external {
-                        ext_dir_action.unwrap_or(Action::Ask)
-                    } else {
-                        Action::Allow
-                    }
-                }
-                other => other,
-            },
-            SecurityMode::Standard => {
-                // Explicit ext_dir rule overrides the base for external
-                // paths. For non-external paths (or external paths
-                // without a matching ext_dir rule) keep the prior
-                // base-action behavior — the catch-all below will
-                // demote unmatched external Allows to Ask.
-                if let Some(a) = ext_dir_action {
-                    a
-                } else {
-                    base
-                }
-            }
-            SecurityMode::Yolo => unreachable!(),
-        };
-
-        let action = if matched.is_empty()
-            && action == Action::Allow
-            && is_external
-            && ext_dir_action.is_none()
-        {
-            Action::Ask
-        } else {
-            action
-        };
-
-        if action != Action::Deny {
-            self.track_doom_loop(tool, path);
-            if self.is_doom_loop(tool, path) {
-                match self.doom_loop_action {
-                    Action::Deny => {
-                        let preview: String = path.chars().take(80).collect();
-                        return CheckResult::Denied(format!(
-                            "Doom loop: repeated identical {} call ({}{})",
-                            tool,
-                            preview,
-                            if path.chars().count() > 80 { "…" } else { "" },
-                        ));
-                    }
-                    Action::Ask => return CheckResult::Ask,
-                    Action::Allow => {}
-                }
-            }
-        }
-
-        match action {
-            Action::Allow => CheckResult::Allowed,
-            Action::Ask => CheckResult::Ask,
-            Action::Deny => CheckResult::Denied(match last_pat {
-                Some(pat) => format!("Blocked by rule: {tool} {pat:?} → deny"),
-                None => format!("Blocked: {tool} denied by default action"),
-            }),
-        }
+        effect_to_result(self.authorize_scope(tool, path, true))
     }
 
     fn is_session_allowed(&self, tool: &str, input: &str) -> bool {
@@ -706,11 +543,15 @@ impl PermissionChecker {
     /// and the resolve-both-forms logic of the real checks so a
     /// relative allow-always pattern matches an absolute probe.
     pub fn session_allows_now(&self, tool: &str, input: &str) -> bool {
+        // Read the ENGINE allowlist (the runtime source of truth that
+        // `enforce` consults), op-scoped.
+        let op = engine::tool_operation(tool);
+        let al = &self.engine.ctx().allowlist;
         if is_path_tool_name(tool) {
             let abs = resolve_absolute(input, &self.working_dir);
-            self.is_session_allowed(tool, input) || self.is_session_allowed(tool, &abs)
+            al.allows(op, input) || al.allows(op, &abs)
         } else {
-            self.is_session_allowed(tool, input)
+            al.allows(op, input)
         }
     }
 
@@ -760,6 +601,20 @@ impl PermissionChecker {
                 &self.working_dir,
             );
         }
+
+        // Engine (runtime source of truth). Op-scoped: write/edit/
+        // apply_patch all map to Operation::Edit, so a single grant
+        // covers the trio — no mirroring needed. Add a canonical
+        // variant for path tools so a relative "allow always" pattern
+        // matches the absolute probe the engine checks against.
+        let op = engine::tool_operation(&tool);
+        self.engine.allow_always(op, pattern_str);
+        if is_path_tool_name(&tool)
+            && let Some(canon) = canonicalize_path_pattern(pattern_str, &self.working_dir)
+            && canon != pattern_str
+        {
+            self.engine.allow_always(op, &canon);
+        }
     }
 
     pub fn load_session_allowlist(&mut self, entries: &[(String, String)]) {
@@ -786,6 +641,7 @@ impl PermissionChecker {
     /// Remove ALL allowlist entries. Used by `/allow clear`.
     pub fn clear_session_allowlist(&mut self) {
         allowlist::clear(&mut self.session_allowlist);
+        self.engine.ctx_mut().allowlist.clear();
     }
 
     pub fn set_mode(&mut self, mode: SecurityMode) {
@@ -858,6 +714,11 @@ impl PermissionChecker {
         self.recent_calls.clear();
         self.repeat_counts.clear();
         self.session_allowlist.clear();
+        // Mirror the reset into the engine: a cwd change drops the
+        // loop-guard counters and session grants tied to the old
+        // project (privilege carry-over guard).
+        self.engine.ctx_mut().repeat.clear();
+        self.engine.ctx_mut().allowlist.clear();
     }
 
     fn is_path_tool(&self, tool: &str) -> bool {

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -156,20 +156,19 @@ fn f2_edit_alias_check_path_directly_for_write_and_apply_patch() {
         checker.check_path("edit", "/tmp/x.rs"),
         CheckResult::Denied(_)
     ));
-    // Direct `write` query (no aliasing at checker level): the
-    // CWD-scoped builtin-allow rule only fires for paths inside
-    // working_dir (/tmp here), so probe an OUTSIDE path to
-    // exercise the global Ask default — that's the "write has
-    // no user-configured rules and no in-CWD allow" path the
-    // checker is asserted on.
+    // F2 dissolution: write/edit/apply_patch now share Operation::Edit,
+    // so the `edit: { "**": deny }` rule governs ALL THREE — a write
+    // anywhere (even outside cwd) is denied by the same `**` rule. The
+    // old aliasing special-case is gone; this falls out of the shared
+    // operation.
     assert!(matches!(
         checker.check_path("write", "/opt/elsewhere/x.rs"),
-        CheckResult::Ask
+        CheckResult::Denied(_)
     ));
-    // `tools::enforce` is what ties these together. The
-    // alias test for that path lives in src/agent/tools/mod.rs
-    // (covered indirectly by the bash F1 tests below since
-    // write rules drive the redirect-target gate).
+    assert!(matches!(
+        checker.check_path("apply_patch", "/opt/elsewhere/x.rs"),
+        CheckResult::Denied(_)
+    ));
 }
 
 /// CWD-scoped builtin-allow for mutating tools: writes inside

--- a/src/permission/engine/build.rs
+++ b/src/permission/engine/build.rs
@@ -14,9 +14,8 @@
 use std::path::PathBuf;
 
 use super::policies::{
-    AcceptModePolicy, BuiltinAllowPolicy, ConfiguredRulePolicy, DefaultActionPolicy,
-    ExternalDirPolicy, LoopGuardPolicy, OpMatch, PromptDenyPolicy, Rule, SessionAllowlistPolicy,
-    YoloPolicy,
+    BuiltinAllowPolicy, ConfiguredRulePolicy, DefaultActionPolicy, ExternalDirPolicy,
+    LoopGuardPolicy, OpMatch, PromptDenyPolicy, Rule, SessionAllowlistPolicy, YoloPolicy,
 };
 use super::policy::{Decider, Modifier, PolicyCtx};
 use super::types::{Effect, Operation, Resource};
@@ -44,17 +43,20 @@ pub fn tool_operation(tool: &str) -> Operation {
         "read" | "grep" | "find_files" | "glob" | "list_dir" | "repo_overview" | "lsp"
         | "list_symbols" | "get_symbol_body" | "find_definition" | "find_callers"
         | "find_callees" => Operation::Read,
-        "write" => Operation::Write,
+        "write" => Operation::Edit,
         "edit" | "apply_patch" => Operation::Edit,
         "bash" | "shell" => Operation::Execute,
         "webfetch" | "websearch" => Operation::Network,
         "mcp_tool" => Operation::Mcp,
         "memory" => Operation::Memory,
         "skill" => Operation::Skill,
-        "task" | "task_status" | "question" | "write_todo_list" => Operation::Meta,
-        // Unknown (plugin) tools: treat as meta — they fall to the
-        // configured rules / default like anything else.
-        _ => Operation::Meta,
+        // Recursive sub-agent execution: high-risk, not auto-allowed.
+        "task" => Operation::Agent,
+        // Internal no-effect tools: builtin-allowed.
+        "task_status" | "question" | "write_todo_list" => Operation::Meta,
+        // Unknown (plugin/MCP) tools: not auto-allowed; fall to
+        // configured rules or the default (Accept-coercible).
+        _ => Operation::Other,
     }
 }
 
@@ -66,11 +68,26 @@ pub fn tool_operation(tool: &str) -> Operation {
 pub fn classify_path(raw: &str, working_dir: &str) -> Resource {
     let resolved_str = resolve_absolute(raw, working_dir);
     let dev_null = resolved_str == "/dev/null" || raw == "/dev/null";
-    let cwd_canonical = canonicalize_for_cache(working_dir);
-    let trimmed = cwd_canonical.trim_end_matches('/');
-    let in_cwd = !trimmed.is_empty()
-        && trimmed != "/"
-        && (resolved_str == trimmed || resolved_str.starts_with(&format!("{trimmed}/")));
+    // Compare against the cwd in every form it might take so a
+    // symlinked root (macOS `/tmp → /private/tmp`) doesn't misclassify
+    // in-tree paths as external: the path resolved through the
+    // deepest-existing-ancestor canonicalization, the cached
+    // canonical, and the literal working_dir.
+    let under = |base: &str| {
+        let b = base.trim_end_matches('/');
+        !b.is_empty()
+            && b != "/"
+            && (resolved_str == b || resolved_str.starts_with(&format!("{b}/")))
+    };
+    // A working_dir containing glob metacharacters can't anchor a
+    // trustworthy in-cwd classification (the old code refused to
+    // install a CWD-allow for such dirs); treat nothing as in-cwd so
+    // those writes still prompt.
+    let cwd_has_glob = working_dir.contains(['*', '?', '[', '{']);
+    let in_cwd = !cwd_has_glob
+        && (under(&resolve_absolute(working_dir, working_dir))
+            || under(&canonicalize_for_cache(working_dir))
+            || under(working_dir));
     Resource::Path {
         raw: raw.to_string(),
         resolved: PathBuf::from(resolved_str),
@@ -83,10 +100,21 @@ pub fn classify_path(raw: &str, working_dir: &str) -> Resource {
 /// narrowed to `tool`.
 fn rules_from_tool_perm(tool: &str, tp: &ToolPerm) -> Vec<Rule> {
     let op = OpMatch::One(tool_operation(tool));
+    // write/edit/apply_patch are the only tools mapping to
+    // Operation::Edit, so leaving the rule tool-unnarrowed makes a
+    // legacy `edit: deny` cover all three — the old F2 aliasing,
+    // now a natural consequence of the shared operation. Other
+    // shared-op tools (the Read group) stay tool-narrowed so a
+    // `grep` rule doesn't bleed onto `read`.
+    let tool_sel = if matches!(tool, "write" | "edit" | "apply_patch") {
+        None
+    } else {
+        Some(tool.to_string())
+    };
     match tp {
         ToolPerm::Simple(action) => vec![Rule {
             op,
-            tool: Some(tool.to_string()),
+            tool: tool_sel.clone(),
             pattern: pattern_for_tool(tool, "*"),
             effect: (*action).into(),
             original: format!("{tool}:*"),
@@ -95,7 +123,7 @@ fn rules_from_tool_perm(tool: &str, tp: &ToolPerm) -> Vec<Rule> {
             .iter()
             .map(|(pat, action)| Rule {
                 op,
-                tool: Some(tool.to_string()),
+                tool: tool_sel.clone(),
                 pattern: pattern_for_tool(tool, pat),
                 effect: (*action).into(),
                 original: format!("{tool}:{pat}"),
@@ -205,7 +233,6 @@ impl Engine {
             Box::new(ConfiguredRulePolicy { rules }),
             Box::new(BuiltinAllowPolicy),
             Box::new(ExternalDirPolicy { rules: ext_rules }),
-            Box::new(AcceptModePolicy),
             Box::new(DefaultActionPolicy { default }),
         ];
         let modifiers: Vec<Box<dyn Modifier>> = vec![Box::new(LoopGuardPolicy {
@@ -242,7 +269,7 @@ mod tests {
     fn tool_operation_mapping() {
         assert_eq!(tool_operation("read"), Operation::Read);
         assert_eq!(tool_operation("grep"), Operation::Read);
-        assert_eq!(tool_operation("write"), Operation::Write);
+        assert_eq!(tool_operation("write"), Operation::Edit);
         assert_eq!(tool_operation("edit"), Operation::Edit);
         assert_eq!(tool_operation("apply_patch"), Operation::Edit);
         assert_eq!(tool_operation("bash"), Operation::Execute);
@@ -373,7 +400,7 @@ mod tests {
         let e = Engine::from_config(&cfg);
         // external write to /shared is allowed by the ext-dir rule
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             "write",
             SecurityMode::Standard,
             vec![classify_path("/shared/lib/x", "/proj")],
@@ -381,7 +408,7 @@ mod tests {
         assert_eq!(d.effect, Effect::Allow);
         // external write elsewhere still asks
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             "write",
             SecurityMode::Standard,
             vec![classify_path("/etc/x", "/proj")],

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -38,6 +38,8 @@ pub mod policies;
 pub mod policy;
 pub mod types;
 
+pub use build::{classify_path, tool_operation};
+
 // Re-export the classification helpers so existing call sites
 // (`engine::pattern_for_tool`, `engine::is_path_tool_name`,
 // `engine::is_high_risk_non_path_tool`) keep resolving unchanged.
@@ -46,6 +48,26 @@ pub use classify::{is_path_tool_name, pattern_for_tool};
 
 use policy::{Decider, Modifier, PolicyCtx};
 use types::{AccessRequest, Decision, Effect, Operation, Resource, TraceEntry};
+
+/// Whether Accept mode may coerce a base `Ask` to `Allow` for this
+/// (op, resource): low-risk operations (not shell/mcp/network/agent)
+/// on a non-external resource. "trust the agent in cwd" doesn't
+/// generalize to external code execution or out-of-tree paths.
+fn accept_eligible(op: Operation, resource: &Resource) -> bool {
+    let high_risk = matches!(
+        op,
+        Operation::Execute | Operation::Mcp | Operation::Network | Operation::Agent
+    );
+    let external_path = matches!(
+        resource,
+        Resource::Path {
+            in_cwd: false,
+            dev_null: false,
+            ..
+        }
+    );
+    !high_risk && !external_path
+}
 
 /// The registered-policy authorization engine. Holds the ordered
 /// decider/modifier sets and the mutable [`PolicyCtx`].
@@ -132,6 +154,32 @@ impl Engine {
                         applied: true,
                     }),
                 }
+            }
+
+            // ---- Mode coercion (Accept): the one place a mode
+            // LOOSENS. Accept turns a base `Ask` into `Allow` for
+            // low-risk, in-tree operations, regardless of whether the
+            // Ask came from a rule or the default. It lives here in the
+            // base layer (not as a tighten-only Stage-B modifier) and
+            // applies AFTER Stage A so it can relax a rule's Ask —
+            // matching the legacy Accept semantics. Deny is never
+            // touched (only `Ask` is coerced); high-risk ops
+            // (Execute/Mcp/Network/Agent) and external paths are
+            // excluded.
+            if req.mode == crate::permission::SecurityMode::Accept
+                && base == Effect::Ask
+                && accept_eligible(req.op, resource)
+            {
+                base = Effect::Allow;
+                let entry = TraceEntry {
+                    policy: "accept-mode",
+                    resource: ri,
+                    effect: Some(Effect::Allow),
+                    why: "accept mode coerced Ask→Allow".to_string(),
+                    applied: true,
+                };
+                trace.push(entry.clone());
+                binding = Some(entry);
             }
 
             // ---- Stage B: modifiers, monotone tighten ----

--- a/src/permission/engine/policies.rs
+++ b/src/permission/engine/policies.rs
@@ -10,8 +10,11 @@
 //! 4. [`ConfiguredRulePolicy`]   — user rules, last-match-wins inside.
 //! 5. [`BuiltinAllowPolicy`]     — read-only ops, memory/skill, dev-null, in-cwd writes.
 //! 6. [`ExternalDirPolicy`]      — out-of-cwd paths → external_directory rule or Ask.
-//! 7. [`AcceptModePolicy`]       — `mode == Accept` coerces the otherwise-default to Allow.
-//! 8. [`DefaultActionPolicy`]    — the configured default (always claims; terminal).
+//! 7. [`DefaultActionPolicy`]    — the configured default (always claims; terminal).
+//!
+//! Accept-mode loosening is NOT a decider — it's a post-Stage-A base
+//! coercion in `Engine::authorize` (it relaxes a base `Ask`→`Allow`,
+//! the one place a mode loosens).
 //!
 //! Modes are folded into the deciders (not a separate stage): because
 //! explicit user rules (ConfiguredRule) outrank the builtin/default
@@ -63,10 +66,13 @@ pub struct Rule {
 }
 
 impl Rule {
-    fn matches(&self, req: &AccessRequest, key: &str) -> bool {
+    fn matches(&self, req: &AccessRequest, resource: &Resource) -> bool {
         self.op.matches(req.op)
             && self.tool.as_deref().is_none_or(|t| t == req.tool)
-            && self.pattern.matches(key)
+            && resource
+                .match_candidates()
+                .iter()
+                .any(|k| self.pattern.matches(k))
     }
 }
 
@@ -131,8 +137,10 @@ impl Decider for SessionAllowlistPolicy {
         true
     }
     fn decide(&self, req: &AccessRequest, resource: &Resource, ctx: &PolicyCtx) -> Option<Verdict> {
-        ctx.allowlist
-            .allows(req.op, resource.match_key())
+        resource
+            .match_candidates()
+            .iter()
+            .any(|k| ctx.allowlist.allows(req.op, k))
             .then(|| Verdict::new(Effect::Allow, "allowed for this session"))
     }
 }
@@ -150,15 +158,15 @@ impl Decider for ConfiguredRulePolicy {
         // Coarse: op + pattern (the tool narrowing is applied in
         // `decide`, which has the full request). A false positive here
         // only means `decide` runs and returns None — harmless.
+        let cands = resource.match_candidates();
         self.rules
             .iter()
-            .any(|r| r.op.matches(op) && r.pattern.matches(resource.match_key()))
+            .any(|r| r.op.matches(op) && cands.iter().any(|k| r.pattern.matches(k)))
     }
     fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
-        let key = resource.match_key();
         self.rules
             .iter()
-            .filter(|r| r.matches(req, key))
+            .filter(|r| r.matches(req, resource))
             .next_back() // last match wins
             .map(|r| Verdict::new(r.effect, format!("rule {:?} → {:?}", r.original, r.effect)))
     }
@@ -192,7 +200,7 @@ impl BuiltinAllowPolicy {
 
             // File mutation: dev-null is a harmless bit-bucket; in-cwd
             // writes are trusted (confirmed under Restrictive).
-            Operation::Write | Operation::Edit => match resource {
+            Operation::Edit => match resource {
                 Resource::Path { dev_null: true, .. } => Some(Effect::Allow),
                 Resource::Path { in_cwd: true, .. } => Some(if restrictive {
                     Effect::Ask
@@ -205,8 +213,14 @@ impl BuiltinAllowPolicy {
             // Internal/meta tools have no external effect.
             Operation::Meta => Some(Effect::Allow),
 
-            // Execute / Network / Mcp are never builtin-allowed.
-            Operation::Execute | Operation::Network | Operation::Mcp => None,
+            // Execute / Network / Mcp / Agent (recursive task) are
+            // never builtin-allowed; Other (unknown/plugin) falls to
+            // configured rules or the default.
+            Operation::Execute
+            | Operation::Network
+            | Operation::Mcp
+            | Operation::Agent
+            | Operation::Other => None,
         }
     }
 }
@@ -223,13 +237,8 @@ impl Decider for BuiltinAllowPolicy {
             Operation::Read | Operation::Memory | Operation::Skill | Operation::Meta
         ) || matches!(
             (op, resource),
-            (
-                Operation::Write | Operation::Edit,
-                Resource::Path { in_cwd: true, .. }
-            ) | (
-                Operation::Write | Operation::Edit,
-                Resource::Path { dev_null: true, .. }
-            )
+            (Operation::Edit, Resource::Path { in_cwd: true, .. })
+                | (Operation::Edit, Resource::Path { dev_null: true, .. })
         )
     }
     fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
@@ -278,17 +287,16 @@ impl Decider for ExternalDirPolicy {
     fn applies_to(&self, op: Operation, resource: &Resource) -> bool {
         // Only governs mutating access to external paths; external
         // reads are already allowed by BuiltinAllow (higher precedence).
-        matches!(op, Operation::Write | Operation::Edit) && Self::is_external_path(resource)
+        matches!(op, Operation::Edit) && Self::is_external_path(resource)
     }
     fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
         if !Self::is_external_path(resource) {
             return None;
         }
-        let key = resource.match_key();
         let matched = self
             .rules
             .iter()
-            .filter(|r| r.matches(req, key))
+            .filter(|r| r.matches(req, resource))
             .next_back();
         match matched {
             Some(r) => Some(Verdict::new(
@@ -297,26 +305,6 @@ impl Decider for ExternalDirPolicy {
             )),
             None => Some(Verdict::new(Effect::Ask, "outside the working directory")),
         }
-    }
-}
-
-/// Accept mode: coerce the otherwise-default to Allow, except for
-/// high-risk operations (shell/mcp/network) which still confirm. Sits
-/// just above the default so it only affects calls nothing else
-/// claimed.
-pub struct AcceptModePolicy;
-
-impl Decider for AcceptModePolicy {
-    fn id(&self) -> &'static str {
-        "accept-mode"
-    }
-    fn applies_to(&self, op: Operation, _: &Resource) -> bool {
-        // High-risk ops are NOT coerced — "trust the agent in cwd"
-        // doesn't generalize to shell/mcp/network execution.
-        !matches!(op, Operation::Execute | Operation::Mcp | Operation::Network)
-    }
-    fn decide(&self, req: &AccessRequest, _: &Resource, _: &PolicyCtx) -> Option<Verdict> {
-        (req.mode == SecurityMode::Accept).then(|| Verdict::new(Effect::Allow, "accept mode"))
     }
 }
 
@@ -378,11 +366,15 @@ impl Modifier for LoopGuardPolicy {
         }
         let prior = ctx.repeat.prior(req.op, resource.match_key());
         if prior >= self.threshold {
+            let preview: String = resource.match_key().chars().take(60).collect();
             Refined::tighten(
                 current,
                 Effect::Deny,
                 "loop-guard",
-                format!("repeated identical prompt {prior}× — breaking retry loop"),
+                format!(
+                    "Doom loop: repeated identical {} call ({preview}) prompted {prior}× — breaking retry loop",
+                    req.tool
+                ),
             )
         } else {
             Refined::noop(current)
@@ -405,7 +397,6 @@ mod tests {
                 Box::new(ConfiguredRulePolicy { rules: vec![] }),
                 Box::new(BuiltinAllowPolicy),
                 Box::new(ExternalDirPolicy { rules: vec![] }),
-                Box::new(AcceptModePolicy),
                 Box::new(DefaultActionPolicy { default }),
             ],
             vec![Box::new(LoopGuardPolicy { threshold: 3 })],
@@ -458,13 +449,13 @@ mod tests {
     fn in_cwd_write_allowed_standard_confirms_restrictive() {
         let e = engine(Effect::Ask);
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             SecurityMode::Standard,
             vec![path("/proj/x", true, false)],
         ));
         assert_eq!(d.effect, Effect::Allow);
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             SecurityMode::Restrictive,
             vec![path("/proj/x", true, false)],
         ));
@@ -475,7 +466,7 @@ mod tests {
     fn external_write_asks_dev_null_allows() {
         let e = engine(Effect::Ask);
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             SecurityMode::Standard,
             vec![path("/etc/x", false, false)],
         ));
@@ -483,7 +474,7 @@ mod tests {
         assert_eq!(d.deciding.unwrap().policy, "external-dir");
 
         let d = e.authorize(&req(
-            Operation::Write,
+            Operation::Edit,
             SecurityMode::Standard,
             vec![path("/dev/null", false, true)],
         ));
@@ -609,7 +600,6 @@ mod tests {
                 Box::new(ConfiguredRulePolicy { rules }),
                 Box::new(BuiltinAllowPolicy),
                 Box::new(ExternalDirPolicy { rules: vec![] }),
-                Box::new(AcceptModePolicy),
                 Box::new(DefaultActionPolicy {
                     default: Effect::Ask,
                 }),

--- a/src/permission/engine/types.rs
+++ b/src/permission/engine/types.rs
@@ -22,12 +22,10 @@ pub enum Operation {
     /// Read-only observation of a file (read, grep, list_dir, lsp,
     /// the semantic readers).
     Read,
-    /// Whole-file creation/overwrite (the `write` tool, bash redirect
-    /// targets, bash mutation paths).
-    Write,
-    /// In-place modification (`edit` / `apply_patch`). Write/Edit/
-    /// apply_patch all normalize here so one rule governs the trio —
-    /// the old F2 aliasing dissolves.
+    /// File mutation — the `write` and `edit`/`apply_patch` tools plus
+    /// bash redirect targets and mutation paths all normalize here, so
+    /// one rule governs them all (the old F2 write↔edit↔apply_patch
+    /// aliasing dissolves into a single operation).
     Edit,
     /// Shell command execution (one segment of a bash invocation).
     Execute,
@@ -39,9 +37,15 @@ pub enum Operation {
     Memory,
     /// Skill load/list (read) or create/edit/patch/delete (write).
     Skill,
-    /// Internal/meta tools with no external effect (write_todo_list,
-    /// task_status, question, task).
+    /// Recursive sub-agent execution (the `task` tool). High-risk —
+    /// not builtin-allowed and not coerced by Accept mode.
+    Agent,
+    /// Internal tools with no external effect (write_todo_list,
+    /// task_status, question) — builtin-allowed.
     Meta,
+    /// Uncategorized / plugin tools. Not builtin-allowed; falls to the
+    /// configured rules or the default (Ask), and IS Accept-coercible.
+    Other,
 }
 
 impl Operation {
@@ -51,11 +55,11 @@ impl Operation {
     pub fn is_side_effecting(self) -> bool {
         matches!(
             self,
-            Operation::Write
-                | Operation::Edit
+            Operation::Edit
                 | Operation::Execute
                 | Operation::Network
                 | Operation::Mcp
+                | Operation::Agent
         )
     }
 }
@@ -102,6 +106,21 @@ impl Resource {
             Resource::Mcp { raw, .. } => raw,
             Resource::Url(u) => u,
             Resource::Bareword(b) => b,
+        }
+    }
+
+    /// Every string form a configured pattern should be tested
+    /// against. Paths expose BOTH the canonical resolved form and the
+    /// raw input, so a user rule written against either (literal
+    /// `/etc/**`, a symlinked root, or a relative path) matches —
+    /// mirroring the old `check_path` `matches(abs) || matches(raw)`.
+    pub fn match_candidates(&self) -> Vec<&str> {
+        match self {
+            Resource::Path { raw, resolved, .. } => {
+                let r = resolved.to_str().unwrap_or(raw);
+                if r == raw { vec![r] } else { vec![r, raw] }
+            }
+            _ => vec![self.match_key()],
         }
     }
 }
@@ -312,7 +331,6 @@ mod tests {
 
     #[test]
     fn side_effecting_classification() {
-        assert!(Operation::Write.is_side_effecting());
         assert!(Operation::Edit.is_side_effecting());
         assert!(Operation::Execute.is_side_effecting());
         assert!(Operation::Network.is_side_effecting());

--- a/src/permission/path.rs
+++ b/src/permission/path.rs
@@ -209,6 +209,7 @@ fn lexical_normalize(p: &Path) -> std::path::PathBuf {
 ///
 /// Returns `Ok(())` for plausible paths, `Err(reason)` for
 /// paths that should be hard-rejected.
+#[allow(dead_code)] // Phase 4: only reached via the legacy check_path facade
 pub fn validate_path(path: &str) -> Result<(), String> {
     let p = Path::new(path);
     if p.is_absolute() {

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -119,19 +119,33 @@ fn doom_loop_deny_names_the_call() {
         SecurityMode::Standard,
         Some(std::path::PathBuf::from("/tmp")),
     );
-    // Three identical calls fires the doom-loop deny.
-    checker.check("bash", "echo hi");
-    checker.check("bash", "echo hi");
-    let result = checker.check("bash", "echo hi");
+    // Loop guard: an Ask op (echo hi isn't a default-allowed bash
+    // command) retried past the threshold (3) is hard-denied on the
+    // 4th identical prompted call. (The new guard never gates an
+    // ALLOWED op and always hard-denies a true retry loop, regardless
+    // of the legacy `doom_loop` action.)
+    assert!(matches!(
+        checker.check("bash", "frobnicate xyz"),
+        CheckResult::Ask
+    ));
+    assert!(matches!(
+        checker.check("bash", "frobnicate xyz"),
+        CheckResult::Ask
+    ));
+    assert!(matches!(
+        checker.check("bash", "frobnicate xyz"),
+        CheckResult::Ask
+    ));
+    let result = checker.check("bash", "frobnicate xyz");
     match result {
         CheckResult::Denied(msg) => {
             assert!(msg.contains("Doom loop"), "must say Doom loop: {msg}");
             assert!(
-                msg.contains("bash") && msg.contains("echo hi"),
+                msg.contains("bash") && msg.contains("frobnicate"),
                 "must name tool + call preview: {msg}",
             );
         }
-        other => panic!("expected Denied; got {other:?}"),
+        other => panic!("expected Denied on the 4th identical Ask; got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Context

Phase 2b completes the chokepoint swap: **the unified engine is now the source of truth for runtime permission decisions.**

- `enforce()` builds an `AccessRequest` and calls `authorize_scope` → `Engine::authorize` + `commit`.
- The legacy `check`/`check_path` facade now **delegates to the engine** too, so the full existing permission suite (~1700 assertions) runs against the engine as the **oracle**.
- The old per-method decision logic (the duplicated, drifted `check`/`check_path` cluster) is bypassed and slated for deletion in **Phase 4** — kept now only for the test oracle + the `semantic-bash` dev-null soft-allow, behind a transitional `#![allow(dead_code)]`.

This is where the session's bug-fixes actually land at runtime: re-reads/in-cwd writes never prompt on repetition; the loop-guard hard-denies a genuine retry loop instead of nagging; `check`/`check_path` divergence is gone (one path); F2 special-casing is gone.

## Engine refinements (driven by the oracle)

- **F2 dissolves:** `write`/`edit`/`apply_patch` share `Operation::Edit`; legacy `write`/`edit`/`apply_patch` config maps to an un-narrowed Edit rule, so one `edit: deny` governs the trio. The `enforce()` F2 merge block is **deleted**.
- **`task` → `Operation::Agent`** (high-risk recursive agent, never auto-allowed/Accept-coerced) and **unknown/plugin tools → `Operation::Other`** (default Ask, Accept-coercible) — fixes over-broad `Meta` auto-allow.
- **Accept coercion** moved to a post-Stage-A base step in `authorize()` — it *loosens* `Ask→Allow` for low-risk in-tree ops (which a tighten-only modifier can't, and must override a rule's Ask to match legacy Accept). Documented as the one place a mode loosens.
- **`classify_path`** in-cwd classification is robust to macOS symlinked roots (`/tmp→/private/tmp`) and refuses glob-metachar working_dirs (no CWD-allow), mirroring the old guard.
- **Rule/session/external matching** tests BOTH the resolved and raw path forms (the old `matches(abs) || matches(raw)`), so a literal `/etc/**` rule matches the resolved `/private/etc/...`.
- Session allowlist + prompt-deny live in the engine `PolicyCtx`; the checker keeps the two views in sync on every write (so the UI coalescing + `/allow` agree with the runtime).

## Behavior changes (locked by updated oracle tests)

- Re-reads / in-cwd writes / memory never prompt on repetition.
- Loop guard hard-denies the **4th** identical *prompted* call (threshold 3) and never gates an allowed op.
- `edit: { "**": deny }` denies `write`/`apply_patch` everywhere (F2 dissolution).
- Accept coerces a config-rule `Ask`→`Allow` for in-tree writes; explicit `Deny` and high-risk ops untouched.

## Tests

Full suite green: **2099** across the complete `build.sh` feature matrix, `RUSTFLAGS=-D warnings`. The ~1700 existing permission assertions now exercise the engine; the handful that encoded the old doom-loop/F2 semantics were updated to the new (intended) behavior with explanatory comments.

## Next
- **Phase 3** — migrate tools to build `AccessRequest` directly; collapse bash into one atomic multi-resource request; trace-rendered prompts + `/why`.
- **Phase 4** — delete the legacy `check`/`check_path`/`CheckResult`/`Scope`/the dead decision cluster + breaking op-based config schema.