### PR TITLE
feat(perm): /why decision-trace command (Phase 3a/4)

### DIFF
--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -25,6 +25,29 @@ pub enum CheckResult {
     Denied(String),
 }
 
+/// Render a decision's audit trail for the `/why` command: the final
+/// effect + deciding policy, then every applicable policy's vote in
+/// evaluation order (and the skipped ones, so it's clear what did and
+/// didn't apply).
+fn format_decision(tool: &str, input: &str, decision: &engine::types::Decision) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "why: {tool} {input:?}");
+    let _ = writeln!(out, "  → {:?}  ({})", decision.effect, decision.reason());
+    for e in &decision.trace {
+        if e.applied {
+            let eff = e
+                .effect
+                .map(|x| format!("{x:?}"))
+                .unwrap_or_else(|| "—".to_string());
+            let _ = writeln!(out, "  · {:<16} {eff:<6} {}", e.policy, e.why);
+        } else {
+            let _ = writeln!(out, "  · {:<16} (n/a)  {}", e.policy, e.why);
+        }
+    }
+    out
+}
+
 /// Map an engine [`Decision`](engine::types::Decision) onto the legacy
 /// `CheckResult` returned by the `check`/`check_path` facade.
 fn effect_to_result(decision: engine::types::Decision) -> CheckResult {
@@ -405,6 +428,16 @@ impl PermissionChecker {
         let decision = self.engine.authorize(&req);
         self.engine.commit(&req, &decision);
         decision
+    }
+
+    /// Dry-run a decision and render its full audit trail (which
+    /// policy decided and why, plus every applicable policy's vote).
+    /// Pure: no commit, no loop-guard accounting. Backs the `/why`
+    /// command so the user can see exactly what governs an action.
+    pub fn explain(&self, tool: &str, input: &str, is_path: bool) -> String {
+        let req = self.build_request(tool, input, is_path);
+        let decision = self.engine.authorize(&req);
+        format_decision(tool, input, &decision)
     }
 
     /// Normalize a (tool, input) pair into a one-resource request. The

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -1447,3 +1447,30 @@ mod reported_permission_ux_regressions {
         let _ = std::fs::remove_dir_all(&proj);
     }
 }
+
+/// `/why` / `explain`: the rendered trace names the final effect, the
+/// deciding policy, and the applicable policies' votes.
+#[test]
+fn explain_renders_decision_trace() {
+    let checker = PermissionChecker::new(
+        &PermissionConfig::default(),
+        SecurityMode::Standard,
+        Some(std::path::PathBuf::from("/tmp/proj")),
+    );
+    // An unfamiliar bash command falls to the default → Ask.
+    let report = checker.explain("bash", "frobnicate --hard", false);
+    assert!(report.contains("frobnicate"), "names the input: {report}");
+    assert!(report.contains("Ask"), "shows the effect: {report}");
+    assert!(
+        report.contains("default"),
+        "names the deciding policy: {report}"
+    );
+
+    // A read is transparently allowed by the builtin-allow policy.
+    let report = checker.explain("read", "/tmp/proj/src/main.rs", true);
+    assert!(report.contains("Allow"), "read allowed: {report}");
+    assert!(
+        report.contains("builtin-allow"),
+        "names builtin-allow as decider: {report}",
+    );
+}

--- a/src/ui/slash/cmd_misc.rs
+++ b/src/ui/slash/cmd_misc.rs
@@ -229,6 +229,39 @@ pub(super) async fn cmd_quit(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     Err(std::io::Error::new(std::io::ErrorKind::Interrupted, "quit").into())
 }
 
+/// `/why <tool> [input]` — explain how the permission engine would
+/// decide a tool call: the final effect, the deciding policy, and
+/// every applicable policy's vote. Dry-run (no side effects).
+pub(super) async fn cmd_why(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow::Result<()> {
+    let perm = match ctx.permission {
+        Some(p) => p,
+        None => {
+            ctx.renderer.write_line(
+                "permission system unavailable (--no-tools mode?)",
+                c_error(),
+            )?;
+            return Ok(());
+        }
+    };
+    let Some(tool) = parts.get(1).copied() else {
+        ctx.renderer.write_line(
+            "usage: /why <tool> [input]   e.g. /why bash cargo test   ·   /why write src/main.rs",
+            c_error(),
+        )?;
+        return Ok(());
+    };
+    let input = parts.get(2..).map(|s| s.join(" ")).unwrap_or_default();
+    let is_path = crate::permission::engine::is_path_tool_name(tool);
+    let report = {
+        let guard = perm.lock().unwrap_or_else(|e| e.into_inner());
+        guard.explain(tool, &input, is_path)
+    };
+    for line in report.lines() {
+        ctx.renderer.write_line(line, c_result())?;
+    }
+    Ok(())
+}
+
 pub(super) async fn cmd_allow(
     ctx: &mut SlashCtx<'_>,
     parts: &[&str],

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -454,6 +454,7 @@ pub async fn handle_slash(
         "/undo" => cmd_session::cmd_undo(&mut ctx).await?,
         "/retry" => cmd_session::cmd_retry(&mut ctx).await?,
         "/allow" => cmd_misc::cmd_allow(&mut ctx, &parts, text).await?,
+        "/why" => cmd_misc::cmd_why(&mut ctx, &parts).await?,
         "/help" => cmd_misc::cmd_help(&mut ctx).await?,
         "/kill" => cmd_misc::cmd_kill(&mut ctx, &parts).await?,
         _ => {
@@ -661,6 +662,7 @@ pub fn slash_command_names() -> Vec<&'static str> {
         "/toggle",
         "/tree",
         "/undo",
+        "/why",
     ];
     #[cfg(feature = "git-worktree")]
     {
@@ -1059,6 +1061,7 @@ mod tests {
             "/toggle",
             "/tree",
             "/undo",
+            "/why",
         ];
         let list = slash_command_names();
         for name in ALWAYS_ON {


### PR DESCRIPTION
## Context

Phase 3a delivers the high-value, low-risk core of Phase 3: the **`/why`** command, which surfaces the engine's decision trace — directly serving the "crystal clear what rules apply to what action and why" requirement.

`/why <tool> [input]` is a dry-run (no commit, no loop-guard accounting) that renders:
- the final effect + the deciding policy and its reason
- every applicable policy's vote in evaluation order (and the skipped ones, marked `n/a`)

```
/why bash cargo test
why: bash "cargo test"
  → Ask  (default action (default))
  · prompt-deny      (n/a)  not applicable
  · configured-rule  Ask    rule "bash:cargo *" → Ask
  · builtin-allow    (n/a)  not applicable
  · default          Ask    default action
```

- `PermissionChecker::explain` + `format_decision` (engine-backed, pure).
- `/why` wired into dispatch + the canonical command list (+ the always-on test).
- New test asserts the trace names the effect + deciding policy.

Full suite green: **2100** across the `build.sh` matrix, `RUSTFLAGS=-D warnings`.

## Phase 3 scope note

The other two Phase-3 items are deliberately **not** in this PR:
- **Tool migration** (each tool builds `AccessRequest` directly): mostly cosmetic — the `enforce(tool, Scope)` adapter already normalizes correctly, so this is churn with little behavior gain. Best folded into Phase 4's cleanup.
- **Atomic bash** (one prompt per command instead of one per segment/redirect/mutation): a real UX win, but it requires an **ask-flow + UI redesign** (multi-claim `AskRequest`, prompt rendering, allow-always applying across claims) — the riskiest surgery in the refactor. Worth its own focused effort.

Recommend treating atomic-bash as a dedicated follow-up rather than rushing it; flagged for a decision.