### PR TITLE
feat(perm): atomic multi-claim requests + atomic bash (Phase 3b/4)

### DIFF
--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, BashArgs, PermCheck, Scope, ToolError, enforce};
+use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError, enforce_request};
 
 use crate::sandbox::Sandbox;
 #[cfg(feature = "semantic-bash")]
@@ -369,187 +369,111 @@ impl Tool for BashTool {
     }
 }
 
-/// dirge-mzs4: bash-segment check with `Ask → Allow` soft-allow
-/// for segments whose only filesystem-touching effect is a redirect
-/// to `/dev/null`. Deny rules and the doom-loop detector still fire
-/// — the only divergence from the normal `enforce(..., "bash", ...)`
-/// path is that an `Ask` outcome is converted to `Allowed` instead
-/// of prompting the user.
-///
-/// Routes through `PermissionChecker::check_bash_dev_null_softallow`
-/// rather than the generic `enforce` chokepoint because the
-/// Ask-upgrade is intentionally scoped to ONE call site (the bash
-/// segment loop after the dev-null parser flagged the segment) and
-/// MUST NOT leak into other tools.
-#[cfg(feature = "semantic-bash")]
-async fn check_bash_segment_dev_null(
-    permission: &Option<PermCheck>,
-    ask_tx: &Option<AskSender>,
-    segment: &str,
-) -> Result<(), ToolError> {
-    use crate::permission::checker::CheckResult;
-
-    let Some(perm) = permission else {
-        return Ok(());
-    };
-
-    let result = {
-        let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
-        guard.check_bash_dev_null_softallow(segment)
-    };
-
-    match result {
-        CheckResult::Allowed => Ok(()),
-        CheckResult::Denied(reason) => {
-            Err(ToolError::Msg(format!("Permission denied: {}", reason)))
-        }
-        // Unreachable: `check_bash_dev_null_softallow` converts Ask
-        // to Allowed before returning. Fall back to the standard
-        // enforce chokepoint defensively — if a future refactor
-        // breaks the conversion, behaviour degrades to "prompt the
-        // user", which is the conservative default.
-        CheckResult::Ask => enforce(permission, ask_tx, "bash", Scope::Raw(segment))
-            .await
-            .map(|_| ()),
-    }
-}
-
 async fn check_bash_segments(
     permission: &Option<PermCheck>,
     ask_tx: &Option<AskSender>,
     command: &str,
 ) -> Result<(), ToolError> {
-    // M3 (dirge-6ab): every bash permission decision routes through
-    // the `enforce` chokepoint. Each compound-statement segment is
-    // checked independently so `git diff && rm -rf /` gets BOTH `git`
-    // AND `rm` checked against the user's bash rules — not just the
-    // leading command. Redirect targets (`> file`) additionally route
-    // through the `write` tool rules so write/edit path rules apply,
-    // closing the C4 audit gap where targets hit bash rules with
-    // path-string inputs and fell through to default Allow.
+    // ATOMIC bash authorization (Phase 3): one bash invocation becomes
+    // ONE multi-claim AccessRequest — an Execute claim per command
+    // segment plus an Edit claim per redirect target / mutation path —
+    // authorized as a unit so the whole command is allowed/denied/
+    // prompted ONCE, not gate-by-gate. (Replaces the old per-call
+    // `enforce` loop that could fire several sequential prompts.)
+    //
+    // Semantics preserved by the engine, not bespoke code here:
+    //   - each compound segment is checked, so `git diff && rm -rf /`
+    //     denies on the `rm` segment (Execute deny rule);
+    //   - redirect/mutation targets route through Edit (the write rules
+    //     + external-dir gate apply, closing the C4 audit gap);
+    //   - `/dev/null` targets are auto-allowed by BuiltinAllow on the
+    //     Edit claim — but the command itself still needs Execute
+    //     permission, so an UNFAMILIAR `cmd > /dev/null` still prompts
+    //     (more correct than the old blanket command soft-allow).
+    let Some(perm) = permission else {
+        return Ok(()); // no checker (ACP / --no-tools) → pass through
+    };
+    let mode = {
+        let g = perm.lock().unwrap_or_else(|e| e.into_inner());
+        g.mode()
+    };
+    use crate::permission::engine::types::{AccessRequest, Claim, Operation, Resource};
+    let cmd_claim = |seg: &str| {
+        Claim::new(
+            Operation::Execute,
+            Resource::Command {
+                raw: seg.to_string(),
+                head: seg.split_whitespace().next().unwrap_or("").to_string(),
+            },
+        )
+    };
+    let mut claims: Vec<Claim> = Vec::new();
+
     #[cfg(feature = "semantic-bash")]
     {
-        // dirge-mzs4: use the dev-null-aware parser. Each segment is
-        // paired with a boolean flag indicating whether its enclosing
-        // `redirected_statement` had at least one file_redirect AND
-        // all those redirects targeted `/dev/null`. Segments with the
-        // flag set get an `Ask → Allow` soft-allow on the bash rule
-        // check — writing to /dev/null has no observable side effect
-        // so prompting on `<cmd> > /dev/null` is pure noise. Deny
-        // rules (default `rm -rf /**` etc.) still fire, and the
-        // doom-loop tracker still runs.
+        let working_dir = {
+            let g = perm.lock().unwrap_or_else(|e| e.into_inner());
+            g.working_dir().to_string()
+        };
+        let path_claim = |p: &str| {
+            Claim::new(
+                Operation::Edit,
+                crate::permission::engine::classify_path(p, &working_dir),
+            )
+        };
         let (segments_with_flag, complex) = bash::parse_bash_segments_with_dev_null(command)
             .unwrap_or_else(|_| (vec![(command.to_string(), false)], false));
-
         if complex {
-            // Subshell / command substitution / process substitution /
-            // arithmetic expansion: tree-sitter declined to split.
-            // Force a prompt on the WHOLE command so the user
-            // confirms the unfamiliar shape. Maki does the same
-            // (maki-agent/src/permissions.rs:441-455).
-            //
-            // PERM-6: even when complex, still extract redirect
-            // targets and mutation paths so that `echo "$(rm /etc/passwd)"`
-            // doesn't slip through when the outer `echo` is allowed.
-            for target in bash::extract_redirect_targets(command) {
-                enforce(permission, ask_tx, "write", Scope::PathResolve(&target)).await?;
-            }
-            for path in bash::extract_mutation_paths(command) {
-                enforce(permission, ask_tx, "write", Scope::PathResolve(&path)).await?;
-            }
-            enforce(permission, ask_tx, "bash", Scope::Raw(command)).await?;
-            return Ok(());
-        }
-
-        for (segment, dev_null_only) in &segments_with_flag {
-            if *dev_null_only {
-                check_bash_segment_dev_null(permission, ask_tx, segment).await?;
-            } else {
-                enforce(permission, ask_tx, "bash", Scope::Raw(segment)).await?;
+            // Subshell / command substitution / etc.: tree-sitter
+            // declined to split — check the whole command as one
+            // Execute claim so the user confirms the unfamiliar shape.
+            claims.push(cmd_claim(command));
+        } else {
+            for (segment, _dev_null) in &segments_with_flag {
+                claims.push(cmd_claim(segment));
             }
         }
-
-        // M3 fix to the C4 redirect-target gap: route targets through
-        // the `write` tool name (not `bash`), since redirection
-        // semantically writes files. Previously this was routed as
-        // `check_perm_path(tool="bash", path=&target)`, looking the
-        // target up in BASH rules — command-style globs that don't
-        // match path strings, falling through to default Allow. With
-        // `tool="write"` the user's write rules govern: deny lists
-        // (`/etc/**`, `~/.ssh/**`, `~/.aws/credentials`) now fire on
-        // bash redirects too. Falsely-prompting `< file` (read-side)
-        // is acceptable; the `extract_redirect_targets` walker
-        // intentionally skips heredoc / herestring and only emits
-        // write-side targets (`>`, `>>`, `&>`, `1>`, `2>`).
+        // PERM-6 / C4 / F1: redirect targets AND file-mutating command
+        // path args (rm/cp/mv/mkdir/touch/chmod/…) both route through
+        // Edit so write deny-lists + the external-dir gate govern them.
         for target in bash::extract_redirect_targets(command) {
-            enforce(permission, ask_tx, "write", Scope::PathResolve(&target)).await?;
+            claims.push(path_claim(&target));
         }
-        // F1 (dirge-dvy): route positional path arguments to
-        // file-mutating commands (rm / cp / mv / mkdir / rmdir /
-        // touch / chmod / chown / ln / tee / dd) through the write
-        // rules too. Without this, a permissive bash rule like
-        // `rm *: allow` silently allowed `rm /etc/passwd` because
-        // the path-side write deny never saw the argument. Ported
-        // from opencode shell.ts:30-51 (`FILES` set) + :191-221
-        // (`pathArgs` filter logic). The extractor skips flags
-        // (`-r`, `--recursive`), chmod permission specs (`+x`),
-        // and chmod/chown's first positional arg (mode / owner).
         for path in bash::extract_mutation_paths(command) {
-            enforce(permission, ask_tx, "write", Scope::PathResolve(&path)).await?;
+            claims.push(path_claim(&path));
         }
-        Ok(())
     }
     #[cfg(not(feature = "semantic-bash"))]
     {
-        // Best-effort coarse split when tree-sitter isn't compiled in.
-        // Without it, a command like `safe_cmd && rm -rf /` would be
-        // checked as a single string against the bash rules and might
-        // squeak through if `safe_cmd && rm` doesn't match any deny.
-        // Split on the unambiguous compound separators (`&&`, `;`,
-        // `||`) so each segment is checked individually.
-        //
-        // F10: the splitter now respects shell quoting. The naive
-        // `command.split(";")` split inside quoted strings, so
-        // `echo "; rm -rf /"` produced segments `echo "` and
-        // `rm -rf /"` — the second matched the bash rule for `rm`
-        // and could trigger a deny that the user thought was safe.
-        // The fixed splitter walks character-by-character and only
-        // emits a boundary when not inside `'…'`, `"…"`, or after
-        // a backslash escape.
-        let segments = quote_aware_split(command);
-
-        // Flag command substitution / subshell constructs / ANSI-C
-        // quoting that need a full parser. Surface as one
-        // whole-command check so the user sees the unfamiliar form
-        // before any segment runs.
-        //
-        // `$'...'` ANSI-C quoting was missing from the original
-        // check, leaving a small bypass: `echo $'hi\nrm -rf /; ls'`
-        // (with embedded literal newlines via `\n`) treated the body
-        // as one quoted token, so `quote_aware_split` didn't see the
-        // `;` as a separator. Adding `$'` to the substitution list
-        // makes the whole command get checked as a single string —
-        // the rules can still match the safe form, but the LLM
-        // doesn't get a free pass on obscure quoting.
+        // Coarse, quote-aware split when tree-sitter isn't compiled in;
+        // command-substitution / heredoc / ANSI-C quoting are checked as
+        // one whole-command claim.
         let has_substitution = command.contains("$(")
             || command.contains('`')
             || command.contains("<(")
             || command.contains(">(")
             || command.contains("$'")
-            // PERM-5: heredocs (`<<` / `<<-`). The heredoc body
-            // is invisible to `quote_aware_split` — the redirect
-            // operator is one token but the body starting on the
-            // next line can contain any command. Treat as complex.
             || command.contains("<<");
         if has_substitution {
-            enforce(permission, ask_tx, "bash", Scope::Raw(command)).await?;
-            return Ok(());
+            claims.push(cmd_claim(command));
+        } else {
+            for segment in quote_aware_split(command) {
+                claims.push(cmd_claim(&segment));
+            }
         }
-        for segment in &segments {
-            enforce(permission, ask_tx, "bash", Scope::Raw(segment)).await?;
-        }
-        Ok(())
     }
+
+    if claims.is_empty() {
+        claims.push(cmd_claim(command));
+    }
+
+    let req = AccessRequest {
+        tool: "bash".to_string(),
+        claims,
+        mode,
+        display_input: command.to_string(),
+    };
+    enforce_request(permission, ask_tx, req).await
 }
 
 /// Split a shell command on `;`, `&&`, `||` separators that appear
@@ -1065,34 +989,48 @@ mod tests {
     // only behavioural change is `Ask → Allow` for the bash segment
     // check.
 
-    /// Each of the 5 whitelisted patterns must pass without prompting,
-    /// even when the underlying command (`unfamiliar_cmd`) doesn't
-    /// match any default bash allow rule and would otherwise route
-    /// to `Ask` (and fail in `--no-ask-tx` test mode).
+    /// The `/dev/null` redirect TARGET is auto-allowed (a harmless
+    /// bit-bucket), so it never adds a prompt of its own. Phase 3
+    /// behavior change: the COMMAND still needs its own Execute
+    /// permission — an unfamiliar command redirected to /dev/null
+    /// still prompts (more correct than the old blanket command
+    /// soft-allow). So an ALLOWED command (`git status -s`) redirected
+    /// to /dev/null passes without prompting; the /dev/null target
+    /// contributes no extra gate.
     #[cfg(feature = "semantic-bash")]
     #[tokio::test]
-    async fn bash_redirects_to_dev_null_auto_allowed() {
+    async fn bash_dev_null_target_adds_no_prompt() {
         use crate::permission::{PermissionConfig, SecurityMode, checker::PermissionChecker};
 
-        let cases = [
-            "unfamiliar_cmd > /dev/null",
-            "unfamiliar_cmd 2> /dev/null",
-            "unfamiliar_cmd &> /dev/null",
-            "unfamiliar_cmd > /dev/null 2>&1",
-            "unfamiliar_cmd &>/dev/null",
+        // `git status` is a default-allowed bash command; redirecting
+        // it to /dev/null must not introduce a prompt.
+        let allowed_cases = [
+            "git status -s > /dev/null",
+            "git status -s 2> /dev/null",
+            "git status -s &> /dev/null",
+            "git status -s > /dev/null 2>&1",
         ];
-
-        for cmd in &cases {
-            let config = PermissionConfig::default();
-            let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
+        for cmd in &allowed_cases {
+            let checker =
+                PermissionChecker::new(&PermissionConfig::default(), SecurityMode::Standard, None);
             let perm = std::sync::Arc::new(std::sync::Mutex::new(checker));
-
             let result = check_bash_segments(&Some(perm), &None, cmd).await;
             assert!(
                 result.is_ok(),
-                "{cmd:?}: /dev/null redirect should auto-allow without prompting; got {result:?}",
+                "{cmd:?}: allowed command + /dev/null target must not prompt; got {result:?}",
             );
         }
+
+        // An UNFAMILIAR command redirected to /dev/null still needs
+        // command permission → prompts (Err in non-interactive test).
+        let checker =
+            PermissionChecker::new(&PermissionConfig::default(), SecurityMode::Standard, None);
+        let perm = std::sync::Arc::new(std::sync::Mutex::new(checker));
+        let result = check_bash_segments(&Some(perm), &None, "unfamiliar_cmd > /dev/null").await;
+        assert!(
+            result.is_err(),
+            "unfamiliar command still needs Execute permission even redirecting to /dev/null; got {result:?}",
+        );
     }
 
     /// Compound redirects (one to /dev/null, one to a real file) must

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -334,6 +334,46 @@ pub async fn enforce(
     }
 }
 
+/// Authorize a pre-built, possibly multi-claim [`AccessRequest`]
+/// atomically: ONE decision, at most ONE prompt. This is the entry
+/// point for tools (bash) that decompose a single invocation into
+/// several claims (command segments + redirect/mutation targets) — the
+/// per-resource effects fold most-restrictive-wins, so the whole
+/// command is allowed/denied/prompted as a unit instead of gate-by-gate.
+///
+/// On `Ask`, the single prompt shows the request's `display_input` (the
+/// whole command); "allow always" allowlists that command. In-cwd write
+/// targets are builtin-allowed and don't re-prompt; external targets are
+/// (correctly) re-scrutinized on the next run.
+pub async fn enforce_request(
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    req: crate::permission::engine::types::AccessRequest,
+) -> Result<(), ToolError> {
+    use crate::permission::engine::types::Effect;
+    let Some(perm) = permission else {
+        return Ok(()); // no checker (ACP / --no-tools) → pass through
+    };
+    let (effect, reason) = {
+        let mut guard = perm.lock().unwrap_or_else(|e| e.into_inner());
+        let decision = guard.authorize_request(&req);
+        (decision.effect, decision.reason())
+    };
+    match effect {
+        Effect::Allow => Ok(()),
+        Effect::Deny => Err(ToolError::Msg(format!("Permission denied: {reason}"))),
+        Effect::Ask => {
+            let Some(tx) = ask_tx else {
+                return Err(ToolError::Msg(
+                    "Permission denied (non-interactive mode)".to_string(),
+                ));
+            };
+            handle_ask_inner(tx, perm, &req.tool, &req.display_input).await?;
+            Ok(())
+        }
+    }
+}
+
 /// Back-compat wrapper for the legacy non-path check. Delegates to
 /// [`enforce`] with [`Scope::Raw`]. New code should call `enforce`
 /// directly.

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -430,6 +430,26 @@ impl PermissionChecker {
         decision
     }
 
+    /// Authorize a pre-built (possibly multi-claim) request and commit
+    /// it. Used by tools — bash especially — that decompose one
+    /// invocation into several claims (command segments + redirect /
+    /// mutation targets) and want ONE atomic decision + at most one
+    /// prompt instead of N independent `enforce` calls.
+    pub fn authorize_request(
+        &mut self,
+        req: &engine::types::AccessRequest,
+    ) -> engine::types::Decision {
+        let decision = self.engine.authorize(req);
+        self.engine.commit(req, &decision);
+        decision
+    }
+
+    /// The checker's working directory — tools building their own
+    /// multi-claim requests need it to classify path resources.
+    pub fn working_dir(&self) -> &str {
+        &self.working_dir
+    }
+
     /// Dry-run a decision and render its full audit trail (which
     /// policy decided and why, plus every applicable policy's vote).
     /// Pure: no commit, no loop-guard accounting. Backs the `/why`
@@ -475,13 +495,13 @@ impl PermissionChecker {
                 _ => Resource::Bareword(input.to_string()),
             }
         };
-        engine::types::AccessRequest {
-            op: engine::tool_operation(tool),
-            tool: tool.to_string(),
-            resources: vec![resource],
-            mode: self.mode,
-            display_input: input.to_string(),
-        }
+        engine::types::AccessRequest::single(
+            tool,
+            engine::tool_operation(tool),
+            resource,
+            self.mode,
+            input,
+        )
     }
 
     /// Install the current prompt's deny-list. Called when the

--- a/src/permission/engine/build.rs
+++ b/src/permission/engine/build.rs
@@ -257,9 +257,11 @@ mod tests {
         resources: Vec<Resource>,
     ) -> AccessRequest {
         AccessRequest {
-            op,
             tool: tool.to_string(),
-            resources,
+            claims: resources
+                .into_iter()
+                .map(|r| crate::permission::engine::types::Claim::new(op, r))
+                .collect(),
             mode,
             display_input: String::new(),
         }

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -113,7 +113,9 @@ impl Engine {
         // Per resource: (effect, binding-trace-entry).
         let mut per_resource: Vec<(Effect, Option<TraceEntry>)> = Vec::new();
 
-        for (ri, resource) in req.resources.iter().enumerate() {
+        for (ri, claim) in req.claims.iter().enumerate() {
+            let op = claim.op;
+            let resource = &claim.resource;
             if let Resource::Path { resolved, .. } = resource {
                 resolved_paths.push(resolved.clone());
             }
@@ -122,7 +124,7 @@ impl Engine {
             let mut base = Effect::Ask; // defensive default; DefaultActionPolicy normally claims
             let mut binding: Option<TraceEntry> = None;
             for d in &self.deciders {
-                if !d.applies_to(req.op, resource) {
+                if !d.applies_to(op, resource) {
                     trace.push(TraceEntry {
                         policy: d.id(),
                         resource: ri,
@@ -132,7 +134,7 @@ impl Engine {
                     });
                     continue;
                 }
-                match d.decide(req, resource, &self.ctx) {
+                match d.decide(req, op, resource, &self.ctx) {
                     Some(v) => {
                         let entry = TraceEntry {
                             policy: d.id(),
@@ -168,7 +170,7 @@ impl Engine {
             // excluded.
             if req.mode == crate::permission::SecurityMode::Accept
                 && base == Effect::Ask
-                && accept_eligible(req.op, resource)
+                && accept_eligible(op, resource)
             {
                 base = Effect::Allow;
                 let entry = TraceEntry {
@@ -185,7 +187,7 @@ impl Engine {
             // ---- Stage B: modifiers, monotone tighten ----
             let mut eff = base;
             for m in &self.modifiers {
-                if !m.applies_to(req.op, resource) {
+                if !m.applies_to(op, resource) {
                     trace.push(TraceEntry {
                         policy: m.id(),
                         resource: ri,
@@ -195,7 +197,7 @@ impl Engine {
                     });
                     continue;
                 }
-                let refined = m.refine(req, resource, eff, &self.ctx);
+                let refined = m.refine(req, op, resource, eff, &self.ctx);
                 if refined.by.is_some() {
                     let entry = TraceEntry {
                         policy: refined.by.unwrap(),
@@ -248,8 +250,8 @@ impl Engine {
     /// Allowed/denied requests don't accumulate retry pressure.
     pub fn commit(&mut self, req: &AccessRequest, decision: &Decision) {
         if decision.effect == Effect::Ask {
-            for resource in &req.resources {
-                self.ctx.repeat.record(req.op, resource.match_key());
+            for claim in &req.claims {
+                self.ctx.repeat.record(claim.op, claim.resource.match_key());
             }
         }
     }
@@ -284,7 +286,13 @@ mod tests {
         fn applies_to(&self, _: Operation, _: &Resource) -> bool {
             self.2
         }
-        fn decide(&self, _: &AccessRequest, _: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+        fn decide(
+            &self,
+            _: &AccessRequest,
+            _: Operation,
+            _: &Resource,
+            _: &PolicyCtx,
+        ) -> Option<Verdict> {
             Some(Verdict::new(self.1, "stub"))
         }
     }
@@ -296,16 +304,25 @@ mod tests {
         fn applies_to(&self, _: Operation, _: &Resource) -> bool {
             true
         }
-        fn refine(&self, _: &AccessRequest, _: &Resource, cur: Effect, _: &PolicyCtx) -> Refined {
+        fn refine(
+            &self,
+            _: &AccessRequest,
+            _: Operation,
+            _: &Resource,
+            cur: Effect,
+            _: &PolicyCtx,
+        ) -> Refined {
             Refined::tighten(cur, self.1, self.0, "stub tighten")
         }
     }
 
     fn req(resources: Vec<Resource>) -> AccessRequest {
         AccessRequest {
-            op: Operation::Execute,
             tool: "test".to_string(),
-            resources,
+            claims: resources
+                .into_iter()
+                .map(|r| Claim::new(Operation::Execute, r))
+                .collect(),
             mode: SecurityMode::Standard,
             display_input: "test".to_string(),
         }
@@ -391,7 +408,13 @@ mod tests {
             fn applies_to(&self, _: Operation, _: &Resource) -> bool {
                 true
             }
-            fn decide(&self, _: &AccessRequest, r: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+            fn decide(
+                &self,
+                _: &AccessRequest,
+                _: Operation,
+                r: &Resource,
+                _: &PolicyCtx,
+            ) -> Option<Verdict> {
                 let eff = if r.match_key().contains("bad") {
                     Effect::Deny
                 } else {

--- a/src/permission/engine/policies.rs
+++ b/src/permission/engine/policies.rs
@@ -66,8 +66,8 @@ pub struct Rule {
 }
 
 impl Rule {
-    fn matches(&self, req: &AccessRequest, resource: &Resource) -> bool {
-        self.op.matches(req.op)
+    fn matches(&self, req: &AccessRequest, op: Operation, resource: &Resource) -> bool {
+        self.op.matches(op)
             && self.tool.as_deref().is_none_or(|t| t == req.tool)
             && resource
                 .match_candidates()
@@ -93,7 +93,13 @@ impl Decider for PromptDenyPolicy {
     fn applies_to(&self, _: Operation, _: &Resource) -> bool {
         true
     }
-    fn decide(&self, req: &AccessRequest, resource: &Resource, ctx: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        _op: Operation,
+        resource: &Resource,
+        ctx: &PolicyCtx,
+    ) -> Option<Verdict> {
         let denied = |name: &str| ctx.prompt_deny.iter().any(|d| d.eq_ignore_ascii_case(name));
         let hit =
             denied(&req.tool) || matches!(resource, Resource::Mcp { name, .. } if denied(name));
@@ -119,7 +125,13 @@ impl Decider for YoloPolicy {
     fn applies_to(&self, _: Operation, _: &Resource) -> bool {
         true
     }
-    fn decide(&self, req: &AccessRequest, _: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        _op: Operation,
+        _: &Resource,
+        _: &PolicyCtx,
+    ) -> Option<Verdict> {
         (req.mode == SecurityMode::Yolo).then(|| Verdict::new(Effect::Allow, "yolo mode"))
     }
 }
@@ -136,11 +148,17 @@ impl Decider for SessionAllowlistPolicy {
     fn applies_to(&self, _: Operation, _: &Resource) -> bool {
         true
     }
-    fn decide(&self, req: &AccessRequest, resource: &Resource, ctx: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        _req: &AccessRequest,
+        op: Operation,
+        resource: &Resource,
+        ctx: &PolicyCtx,
+    ) -> Option<Verdict> {
         resource
             .match_candidates()
             .iter()
-            .any(|k| ctx.allowlist.allows(req.op, k))
+            .any(|k| ctx.allowlist.allows(op, k))
             .then(|| Verdict::new(Effect::Allow, "allowed for this session"))
     }
 }
@@ -163,10 +181,16 @@ impl Decider for ConfiguredRulePolicy {
             .iter()
             .any(|r| r.op.matches(op) && cands.iter().any(|k| r.pattern.matches(k)))
     }
-    fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        op: Operation,
+        resource: &Resource,
+        _: &PolicyCtx,
+    ) -> Option<Verdict> {
         self.rules
             .iter()
-            .filter(|r| r.matches(req, resource))
+            .filter(|r| r.matches(req, op, resource))
             .next_back() // last match wins
             .map(|r| Verdict::new(r.effect, format!("rule {:?} → {:?}", r.original, r.effect)))
     }
@@ -179,9 +203,9 @@ pub struct BuiltinAllowPolicy;
 
 impl BuiltinAllowPolicy {
     /// The effect this policy would contribute, or `None` to pass.
-    fn effect_for(req: &AccessRequest, resource: &Resource) -> Option<Effect> {
+    fn effect_for(op: Operation, req: &AccessRequest, resource: &Resource) -> Option<Effect> {
         let restrictive = req.mode == SecurityMode::Restrictive;
-        match req.op {
+        match op {
             // Observation is always transparent — even in Restrictive,
             // even outside the cwd (the old global `read **` allow).
             Operation::Read => Some(Effect::Allow),
@@ -189,8 +213,7 @@ impl BuiltinAllowPolicy {
             // Memory/skill: reads always allowed; writes allowed except
             // under Restrictive, where they confirm.
             Operation::Memory | Operation::Skill => {
-                let is_read =
-                    matches!(resource, Resource::Bareword(a) if is_read_action(req.op, a));
+                let is_read = matches!(resource, Resource::Bareword(a) if is_read_action(op, a));
                 if is_read || !restrictive {
                     Some(Effect::Allow)
                 } else {
@@ -241,8 +264,14 @@ impl Decider for BuiltinAllowPolicy {
                 | (Operation::Edit, Resource::Path { dev_null: true, .. })
         )
     }
-    fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
-        Self::effect_for(req, resource).map(|e| {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        op: Operation,
+        resource: &Resource,
+        _: &PolicyCtx,
+    ) -> Option<Verdict> {
+        Self::effect_for(op, req, resource).map(|e| {
             let why = match e {
                 Effect::Allow => "built-in allow",
                 _ => "restrictive mode confirms writes",
@@ -289,14 +318,20 @@ impl Decider for ExternalDirPolicy {
         // reads are already allowed by BuiltinAllow (higher precedence).
         matches!(op, Operation::Edit) && Self::is_external_path(resource)
     }
-    fn decide(&self, req: &AccessRequest, resource: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        op: Operation,
+        resource: &Resource,
+        _: &PolicyCtx,
+    ) -> Option<Verdict> {
         if !Self::is_external_path(resource) {
             return None;
         }
         let matched = self
             .rules
             .iter()
-            .filter(|r| r.matches(req, resource))
+            .filter(|r| r.matches(req, op, resource))
             .next_back();
         match matched {
             Some(r) => Some(Verdict::new(
@@ -321,7 +356,13 @@ impl Decider for DefaultActionPolicy {
     fn applies_to(&self, _: Operation, _: &Resource) -> bool {
         true
     }
-    fn decide(&self, req: &AccessRequest, _: &Resource, _: &PolicyCtx) -> Option<Verdict> {
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        _op: Operation,
+        _: &Resource,
+        _: &PolicyCtx,
+    ) -> Option<Verdict> {
         let eff = if req.mode == SecurityMode::Restrictive && self.default == Effect::Allow {
             Effect::Ask
         } else {
@@ -355,6 +396,7 @@ impl Modifier for LoopGuardPolicy {
     fn refine(
         &self,
         req: &AccessRequest,
+        op: Operation,
         resource: &Resource,
         current: Effect,
         ctx: &PolicyCtx,
@@ -364,7 +406,7 @@ impl Modifier for LoopGuardPolicy {
         if current != Effect::Ask {
             return Refined::noop(current);
         }
-        let prior = ctx.repeat.prior(req.op, resource.match_key());
+        let prior = ctx.repeat.prior(op, resource.match_key());
         if prior >= self.threshold {
             let preview: String = resource.match_key().chars().take(60).collect();
             Refined::tighten(
@@ -406,9 +448,11 @@ mod tests {
 
     fn req(op: Operation, mode: SecurityMode, resources: Vec<Resource>) -> AccessRequest {
         AccessRequest {
-            op,
             tool: format!("{op:?}").to_lowercase(),
-            resources,
+            claims: resources
+                .into_iter()
+                .map(|r| crate::permission::engine::types::Claim::new(op, r))
+                .collect(),
             mode,
             display_input: String::new(),
         }

--- a/src/permission/engine/policy.rs
+++ b/src/permission/engine/policy.rs
@@ -131,8 +131,15 @@ pub trait Decider: Send + Sync {
     fn applies_to(&self, op: Operation, resource: &Resource) -> bool;
 
     /// Claim the resource with a verdict, or `None` to pass to the
-    /// next decider. Reads `ctx` but never mutates it.
-    fn decide(&self, req: &AccessRequest, resource: &Resource, ctx: &PolicyCtx) -> Option<Verdict>;
+    /// next decider. `op` is the current claim's operation. Reads
+    /// `ctx` but never mutates it.
+    fn decide(
+        &self,
+        req: &AccessRequest,
+        op: Operation,
+        resource: &Resource,
+        ctx: &PolicyCtx,
+    ) -> Option<Verdict>;
 }
 
 /// Stage B. A modifier may only tighten the running effect for a
@@ -144,10 +151,12 @@ pub trait Modifier: Send + Sync {
     fn applies_to(&self, op: Operation, resource: &Resource) -> bool;
 
     /// Refine the current effect. Must return [`Refined::tighten`] or
-    /// [`Refined::noop`] — it cannot loosen `current`.
+    /// [`Refined::noop`] — it cannot loosen `current`. `op` is the
+    /// current claim's operation.
     fn refine(
         &self,
         req: &AccessRequest,
+        op: Operation,
         resource: &Resource,
         current: Effect,
         ctx: &PolicyCtx,

--- a/src/permission/engine/types.rs
+++ b/src/permission/engine/types.rs
@@ -125,20 +125,55 @@ impl Resource {
     }
 }
 
+/// A single (operation, resource) the agent wants to perform. A bash
+/// command decomposes into many claims with DIFFERENT operations
+/// (command segments → Execute, redirect/mutation targets → Edit),
+/// which is why the operation lives per-claim, not per-request.
+#[derive(Debug, Clone)]
+pub struct Claim {
+    pub op: Operation,
+    pub resource: Resource,
+}
+
+impl Claim {
+    pub fn new(op: Operation, resource: Resource) -> Self {
+        Claim { op, resource }
+    }
+}
+
 /// One logical operation the agent wants to perform. A single bash
-/// invocation produces ONE request holding many resources (command
+/// invocation produces ONE request holding many claims (command
 /// segments + redirect targets + mutation paths), so it is authorized
 /// atomically and prompts at most once — never the old N separate
 /// `enforce()` calls.
 #[derive(Debug, Clone)]
 pub struct AccessRequest {
-    pub op: Operation,
     /// Concrete tool name, for display and the decision trace.
     pub tool: String,
-    pub resources: Vec<Resource>,
+    pub claims: Vec<Claim>,
     pub mode: crate::permission::SecurityMode,
     /// Raw text shown in the Ask prompt.
     pub display_input: String,
+}
+
+impl AccessRequest {
+    /// Convenience constructor for a single-claim request (the common
+    /// case: one tool, one resource).
+    pub fn single(
+        tool: impl Into<String>,
+        op: Operation,
+        resource: Resource,
+        mode: crate::permission::SecurityMode,
+        display_input: impl Into<String>,
+    ) -> Self {
+        let display_input = display_input.into();
+        AccessRequest {
+            tool: tool.into(),
+            claims: vec![Claim::new(op, resource)],
+            mode,
+            display_input,
+        }
+    }
 }
 
 /// The authorization lattice. Ordering IS the combination algebra:


### PR DESCRIPTION
## Context

Completes Phase 3's headline goal: **a bash invocation is now ONE authorization with at most ONE prompt**, instead of an `enforce()` call per command segment / redirect target / mutation path.

## Engine — per-claim requests

`AccessRequest` now carries `Vec<Claim>` where `Claim = { op, resource }`, so a single request can span claims with **different** operations (command segments → `Execute`, redirect/mutation targets → `Edit`). `authorize()` evaluates each claim under its own op and folds the per-claim effects **most-restrictive-wins** → one `Decision`, one prompt. `Decider`/`Modifier` gain an explicit `op` param; the single-claim path (every other tool) is unchanged via `AccessRequest::single`.

## Tools — atomic bash

`check_bash_segments` builds ONE multi-claim `AccessRequest` (Execute per segment + Edit per redirect/mutation target) and calls the new `enforce_request` chokepoint once. The old per-call `enforce` loop and the bespoke dev-null command soft-allow (`check_bash_segment_dev_null` / `check_bash_dev_null_softallow`) are deleted.

**Cleaner `/dev/null` semantics:** the `/dev/null` *target* is auto-allowed (BuiltinAllow on its Edit claim), but the *command* still needs Execute permission — so `git status -s > /dev/null` is silent while an unfamiliar `cmd > /dev/null` still prompts (the command runs regardless of where output goes — more correct than the old blanket command soft-allow). Deny rules still fire across segments (`git diff && rm -rf /` → Deny).

## Tool migration note

Other tools keep building their `AccessRequest` via the centralized `enforce(tool, Scope)` adapter (single-claim) rather than inlining identical construction into each — same normalization, one place. Bash is the tool that genuinely needed the multi-claim treatment.

## Tests

Full suite green: **2100** across the complete `build.sh` feature matrix, `RUSTFLAGS=-D warnings`. Updated the dev-null bash test to the new (command-still-prompts / target-auto-allowed) semantics; engine multi-resource fold + cross-segment deny covered by existing tests.

## Phase 3 complete
`/why` (#200) + atomic bash (this PR). **Next: Phase 4** — delete the legacy `check`/`check_path`/`CheckResult`/`Scope`/the dead decision cluster + the breaking op-based config schema, and add the docs page.