### PR TITLE
feat(permission): hard cutover to op-based rules config schema

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,19 +38,16 @@ Example:
   },
   "permission": {
     "*": "ask",
-    "read": "allow",
-    "write": {
-      "**/*.rs": "allow",
-      "**": "ask"
-    },
-    "bash": {
-      "cargo test": "allow",
-      "rm **": "deny"
-    },
-    "external_directory": {
-      "/tmp/**": "allow",
-      "/**": "ask"
-    },
+    "rules": [
+      { "op": "edit",    "match": "**/*.rs",   "effect": "allow" },
+      { "op": "edit",    "match": "**",        "effect": "ask"   },
+      { "op": "execute", "match": "cargo test", "effect": "allow" },
+      { "op": "execute", "match": "rm **",     "effect": "deny"  }
+    ],
+    "external_directory": [
+      { "match": "/tmp/**", "effect": "allow" },
+      { "match": "/**",     "effect": "ask"   }
+    ],
     "doom_loop": "ask"
   }
 }
@@ -88,38 +85,39 @@ Accepted top-level keys:
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, defaults to a single Exa Web Search server; see below.                                                   |
 | `acp_servers`             | object  | ACP server config map when compiled with the `acp` feature. See the ACP section below.                                                                                       |
 
-Permission actions are lowercase strings: `allow`, `ask`, or `deny`. Each tool
-rule can be a single action or an object mapping glob-like patterns to actions.
-Supported permission tool keys are:
+Permission actions are lowercase strings: `allow`, `ask`, or `deny`. `rules`
+is an **ordered list** read top-to-bottom; **last match wins**. Each rule has:
 
-- File / shell: `bash`, `read`, `write`, `edit`, `grep`, `find_files`,
-  `list_dir`, `apply_patch`, `write_todo_list`
-- LSP / question: `lsp`, `question`
-- Web: `webfetch`, `websearch`
-- Subagent / state: `task`, `task_status`, `memory`, `skill`
-- Semantic (tree-sitter): `list_symbols`, `get_symbol_body`,
-  `find_definition`, `find_callers`, `find_callees`
-- MCP umbrella: `mcp_tool` — patterns match the full key
-  `mcp_tool:{server}:{tool}` so `{"mcp_tool:fs:*": "deny"}` blocks
-  every tool from a `fs` MCP server.
+- `op` — the operation class it governs (NOT a tool name). One of:
+  `read`, `edit`, `execute`, `network`, `mcp`, `memory`, `skill`,
+  `agent`, `meta`, or `*` (any). `edit` covers write/edit/apply_patch —
+  they're one operation, so one rule governs all three.
+- `match` — a glob. Read/edit/`*` use path-style globs (`*` is one path
+  segment, `**` spans directories); execute/network/mcp use shell-style
+  (`*` matches anything, trailing ` *` makes args optional). MCP patterns
+  match the full key `mcp_tool:{server}:{tool}`.
+- `effect` — `allow`, `ask`, or `deny`.
+- `tool` *(optional)* — narrow the rule to a single concrete tool name
+  (e.g. `"grep"`) instead of the whole op.
 
-Use `"*"` for the default action, `external_directory` for
-absolute-path rules outside the working directory, and `doom_loop`
-for repeated identical tool calls (default: `ask`). If `bash` is
-omitted, dirge installs its built-in safe bash allow/deny rules.
+Use `"*"` for the default action, `external_directory` (also a `rules`
+list, op defaults to `*`) for absolute-path rules outside the working
+directory, and `doom_loop` for the retry-loop hard-deny (set to `allow`
+to disable it). dirge always installs its built-in safe bash allow/deny
+rules and a read-only/memory/skill/in-cwd-write allow set beneath your
+rules; your `rules` override them.
 
-If `mcp_tool` is omitted, dirge defaults it to `ask` for ALL
-servers — MCP tools execute external code (the server's
-implementation, plus whatever filesystem / network / API effects it
-has), and silent default-allow let entire query sequences run before
-any prompt fired. To re-enable silent allow for a trusted server:
+MCP tools default to `ask` for ALL servers — they execute external code
+(the server's implementation, plus whatever filesystem / network / API
+effects it has), and silent default-allow let entire query sequences run
+before any prompt fired. To re-enable silent allow for a trusted server:
 
 ```json
 {
   "permission": {
-    "mcp_tool": {
-      "mcp_tool:lattice:*": "allow"
-    }
+    "rules": [
+      { "op": "mcp", "match": "mcp_tool:lattice:*", "effect": "allow" }
+    ]
   }
 }
 ```
@@ -207,10 +205,10 @@ Pair it with a tight `mcp_tool` rule for layered control, e.g.:
     }
   },
   "permission": {
-    "mcp_tool": {
-      "mcp_tool:semantic-index:*":          "allow",
-      "mcp_tool:semantic-index:write_file": "deny"
-    }
+    "rules": [
+      { "op": "mcp", "match": "mcp_tool:semantic-index:*",          "effect": "allow" },
+      { "op": "mcp", "match": "mcp_tool:semantic-index:write_file", "effect": "deny"  }
+    ]
   }
 }
 ```

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -89,29 +89,41 @@ config rule (precedence 4) always overrides them.
 
 ## Configuration
 
-Permissions are configured under the `permission` key. Per-tool rules
-map a glob pattern to an effect; a bare action is shorthand for "all":
+Permissions are configured under the `permission` key. `rules` is an
+**ordered list**; each rule names the operation it governs (`op`), a glob
+to `match`, and the `effect`. Reading top-to-bottom, **last match wins**:
 
 ```jsonc
 {
   "permission": {
-    "*": "ask",                              // default for anything unmatched
-    "bash": { "cargo *": "allow",            // last match wins within a tool
-              "git push *": "deny" },
-    "edit": { "/etc/**": "deny" },           // governs write + edit + apply_patch
-    "external_directory": { "/shared/**": "allow" }
+    "*": "ask",                                          // default for anything unmatched
+    "rules": [
+      { "op": "execute", "match": "cargo *",   "effect": "allow" },
+      { "op": "execute", "match": "git push *", "effect": "deny"  },
+      { "op": "edit",    "match": "/etc/**",   "effect": "deny"  }  // governs write + edit + apply_patch
+    ],
+    "external_directory": [
+      { "match": "/shared/**", "effect": "allow" }
+    ]
   }
 }
 ```
 
-- **`edit` covers write/edit/apply_patch** — they're one operation, so
-  one rule governs all three.
-- **Glob semantics:** path tools use path-style globs (`*` is one path
-  segment, `**` spans directories); command tools use shell-style (`*`
-  matches anything, trailing ` *` makes args optional).
-- **Last-match-wins** within a tool's rules — order them general → specific.
-- `external_directory` rules govern mutating access to paths outside the
-  project root.
+- **`op` is the operation class, not a tool name.** Values: `read`,
+  `edit`, `execute`, `network`, `mcp`, `memory`, `skill`, `agent`,
+  `meta`, or `*` (any). `edit` covers write/edit/apply_patch — they're
+  one operation, so one rule governs all three.
+- **Narrow to a tool** with an optional `"tool": "<name>"` field when a
+  rule should apply to a single concrete tool rather than the whole op.
+- **Glob semantics** are inferred from the op: read/edit/`*` use
+  path-style globs (`*` is one path segment, `**` spans directories);
+  execute/network/mcp use shell-style (`*` matches anything, trailing
+  ` *` makes args optional).
+- **Last-match-wins** across the ordered `rules` list — put general
+  rules first, specific overrides last.
+- `external_directory` is itself a `rules` list (op defaults to `*`)
+  governing access to paths outside the project root.
+- Set `"doom_loop": "allow"` to disable the retry-loop hard-deny.
 
 ### Security modes
 

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -590,6 +590,21 @@ fn push_segment<'a>(command: &'a str, start: usize, end: usize, out: &mut Vec<&'
 mod tests {
     use super::*;
 
+    /// Test helper: build a single op-based rule (tool-agnostic).
+    #[cfg(feature = "semantic-bash")]
+    fn rule(
+        op: crate::permission::OpSpec,
+        pattern: &str,
+        effect: crate::permission::Action,
+    ) -> crate::permission::RuleConfig {
+        crate::permission::RuleConfig {
+            op,
+            pattern: pattern.to_string(),
+            effect,
+            tool: None,
+        }
+    }
+
     /// F6: a timed-out `sleep 9999` (or any long-running command)
     /// must actually be killed when the timeout fires. Before this
     /// fix, dropping the tokio future left the bash child running
@@ -806,18 +821,15 @@ mod tests {
     #[tokio::test]
     async fn redirect_target_routes_through_write_rules() {
         use crate::permission::{
-            Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+            Action, OpSpec, PermissionConfig, SecurityMode, checker::PermissionChecker,
         };
-        use std::collections::HashMap;
 
-        // Configure write to deny everywhere; without an explicit
+        // Configure edit to deny everywhere; without an explicit
         // rule the M2/M4-pre default is still Allow, so we set an
         // explicit deny to make the test robust against the
         // default-flip.
-        let mut write_rules = HashMap::new();
-        write_rules.insert("/etc/**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            write: Some(ToolPerm::Granular(write_rules)),
+            rules: vec![rule(OpSpec::Edit, "/etc/**", Action::Deny)],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
@@ -858,20 +870,17 @@ mod tests {
     #[tokio::test]
     async fn rm_arg_path_routes_through_write_rules() {
         use crate::permission::{
-            Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+            Action, OpSpec, PermissionConfig, SecurityMode, checker::PermissionChecker,
         };
-        use std::collections::HashMap;
 
-        // Permissive bash: allow `rm *`. Restrictive write: deny
-        // `/etc/**`. Without F1, the bash allow would let
+        // Permissive execute: allow `rm *`. Restrictive edit: deny
+        // `/etc/**`. Without F1, the execute allow would let
         // `rm /etc/passwd` through.
-        let mut bash_rules = HashMap::new();
-        bash_rules.insert("rm *".to_string(), Action::Allow);
-        let mut write_rules = HashMap::new();
-        write_rules.insert("/etc/**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            bash: Some(ToolPerm::Granular(bash_rules)),
-            write: Some(ToolPerm::Granular(write_rules)),
+            rules: vec![
+                rule(OpSpec::Execute, "rm *", Action::Allow),
+                rule(OpSpec::Edit, "/etc/**", Action::Deny),
+            ],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
@@ -891,17 +900,14 @@ mod tests {
     #[tokio::test]
     async fn chmod_skips_mode_spec_routes_paths() {
         use crate::permission::{
-            Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+            Action, OpSpec, PermissionConfig, SecurityMode, checker::PermissionChecker,
         };
-        use std::collections::HashMap;
 
-        let mut bash_rules = HashMap::new();
-        bash_rules.insert("chmod *".to_string(), Action::Allow);
-        let mut write_rules = HashMap::new();
-        write_rules.insert("/etc/**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            bash: Some(ToolPerm::Granular(bash_rules)),
-            write: Some(ToolPerm::Granular(write_rules)),
+            rules: vec![
+                rule(OpSpec::Execute, "chmod *", Action::Allow),
+                rule(OpSpec::Edit, "/etc/**", Action::Deny),
+            ],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
@@ -923,17 +929,14 @@ mod tests {
     #[tokio::test]
     async fn flags_skipped_when_extracting_paths() {
         use crate::permission::{
-            Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+            Action, OpSpec, PermissionConfig, SecurityMode, checker::PermissionChecker,
         };
-        use std::collections::HashMap;
 
-        let mut bash_rules = HashMap::new();
-        bash_rules.insert("rm *".to_string(), Action::Allow);
-        let mut write_rules = HashMap::new();
-        write_rules.insert("/etc/**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            bash: Some(ToolPerm::Granular(bash_rules)),
-            write: Some(ToolPerm::Granular(write_rules)),
+            rules: vec![
+                rule(OpSpec::Execute, "rm *", Action::Allow),
+                rule(OpSpec::Edit, "/etc/**", Action::Deny),
+            ],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
@@ -952,23 +955,14 @@ mod tests {
     #[tokio::test]
     async fn redirect_target_allowed_when_write_permits() {
         use crate::permission::{
-            Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+            Action, OpSpec, PermissionConfig, SecurityMode, checker::PermissionChecker,
         };
-        use std::collections::HashMap;
 
-        // M4 (dirge-ojn): `write` no longer defaults to Allow; it
-        // falls to the new global Ask. F2 (dirge-jlj): write
-        // additionally consults `edit` rules. Install allow rules
-        // for BOTH so the combined check passes — matches the
-        // user-facing semantic that "write to X" requires write
-        // AND edit to permit it.
-        let mut write_rules = HashMap::new();
-        write_rules.insert("**".to_string(), Action::Allow);
-        let mut edit_rules = HashMap::new();
-        edit_rules.insert("**".to_string(), Action::Allow);
+        // F2 (dirge-jlj) dissolved: write/edit/apply_patch all map to
+        // Operation::Edit, so a single Edit allow rule governs the
+        // redirect-target write.
         let config = PermissionConfig {
-            write: Some(ToolPerm::Granular(write_rules)),
-            edit: Some(ToolPerm::Granular(edit_rules)),
+            rules: vec![rule(OpSpec::Edit, "**", Action::Allow)],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -432,10 +432,19 @@ pub async fn check_perm_path_resolve(
 mod tests {
     use super::*;
     use crate::permission::{
-        Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+        Action, OpSpec, PermissionConfig, RuleConfig, SecurityMode, checker::PermissionChecker,
     };
-    use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
+
+    /// Test helper: build a single op-based rule (tool-agnostic).
+    fn rule(op: OpSpec, pattern: &str, effect: Action) -> RuleConfig {
+        RuleConfig {
+            op,
+            pattern: pattern.to_string(),
+            effect,
+            tool: None,
+        }
+    }
 
     /// F2 (dirge-jlj): `enforce(write, ...)` MUST also consult the
     /// `edit` rules. A user writing `edit: { "**": "deny" }`
@@ -443,10 +452,8 @@ mod tests {
     /// `EDIT_TOOLS` aliasing.
     #[tokio::test]
     async fn enforce_write_aliases_to_edit_deny() {
-        let mut edit_rules = HashMap::new();
-        edit_rules.insert("**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            edit: Some(ToolPerm::Granular(edit_rules)),
+            rules: vec![rule(OpSpec::Edit, "**", Action::Deny)],
             ..Default::default()
         };
         let checker = PermissionChecker::new(
@@ -485,13 +492,14 @@ mod tests {
     /// but `edit` is Deny, the Deny wins.
     #[tokio::test]
     async fn enforce_write_alias_most_restrictive_wins() {
-        let mut edit_rules = HashMap::new();
-        edit_rules.insert("/etc/**".to_string(), Action::Deny);
-        let mut write_rules = HashMap::new();
-        write_rules.insert("**".to_string(), Action::Allow);
+        // write/edit/apply_patch share Operation::Edit, so both rules
+        // live in ONE ordered ruleset (last-match-wins): allow all,
+        // then deny /etc/**.
         let config = PermissionConfig {
-            edit: Some(ToolPerm::Granular(edit_rules)),
-            write: Some(ToolPerm::Granular(write_rules)),
+            rules: vec![
+                rule(OpSpec::Edit, "**", Action::Allow),
+                rule(OpSpec::Edit, "/etc/**", Action::Deny),
+            ],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);
@@ -524,10 +532,8 @@ mod tests {
     /// `read` shouldn't be affected by edit rules.
     #[tokio::test]
     async fn enforce_read_does_not_alias_to_edit() {
-        let mut edit_rules = HashMap::new();
-        edit_rules.insert("**".to_string(), Action::Deny);
         let config = PermissionConfig {
-            edit: Some(ToolPerm::Granular(edit_rules)),
+            rules: vec![rule(OpSpec::Edit, "**", Action::Deny)],
             ..Default::default()
         };
         let checker = PermissionChecker::new(&config, SecurityMode::Standard, None);

--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -666,9 +666,8 @@ mod tests {
 
     use crate::agent::tools::check_perm;
     use crate::permission::{
-        Action, PermissionConfig, SecurityMode, ToolPerm, checker::PermissionChecker,
+        Action, OpSpec, PermissionConfig, RuleConfig, SecurityMode, checker::PermissionChecker,
     };
-    use std::collections::HashMap;
     use std::sync::{Arc, Mutex as StdMutex};
 
     /// Build a PermissionChecker anchored at a temporary directory
@@ -740,10 +739,13 @@ mod tests {
     async fn mcp_allow_external_paths_does_not_bypass_deny_rules() {
         // Install a deny rule that matches the qualified MCP key
         // `mcp_tool:indexer:scan`.
-        let mut mcp_rules: HashMap<String, Action> = HashMap::new();
-        mcp_rules.insert("mcp_tool:indexer:*".to_string(), Action::Deny);
         let config = PermissionConfig {
-            mcp_tool: Some(ToolPerm::Granular(mcp_rules)),
+            rules: vec![RuleConfig {
+                op: OpSpec::Mcp,
+                pattern: "mcp_tool:indexer:*".to_string(),
+                effect: Action::Deny,
+                tool: None,
+            }],
             ..Default::default()
         };
         let (perm, _cwd) = mk_perm(config);

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -1,5 +1,15 @@
 use super::*;
-use crate::permission::{Action, PermissionConfig};
+use crate::permission::{Action, OpSpec, PermissionConfig, RuleConfig};
+
+/// Concise config-rule constructor for tests.
+fn rule(op: OpSpec, m: &str, effect: Action) -> RuleConfig {
+    RuleConfig {
+        op,
+        pattern: m.to_string(),
+        effect,
+        tool: None,
+    }
+}
 
 fn fresh_checker() -> PermissionChecker {
     PermissionChecker::new(
@@ -135,13 +145,8 @@ fn f2_edit_alias_check_path_directly_for_write_and_apply_patch() {
     // `tools::enforce`. But pin that the checker's `edit`
     // rules behave as the user expects when consulted with
     // the edit tool name.
-    use crate::permission::ToolPerm;
-    use std::collections::HashMap;
-
-    let mut edit_rules = HashMap::new();
-    edit_rules.insert("**".to_string(), Action::Deny);
     let config = PermissionConfig {
-        edit: Some(ToolPerm::Granular(edit_rules)),
+        rules: vec![rule(OpSpec::Edit, "**", Action::Deny)],
         ..Default::default()
     };
 
@@ -216,13 +221,8 @@ fn write_inside_cwd_allowed_outside_cwd_asks() {
 /// CWD-allow installer specifically.
 #[test]
 fn user_write_deny_overrides_cwd_builtin_allow() {
-    use crate::permission::ToolPerm;
-    use std::collections::HashMap;
-
-    let mut write_rules = HashMap::new();
-    write_rules.insert("/tmp/proj/build/**".to_string(), Action::Deny);
     let config = PermissionConfig {
-        write: Some(ToolPerm::Granular(write_rules)),
+        rules: vec![rule(OpSpec::Edit, "/tmp/proj/build/**", Action::Deny)],
         ..Default::default()
     };
 
@@ -356,13 +356,8 @@ fn cwd_allow_refuses_paths_with_glob_metachars() {
 /// Explicit user rules override the M4 builtin-allow list.
 #[test]
 fn m4_user_rule_overrides_builtin_allow() {
-    use crate::permission::ToolPerm;
-    use std::collections::HashMap;
-
-    let mut read_rules = HashMap::new();
-    read_rules.insert("/etc/**".to_string(), Action::Deny);
     let config = PermissionConfig {
-        read: Some(ToolPerm::Granular(read_rules)),
+        rules: vec![rule(OpSpec::Read, "/etc/**", Action::Deny)],
         ..Default::default()
     };
 
@@ -384,36 +379,23 @@ fn m4_user_rule_overrides_builtin_allow() {
     ));
 }
 
-/// M2 (dirge-cep): the unified `tools` map at the top of
-/// `PermissionConfig` lets rules be declared for ANY tool name
-/// (including ones dirge doesn't ship per-tool struct fields
-/// for — plugin-registered tools, future tools). Pin three
-/// invariants:
-///   1. A rule in `tools` for a tool name with no legacy field
-///      is honored.
-///   2. A rule in `tools` for a tool name that ALSO has a
-///      legacy field overrides the legacy field (explicit
-///      newer shape wins).
-///   3. The `Simple(action)` shape (string shorthand for
-///      `{"*": action}`) works in the map.
+/// Op-based rules govern any tool, including ones with no dedicated
+/// handling (a plugin tool → `Operation::Other`) and network tools.
+/// Last-match-wins, and the op selects which calls a rule covers.
 #[test]
-fn tools_map_unified_schema_honored_and_overrides_legacy() {
-    use crate::permission::{PermissionConfig, ToolPerm};
-    use std::collections::HashMap;
-
-    // Tool with no legacy field — only reachable via `tools`.
-    let mut tools_map = HashMap::new();
-    let mut plugin_rules = HashMap::new();
-    plugin_rules.insert("dangerous".to_string(), Action::Deny);
-    tools_map.insert("plugin_xyz".to_string(), ToolPerm::Granular(plugin_rules));
-
-    // Tool with a legacy field — map version should win.
-    tools_map.insert("websearch".to_string(), ToolPerm::Simple(Action::Deny));
-
+fn op_rules_govern_arbitrary_and_network_tools() {
     let config = PermissionConfig {
-        // Legacy field says Allow…
-        websearch: Some(ToolPerm::Simple(Action::Allow)),
-        tools: Some(tools_map),
+        rules: vec![
+            // A network rule denying websearch.
+            rule(OpSpec::Network, "**", Action::Deny),
+            // A catch-all denying the unknown plugin tool's input.
+            RuleConfig {
+                op: OpSpec::Any,
+                pattern: "dangerous".to_string(),
+                effect: Action::Deny,
+                tool: Some("plugin_xyz".to_string()),
+            },
+        ],
         ..Default::default()
     };
 
@@ -423,13 +405,12 @@ fn tools_map_unified_schema_honored_and_overrides_legacy() {
         Some(std::path::PathBuf::from("/tmp")),
     );
 
-    // (1) tools-only entry honored.
+    // Unknown plugin tool, narrowed by `tool`.
     assert!(matches!(
         checker.check("plugin_xyz", "dangerous"),
         CheckResult::Denied(_)
     ));
-
-    // (2) tools map overrides legacy field.
+    // Network op rule governs websearch.
     assert!(matches!(
         checker.check("websearch", "anything"),
         CheckResult::Denied(_)
@@ -530,13 +511,12 @@ fn accept_mode_does_not_coerce_mcp_to_allow() {
 /// configs) still gets the Accept-mode allow.
 #[test]
 fn accept_mode_still_coerces_safe_non_path_tools() {
-    use std::collections::HashMap;
-    let mut config = PermissionConfig::default();
-    // Set question to Ask explicitly so Accept's coercion path
-    // is exercised.
-    let mut q_map: HashMap<String, Action> = HashMap::new();
-    q_map.insert("*".to_string(), Action::Ask);
-    config.question = Some(crate::permission::ToolPerm::Granular(q_map));
+    // Set question (a Meta op) to Ask explicitly so Accept's
+    // coercion path is exercised.
+    let config = PermissionConfig {
+        rules: vec![rule(OpSpec::Meta, "*", Action::Ask)],
+        ..Default::default()
+    };
     let mut checker = PermissionChecker::new(
         &config,
         SecurityMode::Accept,
@@ -554,11 +534,10 @@ fn accept_mode_still_coerces_safe_non_path_tools() {
 /// control — the default-Ask only fires when no rule exists.
 #[test]
 fn mcp_tool_explicit_config_overrides_default_ask() {
-    use std::collections::HashMap;
-    let mut config = PermissionConfig::default();
-    let mut granular = HashMap::new();
-    granular.insert("mcp_tool:lattice:*".to_string(), Action::Allow);
-    config.mcp_tool = Some(crate::permission::ToolPerm::Granular(granular));
+    let config = PermissionConfig {
+        rules: vec![rule(OpSpec::Mcp, "mcp_tool:lattice:*", Action::Allow)],
+        ..Default::default()
+    };
     let mut checker = PermissionChecker::new(
         &config,
         SecurityMode::Standard,

--- a/src/permission/engine/build.rs
+++ b/src/permission/engine/build.rs
@@ -21,7 +21,7 @@ use super::policy::{Decider, Modifier, PolicyCtx};
 use super::types::{Effect, Operation, Resource};
 use super::{Engine, classify::pattern_for_tool};
 use crate::permission::path::{canonicalize_for_cache, resolve_absolute};
-use crate::permission::{Action, PermissionConfig, ToolPerm};
+use crate::permission::{Action, PermissionConfig};
 
 /// Default retry-loop threshold: the Nth identical *prompted* request
 /// is hard-denied. (The breaking config in Phase 4 makes this tunable.)
@@ -96,39 +96,42 @@ pub fn classify_path(raw: &str, working_dir: &str) -> Resource {
     }
 }
 
-/// Translate one legacy `ToolPerm` (or `tools`-map entry) into rules
-/// narrowed to `tool`.
-fn rules_from_tool_perm(tool: &str, tp: &ToolPerm) -> Vec<Rule> {
-    let op = OpMatch::One(tool_operation(tool));
-    // write/edit/apply_patch are the only tools mapping to
-    // Operation::Edit, so leaving the rule tool-unnarrowed makes a
-    // legacy `edit: deny` cover all three — the old F2 aliasing,
-    // now a natural consequence of the shared operation. Other
-    // shared-op tools (the Read group) stay tool-narrowed so a
-    // `grep` rule doesn't bleed onto `read`.
-    let tool_sel = if matches!(tool, "write" | "edit" | "apply_patch") {
-        None
-    } else {
-        Some(tool.to_string())
-    };
-    match tp {
-        ToolPerm::Simple(action) => vec![Rule {
-            op,
-            tool: tool_sel.clone(),
-            pattern: pattern_for_tool(tool, "*"),
-            effect: (*action).into(),
-            original: format!("{tool}:*"),
-        }],
-        ToolPerm::Granular(map) => map
-            .iter()
-            .map(|(pat, action)| Rule {
-                op,
-                tool: tool_sel.clone(),
-                pattern: pattern_for_tool(tool, pat),
-                effect: (*action).into(),
-                original: format!("{tool}:{pat}"),
-            })
-            .collect(),
+/// Map a config `OpSpec` to the engine's `OpMatch`.
+fn op_match(op: crate::permission::OpSpec) -> OpMatch {
+    use crate::permission::OpSpec;
+    match op {
+        OpSpec::Any => OpMatch::Any,
+        OpSpec::Read => OpMatch::One(Operation::Read),
+        OpSpec::Edit => OpMatch::One(Operation::Edit),
+        OpSpec::Execute => OpMatch::One(Operation::Execute),
+        OpSpec::Network => OpMatch::One(Operation::Network),
+        OpSpec::Mcp => OpMatch::One(Operation::Mcp),
+        OpSpec::Memory => OpMatch::One(Operation::Memory),
+        OpSpec::Skill => OpMatch::One(Operation::Skill),
+        OpSpec::Agent => OpMatch::One(Operation::Agent),
+        OpSpec::Meta => OpMatch::One(Operation::Meta),
+    }
+}
+
+/// Glob style for a rule's operation: path-style (`*` = one segment)
+/// for file ops, shell-style for everything else.
+fn pattern_for_op(op: crate::permission::OpSpec, pat: &str) -> crate::permission::pattern::Pattern {
+    use crate::permission::OpSpec;
+    use crate::permission::pattern::Pattern;
+    match op {
+        OpSpec::Read | OpSpec::Edit | OpSpec::Any => Pattern::new(pat),
+        _ => Pattern::new_command(pat),
+    }
+}
+
+/// Build an engine [`Rule`] from a config rule.
+fn rule_from_config(rc: &crate::permission::RuleConfig) -> Rule {
+    Rule {
+        op: op_match(rc.op),
+        tool: rc.tool.clone(),
+        pattern: pattern_for_op(rc.op, &rc.pattern),
+        effect: rc.effect.into(),
+        original: rc.pattern.clone(),
     }
 }
 
@@ -137,92 +140,40 @@ impl Engine {
     /// decider order encodes precedence; see `policies.rs`.
     pub fn from_config(config: &PermissionConfig) -> Engine {
         let mut rules: Vec<Rule> = Vec::new();
-        let mut user_configured: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
 
-        // Legacy per-tool fields, in a stable order.
-        let legacy: [(&str, &Option<ToolPerm>); 25] = [
-            ("bash", &config.bash),
-            ("read", &config.read),
-            ("write", &config.write),
-            ("edit", &config.edit),
-            ("grep", &config.grep),
-            ("find_files", &config.find_files),
-            ("list_dir", &config.list_dir),
-            ("glob", &config.glob),
-            ("repo_overview", &config.repo_overview),
-            ("write_todo_list", &config.write_todo_list),
-            ("apply_patch", &config.apply_patch),
-            ("lsp", &config.lsp),
-            ("question", &config.question),
-            ("webfetch", &config.webfetch),
-            ("websearch", &config.websearch),
-            ("task", &config.task),
-            ("task_status", &config.task_status),
-            ("memory", &config.memory),
-            ("skill", &config.skill),
-            ("list_symbols", &config.list_symbols),
-            ("get_symbol_body", &config.get_symbol_body),
-            ("find_definition", &config.find_definition),
-            ("find_callers", &config.find_callers),
-            ("find_callees", &config.find_callees),
-            ("mcp_tool", &config.mcp_tool),
-        ];
-        for (tool, tp) in legacy {
-            if let Some(tp) = tp {
-                rules.extend(rules_from_tool_perm(tool, tp));
-                user_configured.insert(tool.to_string());
-            }
-        }
-
-        // M2 `tools` map (appended after legacy → last-match-wins).
-        if let Some(tools_map) = &config.tools {
-            for (tool, tp) in tools_map {
-                rules.extend(rules_from_tool_perm(tool, tp));
-                user_configured.insert(tool.clone());
-            }
-        }
-
-        // Bash defaults — only if the user supplied no bash rules.
-        if !user_configured.contains("bash") {
-            for (pat, action) in crate::permission::default_bash_rules() {
-                rules.push(Rule {
-                    op: OpMatch::One(Operation::Execute),
-                    tool: Some("bash".to_string()),
-                    pattern: pattern_for_tool("bash", pat),
-                    effect: action.into(),
-                    original: format!("bash:{pat}"),
-                });
-            }
-        }
-
-        // MCP default: prompt unless the user pinned a server.
-        if !user_configured.contains("mcp_tool") {
+        // Built-in safe-bash defaults (git status / cargo / test
+        // runners allow, `rm -rf /**` etc. deny). Installed FIRST so a
+        // user rule for the same command wins by last-match. These are
+        // dirge's "sane defaults" for Execute, distinct from the
+        // BuiltinAllowPolicy (reads / memory / skill / dev-null / cwd).
+        for (pat, action) in crate::permission::default_bash_rules() {
             rules.push(Rule {
-                op: OpMatch::One(Operation::Mcp),
-                tool: Some("mcp_tool".to_string()),
-                pattern: pattern_for_tool("mcp_tool", "*"),
-                effect: Effect::Ask,
-                original: "mcp_tool:*".to_string(),
+                op: OpMatch::One(Operation::Execute),
+                tool: Some("bash".to_string()),
+                pattern: pattern_for_tool("bash", pat),
+                effect: action.into(),
+                original: format!("bash:{pat}"),
             });
         }
+        // MCP default: prompt unless a user rule allows a server.
+        rules.push(Rule {
+            op: OpMatch::One(Operation::Mcp),
+            tool: None,
+            pattern: pattern_for_tool("mcp_tool", "*"),
+            effect: Effect::Ask,
+            original: "mcp:*".to_string(),
+        });
 
-        // external_directory rules (path-style patterns).
+        // User rules, in order — appended after the defaults so they
+        // override by last-match-wins.
+        rules.extend(config.rules.iter().map(rule_from_config));
+
+        // external_directory rules (governs out-of-project paths).
         let ext_rules: Vec<Rule> = config
             .external_directory
-            .as_ref()
-            .map(|m| {
-                m.iter()
-                    .map(|(pat, action)| Rule {
-                        op: OpMatch::Any,
-                        tool: None,
-                        pattern: crate::permission::pattern::Pattern::new(pat),
-                        effect: (*action).into(),
-                        original: pat.clone(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+            .iter()
+            .map(rule_from_config)
+            .collect();
 
         let default: Effect = config.default.unwrap_or(Action::Ask).into();
 
@@ -262,7 +213,6 @@ mod tests {
     use super::*;
     use crate::permission::SecurityMode;
     use crate::permission::engine::types::AccessRequest;
-    use std::collections::HashMap;
 
     fn req(
         op: Operation,
@@ -352,16 +302,30 @@ mod tests {
         assert_eq!(d.effect, Effect::Ask, "unknown bash command prompts");
     }
 
+    fn rule(
+        op: crate::permission::OpSpec,
+        m: &str,
+        effect: Action,
+    ) -> crate::permission::RuleConfig {
+        crate::permission::RuleConfig {
+            op,
+            pattern: m.to_string(),
+            effect,
+            tool: None,
+        }
+    }
+
     #[test]
-    fn user_bash_rule_suppresses_defaults() {
-        let mut tools = HashMap::new();
-        tools.insert("bash".to_string(), ToolPerm::Simple(Action::Allow));
+    fn user_execute_rule_overrides_default() {
+        use crate::permission::OpSpec;
+        // A blanket `execute **: allow` (appended after the built-in
+        // bash defaults) wins by last-match, so even an unknown command
+        // is allowed.
         let cfg = PermissionConfig {
-            tools: Some(tools),
+            rules: vec![rule(OpSpec::Execute, "**", Action::Allow)],
             ..Default::default()
         };
         let e = Engine::from_config(&cfg);
-        // With a blanket user `bash: allow`, even an unknown command is allowed
         let d = e.authorize(&req(
             Operation::Execute,
             "bash",
@@ -376,11 +340,10 @@ mod tests {
 
     #[test]
     fn user_rule_overrides_builtin_allow() {
+        use crate::permission::OpSpec;
         // read is builtin-allowed; a user deny rule must win.
-        let mut read = HashMap::new();
-        read.insert("/secret/**".to_string(), Action::Deny);
         let cfg = PermissionConfig {
-            read: Some(ToolPerm::Granular(read)),
+            rules: vec![rule(OpSpec::Read, "/secret/**", Action::Deny)],
             ..Default::default()
         };
         let e = Engine::from_config(&cfg);
@@ -407,10 +370,9 @@ mod tests {
 
     #[test]
     fn external_directory_rule_allows_outside_path() {
-        let mut ext = HashMap::new();
-        ext.insert("/shared/**".to_string(), Action::Allow);
+        use crate::permission::OpSpec;
         let cfg = PermissionConfig {
-            external_directory: Some(ext),
+            external_directory: vec![rule(OpSpec::Any, "/shared/**", Action::Allow)],
             ..Default::default()
         };
         let e = Engine::from_config(&cfg);

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -18,7 +18,6 @@ pub fn apply_prompt_deny(perm: &Option<checker::PermCheck>, deny: &[String]) {
 }
 
 use serde::Deserialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -28,110 +27,67 @@ pub enum Action {
     Deny,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(untagged)]
-pub enum ToolPerm {
-    Simple(Action),
-    Granular(HashMap<String, Action>),
+/// The operation class a rule governs — the resource KIND, not a tool
+/// name. `Any` (`"*"`) matches every operation; `tool` on the rule can
+/// narrow to a concrete tool when needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OpSpec {
+    #[default]
+    #[serde(rename = "*", alias = "any")]
+    Any,
+    Read,
+    Edit,
+    Execute,
+    Network,
+    Mcp,
+    Memory,
+    Skill,
+    Agent,
+    Meta,
 }
 
+/// One configured authorization rule. The ordered `rules` list reads
+/// top-to-bottom; **last match wins**. Glob style is inferred from the
+/// operation (path-style for read/edit, shell-style for execute/etc.).
+///
+/// ```jsonc
+/// { "op": "edit",    "match": "/etc/**",  "effect": "deny" }
+/// { "op": "execute", "match": "cargo *",  "effect": "allow" }
+/// { "op": "mcp",     "match": "lattice:*", "effect": "allow" }
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct RuleConfig {
+    #[serde(default)]
+    pub op: OpSpec,
+    #[serde(rename = "match")]
+    pub pattern: String,
+    pub effect: Action,
+    /// Optional: narrow the rule to a single concrete tool name (e.g.
+    /// `"grep"` so a Read rule doesn't also gate `read`).
+    #[serde(default)]
+    pub tool: Option<String>,
+}
+
+/// Permission configuration: a default effect, an ordered rule list,
+/// out-of-project rules, and the loop-guard toggle. Built-in defaults
+/// (read-only/memory/skill/dev-null/in-cwd-write allows + the curated
+/// safe-bash rules) live in the engine and aren't configured here.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct PermissionConfig {
-    #[serde(rename = "*")]
+    /// Fallback effect when no rule matches (alias `*`). Defaults to Ask.
+    #[serde(rename = "*", alias = "default")]
     pub default: Option<Action>,
-    pub bash: Option<ToolPerm>,
-    pub read: Option<ToolPerm>,
-    pub write: Option<ToolPerm>,
-    pub edit: Option<ToolPerm>,
-    pub grep: Option<ToolPerm>,
-    pub find_files: Option<ToolPerm>,
-    pub list_dir: Option<ToolPerm>,
-    /// `glob` — fast filename matcher. Read-only filesystem walker;
-    /// per-pattern rules let users restrict which paths the LLM can
-    /// glob (e.g. allow only project root, deny `/etc/*`). Adversarial-
-    /// review #5 added.
-    pub glob: Option<ToolPerm>,
-    /// `repo_overview` — structural codebase map. Read-only walker;
-    /// per-pattern rules can restrict which roots it can summarize.
-    /// Adversarial-review #5 added.
-    pub repo_overview: Option<ToolPerm>,
-    pub write_todo_list: Option<ToolPerm>,
-    /// `apply_patch` — bulk multi-file patch tool. Mutates the
-    /// filesystem like `write`/`edit`; deserves per-pattern rules.
-    pub apply_patch: Option<ToolPerm>,
-    /// `lsp` — language-server queries (definition, references,
-    /// hover, etc.). Reads project files via the language server.
-    pub lsp: Option<ToolPerm>,
-    /// `question` — interactive user-input solicitation tool. Per-
-    /// pattern rules let users restrict which kinds of questions
-    /// the agent can ask.
-    pub question: Option<ToolPerm>,
-    /// `webfetch` — HTTP(S) fetch tool. Pattern rules can be used to
-    /// restrict the URLs (e.g., \"https://docs.example.com/*\":
-    /// allow).
-    pub webfetch: Option<ToolPerm>,
-    /// `websearch` — Exa-backed web search. Pattern rules restrict
-    /// the query strings.
-    pub websearch: Option<ToolPerm>,
-    /// `task` — subagent runner. The pattern is the subagent prompt.
-    pub task: Option<ToolPerm>,
-    /// `task_status` — companion query tool for `task`. Read-only;
-    /// included for completeness so users can deny it independently
-    /// (e.g. to force background-only invocations).
-    pub task_status: Option<ToolPerm>,
-    /// `memory` — persistent project memory store. Pattern rules
-    /// restrict the memory keys / operations.
-    pub memory: Option<ToolPerm>,
-    /// `skill` — Claude-compatible skill loading. Pattern rules
-    /// restrict which skills can be loaded.
-    pub skill: Option<ToolPerm>,
-    /// Semantic code-graph tools (tree-sitter-backed): `list_symbols`,
-    /// `get_symbol_body`, `find_definition`, `find_callers`,
-    /// `find_callees`. One per tool — pattern matches against the
-    /// tool's primary argument (path for body/list, symbol name for
-    /// find_*).
-    pub list_symbols: Option<ToolPerm>,
-    pub get_symbol_body: Option<ToolPerm>,
-    pub find_definition: Option<ToolPerm>,
-    pub find_callers: Option<ToolPerm>,
-    pub find_callees: Option<ToolPerm>,
-    /// `mcp_tool` — generic catch-all for ALL MCP-provided tools.
-    /// Each MCP tool is permission-checked as
-    /// `mcp_tool:<server>:<tool>`; pattern rules here match against
-    /// that string. e.g.
-    /// `{ \"mcp_tool:filesystem:*\": \"deny\" }` blocks every tool
-    /// from the `filesystem` MCP server.
-    pub mcp_tool: Option<ToolPerm>,
-    pub external_directory: Option<HashMap<String, Action>>,
+    /// Loop-guard control: `"allow"` disables the retry-loop hard-deny;
+    /// any other value (default) keeps it on.
     pub doom_loop: Option<Action>,
-    /// M2 (dirge-cep): unified per-tool rule map. Lets a user write
-    /// rules for ANY tool name (including plugin / MCP / future-added
-    /// tools) without dirge extending its `PermissionConfig` struct.
-    ///
-    /// Schema (JSON):
-    /// ```json
-    /// "permission": {
-    ///   "tools": {
-    ///     "bash":       { "rm *": "deny", "git *": "allow" },
-    ///     "write":      { "/etc/**": "deny", "**": "ask" },
-    ///     "skill":      "allow",
-    ///     "plugin_xyz": "ask"
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// Mirrors opencode's permission shape (Schema.StructWithRest with
-    /// Schema.Record(String, Rule)) and maki's per-tool TOML sections.
-    /// Coexists with the legacy per-tool fields above for back-compat:
-    /// both are merged into the same `HashMap<tool, Vec<(Pattern,
-    /// Action)>>` inside `PermissionChecker::new`. If both name the
-    /// same tool, the `tools` map wins (it's the explicit new shape).
-    ///
-    /// Deprecation path: the legacy `bash`/`read`/`write`/... fields
-    /// stay through one release cycle, then get removed once docs and
-    /// example configs migrate to `tools`. Internally the checker
-    /// treats them as syntactic sugar for `tools.{name}`.
-    pub tools: Option<HashMap<String, ToolPerm>>,
+    /// Ordered authorization rules (last match wins).
+    #[serde(default)]
+    pub rules: Vec<RuleConfig>,
+    /// Rules for paths OUTSIDE the working directory (op defaults to
+    /// `*`). An out-of-project write with no matching rule prompts.
+    #[serde(default)]
+    pub external_directory: Vec<RuleConfig>,
 }
 
 /// Per-session security mode. Selected via `--yolo` / `--accept-all` /

--- a/src/tests/checker_tests.rs
+++ b/src/tests/checker_tests.rs
@@ -1,5 +1,15 @@
 use crate::permission::checker::{CheckResult, PermissionChecker};
-use crate::permission::{Action, PermissionConfig, SecurityMode, ToolPerm};
+use crate::permission::{Action, OpSpec, PermissionConfig, RuleConfig, SecurityMode};
+
+/// Concise config-rule constructor for tests.
+fn rule(op: OpSpec, m: &str, effect: Action) -> RuleConfig {
+    RuleConfig {
+        op,
+        pattern: m.to_string(),
+        effect,
+        tool: None,
+    }
+}
 
 fn make_checker(mode: SecurityMode) -> PermissionChecker {
     PermissionChecker::new(
@@ -39,7 +49,7 @@ fn standard_asks_unknown_tool_with_default() {
 #[test]
 fn accept_auto_allows_inside_working_dir() {
     let config = PermissionConfig {
-        write: Some(ToolPerm::Simple(Action::Ask)),
+        rules: vec![rule(OpSpec::Edit, "**", Action::Ask)],
         ..PermissionConfig::default()
     };
     let mut checker = PermissionChecker::new(
@@ -255,7 +265,7 @@ fn relative_path_escaping_cwd_is_external() {
     // semantics apply: in-tree write is Ask→Allow under Accept,
     // external write is Ask (no ext_dir rule installed).
     let config = PermissionConfig {
-        write: Some(ToolPerm::Simple(Action::Ask)),
+        rules: vec![rule(OpSpec::Edit, "**", Action::Ask)],
         ..PermissionConfig::default()
     };
     let mut checker = PermissionChecker::new(&config, SecurityMode::Accept, Some(cwd.clone()));
@@ -433,13 +443,10 @@ fn session_allowlist_relative_pattern_matches_absolute_check_inside_cwd() {
 #[test]
 fn explicit_granular_rules_take_effect() {
     let config = PermissionConfig {
-        read: Some(ToolPerm::Granular(
-            [
-                ("*.md".to_string(), Action::Allow),
-                ("*.rs".to_string(), Action::Ask),
-            ]
-            .into(),
-        )),
+        rules: vec![
+            rule(OpSpec::Read, "*.md", Action::Allow),
+            rule(OpSpec::Read, "*.rs", Action::Ask),
+        ],
         ..PermissionConfig::default()
     };
     let mut checker = PermissionChecker::new(&config, SecurityMode::Standard, None);


### PR DESCRIPTION
## Summary

Final piece of the unified permission-engine refactor: **breaking** cutover from the legacy per-tool permission config to the clean op-based `rules` array. No legacy translation path.

### Before (legacy)
```jsonc
"permission": {
  "write": { "**/*.rs": "allow", "**": "ask" },
  "bash":  { "cargo test": "allow", "rm **": "deny" },
  "mcp_tool": { "mcp_tool:lattice:*": "allow" }
}
```

### After (op-based, ordered, last-match-wins)
```jsonc
"permission": {
  "rules": [
    { "op": "edit",    "match": "**/*.rs",   "effect": "allow" },
    { "op": "edit",    "match": "**",        "effect": "ask"   },
    { "op": "execute", "match": "cargo test", "effect": "allow" },
    { "op": "execute", "match": "rm **",     "effect": "deny"  },
    { "op": "mcp",     "match": "mcp_tool:lattice:*", "effect": "allow" }
  ]
}
```

## Changes
- **`mod.rs`** — delete `ToolPerm` enum + ~25 per-tool fields + the `tools` map; add `OpSpec` + `RuleConfig`; slim `PermissionConfig` to `{ default, doom_loop, rules, external_directory }`.
- **`engine/build.rs`** — `from_config` installs builtin bash + MCP defaults first, then `config.rules`, then `external_directory`.
- **Tests migrated** — `permission/checker_tests.rs`, `tests/checker_tests.rs`, `agent/tools/bash.rs`, `agent/tools/mod.rs`, `extras/mcp/tool.rs`.
- **Docs** — `CONFIG.md` + `docs/permissions.md` examples updated to the `rules` array.

`op` is the operation class, not a tool name. write/edit/apply_patch all map to `Operation::Edit`, so one Edit rule governs the trio (F2 aliasing dissolved).

## Test plan
All **2100** tests pass under the full feature matrix at `RUSTFLAGS="-D warnings"`.