### PR TITLE
refactor(tools): derive tool classification from the canonical registry

### DIFF
--- a/src/agent/agent_loop/storm.rs
+++ b/src/agent/agent_loop/storm.rs
@@ -211,33 +211,29 @@ impl StormBreaker {
     }
 }
 
-/// Built-in mutating tools: calls that change filesystem state.
-/// Kept in sync with `crate::agent::tools::BUILTIN_TOOL_NAMES`.
+/// Built-in mutating tools: calls that change filesystem state or run
+/// external code. Derived from the canonical tool→[`Operation`] mapping
+/// (`Edit` = file mutation, `Execute` = shell) rather than a hand-kept
+/// name list — so a new mutating tool is classified the moment it has a
+/// permission operation, with no second list to forget (dirge-uxuv).
 pub fn default_mutating(call: &ToolCall) -> bool {
+    use crate::permission::engine::tool_operation;
+    use crate::permission::engine::types::Operation;
     matches!(
-        call.name.as_str(),
-        "write" | "edit" | "bash" | "apply_patch"
+        tool_operation(&call.name),
+        Operation::Edit | Operation::Execute
     )
 }
 
-/// Built-in storm-exempt tools: cheap inspectors that should never
-/// trip the repeat-loop guard regardless of repetition count.
-/// Kept in sync with `crate::agent::tools::BUILTIN_TOOL_NAMES`.
-/// `find_callers` / `find_callees` are behind `#[cfg(feature = "semantic")]`
-/// but listing them here is harmless — the match simply won't fire
-/// when the feature is off.
+/// Built-in storm-exempt tools: read-only inspectors that should never
+/// trip the repeat-loop guard regardless of repetition count. Derived
+/// from the canonical mapping (`Operation::Read`) — covers read/grep/
+/// find/glob/list_dir/repo_overview AND the lsp + semantic read tools,
+/// which are equally side-effect-free (dirge-uxuv).
 pub fn default_exempt(call: &ToolCall) -> bool {
-    matches!(
-        call.name.as_str(),
-        "read"
-            | "list_dir"
-            | "grep"
-            | "find_files"
-            | "glob"
-            | "repo_overview"
-            | "find_callers"
-            | "find_callees"
-    )
+    use crate::permission::engine::tool_operation;
+    use crate::permission::engine::types::Operation;
+    matches!(tool_operation(&call.name), Operation::Read)
 }
 
 impl Default for StormBreaker {
@@ -350,6 +346,43 @@ mod tests {
         // Buffer cleared by write_file — a fresh pair of reads is now safe.
         assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
         assert!(!sb.inspect(&call_json("read_file", "{}")).suppress);
+    }
+
+    // dirge-uxuv: the storm classifiers derive from the canonical
+    // tool_operation mapping, not a hand-kept name list — so they can't
+    // drift from the permission engine's notion of what a tool does.
+    #[test]
+    fn default_classifiers_track_tool_operation() {
+        for t in ["write", "edit", "apply_patch", "bash"] {
+            assert!(
+                default_mutating(&call_json(t, "{}")),
+                "{t} must be mutating"
+            );
+            assert!(
+                !default_exempt(&call_json(t, "{}")),
+                "{t} must not be exempt"
+            );
+        }
+        // Read-only tools — incl. lsp + semantic-read, which the old
+        // hardcoded exempt list omitted.
+        for t in [
+            "read",
+            "grep",
+            "find_files",
+            "glob",
+            "list_dir",
+            "repo_overview",
+            "lsp",
+            "list_symbols",
+        ] {
+            assert!(default_exempt(&call_json(t, "{}")), "{t} must be exempt");
+            assert!(!default_mutating(&call_json(t, "{}")), "{t} not mutating");
+        }
+        // Neither mutating nor exempt → counted normally.
+        for t in ["webfetch", "task", "memory", "mcp_tool"] {
+            assert!(!default_mutating(&call_json(t, "{}")), "{t}");
+            assert!(!default_exempt(&call_json(t, "{}")), "{t}");
+        }
     }
 
     #[test]

--- a/src/ui/permission_ui.rs
+++ b/src/ui/permission_ui.rs
@@ -26,7 +26,12 @@ pub(crate) fn suggest_pattern(tool: &str, input: &str) -> String {
             let first = trimmed.split_whitespace().next().unwrap_or(PLACEHOLDER);
             format!("{} *", first)
         }
-        "read" | "write" | "edit" | "list_dir" => {
+        // Path-arg tools: suggest a `<parent>/**` glob from the input
+        // path. One arm for all of them — previously read/write/edit/
+        // list_dir, apply_patch, and the semantic tools each had an
+        // identical copy of this body (dirge-t1wh).
+        "read" | "write" | "edit" | "list_dir" | "apply_patch" | "list_symbols"
+        | "get_symbol_body" | "find_definition" | "find_callers" | "find_callees" => {
             let path = std::path::Path::new(trimmed);
             let parent = path
                 .parent()
@@ -51,27 +56,6 @@ pub(crate) fn suggest_pattern(tool: &str, input: &str) -> String {
             } else {
                 PLACEHOLDER.to_string()
             }
-        }
-        "apply_patch" => {
-            let path = std::path::Path::new(trimmed);
-            let parent = path
-                .parent()
-                .map(|p| p.to_string_lossy())
-                .unwrap_or(std::borrow::Cow::Borrowed(""));
-            if parent.is_empty() {
-                "**".to_string()
-            } else {
-                format!("{}/**", parent)
-            }
-        }
-        "list_symbols" | "get_symbol_body" | "find_definition" | "find_callers"
-        | "find_callees" => {
-            let path = std::path::Path::new(trimmed);
-            let parent = path
-                .parent()
-                .map(|p| p.to_string_lossy())
-                .unwrap_or(std::borrow::Cow::Borrowed("."));
-            format!("{}/**", parent)
         }
         "webfetch" => "webfetch:*".to_string(),
         "websearch" => "websearch:*".to_string(),


### PR DESCRIPTION
## Summary
Chokepoint A from the ad-hoc-check audit: two subsystems re-answered "what kind of tool is this?" with their own hand-kept name lists instead of consulting the canonical `tool_operation` mapping the permission engine already owns.

Closes **dirge-uxuv**, **dirge-t1wh**.

## Changes
- **Storm-breaker (dirge-uxuv, HIGH).** `default_mutating` / `default_exempt` were hardcoded name lists carrying a *"keep in sync with BUILTIN_TOOL_NAMES"* comment. A new mutating tool got `execution_mode=Sequential` (so it dispatched correctly) but, if forgotten in `default_mutating`, the repeat-loop guard went **blind** to it. Now derived from `tool_operation`: `Edit|Execute ⇒ mutating`, `Read ⇒ exempt`. One source — and it correctly exempts the `lsp` + semantic-read tools the old list omitted.
- **`permission_ui::suggest_pattern` (dirge-t1wh).** `read/write/edit/list_dir`, `apply_patch`, and the five semantic tools each carried an *identical* copy of the `<parent>/**` path-suggestion body. Collapsed into one arm.

## Deliberately not changed
The `tool_display.rs` / `ui/mod.rs` path-label lists were left alone: they encode a **display arg-kind** taxonomy where `grep→"pattern"` intentionally differs from permission path-ness, so forcing `is_path_tool_name` there would mislabel `grep`/`glob`. That's a cosmetic concern, not the same classification.

## Test plan
1 new test (`default_classifiers_track_tool_operation`). **2105 tests pass** under the full feature matrix at `RUSTFLAGS="-D warnings"`.

Follow-up in this thread: **dirge-e1r9** (central absolute-path enforcement via the `semantic:absolute_path` hint) ships as its own PR — it's a validation-layer change, not classification.