### PR TITLE
refactor(tools): single shared absolute-path guard

### DIFF
--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -273,19 +273,16 @@ impl Tool for ApplyPatchTool {
                 | PatchOp::Delete { path }
                 | PatchOp::Rename { path, .. } => path,
             };
-            if !std::path::Path::new(op_path).is_absolute() {
-                return Err(ToolError::Msg(format!(
-                    "apply_patch requires an absolute path, got: {}",
-                    op_path
-                )));
-            }
-            if let PatchOp::Rename { new_path, .. } = op
-                && !std::path::Path::new(new_path).is_absolute()
-            {
-                return Err(ToolError::Msg(format!(
-                    "apply_patch rename requires an absolute new_path, got: {}",
-                    new_path
-                )));
+            // Shared absolute-path guard (the schema requires absolute
+            // paths for both fields).
+            crate::agent::tools::require_absolute_path(op_path, "the apply_patch path")
+                .map_err(ToolError::Msg)?;
+            if let PatchOp::Rename { new_path, .. } = op {
+                crate::agent::tools::require_absolute_path(
+                    new_path,
+                    "the apply_patch rename target",
+                )
+                .map_err(ToolError::Msg)?;
             }
 
             // C1 (audit fix): resolve the path THROUGH the permission

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
-use std::path::Path;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -133,13 +132,10 @@ impl Tool for EditTool {
             ));
         }
 
-        // Reject non-absolute paths immediately with a clear error.
-        if !Path::new(&args.path).is_absolute() {
-            return Err(ToolError::Msg(format!(
-                "Path '{}' is not absolute. Edit takes an absolute path like '/home/user/project/file.txt', not a relative path or bare filename.",
-                args.path,
-            )));
-        }
+        // Reject non-absolute paths immediately with a clear error
+        // (shared guard; the schema requires an absolute path).
+        crate::agent::tools::require_absolute_path(&args.path, "the edit path")
+            .map_err(ToolError::Msg)?;
         // Audit H12: pin file operations to the canonical path the
         // permission check resolved.
         let resolved_path =

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -135,6 +135,26 @@ pub fn is_skip_dir(name: &str) -> bool {
     matches!(name, "node_modules" | "target")
 }
 
+/// Enforce that a tool argument is an absolute filesystem path.
+///
+/// Single source for the check + error message shared by read, write,
+/// edit, and apply_patch (dirge-e1r9). These tools all declare
+/// `dirge-hints.semantic = "absolute_path"` in their schema and used to
+/// each re-implement `Path::is_absolute()` with a slightly different
+/// error string. `subject` names the field for the message (e.g.
+/// `"read path"`, `"apply_patch rename target"`). Returns the message
+/// as a plain `String`; callers wrap it (`.map_err(ToolError::Msg)?`).
+pub fn require_absolute_path(path: &str, subject: &str) -> Result<(), String> {
+    if std::path::Path::new(path).is_absolute() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{subject} must be an absolute path like '/home/user/project/file.txt', \
+             not a relative path or bare filename — got {path:?}"
+        ))
+    }
+}
+
 #[derive(Deserialize)]
 pub struct ReadArgs {
     pub path: String,
@@ -443,6 +463,19 @@ mod tests {
             pattern: pattern.to_string(),
             effect,
             tool: None,
+        }
+    }
+
+    // dirge-e1r9: the shared absolute-path guard accepts absolute paths
+    // and rejects relative / bare ones with a single uniform message.
+    #[test]
+    fn require_absolute_path_accepts_absolute_rejects_relative() {
+        assert!(require_absolute_path("/home/user/x.rs", "read path").is_ok());
+        for bad in ["x.rs", "./x.rs", "../x.rs", "src/x.rs", "1"] {
+            let err = require_absolute_path(bad, "read path")
+                .expect_err("relative path must be rejected");
+            assert!(err.contains("absolute path"), "message: {err}");
+            assert!(err.contains(bad), "message names the offending path: {err}");
         }
     }
 

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
-use std::path::Path;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -179,14 +178,10 @@ impl Tool for ReadTool {
     }
 
     async fn call(&self, args: ReadArgs) -> Result<String, ToolError> {
-        // Reject non-absolute paths immediately with a clear error.
-        // Same guard as `write` — the schema says "must be absolute."
-        if !Path::new(&args.path).is_absolute() {
-            return Err(ToolError::Msg(format!(
-                "Path '{}' is not absolute. Read takes an absolute path like '/home/user/project/file.txt', not a relative path or bare filename.",
-                args.path,
-            )));
-        }
+        // Reject non-absolute paths immediately with a clear error
+        // (shared guard; the schema declares `semantic: absolute_path`).
+        crate::agent::tools::require_absolute_path(&args.path, "the read path")
+            .map_err(ToolError::Msg)?;
         // Audit H12: pin the path we'll actually open to the same
         // canonical form the permission check ran against, so a
         // symlink swap between check and open can't land us on a

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -86,17 +86,13 @@ impl Tool for WriteTool {
     }
 
     async fn call(&self, args: WriteArgs) -> Result<String, ToolError> {
-        // Reject non-absolute paths immediately with a clear error.
-        // The schema says "must be absolute, not relative" — without
-        // this guard the tool silently resolves "1" to "{cwd}/1" and
+        // Reject non-absolute paths immediately with a clear error
+        // (shared guard; the schema requires an absolute path).
+        // Without it the tool silently resolves "1" to "{cwd}/1" and
         // creates the file, confusing the model into thinking it wrote
         // to a real project path.
-        if !Path::new(&args.path).is_absolute() {
-            return Err(ToolError::Msg(format!(
-                "Path '{}' is not absolute. Write takes an absolute path like '/home/user/project/file.txt', not a relative path or bare filename.",
-                args.path,
-            )));
-        }
+        crate::agent::tools::require_absolute_path(&args.path, "the write path")
+            .map_err(ToolError::Msg)?;
         // Audit H12: pin file operations to the canonical path the
         // permission check ran against, so a symlink swap can't
         // redirect the write to an unauthorized target.
@@ -280,7 +276,7 @@ mod tests {
                 .unwrap_err();
             let msg = err.to_string();
             assert!(
-                msg.contains("not absolute"),
+                msg.contains("absolute path"),
                 "path {path:?}: expected absolute-path rejection; got: {msg}",
             );
         }


### PR DESCRIPTION
## Summary
Closes **dirge-e1r9** (completes Chokepoint A / thread 2 from the audit).

`read`/`write`/`edit`/`apply_patch` each re-implemented `Path::is_absolute()` with a slightly different rejection message — and `apply_patch` had two copies (`path` + `new_path`). Five hand-rolled checks, four distinct messages.

## Fix
One `tools::require_absolute_path(path, subject)` helper: single implementation, single uniform message, with the field named per call site (`"the read path"`, `"the apply_patch rename target"`, …). The five sites delegate via `.map_err(ToolError::Msg)?`.

## Why a shared helper, not the schema-driven repair layer
The filed issue suggested enforcing in `validate_and_repair` via the `semantic:absolute_path` tag. I deliberately **didn't**: that path returns `Err`, which arms model **escalation** (`RepairExhausted`) — so a trivial, deterministic relative-path mistake would spuriously escalate to a stronger model. The shared helper removes the duplication + message drift (the actual flagged risk) while preserving today's behavior (a plain error result, no escalation).

Also verified `grep`/`find_files`/`glob`/`list_dir` are untouched — they intentionally allow relative paths (default `"."`), so a blanket schema-driven enforcement would have broken them.

## Test plan
1 new test (`require_absolute_path_accepts_absolute_rejects_relative`); updated `write`'s message assertion. **2112 tests pass** under the full feature matrix at `RUSTFLAGS="-D warnings"`.