### PR TITLE
refactor(recovery): single run_with_retry helper for request retries

### DIFF
--- a/src/agent/recovery.rs
+++ b/src/agent/recovery.rs
@@ -105,6 +105,65 @@ impl RecoveryPolicy {
             None => computed,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_backoff(max_retries: usize, backoff_base: Duration) -> Self {
+        Self {
+            max_retries,
+            backoff_base,
+        }
+    }
+}
+
+/// Run an async operation under a [`RecoveryPolicy`], retrying transient
+/// (network / rate-limit) failures with the policy's exponential
+/// backoff. Auth / context-length / other failures bail immediately.
+///
+/// Single home for the attempt → classify → backoff → sleep loop that
+/// `AnyModel::btw_query` and the summarizer each hand-rolled (dirge-6cvc).
+/// `attempt` is invoked fresh on every try; `label` names the operation
+/// in the retry log line. The error type only needs `Display` — the
+/// message is what `classify_error` inspects.
+///
+/// NOTE: the backoff sleep here is not yet cancellation-aware; wiring an
+/// abort signal through the (signal-less) call sites is tracked
+/// separately. The streaming retry wrapper in `agent_loop::retry` is a
+/// different shape (per-event commit tracking) and keeps its own loop.
+pub async fn run_with_retry<T, E, F, Fut>(
+    policy: &RecoveryPolicy,
+    label: &str,
+    mut attempt: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let mut attempts = 0;
+    loop {
+        match attempt().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                let msg = err.to_string();
+                let kind = classify_error(&msg);
+                if !policy.should_retry(attempts, kind) {
+                    return Err(err);
+                }
+                let delay = policy.backoff_duration_for_msg(attempts, &msg);
+                tracing::warn!(
+                    op = label,
+                    attempt = attempts + 1,
+                    max = policy.max_retries(),
+                    delay_ms = delay.as_millis() as u64,
+                    kind = ?kind,
+                    error = %msg,
+                    "retrying after transient failure",
+                );
+                tokio::time::sleep(delay).await;
+                attempts += 1;
+            }
+        }
+    }
 }
 
 /// Parse a `Retry-After` value out of an error message. Looks for
@@ -483,6 +542,73 @@ pub fn user_facing_error(msg: &str, attempts: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // dirge-6cvc: the shared retry helper — success, immediate bail on a
+    // non-retryable error, and retry-then-succeed on a transient one.
+    #[tokio::test]
+    async fn run_with_retry_returns_first_success() {
+        let policy = RecoveryPolicy::default();
+        let calls = AtomicUsize::new(0);
+        let r: Result<u32, String> = run_with_retry(&policy, "t", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Ok(7) }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "no retry on success");
+    }
+
+    #[tokio::test]
+    async fn run_with_retry_bails_immediately_on_non_retryable() {
+        let policy = RecoveryPolicy::default();
+        let calls = AtomicUsize::new(0);
+        let r: Result<u32, String> = run_with_retry(&policy, "t", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err("invalid api key".to_string()) }
+        })
+        .await;
+        assert!(r.is_err());
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "auth error must not be retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_with_retry_retries_transient_then_succeeds() {
+        // Tiny backoff so the test doesn't actually wait seconds.
+        let policy = RecoveryPolicy::with_backoff(3, Duration::from_millis(1));
+        let calls = AtomicUsize::new(0);
+        let r: Result<u32, String> = run_with_retry(&policy, "t", || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err("rate limit exceeded".to_string())
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(r.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "two retries then success");
+    }
+
+    #[tokio::test]
+    async fn run_with_retry_exhausts_then_returns_last_error() {
+        let policy = RecoveryPolicy::with_backoff(2, Duration::from_millis(1));
+        let calls = AtomicUsize::new(0);
+        let r: Result<u32, String> = run_with_retry(&policy, "t", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { Err("rate limit exceeded".to_string()) }
+        })
+        .await;
+        assert!(r.is_err());
+        // initial attempt + 2 retries = 3 calls.
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
 
     #[test]
     fn test_classify_context_length() {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -585,36 +585,23 @@ impl AnyModel {
         // (`task` tool) call with no retry. Network + rate-limit
         // failures now get the standard 3-retry exponential backoff;
         // auth / context-length / other still bail immediately.
-        use crate::agent::recovery::{RecoveryPolicy, classify_error};
+        use crate::agent::recovery::{RecoveryPolicy, run_with_retry};
         let policy = RecoveryPolicy::default();
+        // The retry/backoff loop lives in `run_with_retry` (dirge-6cvc);
+        // the macro only exists to dispatch over `AnyModel`'s concrete
+        // per-variant model type (each `$m` has a different type).
         macro_rules! one_shot {
             ($m:expr) => {{
-                let m = $m;
-                let mut attempts = 0;
-                loop {
+                let m = $m.clone();
+                run_with_retry(&policy, "btw_query", || {
                     let agent = rig::agent::AgentBuilder::new(m.clone())
                         .preamble(preamble)
                         .build();
-                    match agent.prompt(prompt.clone()).await {
-                        Ok(reply) => break Ok::<String, anyhow::Error>(reply),
-                        Err(e) => {
-                            let msg = e.to_string();
-                            let kind = classify_error(&msg);
-                            if !policy.should_retry(attempts, kind) {
-                                break Err(e.into());
-                            }
-                            let delay = policy.backoff_duration_for_msg(attempts, &msg);
-                            tracing::warn!(
-                                attempt = attempts + 1,
-                                delay_ms = delay.as_millis() as u64,
-                                error = %msg,
-                                "btw_query retrying",
-                            );
-                            tokio::time::sleep(delay).await;
-                            attempts += 1;
-                        }
-                    }
-                }
+                    let prompt = prompt.clone();
+                    async move { agent.prompt(prompt).await }
+                })
+                .await
+                .map_err(anyhow::Error::from)
             }};
         }
         match self {

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -136,64 +136,51 @@ where
     M: rig::completion::CompletionModel + Clone + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
 {
-    use crate::agent::recovery::{self, RecoveryPolicy};
+    use crate::agent::recovery::{RecoveryPolicy, run_with_retry};
     let policy = RecoveryPolicy::default();
-    let mut attempts: usize = 0;
-    loop {
-        let agent = rig::agent::AgentBuilder::new(model.clone())
-            .preamble("You are a conversation summarizer.")
-            .build();
 
-        let mut stream = agent
-            .stream_chat(prompt.clone(), Vec::<rig::completion::Message>::new())
-            .multi_turn(1)
-            .await;
+    // The attempt/classify/backoff/sleep loop lives in `run_with_retry`
+    // (dirge-6cvc). The closure builds + drains one stream and returns a
+    // stream error as `Err(String)` so the helper can classify it; an
+    // empty-but-clean response is returned as `Ok(String::new())` and
+    // rejected (non-retryable) below.
+    let response = run_with_retry(&policy, "summarizer", || {
+        let model = model.clone();
+        let prompt = prompt.clone();
+        async move {
+            let agent = rig::agent::AgentBuilder::new(model)
+                .preamble("You are a conversation summarizer.")
+                .build();
 
-        let mut response = String::new();
-        let mut error: Option<String> = None;
-        use futures::StreamExt;
-        while let Some(item) = stream.next().await {
-            match item {
-                Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
-                    rig::streaming::StreamedAssistantContent::Text(text),
-                )) => response.push_str(&text.text),
-                Ok(rig::agent::MultiTurnStreamItem::FinalResponse(res)) => {
-                    response = res.response().to_string();
-                    break;
+            let mut stream = agent
+                .stream_chat(prompt, Vec::<rig::completion::Message>::new())
+                .multi_turn(1)
+                .await;
+
+            let mut response = String::new();
+            use futures::StreamExt;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(rig::agent::MultiTurnStreamItem::StreamAssistantItem(
+                        rig::streaming::StreamedAssistantContent::Text(text),
+                    )) => response.push_str(&text.text),
+                    Ok(rig::agent::MultiTurnStreamItem::FinalResponse(res)) => {
+                        return Ok(res.response().to_string());
+                    }
+                    Err(e) => return Err(e.to_string()),
+                    _ => {}
                 }
-                Err(e) => {
-                    error = Some(e.to_string());
-                    break;
-                }
-                _ => {}
             }
+            Ok(response)
         }
+    })
+    .await
+    .map_err(|msg| anyhow::anyhow!("Compression failed: {msg}"))?;
 
-        if let Some(msg) = error {
-            let kind = recovery::classify_error(&msg);
-            if policy.should_retry(attempts, kind) {
-                let delay = policy.backoff_duration_for_msg(attempts, &msg);
-                tracing::info!(
-                    "summarizer retry {}/{} after {:?} ({:?}): {}",
-                    attempts + 1,
-                    policy.max_retries(),
-                    delay,
-                    kind,
-                    msg
-                );
-                tokio::time::sleep(delay).await;
-                attempts += 1;
-                continue;
-            }
-            return Err(anyhow::anyhow!("Compression failed: {}", msg));
-        }
-
-        if response.is_empty() {
-            anyhow::bail!("Compression returned empty response");
-        }
-
-        return Ok(response);
+    if response.is_empty() {
+        anyhow::bail!("Compression returned empty response");
     }
+    Ok(response)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Thread 3, item #5 — closes the duplication half of **dirge-6cvc**.

`AnyModel::btw_query` and the summarizer each hand-rolled the same `attempt → classify_error → backoff → sleep` loop around the shared `RecoveryPolicy` — two copies (plus the genuinely-different streaming wrapper) that could drift from each other.

## Fix
Extract `recovery::run_with_retry(policy, label, attempt)` — one loop, generic over the operation's result/error (the error only needs `Display`, which is what `classify_error` inspects). Both call sites delegate:
- `btw_query`'s per-`AnyModel`-variant macro shrinks to just the dispatch (each arm's concrete model type differs — that's the only reason the macro remains).
- the summarizer passes a closure that builds + drains one stream.

## Scope note
- The streaming retry wrapper in `agent_loop::retry` is a **different shape** (per-event commit tracking, and it's *already* cancellation-aware) — it keeps its own loop.
- **Cancellation-during-backoff** for `btw`/`summarize` (the other half of dirge-6cvc) needs an `AbortSignal` threaded through their currently signal-less call sites. Left as a tracked residual on dirge-6cvc — not bundled here, to keep this a clean dedup.

## Test plan
4 new tests (success / non-retryable bail / retry-then-succeed / exhaust-then-error). **2116 pass** under the full feature matrix at `RUSTFLAGS="-D warnings"`.