### PR TITLE
fix(cancel): instant Notify-backed AbortSignal + pin the drop contract

### DIFF
--- a/src/agent/agent_loop/tool.rs
+++ b/src/agent/agent_loop/tool.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::Value;
+use tokio::sync::Notify;
 
 use super::result::LoopToolResult;
 use super::types::ToolExecutionMode;
@@ -30,35 +31,50 @@ use super::types::ToolExecutionMode;
 /// the loop at the next turn boundary but lets in-flight tools
 /// complete normally. Tools never check `is_interjected()`.
 ///
-/// Implemented as `Arc<AtomicBool>` rather than `tokio_util`'s
-/// `CancellationToken` so we don't pull in a new dep for the
-/// trivial case. If we ever need `.cancelled().await` (notifier
-/// semantics for futures that want to race against the signal),
-/// upgrade to `tokio_util::sync::CancellationToken` in a later
-/// phase.
+/// Backed by an `Arc<AtomicBool>` for the cheap `is_cancelled()`
+/// poll that tools use, PLUS an `Arc<Notify>` so a future can
+/// `.cancelled().await` and wake the instant cancellation fires —
+/// no busy-poll, no latency. (Avoids a `tokio_util::CancellationToken`
+/// dep; the `Notify` is already in our tokio feature set.)
 #[derive(Debug, Clone, Default)]
 pub struct AbortSignal {
     cancelled: Arc<AtomicBool>,
     interjected: Arc<AtomicBool>,
+    notify: Arc<Notify>,
 }
 
 impl AbortSignal {
     pub fn new() -> Self {
-        Self {
-            cancelled: Arc::new(AtomicBool::new(false)),
-            interjected: Arc::new(AtomicBool::new(false)),
-        }
+        Self::default()
     }
     /// Trigger hard cancellation. Idempotent — subsequent calls
     /// are no-ops. Tools poll `is_cancelled()` and bail out
-    /// cleanly when true.
+    /// cleanly when true; futures awaiting [`Self::cancelled`] wake
+    /// immediately.
     pub fn cancel(&self) {
         self.cancelled.store(true, Ordering::SeqCst);
+        // Wake everyone racing against cancellation. Set the flag
+        // FIRST so a waiter woken here always observes `true`.
+        self.notify.notify_waiters();
     }
     /// Read the cancelled state. Tools call this from inside
     /// their `execute` loops.
     pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
+    }
+    /// Resolve as soon as the signal is cancelled (immediately if it
+    /// already is). Lets the dispatcher race a tool against
+    /// cancellation without polling, so Ctrl+C is instant. Race-free:
+    /// the waiter is registered via `enable()` BEFORE the state check,
+    /// so a `cancel()` landing in between still wakes it.
+    pub async fn cancelled(&self) {
+        let notified = self.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
     }
     /// LOOP-4: Trigger graceful interjection. Idempotent. The
     /// loop checks this at turn boundaries and stops accepting
@@ -201,5 +217,32 @@ mod tests {
     fn abort_signal_default_uncancelled() {
         let sig = AbortSignal::default();
         assert!(!sig.is_cancelled());
+    }
+
+    /// `cancelled()` returns immediately when already cancelled.
+    #[tokio::test]
+    async fn cancelled_returns_immediately_when_already_cancelled() {
+        let sig = AbortSignal::new();
+        sig.cancel();
+        // Must not hang; complete well within the test timeout.
+        tokio::time::timeout(std::time::Duration::from_secs(1), sig.cancelled())
+            .await
+            .expect("cancelled() must resolve immediately when already cancelled");
+    }
+
+    /// `cancelled()` wakes promptly when `cancel()` fires concurrently
+    /// (no lost wakeup, no 50ms poll latency).
+    #[tokio::test]
+    async fn cancelled_wakes_on_concurrent_cancel() {
+        let sig = AbortSignal::new();
+        let waiter = sig.clone();
+        let handle = tokio::spawn(async move { waiter.cancelled().await });
+        // Give the waiter a moment to register, then cancel.
+        tokio::task::yield_now().await;
+        sig.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("cancelled() must wake promptly on concurrent cancel")
+            .expect("waiter task panicked");
     }
 }

--- a/src/agent/agent_loop/tools.rs
+++ b/src/agent/agent_loop/tools.rs
@@ -510,23 +510,27 @@ async fn execute_prepared_tool_call(
     // Phase 6 — make the tool dispatch responsive to
     // `AbortSignal` even when the underlying tool doesn't
     // poll the signal itself. We race the tool's execute()
-    // against a signal-poll loop:
+    // against `wait_for_cancel` (instant, Notify-backed):
     //   - If the tool finishes first → use its result.
     //   - If the signal fires first → return an aborted
-    //     result. The tool's future is dropped, which
-    //     stops further poll progress. Side effects already
-    //     run (e.g. an in-flight bash process) are NOT
-    //     killed — the rig::Tool surface doesn't expose
-    //     cancellation, and forcing a kill would risk
-    //     orphaned state. The dropped future may continue
-    //     scheduling work in the background; consumers
-    //     should not rely on its absence.
+    //     result and DROP the tool's future. Dropping a
+    //     future cancels it: it won't be polled again, its
+    //     in-progress `.await`s unwind, and its RAII guards
+    //     run — so e.g. bash's `PgKillGuard` SIGKILLs the
+    //     whole process group (not just the immediate child)
+    //     on the drop path. A partial side effect already
+    //     committed before the drop (a half-written file)
+    //     can't be undone — that's inherent to cancelling
+    //     mid-operation.
     //
-    // This gives the loop UX responsive to Ctrl+C even with
-    // legacy tools that don't poll the signal. Tools that
-    // DO poll it (a future generation of LoopTool impls)
-    // get cleaner cancellation since they finish quickly
-    // when cancelled.
+    // Caveat: a tool that detaches work via `tokio::spawn`
+    // (not tied to its own future's lifetime) is responsible
+    // for aborting that itself — dropping the execute future
+    // can't reach a detached task.
+    //
+    // Tools that ALSO poll `is_cancelled()` get even cleaner
+    // cancellation since they bail at their next checkpoint
+    // rather than relying solely on the drop.
     let exec_future = tool.execute(&tool_call.id, args.clone(), signal.clone(), on_update);
     let signal_check = wait_for_cancel(signal.clone());
 
@@ -639,23 +643,13 @@ fn should_terminate_tool_batch(finalized: &[FinalizedOutcome]) -> bool {
             .all(|f| f.result.terminate.unwrap_or(false))
 }
 
-/// Wait for an `AbortSignal` to fire. Polls at 50ms intervals
-/// since `AbortSignal` doesn't expose an async-await primitive
-/// (it's an `Arc<AtomicBool>` wrapper). 50ms gives a snappy UX
-/// (user-perceptible Ctrl+C response) without busy-looping.
-///
-/// Returns when the signal is cancelled. The caller races this
-/// future against the tool's execute() in a `tokio::select!`.
-/// Cancellation of the wait future is automatic when the
-/// select arm doesn't win — `tokio::time::sleep` is
-/// abort-on-drop, and the `is_cancelled()` check is cheap.
+/// Wait for an `AbortSignal` to fire. Resolves the instant the
+/// signal is cancelled — `AbortSignal::cancelled` is `Notify`-backed,
+/// so there's no polling latency. The caller races this against the
+/// tool's execute() in a `tokio::select!`; when the tool arm wins,
+/// this future is simply dropped.
 async fn wait_for_cancel(signal: AbortSignal) {
-    loop {
-        if signal.is_cancelled() {
-            return;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    signal.cancelled().await;
 }
 
 /// Phase 4 part 1: scan an error tool-result for the canonical

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -1129,6 +1129,134 @@ async fn aborted_tool_returns_aborted_error_promptly() {
     assert!(batch.messages[0].is_error);
 }
 
+/// dirge-2mw0: on cancellation the dispatcher DROPS the tool's execute
+/// future — it does not leave it running detached. Proven concretely: a
+/// probe tool holds an RAII guard inside its future that flips a flag on
+/// Drop, and sets a separate `completed` flag only if it runs to the
+/// end. After a mid-execution cancel we observe `dropped == true` and
+/// `completed == false`.
+#[tokio::test]
+async fn cancelled_tool_future_is_dropped_not_detached() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DropFlag(Arc<AtomicBool>);
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct DropProbeTool {
+        started: Arc<AtomicBool>,
+        dropped: Arc<AtomicBool>,
+        completed: Arc<AtomicBool>,
+    }
+    impl LoopTool for DropProbeTool {
+        fn name(&self) -> &str {
+            "probe"
+        }
+        fn description(&self) -> &str {
+            "Signals start, then sleeps; flips a flag if dropped."
+        }
+        fn label(&self) -> &str {
+            "Probe"
+        }
+        fn parameters(&self) -> &Value {
+            static EMPTY: std::sync::OnceLock<Value> = std::sync::OnceLock::new();
+            EMPTY.get_or_init(|| serde_json::json!({"type": "object"}))
+        }
+        fn execute<'a>(
+            &'a self,
+            _id: &'a str,
+            _args: Value,
+            _signal: AbortSignal, // intentionally NOT polled
+            _on_update: LoopToolUpdate,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<LoopToolResult, String>> + Send + 'a>>
+        {
+            let started = self.started.clone();
+            let dropped = self.dropped.clone();
+            let completed = self.completed.clone();
+            Box::pin(async move {
+                let _guard = DropFlag(dropped);
+                started.store(true, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                completed.store(true, Ordering::SeqCst);
+                Ok(LoopToolResult {
+                    content: vec![serde_json::json!({"type": "text", "text": "done"})],
+                    details: Value::Null,
+                    terminate: None,
+                })
+            })
+        }
+    }
+
+    let started = Arc::new(AtomicBool::new(false));
+    let dropped = Arc::new(AtomicBool::new(false));
+    let completed = Arc::new(AtomicBool::new(false));
+    let mut ctx = Context::default();
+    ctx.tools.push(Arc::new(DropProbeTool {
+        started: started.clone(),
+        dropped: dropped.clone(),
+        completed: completed.clone(),
+    }));
+    let signal = AbortSignal::new();
+    let calls = vec![ToolCall {
+        id: "tc-1".to_string(),
+        name: "probe".to_string(),
+        arguments: serde_json::json!({}),
+    }];
+    let assistant = AssistantMessage::new(
+        calls
+            .iter()
+            .map(|c| ContentBlock::ToolCall {
+                id: c.id.clone(),
+                name: c.name.clone(),
+                arguments: c.arguments.clone(),
+            })
+            .collect(),
+        StopReason::ToolUse,
+    );
+    let cfg = build_config();
+    let (tx, _rx) = mpsc::channel::<LoopEvent>(64);
+
+    // Cancel AFTER the tool has started executing, so we exercise the
+    // mid-flight drop path (not a pre-dispatch short-circuit).
+    let canceller = {
+        let signal = signal.clone();
+        let started = started.clone();
+        async move {
+            while !started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+            signal.cancel();
+        }
+    };
+    let inflight = InflightSet::new();
+    let dispatch =
+        execute_tool_calls_sequential(&ctx, &assistant, &calls, &cfg, &signal, &tx, &inflight);
+
+    let (batch, _) = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+        tokio::join!(dispatch, canceller)
+    })
+    .await
+    .expect("cancellation must drop the future promptly, not wait out the 10s sleep");
+
+    assert!(started.load(Ordering::SeqCst), "tool should have started");
+    assert!(
+        dropped.load(Ordering::SeqCst),
+        "tool future must be dropped on cancel"
+    );
+    assert!(
+        !completed.load(Ordering::SeqCst),
+        "tool must NOT run to completion after cancel (no detached execution)"
+    );
+    assert!(
+        batch.messages[0].is_error,
+        "result should be the abort error"
+    );
+}
+
 // ── dirge-du5k/7bwx: truncation brace-closer end-to-end ──────────
 
 /// dirge-du5k + dirge-7bwx end-to-end: a tool call arriving with a


### PR DESCRIPTION
## Summary
Thread 3, item #9 — **dirge-2mw0**.

Investigating "a cancelled tool keeps running detached" showed the dispatcher's drop-on-cancel is **actually correct**: `tokio::select!` dropping the tool's execute future cancels it — no further polls, in-flight `.await`s unwind, and RAII guards run (e.g. bash's `PgKillGuard` already SIGKILLs the whole process group on the drop path). MCP has no detached spawn either. The real shortcomings were *responsiveness* and an over-pessimistic comment — plus no test pinning the contract.

## Changes
- **`AbortSignal` is now `Notify`-backed.** `cancel()` notifies waiters; `cancelled().await` resolves the instant cancellation fires — race-free via `Notified::enable()` before the state check. The cheap `is_cancelled()` poll API is unchanged for tools.
- **`wait_for_cancel` awaits `cancelled()`** instead of a 50ms poll loop → Ctrl+C is immediate, no busy-poll.
- **Corrected the dispatcher comment** to state accurately that dropping the future cancels it (and bash kills its group on drop); the genuine residual is tools that detach via `tokio::spawn`, which must abort that work themselves.

## Test plan
- `AbortSignal::cancelled()` resolves-when-already-cancelled + wakes-on-concurrent-cancel.
- A dispatcher regression proving the tool future is **dropped** on a mid-execution cancel (RAII drop-flag set, completion flag NOT set) — i.e. no detached execution.

**2115 pass** under the full feature matrix at `RUSTFLAGS="-D warnings"`.