### PR TITLE
refactor(config): single-source credential + dir + web-enable resolution

### DIFF
--- a/src/agent/builder.rs
+++ b/src/agent/builder.rs
@@ -454,15 +454,8 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         // forcing webfetch users to edit config.json for an
         // equivalent toggle. The runtime API-key check still has
         // to pass for websearch.
-        let env_true = |k: &str| {
-            std::env::var(k)
-                .map(|v| v == "true" || v == "1")
-                .unwrap_or(false)
-        };
-        let websearch_enabled = cfg.tools.as_ref().and_then(|t| t.websearch).unwrap_or(true)
-            || env_true("WEBSEARCH_ENABLED");
-        let webfetch_enabled = cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(true)
-            || env_true("WEBFETCH_ENABLED");
+        let websearch_enabled = crate::config::websearch_enabled(cfg);
+        let webfetch_enabled = crate::config::webfetch_enabled(cfg);
 
         // Websearch now works out of the box without an API key —
         // mirrors opencode's behavior. Backend: Exa's hosted MCP
@@ -472,7 +465,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
         // optional — when set, it's appended as `?exaApiKey=…` for
         // higher rate limits.
         let websearch_tool = if websearch_enabled {
-            let key = std::env::var("EXA_API_KEY").ok().filter(|k| !k.is_empty());
+            let key = crate::config::exa_api_key();
             Some(Box::new(tools::WebSearchTool::new(
                 permission.clone(),
                 ask_tx.clone(),
@@ -900,17 +893,10 @@ pub async fn build_loop_tools(
     }
 
     // Web tools — network reads, leave at default Parallel.
-    let env_true = |k: &str| {
-        std::env::var(k)
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or(false)
-    };
-    let websearch_enabled = cfg.tools.as_ref().and_then(|t| t.websearch).unwrap_or(true)
-        || env_true("WEBSEARCH_ENABLED");
-    let webfetch_enabled =
-        cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(true) || env_true("WEBFETCH_ENABLED");
+    let websearch_enabled = crate::config::websearch_enabled(cfg);
+    let webfetch_enabled = crate::config::webfetch_enabled(cfg);
     if websearch_enabled {
-        let key = std::env::var("EXA_API_KEY").ok().filter(|k| !k.is_empty());
+        let key = crate::config::exa_api_key();
         tools.push(
             wrap(
                 tools::WebSearchTool::new(permission.clone(), ask_tx.clone(), key),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -438,6 +438,36 @@ impl Config {
 /// Values are the model's documented maximum context (input + output
 /// combined where the provider quotes a unified figure). Update as
 /// providers extend their context budgets.
+/// Read `EXA_API_KEY`, trimming whitespace and treating empty as unset.
+/// Single source so every consumer (web-search tool, MCP auto-register,
+/// the builder) applies the same trim/empty policy (dirge-3xqe).
+pub fn exa_api_key() -> Option<String> {
+    std::env::var("EXA_API_KEY")
+        .ok()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+}
+
+fn web_env_true(k: &str) -> bool {
+    std::env::var(k)
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+}
+
+/// Whether the websearch tool is enabled: config `tools.websearch`
+/// (default true) OR `WEBSEARCH_ENABLED`. Single source for the
+/// precedence duplicated across the two builder paths (dirge-f8oe).
+pub fn websearch_enabled(cfg: &Config) -> bool {
+    cfg.tools.as_ref().and_then(|t| t.websearch).unwrap_or(true)
+        || web_env_true("WEBSEARCH_ENABLED")
+}
+
+/// Whether the webfetch tool is enabled: config `tools.webfetch`
+/// (default true) OR `WEBFETCH_ENABLED`.
+pub fn webfetch_enabled(cfg: &Config) -> bool {
+    cfg.tools.as_ref().and_then(|t| t.webfetch).unwrap_or(true) || web_env_true("WEBFETCH_ENABLED")
+}
+
 pub fn context_window_for_model(model: &str) -> Option<u64> {
     let m = model.to_lowercase();
     // Ordered: most-specific first.
@@ -593,8 +623,8 @@ pub fn load() -> Config {
         // register Exa anyway with an empty header, then every web-
         // search call failed with 401 at first use. Skip cleanly
         // when no usable key is present.
-        match std::env::var("EXA_API_KEY") {
-            Ok(key) if !key.is_empty() => {
+        match exa_api_key() {
+            Some(key) => {
                 let mut headers = HashMap::new();
                 headers.insert("x-api-key".to_string(), key);
                 let mut defaults = HashMap::new();

--- a/src/extras/loop/transcript.rs
+++ b/src/extras/loop/transcript.rs
@@ -3,9 +3,11 @@ use std::path::PathBuf;
 use chrono::Utc;
 
 fn transcript_dir(session_id: &str) -> PathBuf {
-    dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from(".dirge"))
-        .join("dirge")
+    // Route through the shared data-dir base so `DIRGE_DATA_DIR` is
+    // honored here too — previously this used `dirs::data_dir()`
+    // directly, so an override relocated sessions but NOT loop
+    // transcripts (dirge-f8oe).
+    crate::session::storage::dirs_path()
         .join("loops")
         .join(session_id)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,12 +571,11 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "plugin")]
     if let Some(pm_arc) = plugin_manager.as_ref() {
         use std::path::PathBuf;
+        // Honor DIRGE_CONFIG_DIR via the shared base, like config.json
+        // (dirge-f8oe) — previously this hard-coded ~/.config/dirge, so
+        // an override moved config but left plugins behind.
         let candidate_dirs: Vec<PathBuf> = vec![
-            dirs::home_dir()
-                .unwrap_or_default()
-                .join(".config")
-                .join("dirge")
-                .join("plugins"),
+            crate::session::storage::config_path().join("plugins"),
             PathBuf::from(".dirge").join("plugins"),
         ];
         // Silently drop missing default dirs; only surface real errors below.

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -12,7 +12,7 @@ fn home_fallback() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from("."))
 }
 
-fn dirs_path() -> PathBuf {
+pub(crate) fn dirs_path() -> PathBuf {
     if let Some(dir) = std::env::var_os("DIRGE_DATA_DIR") {
         return PathBuf::from(dir);
     }


### PR DESCRIPTION
Closes **dirge-f8oe**; closes the EXA part of **dirge-3xqe**.

- **EXA_API_KEY** → one `config::exa_api_key()` (trim + empty→None) replacing three reads with two different empty-string policies.
- **web-tool enable** → `config::websearch_enabled` / `webfetch_enabled` replacing the `cfg.tools.X.unwrap_or(true) || env_true(...)` precedence + its `env_true` closure, copy-pasted across two builder paths.
- **DIRGE_DATA_DIR** → loop transcripts route through `storage::dirs_path()` so an override relocates transcripts too (was split state).
- **DIRGE_CONFIG_DIR** → plugin search dir routes through `storage::config_path()` (themes/prompts already did).

Behavior-preserving dedup. **2119 pass** at `-D warnings`.