### PR TITLE
refactor(tools): shared head_cap for per-tool byte ceilings

### DIFF
--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -7,11 +7,12 @@ use tokio::task::JoinHandle;
 /// dirge-nmv5: legacy hard cap retained for the `Failed` error
 /// path only. Error strings are typically a single-line provider
 /// error or "subagent timed out" message — relaying them to disk
-/// would be wasteful. Truncation here is char-counted, UTF-8-safe.
-/// Completed payloads no longer hit this cap: they go through the
-/// disk-backed `output_relay` instead, so the full subagent answer
-/// is recoverable via the `read` tool even when the inline summary
-/// elides the middle.
+/// would be wasteful. Capping goes through `tools::head_cap`
+/// (byte-bounded, UTF-8-safe, marker appended — no longer a silent
+/// chop; dirge-06cp). Completed payloads no longer hit this cap: they
+/// go through the disk-backed `output_relay` instead, so the full
+/// subagent answer is recoverable via the `read` tool even when the
+/// inline summary elides the middle.
 const MAX_TASK_OUTPUT_CHARS: usize = 3000;
 
 /// Maximum number of tasks retained in the store. When a new task is
@@ -409,8 +410,13 @@ fn truncate_state(state: TaskState) -> TaskState {
             TaskState::Completed(outcome.text)
         }
         TaskState::Failed(err) => {
-            let e: String = err.chars().take(MAX_TASK_OUTPUT_CHARS).collect();
-            TaskState::Failed(e)
+            // Was a silent `chars().take` chop; now caps with a marker
+            // so the agent knows the error was truncated (dirge-06cp).
+            TaskState::Failed(crate::agent::tools::head_cap(
+                err,
+                MAX_TASK_OUTPUT_CHARS,
+                "task error",
+            ))
         }
         s => s,
     }
@@ -541,12 +547,23 @@ mod tests {
         let store = BackgroundStore::new();
         store.insert("t1".into());
         let huge = "e".repeat(MAX_TASK_OUTPUT_CHARS * 2);
+        let huge_len = huge.len();
         store.notify("t1", TaskState::Failed(huge));
 
         let TaskState::Failed(text) = store.get("t1").unwrap().state else {
             panic!("expected Failed");
         };
-        assert_eq!(text.chars().count(), MAX_TASK_OUTPUT_CHARS);
+        // dirge-06cp: capped to the byte ceiling AND marked (no longer a
+        // silent chop) — head preserved, a truncation marker appended.
+        assert!(
+            text.starts_with(&"e".repeat(MAX_TASK_OUTPUT_CHARS)),
+            "head must be preserved up to the cap"
+        );
+        assert!(
+            text.contains("truncated"),
+            "must carry a truncation marker: {text}"
+        );
+        assert!(text.len() < huge_len, "must be shorter than the original");
     }
 
     // dirge-nmv5: short Completed payloads must pass through the

--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -332,20 +332,7 @@ impl Tool for BashTool {
         // ever races. 256 KiB ≈ 65k tokens worst-case, already well
         // above any sensible single-command output.
         const BASH_OUTPUT_CAP_BYTES: usize = 256 * 1024;
-        if result.len() > BASH_OUTPUT_CAP_BYTES {
-            // Slice at UTF-8 char boundary.
-            let mut cut = BASH_OUTPUT_CAP_BYTES;
-            while cut > 0 && !result.is_char_boundary(cut) {
-                cut -= 1;
-            }
-            let dropped = result.len() - cut;
-            result.truncate(cut);
-            result.push_str(&format!(
-                "\n…[bash output truncated: dropped {} bytes ({} KiB total); pipe through head/grep to keep the LLM context lean]",
-                dropped,
-                (cut + dropped) / 1024,
-            ));
-        }
+        result = crate::agent::tools::head_cap(result, BASH_OUTPUT_CAP_BYTES, "bash output");
         // Bash may have mutated the filesystem; conservatively invalidate the
         // per-turn read/grep/list cache.
         if let Some(ref cache) = self.cache {

--- a/src/agent/tools/memory.rs
+++ b/src/agent/tools/memory.rs
@@ -122,11 +122,11 @@ ACTIONS:
             // out as `payload` to avoid the "always a new value"
             // misreading.
             "add" => {
-                let content = args
-                    .content
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| ToolError::Msg("content is required for 'add'".to_string()))?;
+                let content = crate::agent::tools::required_nonblank(
+                    args.content.as_deref(),
+                    "content",
+                    "add",
+                )?;
                 let resp = self.store.add(target, content).map_err(ToolError::Msg)?;
                 crate::agent::review::fire_memory_write(
                     self.store.as_ref(),
@@ -138,20 +138,16 @@ ACTIONS:
                     .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()))
             }
             "replace" => {
-                let old_text = args
-                    .old_text
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| {
-                        ToolError::Msg("old_text is required for 'replace'".to_string())
-                    })?;
-                let content = args
-                    .content
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| {
-                        ToolError::Msg("content is required for 'replace'".to_string())
-                    })?;
+                let old_text = crate::agent::tools::required_nonblank(
+                    args.old_text.as_deref(),
+                    "old_text",
+                    "replace",
+                )?;
+                let content = crate::agent::tools::required_nonblank(
+                    args.content.as_deref(),
+                    "content",
+                    "replace",
+                )?;
                 let resp = self
                     .store
                     .replace(target, old_text, content)
@@ -166,13 +162,11 @@ ACTIONS:
                     .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string()))
             }
             "remove" => {
-                let old_text = args
-                    .old_text
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| {
-                        ToolError::Msg("old_text is required for 'remove'".to_string())
-                    })?;
+                let old_text = crate::agent::tools::required_nonblank(
+                    args.old_text.as_deref(),
+                    "old_text",
+                    "remove",
+                )?;
                 let resp = self
                     .store
                     .remove(target, old_text)

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -135,6 +135,35 @@ pub fn is_skip_dir(name: &str) -> bool {
     matches!(name, "node_modules" | "target")
 }
 
+/// Head-truncate `text` to at most `max_bytes` (landing on a UTF-8 char
+/// boundary), appending a uniform marker noting how much was dropped.
+/// Single source for the per-tool byte caps (dirge-06cp) so the marker
+/// is consistent and truncation is never *silent*. Takes ownership and
+/// returns the input untouched when it's within the cap (no copy).
+/// `what` names the source for the marker (e.g. "bash output").
+///
+/// NOTE: this is for the in-tool byte ceilings only. The LLM-context cap
+/// (head+tail, `compression`), the UI display cap (line-aware), grep's
+/// per-line cap, and list_dir's per-item cap are deliberately separate
+/// concerns/layers, not folded in here.
+pub fn head_cap(text: String, max_bytes: usize, what: &str) -> String {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let mut cut = max_bytes;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let total = text.len();
+    let dropped = total - cut;
+    let mut out = text;
+    out.truncate(cut);
+    out.push_str(&format!(
+        "\n…[{what} truncated: dropped {dropped} of {total} bytes; narrow the command (head/grep) to keep context lean]"
+    ));
+    out
+}
+
 /// Enforce that a tool argument is an absolute filesystem path.
 ///
 /// Single source for the check + error message shared by read, write,
@@ -464,6 +493,27 @@ mod tests {
             effect,
             tool: None,
         }
+    }
+
+    // dirge-06cp: head_cap returns short input untouched and marks any
+    // truncation (never silent), landing on a UTF-8 boundary.
+    #[test]
+    fn head_cap_passes_short_and_marks_truncation() {
+        assert_eq!(head_cap("short".to_string(), 100, "x"), "short");
+
+        let capped = head_cap("a".repeat(50), 10, "bash output");
+        assert!(capped.starts_with(&"a".repeat(10)), "kept head: {capped}");
+        assert!(capped.contains("truncated"), "marked: {capped}");
+        assert!(
+            capped.contains("dropped 40 of 50 bytes"),
+            "counts: {capped}"
+        );
+
+        // Multibyte: 'é' is 2 bytes; a cap of 5 must land on a boundary
+        // (4 bytes = 2 chars) without panicking or splitting a char.
+        let capped = head_cap("é".repeat(10), 5, "x");
+        assert!(capped.starts_with("éé"), "boundary-safe head: {capped}");
+        assert!(capped.contains("truncated"));
     }
 
     // dirge-e1r9: the shared absolute-path guard accepts absolute paths

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -164,6 +164,29 @@ pub fn head_cap(text: String, max_bytes: usize, what: &str) -> String {
     out
 }
 
+/// Extract a required, non-blank string argument for a multiplexer
+/// tool's action, with a uniform error message. Replaces the per-action
+/// `ok_or_else(|| Msg("X is required for 'Y'"))` checks that memory and
+/// skill each hand-rolled with slightly different wording (dirge-8k3k).
+///
+/// Kept as a call-site helper rather than a schema-driven
+/// `validate_and_repair` rule on purpose: a missing field there returns
+/// `Err` from the repair layer, which arms model escalation — overkill
+/// for a "you forgot a field for this action" error. Same reasoning as
+/// [`require_absolute_path`].
+pub fn required_nonblank<'a>(
+    value: Option<&'a str>,
+    field: &str,
+    action: &str,
+) -> Result<&'a str, ToolError> {
+    match value {
+        Some(s) if !s.trim().is_empty() => Ok(s),
+        _ => Err(ToolError::Msg(format!(
+            "`{field}` is required for action '{action}'"
+        ))),
+    }
+}
+
 /// Enforce that a tool argument is an absolute filesystem path.
 ///
 /// Single source for the check + error message shared by read, write,
@@ -492,6 +515,23 @@ mod tests {
             pattern: pattern.to_string(),
             effect,
             tool: None,
+        }
+    }
+
+    // dirge-8k3k: required_nonblank extracts a present, non-blank value
+    // or errors with a uniform "`field` is required for action 'x'".
+    #[test]
+    fn required_nonblank_extracts_or_errors() {
+        assert_eq!(
+            required_nonblank(Some("hello"), "content", "add").unwrap(),
+            "hello"
+        );
+        for bad in [None, Some(""), Some("   \t")] {
+            let msg = required_nonblank(bad, "content", "add")
+                .unwrap_err()
+                .to_string();
+            assert!(msg.contains("content"), "names the field: {msg}");
+            assert!(msg.contains("add"), "names the action: {msg}");
         }
     }
 

--- a/src/agent/tools/skill.rs
+++ b/src/agent/tools/skill.rs
@@ -125,10 +125,8 @@ impl Tool for SkillTool {
 
         match args.action.as_str() {
             "load" => {
-                let name = args
-                    .name
-                    .as_deref()
-                    .ok_or_else(|| ToolError::Msg("name is required for 'load'".to_string()))?;
+                let name =
+                    crate::agent::tools::required_nonblank(args.name.as_deref(), "name", "load")?;
                 let Some(skill) = skill::find_skill(name, &self.skills) else {
                     return Err(ToolError::Msg(format!(
                         "Skill '{}' not found. Available: {}",
@@ -171,17 +169,13 @@ impl Tool for SkillTool {
             }
 
             "create" => {
-                let name = args
-                    .name
-                    .as_deref()
-                    .ok_or_else(|| ToolError::Msg("name is required for 'create'".to_string()))?;
-                let content = args
-                    .content
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| {
-                        ToolError::Msg("content is required for 'create'".to_string())
-                    })?;
+                let name =
+                    crate::agent::tools::required_nonblank(args.name.as_deref(), "name", "create")?;
+                let content = crate::agent::tools::required_nonblank(
+                    args.content.as_deref(),
+                    "content",
+                    "create",
+                )?;
                 self.manager
                     .create_from_content(name, content)
                     .map_err(ToolError::Msg)?;
@@ -193,15 +187,13 @@ impl Tool for SkillTool {
             }
 
             "edit" => {
-                let name = args
-                    .name
-                    .as_deref()
-                    .ok_or_else(|| ToolError::Msg("name is required for 'edit'".to_string()))?;
-                let content = args
-                    .content
-                    .as_deref()
-                    .filter(|c| !c.trim().is_empty())
-                    .ok_or_else(|| ToolError::Msg("content is required for 'edit'".to_string()))?;
+                let name =
+                    crate::agent::tools::required_nonblank(args.name.as_deref(), "name", "edit")?;
+                let content = crate::agent::tools::required_nonblank(
+                    args.content.as_deref(),
+                    "content",
+                    "edit",
+                )?;
                 self.manager
                     .edit_from_content(name, content)
                     .map_err(ToolError::Msg)?;
@@ -213,10 +205,8 @@ impl Tool for SkillTool {
             }
 
             "patch" => {
-                let name = args
-                    .name
-                    .as_deref()
-                    .ok_or_else(|| ToolError::Msg("name is required for 'patch'".to_string()))?;
+                let name =
+                    crate::agent::tools::required_nonblank(args.name.as_deref(), "name", "patch")?;
                 let old_string = args
                     .old_string
                     .as_deref()
@@ -236,10 +226,8 @@ impl Tool for SkillTool {
             }
 
             "delete" => {
-                let name = args
-                    .name
-                    .as_deref()
-                    .ok_or_else(|| ToolError::Msg("name is required for 'delete'".to_string()))?;
+                let name =
+                    crate::agent::tools::required_nonblank(args.name.as_deref(), "name", "delete")?;
                 self.manager.delete(name).map_err(ToolError::Msg)?;
                 Ok(format!("Skill '{}' deleted.", name))
             }


### PR DESCRIPTION
Closes **dirge-06cp**.

The per-tool output ceilings were each hand-rolled: bash truncated at 256 KiB with its own marker; background's `Failed`-error path did a **silent** `chars().take(3000)` (dropped the tail with no indication).

Add `tools::head_cap(text, max_bytes, what)` — one boundary-safe head truncation with a uniform, **non-silent** marker. Routed bash + background's error cap through it. Fixes the silent drop (the error is now marked as truncated) and unifies the marker.

**Scope note (re: the audit's "no pipeline" framing):** this covers only the in-tool *byte* ceilings. The LLM-context cap (head+tail, `compression`), the UI display cap (line-aware, `tool_display`), grep's per-*line* cap, and list_dir's per-*item* cap are deliberately distinct layers — different units, limits, and purposes. They are *supposed* to differ (LLM context budget ≠ terminal display ≠ per-line readability), so they're not folded into one helper.

New test for `head_cap`; updated background's truncation regression to the marked behavior. **2120 pass** at `-D warnings`.