### PR TITLE
fix(ui): soft-wrap questionnaire custom answer

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3442,15 +3442,41 @@ pub async fn run_interactive(
                                     renderer.write_line("  enter your answer:", c_perm())?;
                                     let input_anchor = renderer.buffer_len();
                                     loop {
-                                        renderer.replace_from(
-                                            input_anchor,
-                                            vec![LineEntry {
-                                                text: compact_str::CompactString::new(
-                                                    format!("  > {}", buf),
-                                                ),
-                                                color: c_perm(),
-                                            }],
+                                        // Soft-wrap the typed answer to the
+                                        // available width (reusing the compose
+                                        // box's wrap helper) so a long custom
+                                        // answer flows onto new lines and the
+                                        // tail stays visible instead of running
+                                        // off the right edge (dirge-0dqe). The
+                                        // "  > " / "    " prefixes are 4 cols.
+                                        let wrap_w =
+                                            renderer.content_width().saturating_sub(4).max(1);
+                                        let (rows, _, _) = crate::ui::renderer::wrap_editor(
+                                            &buf,
+                                            buf.len(),
+                                            wrap_w,
                                         );
+                                        let lines: Vec<LineEntry> = if rows.is_empty() {
+                                            vec![LineEntry {
+                                                text: compact_str::CompactString::new("  > "),
+                                                color: c_perm(),
+                                            }]
+                                        } else {
+                                            rows.iter()
+                                                .enumerate()
+                                                .map(|(i, row)| LineEntry {
+                                                    text: compact_str::CompactString::new(
+                                                        if i == 0 {
+                                                            format!("  > {row}")
+                                                        } else {
+                                                            format!("    {row}")
+                                                        },
+                                                    ),
+                                                    color: c_perm(),
+                                                })
+                                                .collect()
+                                        };
+                                        renderer.replace_from(input_anchor, lines);
                                         renderer.render_viewport()?;
                                         renderer.draw_bottom(
                                             &input,

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -42,6 +42,33 @@ fn wrap_editor_soft_wrap() {
     assert_eq!((r, c), (2, 2));
 }
 
+/// dirge-0dqe / dirge-5w9v: a long single (un-newlined) buffer with
+/// the cursor at the end soft-wraps to many rows, each ≤ wrap_w cells,
+/// and the cursor lands on the LAST row — the property both the
+/// questionnaire wrap and the compose-box scroll rely on to keep the
+/// typed tail visible.
+#[test]
+fn wrap_editor_long_buffer_tail_on_last_row() {
+    use unicode_width::UnicodeWidthStr;
+    let s = "word ".repeat(60); // ~300 cells, no hard newlines
+    let wrap_w = 20;
+    let (rows, cursor_row, _) = wrap_editor(&s, s.len(), wrap_w);
+    assert!(rows.len() > 1, "long buffer must wrap to multiple rows");
+    for row in &rows {
+        assert!(
+            UnicodeWidthStr::width(row.as_str()) <= wrap_w,
+            "each row must fit wrap_w; got {:?} ({} cells)",
+            row,
+            UnicodeWidthStr::width(row.as_str())
+        );
+    }
+    assert_eq!(
+        cursor_row as usize,
+        rows.len() - 1,
+        "cursor at end of buffer must land on the last (visible) row"
+    );
+}
+
 /// dirge-ov2 Phase A: chat switching saves the prior chat's
 /// buffer and selection, then loads the target chat's snapshot.
 /// Round-trip preserves content.


### PR DESCRIPTION
Closes **dirge-0dqe**.

The custom free-text answer in the question UI rendered as a single `format!("  > {buf}")` line that never wrapped — a long answer ran off the right edge and the tail (where you're typing) disappeared.

**Fix:** route it through `renderer::wrap_editor` — the same soft-wrap helper the compose box uses — at `content_width - 4` (the `"  > "`/`"    "` prefixes), emitting one `LineEntry` per wrapped row. The cursor sits at buffer end, so the tail always lands on the last row and stays visible. Both input surfaces now share one wrap helper.

New `wrap_editor` test pinning the long-buffer / tail-on-last-row property. **2124 pass** at `-D warnings`.