### PR TITLE
fix(ui): scroll the input box to keep the cursor row visible

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -142,6 +142,52 @@ fn next_line_start(s: &str, cursor: usize) -> Option<usize> {
     after.find('\n').map(|p| cursor + p + 1)
 }
 
+/// Byte offset to move the cursor to for a vertical (Up/Down) keystroke
+/// across SOFT-wrapped display rows (dirge-5w9v). Reuses the renderer's
+/// `wrap_editor` (the single soft-wrap source — no duplicated logic) to
+/// find the cursor's display `(row, col)`, then locates the byte on the
+/// adjacent row nearest that column. Returns `None` at the top/bottom
+/// display row (caller then falls through to history). Every returned
+/// offset is a real char boundary (the scan steps by `next_char_boundary`),
+/// so a subsequent slice can't panic. O(rows·len) but only on a keypress
+/// over a small compose buffer.
+///
+/// Only valid when the display buffer equals the raw buffer (no paste
+/// placeholders); callers guard on that.
+fn wrap_vertical_target(s: &str, cursor: usize, wrap_w: usize, up: bool) -> Option<usize> {
+    use crate::ui::renderer::wrap_editor;
+    let (rows, cur_row, cur_col) = wrap_editor(s, cursor, wrap_w);
+    let target_row: u16 = if up {
+        cur_row.checked_sub(1)?
+    } else {
+        let next = cur_row + 1;
+        if next as usize >= rows.len() {
+            return None;
+        }
+        next
+    };
+    // Scan char boundaries; on the target row, return the first offset
+    // whose display column reaches `cur_col`, else the row's last offset.
+    let mut best: Option<usize> = None;
+    let mut b = 0usize;
+    loop {
+        let (_, r, c) = wrap_editor(s, b, wrap_w);
+        if r == target_row {
+            if c >= cur_col {
+                return Some(b);
+            }
+            best = Some(b);
+        } else if r > target_row {
+            break;
+        }
+        if b >= s.len() {
+            break;
+        }
+        b = next_char_boundary(s, b);
+    }
+    best
+}
+
 /// Map a CHAR column on the line `[start..end]` of `s` to its
 /// byte offset within `s`. Clamps to `end` when the column exceeds
 /// the line's char count. Used by history Up/Down (H-batch1-2) so
@@ -188,6 +234,11 @@ pub struct InputEditor {
     pastes: Vec<Option<CompactString>>,
     /// Current slash-command completion state, for rendering a preview.
     pub completion: Option<CompletionResult>,
+    /// Display width the buffer is soft-wrapped to in the box, pushed in
+    /// from the renderer before each key dispatch. `0` = unknown (e.g.
+    /// before the first render) → Up/Down fall back to hard-newline
+    /// motion. Used to make vertical motion wrap-aware (dirge-5w9v).
+    wrap_w: usize,
 }
 
 /// Find the marker block `\x01<digits>\x01` containing or starting at
@@ -340,7 +391,14 @@ impl InputEditor {
             yank_state: None,
             pastes: Vec::new(),
             completion: None,
+            wrap_w: 0,
         }
+    }
+
+    /// Push the current display wrap width (from the renderer) so Up/Down
+    /// can move by SOFT-wrapped display rows, not just hard newlines.
+    pub fn set_wrap_width(&mut self, wrap_w: usize) {
+        self.wrap_w = wrap_w;
     }
 
     /// Insert pasted text. If it spans `PASTE_COLLAPSE_LINES` or more lines,
@@ -1081,7 +1139,22 @@ impl InputEditor {
                     self.history_up();
                     return None;
                 }
-                // Try moving up within the multiline buffer first.
+                // Wrap-aware vertical motion: move by displayed (soft-
+                // wrapped) rows when the width is known and the buffer
+                // has no paste placeholders (display == raw). At the top
+                // display row, fall through to history (dirge-5w9v).
+                if self.wrap_w > 0 && marker_blocks(&self.buffer).is_empty() {
+                    if let Some(pos) =
+                        wrap_vertical_target(&self.buffer, self.cursor, self.wrap_w, true)
+                    {
+                        self.cursor = pos;
+                    } else {
+                        self.history_up();
+                    }
+                    return None;
+                }
+                // Fallback (markers present / width unknown): hard-newline
+                // motion, then history.
                 if let Some(pos) = prev_line_start(&self.buffer, self.cursor) {
                     let line_start = cursor_line_start(&self.buffer, self.cursor);
                     // H-batch1-2 (audit fix): map by CHAR column, not
@@ -1110,7 +1183,20 @@ impl InputEditor {
                     self.history_down();
                     return None;
                 }
-                // Try moving down within the multiline buffer first.
+                // Wrap-aware vertical motion (see KeyCode::Up). At the
+                // bottom display row, fall through to history (dirge-5w9v).
+                if self.wrap_w > 0 && marker_blocks(&self.buffer).is_empty() {
+                    if let Some(pos) =
+                        wrap_vertical_target(&self.buffer, self.cursor, self.wrap_w, false)
+                    {
+                        self.cursor = pos;
+                    } else {
+                        self.history_down();
+                    }
+                    return None;
+                }
+                // Fallback (markers present / width unknown): hard-newline
+                // motion, then history.
                 if let Some(pos) = next_line_start(&self.buffer, self.cursor) {
                     let line_start = cursor_line_start(&self.buffer, self.cursor);
                     // H-batch1-2 (audit fix) — see KeyCode::Up.
@@ -1208,6 +1294,24 @@ impl InputEditor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // dirge-5w9v: vertical motion moves by SOFT-wrapped display rows.
+    // "abcdefghij" at wrap_w=4 wraps to ["abcd","efgh","ij"].
+    #[test]
+    fn wrap_vertical_target_moves_by_display_rows() {
+        let s = "abcdefghij";
+        let w = 4;
+        // From end (row 2, col 2), Up lands on row 1 at the same column
+        // ('g' = byte 6).
+        assert_eq!(wrap_vertical_target(s, s.len(), w, true), Some(6));
+        // From there (row 1, col 2), Down returns to row 2, column
+        // clamped to its length (end = byte 10).
+        assert_eq!(wrap_vertical_target(s, 6, w, false), Some(10));
+        // Top display row → None (caller falls through to history).
+        assert_eq!(wrap_vertical_target(s, 1, w, true), None);
+        // Bottom display row → None.
+        assert_eq!(wrap_vertical_target(s, 9, w, false), None);
+    }
 
     #[test]
     fn test_prev_word_boundary_basic() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1215,6 +1215,10 @@ pub async fn run_interactive(
                                 continue;
                             }
 
+                        // Keep the editor's wrap width in sync with the
+                        // rendered box so Up/Down move by wrapped display
+                        // rows (dirge-5w9v).
+                        input.set_wrap_width(renderer.input_wrap_w());
                         if let Some(text) = input.handle_key(key) {
                             // Review #4: any submission starts a new
                             // turn — drop the collapsed-result stash

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -463,9 +463,27 @@ impl Renderer {
                 lines: lines.as_slice(),
             }
         } else {
+            // dirge-5w9v: scroll the editor so the cursor's wrapped row
+            // stays visible once the content exceeds the capped box
+            // height. The painter draws from row 0 and `.take()`s the
+            // window, so without this the newest/cursor lines fell off
+            // the bottom and the user's typing appeared to vanish.
+            let completion_extra = if cached_completion_preview.is_empty() {
+                0
+            } else {
+                1
+            };
+            let window = (*input_rows as usize)
+                .saturating_sub(completion_extra)
+                .max(1);
+            let offset = editor_scroll_offset(
+                cached_input_rows.len(),
+                *cached_input_cursor_row as usize,
+                window,
+            );
             BottomBody::Editor {
-                rows: cached_input_rows.as_slice(),
-                cursor_row: *cached_input_cursor_row,
+                rows: &cached_input_rows[offset..],
+                cursor_row: cached_input_cursor_row.saturating_sub(offset as u16),
                 cursor_col: *cached_input_cursor_col,
                 is_running: *cached_is_running,
                 completion_preview: cached_completion_preview.as_str(),
@@ -1620,6 +1638,23 @@ pub(crate) fn wrap_editor(
         rows.push(String::new());
     }
     (rows, cursor_row, cursor_col)
+}
+
+/// Top scroll offset for the editor box so the cursor's wrapped row
+/// stays visible within a `window`-row viewport (dirge-5w9v). Returns
+/// the index of the first row to paint. `0` when everything fits.
+///
+/// Pre-fix the painter always drew from row 0 and `.take(window)`'d, so
+/// once the wrapped content exceeded the capped box height the newest /
+/// cursor lines fell off the bottom and the user's typing "vanished".
+pub(crate) fn editor_scroll_offset(total_rows: usize, cursor_row: usize, window: usize) -> usize {
+    if window == 0 || total_rows <= window {
+        return 0;
+    }
+    let max_offset = total_rows - window;
+    // Scroll just enough to land the cursor on the last visible row when
+    // it's past the window; clamp so we never scroll past the end.
+    cursor_row.saturating_sub(window - 1).min(max_offset)
 }
 
 // Used by the legacy modified-files panel; the new SubPanel widget

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -922,6 +922,14 @@ impl Renderer {
         self.content_width()
     }
 
+    /// The display width the compose buffer is soft-wrapped to in the
+    /// input box (content width minus the 3-col prompt prefix). Mirrors
+    /// the `wrap_w` computed in `draw_bottom`; pushed into the editor so
+    /// Up/Down can move by wrapped display rows (dirge-5w9v).
+    pub fn input_wrap_w(&self) -> usize {
+        self.content_width().saturating_sub(3).max(1)
+    }
+
     /// Raw width of the chat band (terminal width minus 2 cols for
     /// the chat frame's left + right ║). Used for *positioning*
     /// math (`content_indent`, panel widths) — chat text wrapping

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -69,6 +69,26 @@ fn wrap_editor_long_buffer_tail_on_last_row() {
     );
 }
 
+/// dirge-5w9v: editor_scroll_offset keeps the cursor row inside the
+/// window once wrapped content exceeds the capped box height.
+#[test]
+fn editor_scroll_offset_keeps_cursor_visible() {
+    // Everything fits → no scroll.
+    assert_eq!(editor_scroll_offset(5, 4, 8), 0);
+    assert_eq!(editor_scroll_offset(8, 7, 8), 0);
+    // Content exceeds window; cursor near the end → scroll so the
+    // cursor lands on the last visible row.
+    assert_eq!(editor_scroll_offset(20, 19, 8), 12); // 19 - (8-1)
+    assert_eq!(editor_scroll_offset(20, 10, 8), 3); // 10 - 7
+    // Cursor still within the first window → no scroll.
+    assert_eq!(editor_scroll_offset(20, 5, 8), 0);
+    // Never scroll past the end.
+    assert_eq!(editor_scroll_offset(10, 9, 8), 2); // max_offset = 10-8
+    // Degenerate windows.
+    assert_eq!(editor_scroll_offset(10, 9, 0), 0);
+    assert_eq!(editor_scroll_offset(0, 0, 8), 0);
+}
+
 /// dirge-ov2 Phase A: chat switching saves the prior chat's
 /// buffer and selection, then loads the target chat's snapshot.
 /// Round-trip preserves content.


### PR DESCRIPTION
Addresses the scroll half of **dirge-5w9v** (the critical "typed text isn't rendered" bug).

The compose box wraps to N rows, but the box height is capped (`MAX_INPUT_VISIBLE_LINES = 8`) and the painter always drew from row 0 then `.take(window)`. So once wrapped content exceeded 8 rows, the newest/cursor lines fell off the bottom and typing appeared to **vanish** — there was no scroll.

**Fix:** pure `editor_scroll_offset(total_rows, cursor_row, window)`, applied where the `BottomBody::Editor` frame is built — slice `cached_input_rows[offset..]` and pass a cursor_row relative to the slice. The hardware cursor (placed at `box.y + 1 + cursor_row`) lands correctly with no scene-side change. The box still grows to the cap, then scrolls to track the cursor.

New unit test for `editor_scroll_offset`. **2124 pass** at `-D warnings`.

**Follow-up:** the Up/Down arrow nav across *soft-wrapped* rows (the other half of dirge-5w9v) is split to **dirge-4ie9** — it needs display↔raw cursor mapping (the editor's paste-marker projection) done carefully, which I didn't want to rush.

| In-flight PRs | |
|---|---|
| #215 | retry connect/send failures (issue 1) |
| #216 | questionnaire soft-wrap (issue 3) |
| this | input-box scroll (issue 2a) |