### PR TITLE
chore: add author; full feature set on by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 # edition 2024 was stabilized in Rust 1.85; pin the MSRV so older
 # toolchains get a clear error instead of a cryptic edition failure.
 rust-version = "1.85"
-authors = ["Giuseppe Della Vedova"]
+authors = ["Giuseppe Della Vedova", "Yogthos <yogthos@gmail.com>"]
 description = "Minimalistic coding agent written in Rust, optimized for memory footprint and performance"
 license = "GPL-3.0-only"
 homepage = "https://github.com/dirge-code/dirge"
@@ -45,7 +45,29 @@ path = "src/main.rs"
 ignored = ["rig-core"]
 
 [features]
-default = ['loop', 'git-worktree', 'mcp', 'lsp']
+# Batteries-included by default: `cargo install dirge-agent` and the
+# release binaries get the whole tool (MCP, LSP, ACP, plugins, and every
+# tree-sitter language). The two `experimental-ui-*` flags stay opt-in.
+# To build a leaner binary, use `--no-default-features --features "…"`.
+default = [
+    'loop',
+    'git-worktree',
+    'mcp',
+    'lsp',
+    'acp',
+    'plugin',
+    'semantic-ts',
+    'semantic-python',
+    'semantic-bash',
+    'semantic-clojure',
+    'semantic-go',
+    'semantic-ruby',
+    'semantic-rust',
+    'semantic-java',
+    'semantic-c',
+    'semantic-cpp',
+    'semantic-elixir',
+]
 loop = []
 git-worktree = []
 mcp = [

--- a/README.md
+++ b/README.md
@@ -64,17 +64,20 @@ Transient API errors (network, rate limits, Anthropic `overloaded_error`) are au
 > already taken on crates.io). The installed command is still `dirge`.
 
 ```bash
-# Default — MCP, loop, LSP, and git-worktree included
+# Batteries included — MCP, LSP, ACP, plugins, and every tree-sitter
+# language are on by default.
 cargo install dirge-agent
+```
 
-# With semantic code tools (tree-sitter)
-cargo install dirge-agent --features "semantic,semantic-ts,semantic-python,semantic-bash,semantic-clojure,semantic-go,semantic-ruby,semantic-rust,semantic-java,semantic-c,semantic-cpp"
+Want a leaner binary? Opt out of the defaults and pick only what you need:
 
-# With ACP (Agent Communication Protocol) support for editor integration
-cargo install dirge-agent --features acp
+```bash
+# Minimal: just the core agent + MCP, no semantic tools / plugins / ACP
+cargo install dirge-agent --no-default-features --features "loop,git-worktree,mcp,lsp"
 
-# All features
-cargo install dirge-agent --features "acp,loop,git-worktree,mcp,lsp,semantic,semantic-ts,semantic-python,semantic-bash,semantic-clojure,semantic-go,semantic-ruby,semantic-rust,semantic-java,semantic-c,semantic-cpp,plugin"
+# Core + only the languages you use
+cargo install dirge-agent --no-default-features \
+  --features "loop,git-worktree,mcp,lsp,semantic-rust,semantic-python"
 ```
 
 Prebuilt binaries for Linux (glibc + static musl), macOS (Intel + Apple


### PR DESCRIPTION
Two small release-prep changes:

- **Author:** add `Yogthos <yogthos@gmail.com>` (keeping the original zerostack author, per GPL).
- **Full feature set by default:** `default` now includes `loop, git-worktree, mcp, lsp, acp, plugin` + every `semantic-*` tree-sitter language. So both `cargo install dirge-agent` **and** the tag-triggered release binaries (which run `cargo build --release` with no feature flags) ship the complete tool. The two `experimental-ui-*` flags stay opt-in; README documents `--no-default-features` for lean builds.

`cargo check` with the new default compiles clean; CI will validate the full default build/test.

> Note: with `plugin` (Janet/C) + all tree-sitter (C) now default, the **musl static** release target cross-compiles a lot of C — worth watching the first `v*` tag build; if musl chokes on the C deps we can drop it from the matrix or build it with reduced features.