### PR TITLE
feat(agent-loop): compaction circuit breaker (IMPROVEMENTS_PLAN #1)

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -169,18 +169,52 @@ fn transcript_from_value_slice(messages: &[serde_json::Value]) -> String {
     out
 }
 
+/// Consecutive summarizer failures (per run) before the compaction
+/// circuit breaker opens and the LLM summarizer is skipped for the rest
+/// of the run — the cheap `prune_tool_outputs` pass still runs, so
+/// context can't grow unbounded. 3 tolerates two transient failures; a
+/// third means the summarizer is systematically broken and retrying it
+/// every fold just wastes API calls (IMPROVEMENTS_PLAN #1).
+const MAX_CONSECUTIVE_COMPACTION_FAILURES: u32 = 3;
+
+/// What the LLM-summary stage of a compaction pass did, so `run_loop`
+/// can drive the circuit-breaker counter. (The cheap prune always runs
+/// regardless of this outcome.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SummaryOutcome {
+    /// A valid summary was produced (LLM or plugin) and applied.
+    Succeeded,
+    /// The summarizer ran but returned an error or an invalid summary.
+    Failed,
+    /// The summarizer was not run: none wired, breaker open, or no
+    /// foldable middle. Not a failure — doesn't trip the breaker.
+    Skipped,
+}
+
+/// Fold a compaction pass outcome into the per-run failure counter:
+/// reset on success, increment on failure, leave untouched on skip.
+fn record_compaction_outcome(failures: &mut u32, outcome: SummaryOutcome) {
+    match outcome {
+        SummaryOutcome::Succeeded => *failures = 0,
+        SummaryOutcome::Failed => *failures = failures.saturating_add(1),
+        SummaryOutcome::Skipped => {}
+    }
+}
+
 async fn run_compaction_pass(
     current_context: &mut Context,
     summarize_fn: &Option<crate::agent::compression::SummarizeFn>,
     protect_tail: usize,
+    compaction_failures: u32,
     memory_provider: &Option<std::sync::Arc<dyn crate::extras::memory_provider::MemoryProvider>>,
     compaction_hooks: Option<&crate::agent::agent_loop::types::CompactionHooks>,
     emit: &mpsc::Sender<LoopEvent>,
-) {
+) -> SummaryOutcome {
     run_compaction_pass_with_focus(
         current_context,
         summarize_fn,
         protect_tail,
+        compaction_failures,
         None,
         memory_provider,
         compaction_hooks,
@@ -204,11 +238,12 @@ async fn run_compaction_pass_with_focus(
     current_context: &mut Context,
     summarize_fn: &Option<crate::agent::compression::SummarizeFn>,
     protect_tail: usize,
+    compaction_failures: u32,
     focus_topic: Option<String>,
     memory_provider: &Option<std::sync::Arc<dyn crate::extras::memory_provider::MemoryProvider>>,
     compaction_hooks: Option<&crate::agent::agent_loop::types::CompactionHooks>,
     emit: &mpsc::Sender<LoopEvent>,
-) {
+) -> SummaryOutcome {
     use crate::agent::compression;
 
     let before = compression::estimate_messages_tokens(&current_context.messages);
@@ -236,7 +271,20 @@ async fn run_compaction_pass_with_focus(
     // their content in place. compress_reporting handles that
     // gracefully (zero-width fold).
     let mut applied_first_kept = current_context.messages.len();
-    if let Some(sfn) = summarize_fn {
+    // Drives the per-run circuit breaker: Skipped unless the summarizer
+    // actually runs and resolves to a valid summary (Succeeded) or an
+    // error / invalid summary (Failed).
+    let mut outcome = SummaryOutcome::Skipped;
+    if compaction_failures >= MAX_CONSECUTIVE_COMPACTION_FAILURES {
+        // Circuit breaker open: the summarizer has failed too many times
+        // this run. Skip the LLM call entirely and keep the pruned
+        // context (IMPROVEMENTS_PLAN #1).
+        tracing::warn!(
+            target: "dirge::agent_loop",
+            failures = compaction_failures,
+            "compaction summarizer failed {compaction_failures} consecutive times — circuit breaker open, skipping LLM summarization",
+        );
+    } else if let Some(sfn) = summarize_fn {
         let (start, end) = compression::compute_compress_window(
             &current_context.messages,
             compression::PROTECT_HEAD_DEFAULT,
@@ -295,12 +343,14 @@ async fn run_compaction_pass_with_focus(
                     // is therefore `start` — anything below was
                     // protected, anything above was folded.
                     applied_first_kept = start;
+                    outcome = SummaryOutcome::Succeeded;
                 }
                 Ok(_) => {
                     tracing::warn!(
                         target: "dirge::agent_loop",
                         "compaction summarizer returned an unvalidated summary — keeping pruned context",
                     );
+                    outcome = SummaryOutcome::Failed;
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -308,6 +358,7 @@ async fn run_compaction_pass_with_focus(
                         error = %e,
                         "compaction summarizer failed — keeping pruned context",
                     );
+                    outcome = SummaryOutcome::Failed;
                 }
             }
         }
@@ -323,6 +374,8 @@ async fn run_compaction_pass_with_focus(
             first_kept_index: applied_first_kept,
         })
         .await;
+
+    outcome
 }
 
 /// Public entry point: start a new run from one or more prompt
@@ -435,6 +488,12 @@ pub async fn run_loop(
     // Reset each new user turn; set true when a fold happens.
     let mut folded_this_turn: bool;
 
+    // Circuit breaker: consecutive summarizer failures this run. After
+    // MAX_CONSECUTIVE_COMPACTION_FAILURES, compaction skips the LLM
+    // summarizer (cheap pruning still runs). Per-run — a fresh run_loop
+    // starts at 0 (IMPROVEMENTS_PLAN #1).
+    let mut compaction_failures: u32 = 0;
+
     // Pi line 167: initial steering poll.
     // Phase 4 part 2: composes with the file-touch tracker's
     // reminder poll when configured.
@@ -502,15 +561,17 @@ pub async fn run_loop(
                         "context-manager: turn-start fold firing ({}% of context)",
                         (estimate.ratio * 100.0) as u32,
                     );
-                    run_compaction_pass(
+                    let outcome = run_compaction_pass(
                         &mut current_context,
                         &summarize_fn,
                         5, // protect last 5 messages
+                        compaction_failures,
                         &memory_provider,
                         config.compaction_hooks.as_ref(),
                         emit,
                     )
                     .await;
+                    record_compaction_outcome(&mut compaction_failures, outcome);
                     folded_this_turn = true;
                 }
             }
@@ -823,15 +884,17 @@ pub async fn run_loop(
                         if let Some(prompt_tokens) = token_usage.map(|u| u.input_tokens)
                             && crate::agent::compression::should_compress(prompt_tokens, ctx_max)
                         {
-                            run_compaction_pass(
+                            let outcome = run_compaction_pass(
                                 &mut current_context,
                                 &summarize_fn,
                                 5, // protect last 5 messages
+                                compaction_failures,
                                 &memory_provider,
                                 config.compaction_hooks.as_ref(),
                                 emit,
                             )
                             .await;
+                            record_compaction_outcome(&mut compaction_failures, outcome);
                         }
                     }
                     PostUsageDecisionKind::ExitWithSummary => {
@@ -843,15 +906,17 @@ pub async fn run_loop(
                         // When context is critically over the threshold,
                         // prune aggressively then run the structured-summary
                         // pass if a summarizer is wired.
-                        run_compaction_pass(
+                        let outcome = run_compaction_pass(
                             &mut current_context,
                             &summarize_fn,
                             3, // protect only last 3
+                            compaction_failures,
                             &memory_provider,
                             config.compaction_hooks.as_ref(),
                             emit,
                         )
                         .await;
+                        record_compaction_outcome(&mut compaction_failures, outcome);
                     }
                     _ => {}
                 }

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -152,7 +152,7 @@ async fn run_compaction_pass_inserts_summary_and_rotates_session() {
         }));
 
     let (tx, mut rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, &None, None, &tx).await;
+    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, None, &tx).await;
     drop(tx);
 
     // (a) older messages dropped.
@@ -250,7 +250,7 @@ async fn compaction_on_compact_hook_overrides_llm_summary() {
     };
 
     let (tx, _rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, &None, Some(&hooks), &tx).await;
+    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, Some(&hooks), &tx).await;
     drop(tx);
 
     // on-before-compact observed the fold.
@@ -329,7 +329,7 @@ async fn compaction_invalid_plugin_summary_falls_through_to_llm() {
     };
 
     let (tx, _rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, &None, Some(&hooks), &tx).await;
+    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, Some(&hooks), &tx).await;
     drop(tx);
 
     assert_eq!(
@@ -371,7 +371,7 @@ async fn run_compaction_pass_without_summarizer_prunes_only() {
     // Use protect_tail = 2 so the large tool result is eligible
     // for pruning (it's at index 1, end = 4 - 2 = 2, so index
     // 1 is in-range).
-    super::run_compaction_pass(&mut ctx, &None, 2, &None, None, &tx).await;
+    super::run_compaction_pass(&mut ctx, &None, 2, 0, &None, None, &tx).await;
     drop(tx);
 
     // No SUMMARY_PREFIX message inserted.
@@ -2127,5 +2127,105 @@ async fn dirge_el3n_proactive_fold_does_not_fire_under_threshold() {
     assert!(
         total >= 4_000,
         "under-threshold ratio must not trigger fold; saw {total} chars (input was 4000)",
+    );
+}
+
+// IMPROVEMENTS_PLAN #1: the compaction circuit breaker. After
+// MAX_CONSECUTIVE_COMPACTION_FAILURES failures the LLM summarizer is no
+// longer invoked (cheap pruning still runs).
+#[test]
+fn record_compaction_outcome_drives_counter() {
+    let mut f = 0u32;
+    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Failed);
+    assert_eq!(f, 1);
+    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Failed);
+    assert_eq!(f, 2);
+    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Skipped);
+    assert_eq!(f, 2, "skip must not change the counter");
+    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Succeeded);
+    assert_eq!(f, 0, "success resets the counter");
+}
+
+#[tokio::test]
+async fn compaction_circuit_breaker_skips_summarizer_after_max_failures() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let calls_inner = calls.clone();
+    // Summarizer that always fails — and counts its invocations.
+    let summarize_fn: Option<crate::agent::compression::SummarizeFn> =
+        Some(std::sync::Arc::new(move |_prompt: String| {
+            let c = calls_inner.clone();
+            Box::pin(async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(anyhow::anyhow!("summarizer boom"))
+            })
+        }));
+
+    let make_ctx = || {
+        let mut ctx = empty_context();
+        ctx.messages
+            .push(serde_json::json!({"role":"system","content":"agent"}));
+        ctx.messages
+            .push(serde_json::json!({"role":"user","content":"task"}));
+        for i in 0..20 {
+            let role = if i % 2 == 0 { "assistant" } else { "user" };
+            ctx.messages.push(serde_json::json!({
+                "role": role, "content": format!("turn {i} with filler content")
+            }));
+        }
+        ctx.messages
+            .push(serde_json::json!({"role":"user","content":"latest"}));
+        ctx
+    };
+
+    let (tx, _rx) = mpsc::channel::<LoopEvent>(64);
+
+    // Sub-threshold: the summarizer IS called and reports Failed.
+    for failures in 0..super::MAX_CONSECUTIVE_COMPACTION_FAILURES {
+        let mut ctx = make_ctx();
+        let outcome =
+            super::run_compaction_pass(&mut ctx, &summarize_fn, 5, failures, &None, None, &tx)
+                .await;
+        assert_eq!(
+            outcome,
+            super::SummaryOutcome::Failed,
+            "failures={failures}: summarizer should run and fail"
+        );
+    }
+    let calls_before_open = calls.load(Ordering::SeqCst);
+    assert_eq!(
+        calls_before_open,
+        super::MAX_CONSECUTIVE_COMPACTION_FAILURES as usize,
+        "summarizer should run once per sub-threshold attempt"
+    );
+
+    // At the threshold: breaker open → summarizer NOT called again, and
+    // the cheap prune-only fallback still runs (context doesn't grow).
+    let mut ctx = make_ctx();
+    let n_before = ctx.messages.len();
+    let outcome = super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        super::MAX_CONSECUTIVE_COMPACTION_FAILURES,
+        &None,
+        None,
+        &tx,
+    )
+    .await;
+    assert_eq!(
+        outcome,
+        super::SummaryOutcome::Skipped,
+        "breaker open → summarizer skipped"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        calls_before_open,
+        "breaker open: summarizer must NOT be invoked"
+    );
+    assert!(
+        ctx.messages.len() <= n_before,
+        "prune-only fallback must not grow context"
     );
 }


### PR DESCRIPTION
First of the 5 IMPROVEMENTS_PLAN phases — one PR per feature for review.

## Problem
A failing summarizer (network errors / invalid summaries / model garbage) was retried on **every** fold trigger, silently falling back to pruned-only context each time — burning API calls for the whole run.

## Fix
Per-run consecutive-failure counter:
- `run_compaction_pass[_with_focus]` now takes the current failure count and returns a `SummaryOutcome` (`Succeeded`/`Failed`/`Skipped`).
- `run_loop` folds that into `compaction_failures` via `record_compaction_outcome` at all three call sites (turn-start fold, post-usage fold, exit-with-summary).
- At `MAX_CONSECUTIVE_COMPACTION_FAILURES = 3`, the pass skips the LLM summarizer (logs *circuit breaker open*); the cheap `prune_tool_outputs` still runs, so context stays bounded.
- Per-run (resets on success and on a fresh `run_loop`), matching the plan's design decision.

## Tests
- Pure counter logic (`record_compaction_outcome`: reset/increment/skip).
- End-to-end: summarizer invoked once per sub-threshold attempt, then **not** called once the breaker opens, with the prune-only fallback still shrinking context.

**2135 pass** under the full feature matrix at `-D warnings`.

Next phases (each its own PR): #3 aggressive prune tier → #4 snip feedback loop → #2 post-compaction file restore → #5 report enrichment.