### PR TITLE
feat(agent-loop): aggressive prune tier at 60% context (#3)

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -616,9 +616,23 @@ pub async fn run_loop(
             // 1-line summarization — this cap is the per-result
             // safety net so a single 50KB tool output doesn't
             // dominate the prompt until fold fires.
+            //
+            // Tiered (IMPROVEMENTS_PLAN #3): above 60% estimated context
+            // the cap tightens (3000 → 1000 tokens) so a single oversized
+            // result can't push the NEXT request over the limit before
+            // the (reactive) post-response fold fires.
+            let cap_ctx_max = config
+                .model_name
+                .as_deref()
+                .and_then(crate::config::context_window_for_model)
+                .unwrap_or(128_000);
+            let cap_estimate =
+                crate::agent::compression::estimate_messages_tokens(&current_context.messages);
+            let result_cap =
+                crate::agent::compression::tiered_result_cap(cap_estimate, cap_ctx_max);
             current_context.messages = crate::agent::compression::cap_oversized_tool_results(
                 &current_context.messages,
-                crate::agent::compression::TURN_END_RESULT_CAP_TOKENS,
+                result_cap,
             );
 
             // Pi lines 192-194: LLM call.

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -75,6 +75,31 @@ const SUMMARY_TOKENS_CEILING: u64 = 12_000;
 /// the model can re-call if it needs more.
 pub const TURN_END_RESULT_CAP_TOKENS: u64 = 3000;
 
+/// When the estimated context exceeds this fraction of the model window,
+/// switch the per-result cap to the tighter `AGGRESSIVE_RESULT_CAP_TOKENS`
+/// to head off an overflow BEFORE the (reactive, post-response) fold
+/// trigger fires. Intentionally below the 75% fold threshold so the
+/// tighter cap has room to work first (IMPROVEMENTS_PLAN #3).
+pub const AGGRESSIVE_CAP_THRESHOLD: f64 = 0.60;
+
+/// Per-result token cap in the aggressive tier — still enough to see an
+/// error message + key output lines, tight enough that one `grep`/`find`
+/// result can't eat ~10% of the window before a fold runs.
+pub const AGGRESSIVE_RESULT_CAP_TOKENS: u64 = 1000;
+
+/// Pick the per-result cap for `cap_oversized_tool_results` based on how
+/// full the context already is: the tighter aggressive cap once
+/// estimated usage crosses `AGGRESSIVE_CAP_THRESHOLD`, else the normal
+/// cap (IMPROVEMENTS_PLAN #3). Pure so the tiering is unit-testable.
+pub fn tiered_result_cap(estimate_tokens: u64, ctx_max: u64) -> u64 {
+    let ratio = estimate_tokens as f64 / ctx_max.max(1) as f64;
+    if ratio > AGGRESSIVE_CAP_THRESHOLD {
+        AGGRESSIVE_RESULT_CAP_TOKENS
+    } else {
+        TURN_END_RESULT_CAP_TOKENS
+    }
+}
+
 /// Chars-per-token rough estimate. Port of Hermes's _CHARS_PER_TOKEN.
 const CHARS_PER_TOKEN: u64 = 4;
 
@@ -667,6 +692,29 @@ pub fn rotate_session_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // IMPROVEMENTS_PLAN #3: the per-result cap tightens above 60% ctx.
+    #[test]
+    fn tiered_result_cap_switches_at_threshold() {
+        let ctx = 128_000u64;
+        // Well below 60% → normal cap.
+        assert_eq!(
+            tiered_result_cap(ctx / 4, ctx), // 25%
+            TURN_END_RESULT_CAP_TOKENS
+        );
+        // Exactly at 60% is NOT over the threshold (strict `>`).
+        assert_eq!(
+            tiered_result_cap((ctx as f64 * 0.60) as u64, ctx),
+            TURN_END_RESULT_CAP_TOKENS
+        );
+        // Above 60% → aggressive cap.
+        assert_eq!(
+            tiered_result_cap((ctx as f64 * 0.70) as u64, ctx),
+            AGGRESSIVE_RESULT_CAP_TOKENS
+        );
+        // Degenerate ctx_max doesn't panic (div-by-zero guard).
+        let _ = tiered_result_cap(100, 0);
+    }
 
     // ── should_compress ─────────────────────────────────
 


### PR DESCRIPTION
Phase 2 of IMPROVEMENTS_PLAN. **Stacked on #220** (base = circuit-breaker branch).

## Problem
`cap_oversized_tool_results` used a flat 3000-token cap at every context level. Near the limit, one uncapped tool result could push the next request over before the reactive 75% post-response fold fires.

## Fix
Tiered cap via a pure `tiered_result_cap(estimate, ctx_max)`: above `AGGRESSIVE_CAP_THRESHOLD = 0.60` the per-result cap tightens to `AGGRESSIVE_RESULT_CAP_TOKENS = 1000`; below, it stays 3000. 60% sits under the 75% fold trigger so the tighter cap has room to work first. Wired at the pre-send cap site in `run_loop`.

Unit test covers normal (<60%), the strict 60% boundary, aggressive (>60%), and a div-by-zero guard. **2136 pass** at `-D warnings`.

> Review note: this PR targets the #220 branch (stacked). Merge #220 first; this will retarget to main automatically.

Next: #4 snip feedback loop (builds on this), then #2 file restore, then #5 report enrichment.