### PR TITLE
feat(agent-loop): snip-tokens-freed feedback loop (#4)

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -494,6 +494,11 @@ pub async fn run_loop(
     // starts at 0 (IMPROVEMENTS_PLAN #1).
     let mut compaction_failures: u32 = 0;
 
+    // Tokens the pre-send snip freed this iteration. If it freed enough
+    // headroom, the post-response NORMAL fold is skipped
+    // (IMPROVEMENTS_PLAN #4). Reset after each post-usage decision.
+    let mut snip_tokens_freed: u64 = 0;
+
     // Pi line 167: initial steering poll.
     // Phase 4 part 2: composes with the file-touch tracker's
     // reminder poll when configured.
@@ -630,10 +635,15 @@ pub async fn run_loop(
                 crate::agent::compression::estimate_messages_tokens(&current_context.messages);
             let result_cap =
                 crate::agent::compression::tiered_result_cap(cap_estimate, cap_ctx_max);
-            current_context.messages = crate::agent::compression::cap_oversized_tool_results(
+            // Counted variant (IMPROVEMENTS_PLAN #4): track how much the
+            // snip freed so the post-response fold can be skipped if it
+            // bought enough headroom.
+            let (capped, freed) = crate::agent::compression::cap_oversized_tool_results_counted(
                 &current_context.messages,
                 result_cap,
             );
+            current_context.messages = capped;
+            snip_tokens_freed = snip_tokens_freed.saturating_add(freed);
 
             // Pi lines 192-194: LLM call.
             let (assistant_msg, token_usage) = stream_assistant_response(
@@ -883,32 +893,51 @@ pub async fn run_loop(
                 match decision.kind {
                     PostUsageDecisionKind::Fold if !folded_this_turn => {
                         folded_this_turn = true;
-                        tracing::info!(
-                            target: "dirge::agent_loop",
-                            ratio = %decision.ratio,
-                            aggressive = decision.aggressive,
-                            tail_budget = ?decision.tail_budget,
-                            "context-manager: fold recommended ({})",
-                            if decision.aggressive { "aggressive" } else { "normal" },
-                        );
+                        // IMPROVEMENTS_PLAN #4: if the pre-send snip
+                        // already freed enough headroom, skip a NORMAL
+                        // fold this turn (aggressive folds still fire).
+                        if crate::agent::compression::snip_bought_enough(
+                            snip_tokens_freed,
+                            ctx_max,
+                            decision.aggressive,
+                        ) {
+                            tracing::info!(
+                                target: "dirge::agent_loop",
+                                freed = snip_tokens_freed,
+                                ratio = %decision.ratio,
+                                "snip freed {snip_tokens_freed} tokens — sufficient, skipping fold",
+                            );
+                        } else {
+                            tracing::info!(
+                                target: "dirge::agent_loop",
+                                ratio = %decision.ratio,
+                                aggressive = decision.aggressive,
+                                tail_budget = ?decision.tail_budget,
+                                "context-manager: fold recommended ({})",
+                                if decision.aggressive { "aggressive" } else { "normal" },
+                            );
 
-                        // Context compaction: prune old tool results and
-                        // compress the middle section of the conversation.
-                        // Port of Hermes's compression pass.
-                        if let Some(prompt_tokens) = token_usage.map(|u| u.input_tokens)
-                            && crate::agent::compression::should_compress(prompt_tokens, ctx_max)
-                        {
-                            let outcome = run_compaction_pass(
-                                &mut current_context,
-                                &summarize_fn,
-                                5, // protect last 5 messages
-                                compaction_failures,
-                                &memory_provider,
-                                config.compaction_hooks.as_ref(),
-                                emit,
-                            )
-                            .await;
-                            record_compaction_outcome(&mut compaction_failures, outcome);
+                            // Context compaction: prune old tool results and
+                            // compress the middle section of the conversation.
+                            // Port of Hermes's compression pass.
+                            if let Some(prompt_tokens) = token_usage.map(|u| u.input_tokens)
+                                && crate::agent::compression::should_compress(
+                                    prompt_tokens,
+                                    ctx_max,
+                                )
+                            {
+                                let outcome = run_compaction_pass(
+                                    &mut current_context,
+                                    &summarize_fn,
+                                    5, // protect last 5 messages
+                                    compaction_failures,
+                                    &memory_provider,
+                                    config.compaction_hooks.as_ref(),
+                                    emit,
+                                )
+                                .await;
+                                record_compaction_outcome(&mut compaction_failures, outcome);
+                            }
                         }
                     }
                     PostUsageDecisionKind::ExitWithSummary => {
@@ -934,6 +963,10 @@ pub async fn run_loop(
                     }
                     _ => {}
                 }
+                // Snip credit is per-iteration: it informed THIS post-usage
+                // decision; clear it so a later iteration's fold isn't
+                // suppressed by a stale snip (IMPROVEMENTS_PLAN #4).
+                snip_tokens_freed = 0;
             }
 
             // Pi lines 220-239: prepareNextTurn.

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -100,6 +100,19 @@ pub fn tiered_result_cap(estimate_tokens: u64, ctx_max: u64) -> u64 {
     }
 }
 
+/// When the pre-send snip (`cap_oversized_tool_results`) frees at least
+/// this fraction of the context window, a NORMAL post-response fold can
+/// be skipped — the snip already bought enough headroom
+/// (IMPROVEMENTS_PLAN #4).
+pub const SNIP_SUFFICIENT_FRACTION: f64 = 0.10;
+
+/// Whether a snip that freed `freed` tokens bought enough headroom to
+/// skip a normal fold this turn. Aggressive / force-summary folds always
+/// proceed regardless — at 80%+ you need the summary. Pure for testing.
+pub fn snip_bought_enough(freed: u64, ctx_max: u64, aggressive: bool) -> bool {
+    !aggressive && (freed as f64 / ctx_max.max(1) as f64) > SNIP_SUFFICIENT_FRACTION
+}
+
 /// Chars-per-token rough estimate. Port of Hermes's _CHARS_PER_TOKEN.
 const CHARS_PER_TOKEN: u64 = 4;
 
@@ -243,6 +256,23 @@ pub fn cap_oversized_tool_results(messages: &[Value], max_tokens: u64) -> Vec<Va
             }
         })
         .collect()
+}
+
+/// Like [`cap_oversized_tool_results`] but also reports how many tokens
+/// the capping freed (IMPROVEMENTS_PLAN #4), measured with the same
+/// estimator the fold decision uses — so the loop can tell whether the
+/// snip already bought enough headroom to skip a fold. Delegates to the
+/// unchanged capper so its behavior (and every existing caller) is
+/// untouched.
+pub fn cap_oversized_tool_results_counted(
+    messages: &[Value],
+    max_tokens: u64,
+) -> (Vec<Value>, u64) {
+    let before = estimate_messages_tokens(messages);
+    let capped = cap_oversized_tool_results(messages, max_tokens);
+    let after = estimate_messages_tokens(&capped);
+    let freed = before.saturating_sub(after);
+    (capped, freed)
 }
 
 /// Minimum per-block content budget when splitting `max_chars`
@@ -714,6 +744,40 @@ mod tests {
         );
         // Degenerate ctx_max doesn't panic (div-by-zero guard).
         let _ = tiered_result_cap(100, 0);
+    }
+
+    // IMPROVEMENTS_PLAN #4: snip feedback loop.
+    #[test]
+    fn snip_bought_enough_gates_normal_folds_only() {
+        let ctx = 128_000u64;
+        // > 10% freed, normal fold → enough.
+        assert!(snip_bought_enough((ctx as f64 * 0.11) as u64, ctx, false));
+        // < 10% freed → not enough.
+        assert!(!snip_bought_enough((ctx as f64 * 0.05) as u64, ctx, false));
+        // Aggressive fold always proceeds, even if a lot was freed.
+        assert!(!snip_bought_enough(ctx, ctx, true));
+        // div-by-zero guard.
+        assert!(!snip_bought_enough(0, 0, false));
+    }
+
+    #[test]
+    fn cap_counted_reports_freed_tokens() {
+        // One oversized tool result.
+        let big = "x".repeat(40_000); // ~10k tokens
+        let msgs = vec![serde_json::json!({"role": "tool", "content": big})];
+        let (capped, freed) = cap_oversized_tool_results_counted(&msgs, 1000);
+        // Same result as the uncounted capper.
+        assert_eq!(capped, cap_oversized_tool_results(&msgs, 1000));
+        // It freed a meaningful number of tokens (oversized → trimmed).
+        assert!(
+            freed > 5_000,
+            "expected substantial freed tokens, got {freed}"
+        );
+
+        // A result already under the cap frees nothing.
+        let small = vec![serde_json::json!({"role": "tool", "content": "ok"})];
+        let (_, freed0) = cap_oversized_tool_results_counted(&small, 1000);
+        assert_eq!(freed0, 0);
     }
 
     // ── should_compress ─────────────────────────────────


### PR DESCRIPTION
Phase 3 of IMPROVEMENTS_PLAN. **Stacked on #221** (base = aggressive-prune branch).

## Problem
The pre-send snip freed tokens silently; the 75% post-response fold fired regardless of whether the snip had already bought enough headroom — wasting a summarizer call.

## Fix
- `cap_oversized_tool_results_counted` wraps the **unchanged** capper and reports freed tokens (measured with `estimate_messages_tokens`, the same estimator the fold decision uses). No churn to the ~12 existing callers.
- `run_loop` tracks `snip_tokens_freed` from the tiered cap site.
- A pure `snip_bought_enough(freed, ctx_max, aggressive)` skips a **normal** fold when the snip freed > `SNIP_SUFFICIENT_FRACTION` (10%) of the window. **Aggressive / force-summary folds always proceed.** Credit resets after each post-usage decision (no stale carry-over).

Tests: gating logic (normal vs aggressive, <10%, div-0) + freed-token accuracy. **2138 pass** at `-D warnings`.

> Stacked: targets #221. Merge order #220 → #221 → this. Next: #2 file restore, then #5 report enrichment.