### PR TITLE
feat(agent-loop): post-compaction file restoration (#2)

### DIFF
--- a/src/agent/agent_loop/context_depth.rs
+++ b/src/agent/agent_loop/context_depth.rs
@@ -142,6 +142,18 @@ impl FileTouchTracker {
         let wrapped = format!("{}\n{}", MID_TURN_STEER_WRAPPER, body);
         vec![LoopMessage::User(UserMessage { content: wrapped })]
     }
+
+    /// The current working-set files (the `last_files` overlap), sorted
+    /// for deterministic ordering. Consulted after compaction to re-read
+    /// and re-inject the files the agent was actively editing, so a fold
+    /// doesn't strand it without the concrete file state
+    /// (IMPROVEMENTS_PLAN #2).
+    pub fn working_files(&self) -> Vec<PathBuf> {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut files: Vec<PathBuf> = inner.last_files.iter().cloned().collect();
+        files.sort();
+        files
+    }
 }
 
 /// Walk `args` looking for top-level `path` / `paths` / `file_path`
@@ -218,6 +230,22 @@ mod tests {
         t.record_tool_call("edit", &json!({"file_path": "foo.rs"}));
         let inner = t.inner.lock().unwrap();
         assert_eq!(inner.consecutive, 3);
+    }
+
+    // IMPROVEMENTS_PLAN #2: working_files() exposes the tracked overlap
+    // set (sorted) for post-compaction re-injection.
+    #[test]
+    fn working_files_returns_sorted_overlap() {
+        let t = FileTouchTracker::new(8, "edit".to_string());
+        // Touch two files together, then re-touch them → overlap kept.
+        t.record_tool_call("edit", &json!({"paths": ["b.rs", "a.rs"]}));
+        t.record_tool_call("edit", &json!({"paths": ["a.rs", "b.rs"]}));
+        let files = t.working_files();
+        assert_eq!(
+            files,
+            vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")],
+            "working_files must be the tracked set, sorted"
+        );
     }
 
     #[test]

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -182,8 +182,11 @@ const MAX_CONSECUTIVE_COMPACTION_FAILURES: u32 = 3;
 /// regardless of this outcome.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SummaryOutcome {
-    /// A valid summary was produced (LLM or plugin) and applied.
-    Succeeded,
+    /// A valid summary was produced (LLM or plugin) and applied. Carries
+    /// the index of the inserted summary message so the caller can
+    /// re-inject working-set file snapshots right after it
+    /// (IMPROVEMENTS_PLAN #2).
+    Succeeded(usize),
     /// The summarizer ran but returned an error or an invalid summary.
     Failed,
     /// The summarizer was not run: none wired, breaker open, or no
@@ -195,7 +198,7 @@ enum SummaryOutcome {
 /// reset on success, increment on failure, leave untouched on skip.
 fn record_compaction_outcome(failures: &mut u32, outcome: SummaryOutcome) {
     match outcome {
-        SummaryOutcome::Succeeded => *failures = 0,
+        SummaryOutcome::Succeeded(_) => *failures = 0,
         SummaryOutcome::Failed => *failures = failures.saturating_add(1),
         SummaryOutcome::Skipped => {}
     }
@@ -343,7 +346,7 @@ async fn run_compaction_pass_with_focus(
                     // is therefore `start` — anything below was
                     // protected, anything above was folded.
                     applied_first_kept = start;
-                    outcome = SummaryOutcome::Succeeded;
+                    outcome = SummaryOutcome::Succeeded(start);
                 }
                 Ok(_) => {
                     tracing::warn!(
@@ -376,6 +379,45 @@ async fn run_compaction_pass_with_focus(
         .await;
 
     outcome
+}
+
+/// IMPROVEMENTS_PLAN #2: after a successful summary fold, re-read the
+/// working-set files the agent was editing and splice fresh
+/// `[Post-compaction file snapshot]` system messages in right after the
+/// summary (index `summary_idx`) — so the fold doesn't strand the model
+/// without the concrete file state it had been working from.
+///
+/// No-op without a file-touch tracker or with no tracked files. The
+/// reads are bounded (`POST_COMPACT_MAX_FILES`) and each snapshot is
+/// size-capped by `build_post_compact_snapshots`, so restoration can't
+/// itself overflow the window. Unreadable files are skipped.
+async fn restore_working_files(config: &LoopConfig, ctx: &mut Context, summary_idx: usize) {
+    let Some(tracker) = &config.file_touch_tracker else {
+        return;
+    };
+    let files = tracker.working_files();
+    if files.is_empty() {
+        return;
+    }
+    let mut contents: Vec<(std::path::PathBuf, String)> = Vec::new();
+    for path in files
+        .into_iter()
+        .take(crate::agent::compression::POST_COMPACT_MAX_FILES)
+    {
+        if let Ok(body) = tokio::fs::read_to_string(&path).await {
+            contents.push((path, body));
+        }
+    }
+    if contents.is_empty() {
+        return;
+    }
+    let snapshots = crate::agent::compression::build_post_compact_snapshots(&contents);
+    // Insert right after the summary message, before the protected tail.
+    let mut at = (summary_idx + 1).min(ctx.messages.len());
+    for snap in snapshots {
+        ctx.messages.insert(at, snap);
+        at += 1;
+    }
 }
 
 /// Public entry point: start a new run from one or more prompt
@@ -576,6 +618,9 @@ pub async fn run_loop(
                         emit,
                     )
                     .await;
+                    if let SummaryOutcome::Succeeded(idx) = outcome {
+                        restore_working_files(&config, &mut current_context, idx).await;
+                    }
                     record_compaction_outcome(&mut compaction_failures, outcome);
                     folded_this_turn = true;
                 }
@@ -936,6 +981,9 @@ pub async fn run_loop(
                                     emit,
                                 )
                                 .await;
+                                if let SummaryOutcome::Succeeded(idx) = outcome {
+                                    restore_working_files(&config, &mut current_context, idx).await;
+                                }
                                 record_compaction_outcome(&mut compaction_failures, outcome);
                             }
                         }
@@ -959,6 +1007,9 @@ pub async fn run_loop(
                             emit,
                         )
                         .await;
+                        if let SummaryOutcome::Succeeded(idx) = outcome {
+                            restore_working_files(&config, &mut current_context, idx).await;
+                        }
                         record_compaction_outcome(&mut compaction_failures, outcome);
                     }
                     _ => {}

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -2142,7 +2142,7 @@ fn record_compaction_outcome_drives_counter() {
     assert_eq!(f, 2);
     super::record_compaction_outcome(&mut f, super::SummaryOutcome::Skipped);
     assert_eq!(f, 2, "skip must not change the counter");
-    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Succeeded);
+    super::record_compaction_outcome(&mut f, super::SummaryOutcome::Succeeded(0));
     assert_eq!(f, 0, "success resets the counter");
 }
 

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -275,6 +275,40 @@ pub fn cap_oversized_tool_results_counted(
     (capped, freed)
 }
 
+/// Max working-set files re-injected after a fold, and the per-file
+/// token budget. 5 × 5000 = 25k tokens worst case — bounded so the
+/// restoration can't itself trigger ANOTHER fold (IMPROVEMENTS_PLAN #2).
+pub const POST_COMPACT_MAX_FILES: usize = 5;
+pub const POST_COMPACT_MAX_TOKENS_PER_FILE: u64 = 5_000;
+
+/// Build `[Post-compaction file snapshot]` system messages for the
+/// working-set files, capping the count (`POST_COMPACT_MAX_FILES`) and
+/// per-file size (`POST_COMPACT_MAX_TOKENS_PER_FILE`, head+tail
+/// truncated). Pure — the file reads happen in the caller — so the cap
+/// + truncation are unit-testable (IMPROVEMENTS_PLAN #2).
+pub fn build_post_compact_snapshots(files: &[(std::path::PathBuf, String)]) -> Vec<Value> {
+    let per_file_chars = (POST_COMPACT_MAX_TOKENS_PER_FILE * CHARS_PER_TOKEN) as usize;
+    files
+        .iter()
+        .take(POST_COMPACT_MAX_FILES)
+        .map(|(path, content)| {
+            let body = if content.len() > per_file_chars {
+                truncate_with_head_tail(content, per_file_chars)
+            } else {
+                content.clone()
+            };
+            serde_json::json!({
+                "role": "system",
+                "content": format!(
+                    "[Post-compaction file snapshot: {}]\n{}",
+                    path.display(),
+                    body
+                ),
+            })
+        })
+        .collect()
+}
+
 /// Minimum per-block content budget when splitting `max_chars`
 /// across multiple text blocks. Ensures each block can hold at
 /// least the marker payload — without this floor a
@@ -778,6 +812,37 @@ mod tests {
         let small = vec![serde_json::json!({"role": "tool", "content": "ok"})];
         let (_, freed0) = cap_oversized_tool_results_counted(&small, 1000);
         assert_eq!(freed0, 0);
+    }
+
+    // IMPROVEMENTS_PLAN #2: post-compaction working-set snapshots.
+    #[test]
+    fn build_post_compact_snapshots_caps_count_and_truncates() {
+        use std::path::PathBuf;
+        // More files than the cap → capped, in order.
+        let files: Vec<(PathBuf, String)> = (0..8)
+            .map(|i| (PathBuf::from(format!("f{i}.rs")), "x".repeat(100)))
+            .collect();
+        let snaps = build_post_compact_snapshots(&files);
+        assert_eq!(snaps.len(), POST_COMPACT_MAX_FILES, "capped at MAX_FILES");
+        for (i, s) in snaps.iter().enumerate() {
+            assert_eq!(s["role"], "system");
+            let c = s["content"].as_str().unwrap();
+            assert!(
+                c.contains(&format!("[Post-compaction file snapshot: f{i}.rs]")),
+                "snapshot marker + path missing: {c}"
+            );
+        }
+
+        // An oversized file is truncated to roughly the per-file budget.
+        let per_file_chars = (POST_COMPACT_MAX_TOKENS_PER_FILE * CHARS_PER_TOKEN) as usize;
+        let big = (PathBuf::from("big.rs"), "y".repeat(per_file_chars * 4));
+        let snaps = build_post_compact_snapshots(std::slice::from_ref(&big));
+        let c = snaps[0]["content"].as_str().unwrap();
+        assert!(
+            c.len() < per_file_chars + 1_000,
+            "oversized file must be truncated to ~budget; got {} chars",
+            c.len()
+        );
     }
 
     // ── should_compress ─────────────────────────────────


### PR DESCRIPTION
Phase 4 of IMPROVEMENTS_PLAN. **Stacked on #222**.

## Problem
After a summary fold, the model lost the concrete contents of the files it was editing — forcing re-reads or stale-assumption errors.

## Fix
- `FileTouchTracker::working_files()` → the tracked overlap set, sorted.
- `SummaryOutcome::Succeeded(idx)` carries the summary insertion index.
- pure `compression::build_post_compact_snapshots` → `[Post-compaction file snapshot: <path>]` system messages, capped at **5 files × 5000 tokens** (head+tail truncated) so restoration can't trigger another fold.
- `run_loop::restore_working_files` re-reads them (thin `tokio::fs`, unreadable skipped) and splices the snapshots right after the summary, at all three fold sites.

**Design deviation from the plan:** I used a pure builder + thin in-loop read instead of a `LoopConfig` reader-closure. Same testability for the meaningful logic (cap/truncation/message shape) without adding a closure field to `LoopConfig` (Clone/Debug/Default/builder churn). Noted for review.

Tests: sorted-overlap `working_files`, snapshot cap + truncation. **2140 pass** at `-D warnings`.

Last phase next: #5 compaction report enrichment.