### PR TITLE
feat(agent-loop): compaction report enrichment (#5)

### DIFF
--- a/src/agent/agent_loop/bridge.rs
+++ b/src/agent/agent_loop/bridge.rs
@@ -108,6 +108,8 @@ impl EventBridge {
                 tokens_after,
                 ref summary,
                 first_kept_index,
+                compaction_kind,
+                ref summary_model,
             } => {
                 tracing::info!(
                     target: "dirge::agent_loop",
@@ -116,6 +118,7 @@ impl EventBridge {
                     tokens_after,
                     has_summary = !summary.is_empty(),
                     first_kept_index,
+                    kind = ?compaction_kind,
                     "context compacted — session rotated"
                 );
                 vec![AgentEvent::ContextCompacted {
@@ -124,6 +127,8 @@ impl EventBridge {
                     tokens_after,
                     summary: CompactString::new(summary),
                     first_kept_index,
+                    compaction_kind,
+                    summary_model: summary_model.as_deref().map(CompactString::new),
                 }]
             }
 

--- a/src/agent/agent_loop/message.rs
+++ b/src/agent/agent_loop/message.rs
@@ -374,6 +374,13 @@ pub enum LoopEvent {
         /// `Session::compress_reporting` so it knows which middle
         /// turns were folded.
         first_kept_index: usize,
+        /// Pruning-only vs prune+summary vs prune+failed-summary
+        /// (IMPROVEMENTS_PLAN #5). Bridged to the AgentEvent so the UI
+        /// / telemetry can distinguish — and flag a failing summarizer.
+        compaction_kind: crate::event::CompactionKind,
+        /// Summary model name, if known (`None` today — the summarizer
+        /// closure doesn't expose it; threading it is a follow-up).
+        summary_model: Option<String>,
     },
 
     /// PROV-2: the retry layer is about to re-attempt the stream.

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -367,6 +367,14 @@ async fn run_compaction_pass_with_focus(
         }
     }
 
+    // IMPROVEMENTS_PLAN #5: report what the pass did so consumers can
+    // tell pruning-only from a summary, and spot a failing summarizer.
+    let compaction_kind = match outcome {
+        SummaryOutcome::Succeeded(_) => crate::event::CompactionKind::PruneAndSummary,
+        SummaryOutcome::Failed => crate::event::CompactionKind::PruneAndFailedSummary,
+        SummaryOutcome::Skipped => crate::event::CompactionKind::PruneOnly,
+    };
+
     let new_id = compression::rotate_session_id();
     let _ = emit
         .send(LoopEvent::ContextCompacted {
@@ -375,6 +383,10 @@ async fn run_compaction_pass_with_focus(
             tokens_after: after_summary,
             summary: applied_summary,
             first_kept_index: applied_first_kept,
+            compaction_kind,
+            // The summarizer model name isn't threaded through the opaque
+            // SummarizeFn closure yet (follow-up).
+            summary_model: None,
         })
         .await;
 

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -278,10 +278,14 @@ async fn run_compaction_pass_with_focus(
     // actually runs and resolves to a valid summary (Succeeded) or an
     // error / invalid summary (Failed).
     let mut outcome = SummaryOutcome::Skipped;
+    // Tracks the breaker-open case so the emitted CompactionKind stays a
+    // distinct failure signal (not a healthy-looking PruneOnly).
+    let mut breaker_open = false;
     if compaction_failures >= MAX_CONSECUTIVE_COMPACTION_FAILURES {
         // Circuit breaker open: the summarizer has failed too many times
         // this run. Skip the LLM call entirely and keep the pruned
         // context (IMPROVEMENTS_PLAN #1).
+        breaker_open = true;
         tracing::warn!(
             target: "dirge::agent_loop",
             failures = compaction_failures,
@@ -369,10 +373,16 @@ async fn run_compaction_pass_with_focus(
 
     // IMPROVEMENTS_PLAN #5: report what the pass did so consumers can
     // tell pruning-only from a summary, and spot a failing summarizer.
-    let compaction_kind = match outcome {
-        SummaryOutcome::Succeeded(_) => crate::event::CompactionKind::PruneAndSummary,
-        SummaryOutcome::Failed => crate::event::CompactionKind::PruneAndFailedSummary,
-        SummaryOutcome::Skipped => crate::event::CompactionKind::PruneOnly,
+    // Breaker-open is its OWN kind so the failure signal survives after
+    // the breaker latches (it'd otherwise look like a healthy PruneOnly).
+    let compaction_kind = if breaker_open {
+        crate::event::CompactionKind::PruneSummarizerDisabled
+    } else {
+        match outcome {
+            SummaryOutcome::Succeeded(_) => crate::event::CompactionKind::PruneAndSummary,
+            SummaryOutcome::Failed => crate::event::CompactionKind::PruneAndFailedSummary,
+            SummaryOutcome::Skipped => crate::event::CompactionKind::PruneOnly,
+        }
     };
 
     let new_id = compression::rotate_session_id();
@@ -393,17 +403,37 @@ async fn run_compaction_pass_with_focus(
     outcome
 }
 
+/// Per-file read ceiling for restoration. A file larger than this is
+/// skipped entirely rather than read into memory just to truncate it to
+/// the snapshot budget — avoids an OOM if the agent touched a multi-GB
+/// artifact (review fix). Generous vs the snapshot budget so normal
+/// source files always restore.
+const POST_COMPACT_MAX_READ_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Don't re-inject file snapshots if the just-folded context is already
+/// above this fraction of the window: adding up to ~25k tokens of files
+/// could re-cross the fold threshold and chatter fold↔restore (review
+/// fix). Restoration is a convenience, not load-bearing — skip it when
+/// there's no headroom.
+const POST_COMPACT_RESTORE_CEILING: f64 = 0.50;
+
 /// IMPROVEMENTS_PLAN #2: after a successful summary fold, re-read the
 /// working-set files the agent was editing and splice fresh
 /// `[Post-compaction file snapshot]` system messages in right after the
 /// summary (index `summary_idx`) — so the fold doesn't strand the model
 /// without the concrete file state it had been working from.
 ///
-/// No-op without a file-touch tracker or with no tracked files. The
-/// reads are bounded (`POST_COMPACT_MAX_FILES`) and each snapshot is
-/// size-capped by `build_post_compact_snapshots`, so restoration can't
-/// itself overflow the window. Unreadable files are skipped.
-async fn restore_working_files(config: &LoopConfig, ctx: &mut Context, summary_idx: usize) {
+/// No-op without a file-touch tracker or tracked files, when the
+/// post-fold context already lacks headroom, or when all candidate files
+/// are unreadable / oversized. Reads are bounded by file count
+/// (`POST_COMPACT_MAX_FILES`) AND per-file size (`POST_COMPACT_MAX_READ_BYTES`),
+/// and each snapshot is token-capped by `build_post_compact_snapshots`.
+async fn restore_working_files(
+    config: &LoopConfig,
+    ctx: &mut Context,
+    summary_idx: usize,
+    ctx_max: u64,
+) {
     let Some(tracker) = &config.file_touch_tracker else {
         return;
     };
@@ -411,11 +441,31 @@ async fn restore_working_files(config: &LoopConfig, ctx: &mut Context, summary_i
     if files.is_empty() {
         return;
     }
+    // Headroom guard: if the freshly-folded context is already high,
+    // re-injecting files risks immediately re-crossing the fold
+    // threshold. Restoration is optional — skip rather than oscillate.
+    let post_fold = crate::agent::compression::estimate_messages_tokens(&ctx.messages);
+    if post_fold as f64 > POST_COMPACT_RESTORE_CEILING * ctx_max.max(1) as f64 {
+        tracing::debug!(
+            target: "dirge::agent_loop",
+            post_fold,
+            ctx_max,
+            "skipping post-compaction file restore — insufficient headroom",
+        );
+        return;
+    }
     let mut contents: Vec<(std::path::PathBuf, String)> = Vec::new();
     for path in files
         .into_iter()
         .take(crate::agent::compression::POST_COMPACT_MAX_FILES)
     {
+        // Skip files too large to read cheaply — don't materialize a
+        // huge artifact in memory just to truncate it.
+        match tokio::fs::metadata(&path).await {
+            Ok(m) if m.len() > POST_COMPACT_MAX_READ_BYTES => continue,
+            Ok(_) => {}
+            Err(_) => continue,
+        }
         if let Ok(body) = tokio::fs::read_to_string(&path).await {
             contents.push((path, body));
         }
@@ -576,6 +626,13 @@ pub async fn run_loop(
 
         // Pi line 174: INNER LOOP.
         while has_more_tool_calls || !pending_messages.is_empty() {
+            // Circuit-breaker bookkeeping is at-most-once per iteration:
+            // a single iteration can run BOTH the turn-start fold and the
+            // (ungated) post-usage ExitWithSummary pass, and counting two
+            // failures from one iteration would open the breaker before
+            // the intended 3-round budget (review fix). First record wins.
+            let mut compaction_recorded_this_iter = false;
+
             // Pi lines 175-179: turn_start (skipped on very first
             // iteration — the outer wrapper already emitted it).
             if !first_turn {
@@ -631,9 +688,12 @@ pub async fn run_loop(
                     )
                     .await;
                     if let SummaryOutcome::Succeeded(idx) = outcome {
-                        restore_working_files(&config, &mut current_context, idx).await;
+                        restore_working_files(&config, &mut current_context, idx, ctx_max).await;
                     }
-                    record_compaction_outcome(&mut compaction_failures, outcome);
+                    if !compaction_recorded_this_iter {
+                        record_compaction_outcome(&mut compaction_failures, outcome);
+                        compaction_recorded_this_iter = true;
+                    }
                     folded_this_turn = true;
                 }
             }
@@ -994,9 +1054,22 @@ pub async fn run_loop(
                                 )
                                 .await;
                                 if let SummaryOutcome::Succeeded(idx) = outcome {
-                                    restore_working_files(&config, &mut current_context, idx).await;
+                                    restore_working_files(
+                                        &config,
+                                        &mut current_context,
+                                        idx,
+                                        ctx_max,
+                                    )
+                                    .await;
                                 }
-                                record_compaction_outcome(&mut compaction_failures, outcome);
+                                // Guard against double-counting if a
+                                // turn-start fold already recorded this
+                                // iteration. No write-back needed — only one
+                                // post-usage arm runs and the iteration ends
+                                // right after.
+                                if !compaction_recorded_this_iter {
+                                    record_compaction_outcome(&mut compaction_failures, outcome);
+                                }
                             }
                         }
                     }
@@ -1020,9 +1093,12 @@ pub async fn run_loop(
                         )
                         .await;
                         if let SummaryOutcome::Succeeded(idx) = outcome {
-                            restore_working_files(&config, &mut current_context, idx).await;
+                            restore_working_files(&config, &mut current_context, idx, ctx_max)
+                                .await;
                         }
-                        record_compaction_outcome(&mut compaction_failures, outcome);
+                        if !compaction_recorded_this_iter {
+                            record_compaction_outcome(&mut compaction_failures, outcome);
+                        }
                     }
                     _ => {}
                 }

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -2229,3 +2229,61 @@ async fn compaction_circuit_breaker_skips_summarizer_after_max_failures() {
         "prune-only fallback must not grow context"
     );
 }
+
+// IMPROVEMENTS_PLAN #5: the ContextCompacted event reports whether the
+// pass was prune-only, prune+summary, or prune+failed-summary.
+#[tokio::test]
+async fn context_compacted_reports_compaction_kind() {
+    use crate::event::CompactionKind;
+
+    async fn kind_for(
+        summarize_fn: Option<crate::agent::compression::SummarizeFn>,
+    ) -> CompactionKind {
+        let mut ctx = empty_context();
+        ctx.messages
+            .push(serde_json::json!({"role":"system","content":"agent"}));
+        ctx.messages
+            .push(serde_json::json!({"role":"user","content":"task"}));
+        for i in 0..20 {
+            let role = if i % 2 == 0 { "assistant" } else { "user" };
+            ctx.messages.push(serde_json::json!({
+                "role": role, "content": format!("turn {i} with filler content")
+            }));
+        }
+        ctx.messages
+            .push(serde_json::json!({"role":"user","content":"latest"}));
+        let (tx, mut rx) = mpsc::channel::<LoopEvent>(8);
+        super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, None, &tx).await;
+        drop(tx);
+        while let Some(ev) = rx.recv().await {
+            if let LoopEvent::ContextCompacted {
+                compaction_kind, ..
+            } = ev
+            {
+                return compaction_kind;
+            }
+        }
+        panic!("no ContextCompacted event emitted");
+    }
+
+    // Valid summary → PruneAndSummary.
+    let good: Option<crate::agent::compression::SummarizeFn> = Some(std::sync::Arc::new(
+        |_p: String| {
+            Box::pin(async move {
+                Ok("## Active Task\nx\n\n## Goal\ny\n\n## Completed Actions\n1. z\n\n## Remaining Work\nw"
+                    .to_string())
+            })
+        },
+    ));
+    assert_eq!(kind_for(good).await, CompactionKind::PruneAndSummary);
+
+    // Failing summary → PruneAndFailedSummary.
+    let bad: Option<crate::agent::compression::SummarizeFn> =
+        Some(std::sync::Arc::new(|_p: String| {
+            Box::pin(async move { Err(anyhow::anyhow!("boom")) })
+        }));
+    assert_eq!(kind_for(bad).await, CompactionKind::PruneAndFailedSummary);
+
+    // No summarizer wired → PruneOnly.
+    assert_eq!(kind_for(None).await, CompactionKind::PruneOnly);
+}

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -276,8 +276,11 @@ pub fn cap_oversized_tool_results_counted(
 }
 
 /// Max working-set files re-injected after a fold, and the per-file
-/// token budget. 5 × 5000 = 25k tokens worst case — bounded so the
-/// restoration can't itself trigger ANOTHER fold (IMPROVEMENTS_PLAN #2).
+/// token budget. 5 × 5000 = 25k tokens worst case. This bounds the
+/// restoration cost but does NOT by itself guarantee the window won't
+/// re-cross the fold threshold near-full — the caller
+/// (`restore_working_files`) enforces that separately via a post-fold
+/// headroom guard before injecting (IMPROVEMENTS_PLAN #2).
 pub const POST_COMPACT_MAX_FILES: usize = 5;
 pub const POST_COMPACT_MAX_TOKENS_PER_FILE: u64 = 5_000;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,6 +26,23 @@ pub enum ToolContent {
     File,
 }
 
+/// What a compaction pass actually did, so consumers (UI / telemetry)
+/// can distinguish a cheap pruning-only pass from a real summary — and,
+/// crucially, surface when the LLM summarizer is *failing*
+/// (IMPROVEMENTS_PLAN #5). A spike in `PruneAndFailedSummary` is an
+/// early warning that the summarizer is broken.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionKind {
+    /// Pruning only — no LLM summarizer ran (none wired, circuit breaker
+    /// open, or the middle was empty).
+    PruneOnly,
+    /// Pruning + a successful LLM/plugin summary.
+    PruneAndSummary,
+    /// Pruning + a failed summary (error or invalid) — fell back to the
+    /// pruned context.
+    PruneAndFailedSummary,
+}
+
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
     Token(CompactString),
@@ -100,6 +117,14 @@ pub enum AgentEvent {
         tokens_after: u64,
         summary: CompactString,
         first_kept_index: usize,
+        /// Whether this pass was pruning-only, prune+summary, or
+        /// prune+failed-summary (IMPROVEMENTS_PLAN #5).
+        compaction_kind: CompactionKind,
+        /// Model that produced the summary, if known. `None` for
+        /// pruning-only passes (and currently for summary passes — the
+        /// summarizer closure is opaque; threading the model name is a
+        /// follow-up).
+        summary_model: Option<CompactString>,
     },
     Done {
         response: CompactString,

--- a/src/event.rs
+++ b/src/event.rs
@@ -41,6 +41,11 @@ pub enum CompactionKind {
     /// Pruning + a failed summary (error or invalid) — fell back to the
     /// pruned context.
     PruneAndFailedSummary,
+    /// Pruning only because the summarizer circuit breaker is OPEN (it
+    /// failed too many times this run). Distinct from `PruneOnly` so the
+    /// ongoing-failure signal stays visible after the breaker latches
+    /// rather than masquerading as a healthy no-summarizer deployment.
+    PruneSummarizerDisabled,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2208,7 +2208,20 @@ pub async fn run_interactive(
                         tokens_after,
                         ref summary,
                         first_kept_index,
+                        compaction_kind,
+                        ref summary_model,
                     } => {
+                        // IMPROVEMENTS_PLAN #5: surface what the pass did
+                        // (prune-only / +summary / +failed-summary) so a
+                        // failing summarizer is visible in the logs.
+                        tracing::debug!(
+                            target: "dirge::ui::compaction",
+                            kind = ?compaction_kind,
+                            summary_model = ?summary_model,
+                            tokens_before,
+                            tokens_after,
+                            "context compacted",
+                        );
                         // Persist session rotation to DB: end the old session
                         // with reason "compression", insert the new session.
                         let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());


### PR DESCRIPTION
Final phase (5/5) of IMPROVEMENTS_PLAN. **Stacked on #223**.

## Problem
`ContextCompacted` consumers couldn't distinguish a pruning-only pass from a real summary — or detect a failing summarizer.

## Fix
- `event::CompactionKind` { `PruneOnly`, `PruneAndSummary`, `PruneAndFailedSummary` }, derived from the pass's `SummaryOutcome`.
- Added `compaction_kind` + `summary_model: Option<_>` to **both** `LoopEvent::ContextCompacted` and `AgentEvent::ContextCompacted`, threaded through the bridge. The bridge **and** the UI handler log the kind — a spike in `PruneAndFailedSummary` is the operator's early warning that the summarizer is broken (the plan's stated goal).
- `summary_model` is `None` for now: the `SummarizeFn` closure is opaque (doesn't carry its model name). Documented follow-up rather than fake data.

Test asserts the kind for valid / failing / no summarizer. **2141 pass** at `-D warnings`.

---
## All 5 phases now up as stacked PRs (merge in order)
| PR | Phase | Plan |
|----|-------|------|
| #220 | circuit breaker | #1 |
| #221 | aggressive prune tier | #3 |
| #222 | snip feedback loop | #4 |
| #223 | post-compaction file restore | #2 |
| this | report enrichment | #5 |

Each is independently TDD'd; the stack builds clean at `-D warnings` (2141 tests).