### PR TITLE
fix(bash): address code-review findings on background shells

### DIFF
--- a/src/agent/tools/bash.rs
+++ b/src/agent/tools/bash.rs
@@ -244,6 +244,12 @@ async fn run_with_timeout(cmd: Command, secs: u64) -> Result<InterleavedOutput, 
 /// (the Claude-Code model — for dev servers / watchers); `Some(secs)`
 /// auto-kills after that long. The task records a terminal `ShellStatus`
 /// on the store when it ends.
+///
+/// Process-group cleanup is Unix-only (same as `run_with_timeout`): on
+/// Windows there's no `process_group`/`PgKillGuard`, so aborting the task
+/// signals only the immediate child via `kill_on_drop` — a backgrounded
+/// process's grandchildren can be orphaned. Background shells are an
+/// inherently Unix-oriented feature; Windows is best-effort.
 fn spawn_streaming_shell(
     cmd: Command,
     store: crate::agent::tools::bg_shell::BackgroundShellStore,
@@ -270,7 +276,7 @@ fn spawn_streaming_shell(
         };
         let pid = child.id();
         #[cfg(unix)]
-        let _pgguard = pid.map(PgKillGuard::new);
+        let mut pgguard = pid.map(PgKillGuard::new);
 
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
@@ -344,6 +350,16 @@ fn spawn_streaming_shell(
                 Err(e) => ShellStatus::Failed(e.to_string()),
             },
         };
+        // We only reach here when the task was NOT aborted: the process
+        // has already exited (natural) or been SIGKILLed (timeout). Disarm
+        // the guard so its Drop doesn't re-signal a now-reaped (possibly
+        // OS-recycled) process-group id — matching `run_with_timeout`. On
+        // abort (kill_shell / kill_all) we never get here, so the guard
+        // fires on drop and kills the group — which is how kill works.
+        #[cfg(unix)]
+        if let Some(g) = pgguard.as_mut() {
+            g.disarm();
+        }
         store.finish(&id, status);
     })
 }
@@ -419,7 +435,7 @@ impl Tool for BashTool {
                 "properties": {
                     "command": { "type": "string", "description": "Bash command to execute" },
                     "timeout": { "type": "integer", "description": "Timeout in seconds (optional; default 120, or 600 when background)" },
-                    "background": { "type": "boolean", "description": "Run detached: returns immediately with a shell id; the output is delivered automatically when the command finishes (do NOT poll). Use for long-running commands (builds, servers, watchers) so they don't block the turn. Killed at the timeout." }
+                    "background": { "type": "boolean", "description": "Run detached and unbounded: returns immediately with a shell id (does NOT block the turn). Use for long-running commands — dev servers, watch builds, tails. Read its accumulated output with the bash_output tool (pass the id; poll it to follow progress) and stop it with kill_shell (pass the id). Output is NOT auto-delivered. If `timeout` is set, the shell is auto-killed after that many seconds; otherwise it runs until it exits or you kill it." }
                 },
                 "required": ["command"]
             }),
@@ -757,8 +773,8 @@ mod tests {
     use super::*;
 
     /// End-to-end: `background: true` returns immediately with a shell id,
-    /// registers a `TaskKind::Shell` in the store, and delivers the
-    /// command's output via the store's completion path once it finishes.
+    /// registers the shell in the `BackgroundShellStore`, and streams the
+    /// command's output into the store's per-shell buffer as it runs.
     #[tokio::test]
     async fn background_bash_registers_shell_and_streams_output() {
         use crate::agent::tools::BashArgs;

--- a/src/agent/tools/bg_shell.rs
+++ b/src/agent/tools/bg_shell.rs
@@ -135,11 +135,27 @@ impl BackgroundShellStore {
     }
 
     /// Register a freshly-started shell in `Running` state. Evicts the
-    /// oldest entry if at capacity.
+    /// oldest entry if at capacity — preferring the oldest TERMINAL entry,
+    /// and only evicting a still-running one as a last resort (aborting it
+    /// first so we never silently detach a live process group; dropping a
+    /// `JoinHandle` would otherwise leak it).
     pub fn register(&self, id: String, command: String) {
         let mut map = self.lock();
         if !map.contains_key(&id) && map.len() >= STORE_CAPACITY {
-            map.shift_remove_index(0);
+            // Prefer evicting the oldest finished shell.
+            let victim = map
+                .iter()
+                .find(|(_, e)| !e.status.is_running())
+                .map(|(id, _)| id.clone())
+                .or_else(|| map.keys().next().cloned());
+            if let Some(victim) = victim
+                && let Some(mut e) = map.shift_remove(&victim)
+                && let Some(h) = e.handle.take()
+            {
+                // Last-resort eviction of a running shell: abort its drain
+                // task so the process group is SIGKILLed, not orphaned.
+                h.abort();
+            }
         }
         map.insert(
             id,
@@ -442,6 +458,78 @@ mod tests {
         let (out, _) = s.read_new("a").unwrap();
         assert!(out.len() <= MAX_UNREAD_BYTES + 200, "len was {}", out.len());
         assert!(out.contains("exceeded the unread-buffer cap"));
+    }
+
+    #[tokio::test]
+    async fn eviction_aborts_an_evicted_running_shell() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let store = BackgroundShellStore::new();
+        let dropped = Arc::new(AtomicBool::new(false));
+
+        // Fill to capacity with running shells; the oldest (s0) carries a
+        // task whose Drop flips a flag, so we can prove eviction ABORTS it
+        // (drops its future) rather than silently detaching the handle.
+        for n in 0..STORE_CAPACITY {
+            let id = format!("s{n}");
+            store.register(id.clone(), "x".to_string());
+            if n == 0 {
+                let flag = dropped.clone();
+                let h = tokio::spawn(async move {
+                    struct G(Arc<AtomicBool>);
+                    impl Drop for G {
+                        fn drop(&mut self) {
+                            self.0.store(true, Ordering::SeqCst);
+                        }
+                    }
+                    let _g = G(flag);
+                    std::future::pending::<()>().await;
+                });
+                store.attach_handle(&id, h);
+            }
+        }
+
+        // Let s0's task actually start so its drop-guard is constructed
+        // (on a current-thread runtime a freshly-spawned task isn't polled
+        // until we yield).
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // One more → must evict s0 (all entries running, none terminal).
+        store.register("overflow".to_string(), "y".to_string());
+
+        // The evicted task's future should be dropped (aborted) soon.
+        for _ in 0..100 {
+            if dropped.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "evicted running shell's drain task must be aborted, not detached"
+        );
+        assert!(
+            store.list().iter().all(|s| s.id != "s0"),
+            "evicted shell must be gone from the registry"
+        );
+    }
+
+    #[tokio::test]
+    async fn eviction_prefers_terminal_over_running() {
+        let store = BackgroundShellStore::new();
+        // s0 running (oldest), then a terminal one, then fill the rest.
+        store.register("s0".to_string(), "x".to_string());
+        store.register("term".to_string(), "x".to_string());
+        store.finish("term", ShellStatus::Exited(0));
+        for n in 1..(STORE_CAPACITY - 1) {
+            store.register(format!("s{n}"), "x".to_string());
+        }
+        // At capacity; overflow should evict the terminal entry, not s0.
+        store.register("overflow".to_string(), "x".to_string());
+        let ids: Vec<_> = store.list().into_iter().map(|s| s.id).collect();
+        assert!(ids.contains(&"s0".to_string()), "running s0 must survive");
+        assert!(!ids.contains(&"term".to_string()), "terminal entry evicted");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -836,6 +836,9 @@ async fn main() -> anyhow::Result<()> {
                 eprintln!("warning: failed to save session: {}", e);
             }
         }
+        // Kill any detached background shells the run started so they don't
+        // outlive this headless process (they're in their own process group).
+        crate::agent::tools::bg_shell::global().kill_all();
     } else {
         #[cfg(feature = "loop")]
         if cli.loop_mode {
@@ -919,6 +922,7 @@ async fn main() -> anyhow::Result<()> {
                         // "flush buffered state" signal for plugin
                         // providers.
                         crate::agent::review::maybe_fire_session_end(&current_agent, &session);
+                        crate::agent::tools::bg_shell::global().kill_all();
                         return Ok(());
                     }
                     #[cfg(feature = "plugin")]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3965,6 +3965,13 @@ pub async fn run_interactive(
         }
     }
 
+    // Session over (/quit, Ctrl+C/D, EOF). Kill any detached background
+    // shells — they run in their own process group and would otherwise
+    // survive dirge's exit, orphaning servers/watchers and their ports.
+    if let Some(store) = shell_store.as_ref() {
+        store.kill_all();
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Post-merge code review of #236 (background-shells rework) surfaced six findings; this fixes #1–#5 and documents #6.

| # | Sev | Fix |
|---|-----|-----|
| 1 | **HIGH** | `spawn_streaming_shell` never disarmed its `PgKillGuard`, so on natural (and timeout) exit the guard's `Drop` fired a **second `killpg(SIGKILL)`** against an already-reaped — possibly OS-recycled — process-group id (could kill an unrelated group). Now disarmed before `finish()` on every non-aborted completion path, matching `run_with_timeout`. The guard still fires on the abort path, which is exactly how `kill_shell`/`kill_all` kill the group. |
| 2 | **MED-HIGH** | Background shells (own process group) **leaked past normal exit** — `kill_all()` only ran on session swap. Now also called when `run_interactive` returns (`/quit`, Ctrl+C/D, EOF) and at the headless session-end points. |
| 3 | **MED** | `register()` eviction at capacity dropped a still-running entry's `JoinHandle` (tokio *detaches* on drop → orphaned, untracked process). Now evicts the oldest **terminal** entry preferentially, and **aborts** the handle if a running entry must be evicted as a last resort. |
| 4 | **MED** | The `background` arg **schema description** still described the reverted push-once model ("output delivered automatically, do NOT poll, killed at the timeout") — which would stop the model from ever polling `bash_output`. Rewritten to the poll / unbounded / `kill_shell` model. |
| 5 | LOW | Fixed a stale test doc-comment referencing the removed `TaskKind::Shell`. |
| 6 | LOW | Documented the Windows process-tree-kill limitation on `spawn_streaming_shell` (Unix-only `PgKillGuard`; grandchildren best-effort on Windows). |

Verified-clean in review and left as-is: the abort→SIGKILL chain on unix, drain-EOF-while-process-alive, the cap TOCTOU (bash is `Sequential`), global-store sharing, `/tasks` listing, and the status-bar call sites. The soft output-buffer cap and capturing trailing output after exit are intentional.

## Tests
- New: eviction **aborts** (not detaches) an evicted running shell; eviction **prefers terminal** entries over running ones.
- Full feature-matrix suite green at `-D warnings` (2166 passed).
