### PR TITLE
chore(build): cargo-wizard-tuned profiles (dist/fast-runtime + dev fast-compile)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,9 +216,45 @@ tokio = { version = "1", features = ["test-util"] }
 # dep moved back to [dependencies].
 nucleo-matcher = "0.3"
 
+# Profiles tuned with cargo-wizard, then adjusted for dirge's constraints.
+#
+# `release` — the SHIPPED, size-optimized binary (cargo-wizard `min-size`,
+# which dirge already matched). NOTE: we deliberately do NOT set
+# `panic = "abort"` here even though min-size suggests it: the Janet plugin
+# worker relies on `std::panic::catch_unwind` (src/plugin/worker.rs) to
+# contain panics from unsafe FFI, and many background tokio tasks
+# (subagents, background shells) rely on a panicking task NOT aborting the
+# whole process. `panic = "abort"` would break both.
 [profile.release]
 opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
 debug = false
+
+# `dist` — opt for runtime SPEED over size (cargo-wizard `fast-runtime`),
+# for when you want the fastest binary and don't mind it being larger.
+# Build with `cargo build --profile dist`.
+#
+# Adjusted vs the raw template:
+#   - `panic = "unwind"` (template said "abort") — same plugin/​task-isolation
+#     reason as release above.
+#   - `strip = true` (template said "none") — keep the distributed binary lean.
+#   - We intentionally do NOT add `-Ctarget-cpu=native`: it would make the
+#     binary SIGILL on any CPU older than the build host. A user building
+#     for their OWN machine can add `RUSTFLAGS="-Ctarget-cpu=native"`.
+[profile.dist]
+inherits = "release"
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true
+debug = false
+panic = "unwind"
+
+# `dev` — fast iterate/test loop (cargo-wizard `fast-compile`). `debug = 0`
+# drops debuginfo generation for faster builds; pair with the linker /
+# split-debuginfo settings in `.cargo/config.toml`. If you need line numbers
+# in a dev backtrace, set `debug = "line-tables-only"`.
+[profile.dev]
+debug = 0


### PR DESCRIPTION
Set up [cargo-wizard](https://github.com/Kobzol/cargo-wizard) and used it to evaluate the three templates against dirge, keeping the safe/additive parts and rejecting the ones that conflict with dirge's design.

## Kept
- **New `[profile.dist]`** (from `fast-runtime`): `opt-level=3` + fat `lto` + `codegen-units=1` — a runtime-speed binary for when you want max throughput over size. Build with `cargo build --profile dist`.
- **`[profile.dev]` `debug=0`** (from `fast-compile`): faster build/test loop.
- **`[profile.release]`** unchanged — it already matched `min-size` (opt-level=z, lto, codegen-units=1, strip).

## Rejected (would regress dirge) — with reasons in the manifest comments
- **`panic = "abort"`** (which `min-size`/`fast-runtime` add to release/dist): the Janet plugin worker relies on `std::panic::catch_unwind` (`src/plugin/worker.rs`) to contain panics from unsafe FFI, and background tokio tasks (subagents, background shells) must not abort the whole process on a task panic. So `dist` is pinned to `panic = "unwind"` and `release` keeps the default.
- **Global `[build] rustflags = ["-Ctarget-cpu=native"]`** (which `fast-runtime` writes to `.cargo/config.toml`): this poisons *every* profile including the shipped `release`, so distributed binaries would SIGILL on any CPU older than the build host (cargo-wizard itself warns about this). Left the existing, more careful cross-platform linker config (`mold` on Linux, no override on macOS) untouched. A user wanting a max-perf local build can set `RUSTFLAGS="-Ctarget-cpu=native"` themselves.
- Also tweaked `dist` to `strip = true` (template left it `"none"`) to keep the distributed binary lean.

## Verification
- All three profiles build (`dev` unoptimized, `release`/`dist` optimized + LTO link cleanly).
- Full feature-matrix suite green at `-D warnings` (2166 passed) on the `debug=0` dev/test profile.

Docs-adjacent follow-up (not in this PR): the release CI could optionally build `--profile dist` if you want the shipped binaries optimized for speed instead of size — happy to wire that if you want it.