### PR TITLE
perf(build): make the release profile speed-optimized (opt-level 3 + fat LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,39 +218,28 @@ nucleo-matcher = "0.3"
 
 # Profiles tuned with cargo-wizard, then adjusted for dirge's constraints.
 #
-# `release` — the SHIPPED, size-optimized binary (cargo-wizard `min-size`,
-# which dirge already matched). NOTE: we deliberately do NOT set
-# `panic = "abort"` here even though min-size suggests it: the Janet plugin
-# worker relies on `std::panic::catch_unwind` (src/plugin/worker.rs) to
-# contain panics from unsafe FFI, and many background tokio tasks
-# (subagents, background shells) rely on a panicking task NOT aborting the
-# whole process. `panic = "abort"` would break both.
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-strip = true
-debug = false
-
-# `dist` — opt for runtime SPEED over size (cargo-wizard `fast-runtime`),
-# for when you want the fastest binary and don't mind it being larger.
-# Build with `cargo build --profile dist`.
+# `release` — the SHIPPED binary, optimized for runtime SPEED (cargo-wizard
+# `fast-runtime`): opt-level=3 + fat LTO + a single codegen unit, still
+# `strip`ped so it stays lean. The binary is small enough that we favor
+# speed over squeezing the last bytes (the old `opt-level="z"` min-size
+# tuning). Both `cargo install dirge-agent` AND the prebuilt release
+# binaries use this profile, so every shipped artifact is the fast one.
 #
-# Adjusted vs the raw template:
-#   - `panic = "unwind"` (template said "abort") — same plugin/​task-isolation
-#     reason as release above.
-#   - `strip = true` (template said "none") — keep the distributed binary lean.
-#   - We intentionally do NOT add `-Ctarget-cpu=native`: it would make the
-#     binary SIGILL on any CPU older than the build host. A user building
-#     for their OWN machine can add `RUSTFLAGS="-Ctarget-cpu=native"`.
-[profile.dist]
-inherits = "release"
+# NOTE: deliberately NOT `panic = "abort"` (which `fast-runtime`/`min-size`
+# suggest): the Janet plugin worker relies on `std::panic::catch_unwind`
+# (src/plugin/worker.rs) to contain panics from unsafe FFI, and background
+# tokio tasks (subagents, background shells) rely on a panicking task NOT
+# aborting the whole process. `panic = "abort"` would break both.
+#
+# We also deliberately do NOT add `-Ctarget-cpu=native`: it would make the
+# distributed binary SIGILL on any CPU older than the build host. A user
+# building for their OWN machine can set `RUSTFLAGS="-Ctarget-cpu=native"`.
+[profile.release]
 opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
 debug = false
-panic = "unwind"
 
 # `dev` — fast iterate/test loop (cargo-wizard `fast-compile`). `debug = 0`
 # drops debuginfo generation for faster builds; pair with the linker /

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal, fast coding agent written in Rust — inspired by [pi](https://pi.dev
 
 What sets dirge apart from other agentic editors:
 
-- **Tiny and fast.** ~8 MB RAM idle, ~15 MB working, 25 MB binary — versus ~300 MB for JS-based agents. Native Rust, no runtime.
+- **Tiny and fast.** ~8 MB RAM idle, ~15 MB working, ~36 MB binary (speed-optimized: `opt-level=3` + LTO) — versus ~300 MB for JS-based agents. Native Rust, no runtime.
 - **Built to keep weaker/cheaper models on the rails.** A [robust agent loop](docs/features.md#robust-agent-loop) repairs malformed tool calls, validates every write through tree-sitter *before* it touches disk, escalates to a stronger model on repeated failure, and trips circuit breakers on non-progressing loops.
 - **One explainable permission engine.** All authorization flows through a single Policy Decision Point with four modes, op-based rules, session allowlists, and a `/why` command that traces exactly which policy decided and why. See [docs/permissions.md](docs/permissions.md).
 - **Role-based multi-provider routing.** Point the main loop, review, escalation, summarization, and subagent roles at different models — mix DeepSeek, GLM, Anthropic, OpenAI, Ollama, and any OpenAI-compatible endpoint in one session.

--- a/docs/features.md
+++ b/docs/features.md
@@ -49,7 +49,7 @@ Hardening against the failure modes that plague long sessions and weaker models.
 dirge is one of the smallest and most performant coding agents on the market.
 
 - Lines of code: ~100k LoC
-- Binary size: 25 MB
+- Binary size: ~36 MB (the `release` profile is speed-optimized — `opt-level=3` + fat LTO + `strip`; an `opt-level="z"` build is ~28 MB if you prefer size)
 - RAM footprint: ~8 MB on an empty session, ~15 MB when working (vs ~300 MB for opencode or other JS-based coding agents)
 
 ### Tool result caching


### PR DESCRIPTION
Follow-up to #238. The binary is small enough that favoring runtime speed over the last bytes of size makes sense — and since `cargo install dirge-agent` can only build the `release` profile, optimizing `release` itself (rather than a separate `dist`) means **both** crates.io installers and the prebuilt GitHub release binaries get the fast build.

## Changes
- **`[profile.release]`**: `opt-level` `"z"` → `3`; keeps fat `lto`, `codegen-units=1`, `strip`. Still **not** `panic="abort"` (plugin `catch_unwind` + tokio task isolation) and still **no** `-Ctarget-cpu=native` (portable distributed binary).
- **Dropped `[profile.dist]`** — redundant now that `release` is the fast profile.
- **No release-workflow change needed** — it already builds `--release`.
- **Binary size**: ~28 MB → **~36 MB** (measured, macOS arm64, stripped). Updated the figures in `README.md` and `docs/features.md`, noting the size/speed tradeoff (and that an `opt-level="z"` build is ~28 MB for anyone who prefers size).

## Verification
- Full release binary builds clean with fat LTO (4m41s).
- `dev`/`test` profile unchanged (still `debug=0` from #238); source untouched, so the 2166-test suite is unaffected.