### PR TITLE
fix(permission): doom-loop no longer hard-denies repeated calls the user keeps approving

### DIFF
--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -411,6 +411,12 @@ pub async fn enforce(
                 ));
             };
             handle_ask_inner(tx, perm, tool, raw_scope).await?;
+            // Approved → clear the loop-guard counter so a repeated call
+            // the user keeps allowing never trips the doom-loop hard-deny
+            // (only repeatedly-denied prompts accumulate).
+            perm.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .note_allowed_scope(tool, raw_scope, is_path);
             Ok(resolved)
         }
     }
@@ -451,6 +457,10 @@ pub async fn enforce_request(
                 ));
             };
             handle_ask_inner(tx, perm, &req.tool, &req.display_input).await?;
+            // Approved → clear the loop-guard counter (see `enforce`).
+            perm.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .note_allowed_request(&req);
             Ok(())
         }
     }

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -146,6 +146,21 @@ impl PermissionChecker {
         decision
     }
 
+    /// Clear loop-guard retry pressure for a (tool, input) scope after
+    /// the user APPROVED its prompt. Rebuilds the same request the
+    /// matching `authorize_scope` committed (same `is_path` → same key),
+    /// so an approved-but-repeated action never trips the hard-deny.
+    pub fn note_allowed_scope(&mut self, tool: &str, input: &str, is_path: bool) {
+        let req = self.build_request(tool, input, is_path);
+        self.engine.note_allowed(&req);
+    }
+
+    /// Clear loop-guard retry pressure for a pre-built request after the
+    /// user APPROVED its prompt (the bash multi-claim path).
+    pub fn note_allowed_request(&mut self, req: &engine::types::AccessRequest) {
+        self.engine.note_allowed(req);
+    }
+
     /// The checker's working directory — tools building their own
     /// multi-claim requests need it to classify path resources. (Only
     /// the `semantic-bash` bash path uses this today.)

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -274,6 +274,21 @@ impl Engine {
         }
     }
 
+    /// Clear the loop-guard retry pressure for `req` — call this once the
+    /// user has APPROVED its prompt. An approved-but-repeated action is a
+    /// productive loop (the user keeps saying yes), so it must not trip
+    /// the hard-deny; only prompts the user keeps DENYING accumulate. The
+    /// dedup mirrors `commit` so the reset matches what was recorded.
+    pub fn note_allowed(&mut self, req: &AccessRequest) {
+        let mut seen = std::collections::HashSet::new();
+        for claim in &req.claims {
+            let key = claim.resource.match_key();
+            if seen.insert((claim.op, key)) {
+                self.ctx.repeat.reset(claim.op, key);
+            }
+        }
+    }
+
     /// Register a session-scoped "allow always" grant (from the UI's
     /// AllowAlways reply).
     pub fn allow_always(&mut self, op: Operation, original: &str) {

--- a/src/permission/engine/policies.rs
+++ b/src/permission/engine/policies.rs
@@ -471,6 +471,9 @@ mod tests {
             head: s.split_whitespace().next().unwrap_or("").to_string(),
         }
     }
+    fn url(u: &str) -> Resource {
+        Resource::Url(u.to_string())
+    }
     fn word(s: &str) -> Resource {
         Resource::Bareword(s.to_string())
     }
@@ -747,5 +750,50 @@ mod tests {
             "4th identical Ask retry hard-denied"
         );
         assert_eq!(effects[4], Effect::Deny);
+    }
+
+    #[test]
+    fn approved_repeats_never_trip_loop_guard() {
+        // A repeated Ask op that the user APPROVES each time (modeled by
+        // `note_allowed` after each commit) must keep prompting forever —
+        // it never accrues toward the hard-deny.
+        let mut e = engine(Effect::Ask);
+        let r = req(
+            Operation::Network,
+            SecurityMode::Standard,
+            vec![url("https://example.com/x")],
+        );
+        for i in 0..10 {
+            let d = e.authorize(&r);
+            assert_eq!(d.effect, Effect::Ask, "iteration {i}: must keep asking");
+            e.commit(&r, &d);
+            e.note_allowed(&r); // user approved this prompt
+        }
+    }
+
+    #[test]
+    fn denials_still_hard_deny_even_after_an_earlier_approval() {
+        // approve once (resets), then 4 denials → still hard-denies, so
+        // the protection against a genuinely-stuck loop is preserved.
+        let mut e = engine(Effect::Ask);
+        let r = req(
+            Operation::Execute,
+            SecurityMode::Standard,
+            vec![cmd("frobnicate")],
+        );
+        let d = e.authorize(&r);
+        e.commit(&r, &d);
+        e.note_allowed(&r); // approved → counter reset to 0
+        let mut effects = vec![];
+        for _ in 0..5 {
+            let d = e.authorize(&r);
+            effects.push(d.effect);
+            e.commit(&r, &d); // denied at the prompt → no note_allowed
+        }
+        assert_eq!(
+            effects[3],
+            Effect::Deny,
+            "hard-deny still trips on pure denials"
+        );
     }
 }

--- a/src/permission/engine/policy.rs
+++ b/src/permission/engine/policy.rs
@@ -46,6 +46,14 @@ impl RepeatCounter {
         *self.counts.entry(Self::key(op, key)).or_insert(0) += 1;
     }
 
+    /// Drop the count for a single (op, resource-key). Called when the
+    /// user APPROVES a prompt for it: an approved-but-repeated action is
+    /// a productive loop, not a stuck one, so it shouldn't accrue toward
+    /// the hard-deny. Only repeatedly *denied* prompts keep accumulating.
+    pub fn reset(&mut self, op: Operation, key: &str) {
+        self.counts.remove(&Self::key(op, key));
+    }
+
     /// Drop all counts (e.g. on cwd change, mirroring the old
     /// `set_working_dir` reset).
     pub fn clear(&mut self) {


### PR DESCRIPTION
## Problem
A user hit `Permission denied: Doom loop: repeated identical webfetch call` and got locked out — unable to allow the call again.

The loop guard bumps its per-`(op, resource)` counter on **every prompt** (`decision == Ask`), regardless of the user's answer, then hard-denies at the threshold. So someone who legitimately keeps **approving** a repeated call (e.g. `webfetch` of the same URL) trips the hard-deny and can no longer approve it.

## Fix
When the user **approves** a prompt, reset that `(op, resource)` counter. An approved-but-repeated action is a *productive* loop (the user keeps saying yes), so it keeps prompting — "ask for permission again" — instead of escalating to a hard-deny. Only prompts the user keeps **denying** accumulate toward the guard, so the protection against a model spamming an action it can't get past is preserved.

- `RepeatCounter::reset(op, key)` — clear one entry.
- `Engine::note_allowed(req)` — reset each claim's counter (dedup mirrors `commit`).
- `PermissionChecker::note_allowed_scope` / `note_allowed_request` facades.
- `enforce` / `enforce_request` call them after `handle_ask_inner` returns `Ok` (AllowOnce **or** AllowAlways), using the same scope/request that was committed so the reset key matches the bump key.

## Tests
- Approved repeats keep asking forever (never trip the guard).
- Pure denials still hard-deny at the threshold even after an earlier approval (protection intact).
- Full feature-matrix suite green at `-D warnings` (2175 passed).