### PR TITLE
feat(ui): configurable key bindings for global commands (VSCode-style)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -349,6 +349,57 @@ Provider name matching is case-insensitive (`anthropic` matches
 }
 ```
 
+## Key bindings
+
+VSCode-style overrides for the global "command" keys. `keybindings` is an
+array of `{ "key": "<chord>", "command": "<command>" }`; each entry is
+layered over the built-in defaults, so you only list what you want to
+change.
+
+```json
+{
+  "keybindings": [
+    { "key": "ctrl-t",       "command": "toggle_reasoning" },
+    { "key": "ctrl-shift-k", "command": "kill_subagent" },
+    { "key": "ctrl-r",       "command": "none" }
+  ]
+}
+```
+
+- **`key`** — a chord: case-insensitive, `-` or `+` separated, modifiers
+  before the key. Modifiers: `ctrl`, `alt` (a.k.a. `meta`/`option`),
+  `shift`. Keys: a single character, `f1`–`f12`, or a named key
+  (`enter`, `esc`, `tab`, `backspace`, `delete`, `insert`, `space`,
+  `up`/`down`/`left`/`right`, `home`, `end`, `pageup`/`pgup`,
+  `pagedown`/`pgdn`). Examples: `ctrl-t`, `pageup`, `ctrl-shift-x`, `f5`.
+- **`command`** — one of the rebindable commands below, or **`none`**
+  (also `unbind`) to disable the default binding on that chord.
+- Binding a command to a new chord **adds** it (the default chord still
+  works unless you separately unbind it). Binding a chord that already
+  has a default **replaces** it.
+
+| Command | Default | Action |
+|---|---|---|
+| `toggle_reasoning` | `ctrl-r` | Show/hide reasoning tokens |
+| `scroll_page_up` | `pageup` | Scroll chat up one page |
+| `scroll_page_down` | `pagedown` | Scroll chat down one page |
+| `scroll_to_top` | `home` | Jump to top of chat |
+| `scroll_to_bottom` | `end` | Jump to bottom of chat |
+| `next_chat` | `ctrl-n` | Next subagent chat window |
+| `prev_chat` | `ctrl-p` | Previous subagent chat window |
+| `close_chat` | `ctrl-x` | Close the active chat window |
+| `kill_subagent` | `ctrl-k` | Kill the focused subagent |
+
+Notes:
+- **Not rebindable** (kept fixed): the text-editing keys in the input box
+  (Ctrl+A/E/W, kill-ring, word motion, history) and the universal
+  cancel/interrupt gesture (**Ctrl+C / Ctrl+D / Esc**) — the latter must
+  always be available as the panic button.
+- Rebinding a command to a key the input editor uses (e.g. `ctrl-a`)
+  shadows that editing key while the binding is active.
+- Unrecognized chords or unknown commands are skipped with a warning on
+  startup; the rest of the config still loads.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -5,6 +5,10 @@ slash-command list, see the top-level [README](../README.md#slash-commands).
 
 ## Key bindings
 
+The global command keys (toggle reasoning, scroll, chat navigation,
+kill-subagent) are **rebindable** via the `keybindings` config — see
+[config.md](config.md#key-bindings). The defaults are listed below.
+
 ### Input editing
 
 | Key | Action |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,6 +102,17 @@ pub enum ConfigRole {
     Subagent,
 }
 
+/// One VSCode-style key binding: bind a key chord to a named command.
+/// `key` is a chord like `"ctrl-t"` / `"pageup"` / `"ctrl-shift-x"`;
+/// `command` is one of the rebindable global commands (see
+/// `ui::keymap::KeyAction`), or `"none"` to unbind the default on that
+/// chord. Parsed by `ui::keymap::Keymap::from_config`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct KeybindingConfig {
+    pub key: String,
+    pub command: String,
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct ToolsConfig {
@@ -260,6 +271,10 @@ pub struct Config {
     /// falls back to phosphor with a warning rather than refusing
     /// to start.
     pub theme: Option<String>,
+    /// VSCode-style key-binding overrides for the global command keys.
+    /// Each entry binds a chord to a command (see `KeybindingConfig`);
+    /// applied over the built-in defaults by `ui::keymap`.
+    pub keybindings: Option<Vec<KeybindingConfig>>,
     pub tools: Option<ToolsConfig>,
 
     /// Phase-3 (`docs/AGENTIC_LOOP_PLAN.md`): when true, ship only

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -1,0 +1,328 @@
+//! Configurable key bindings for the global "command" keys (VSCode-style).
+//!
+//! The TUI's agent-control keys (toggle reasoning, scroll, chat
+//! navigation, kill-subagent) resolve through a [`Keymap`] that maps a
+//! key chord → [`KeyAction`]. Built-in defaults reproduce the historical
+//! bindings; the user's `keybindings` config (an array of
+//! `{ key, command }`) overrides them per chord, exactly like a VSCode
+//! `keybindings.json`.
+//!
+//! Out of scope (kept fixed): the input-editor's text-editing keys
+//! (Ctrl+A/E/W, kill-ring, word motion, history) and the universal
+//! cancel/interrupt gesture (Ctrl+C / Ctrl+D / Esc) — the latter must
+//! always be available as the panic button.
+
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::config::KeybindingConfig;
+
+/// A rebindable global command. Each maps to a stable `command` string
+/// used in the config and to a set of default chords.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAction {
+    ToggleReasoning,
+    ScrollPageUp,
+    ScrollPageDown,
+    ScrollToTop,
+    ScrollToBottom,
+    NextChat,
+    PrevChat,
+    CloseChat,
+    KillSubagent,
+}
+
+impl KeyAction {
+    /// All actions, with their config command name and default chords.
+    /// Single source of truth for both the default keymap and the
+    /// command-name lookup / docs.
+    pub const ALL: &'static [(KeyAction, &'static str, &'static [(KeyCode, KeyModifiers)])] = &[
+        (
+            KeyAction::ToggleReasoning,
+            "toggle_reasoning",
+            &[(KeyCode::Char('r'), KeyModifiers::CONTROL)],
+        ),
+        (
+            KeyAction::ScrollPageUp,
+            "scroll_page_up",
+            &[(KeyCode::PageUp, KeyModifiers::NONE)],
+        ),
+        (
+            KeyAction::ScrollPageDown,
+            "scroll_page_down",
+            &[(KeyCode::PageDown, KeyModifiers::NONE)],
+        ),
+        (
+            KeyAction::ScrollToTop,
+            "scroll_to_top",
+            &[(KeyCode::Home, KeyModifiers::NONE)],
+        ),
+        (
+            KeyAction::ScrollToBottom,
+            "scroll_to_bottom",
+            &[(KeyCode::End, KeyModifiers::NONE)],
+        ),
+        (
+            KeyAction::NextChat,
+            "next_chat",
+            &[(KeyCode::Char('n'), KeyModifiers::CONTROL)],
+        ),
+        (
+            KeyAction::PrevChat,
+            "prev_chat",
+            &[(KeyCode::Char('p'), KeyModifiers::CONTROL)],
+        ),
+        (
+            KeyAction::CloseChat,
+            "close_chat",
+            &[(KeyCode::Char('x'), KeyModifiers::CONTROL)],
+        ),
+        (
+            KeyAction::KillSubagent,
+            "kill_subagent",
+            &[(KeyCode::Char('k'), KeyModifiers::CONTROL)],
+        ),
+    ];
+
+    /// Resolve a config command name (case-insensitive, `-`/`_` agnostic)
+    /// to an action. `None` for unknown commands.
+    pub fn from_command(name: &str) -> Option<KeyAction> {
+        let norm = name.trim().to_ascii_lowercase().replace('-', "_");
+        Self::ALL
+            .iter()
+            .find(|(_, cmd, _)| *cmd == norm)
+            .map(|(a, _, _)| *a)
+    }
+
+    /// Comma-separated list of every valid command name (for help /
+    /// warning text).
+    pub fn command_list() -> String {
+        Self::ALL
+            .iter()
+            .map(|(_, c, _)| *c)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// Resolves key chords to [`KeyAction`]s: built-in defaults plus the
+/// user's per-chord overrides.
+#[derive(Debug, Clone, Default)]
+pub struct Keymap {
+    map: HashMap<(KeyCode, KeyModifiers), KeyAction>,
+}
+
+impl Keymap {
+    /// The built-in keymap (no config applied).
+    pub fn defaults() -> Self {
+        let mut map = HashMap::new();
+        for (action, _, chords) in KeyAction::ALL {
+            for chord in *chords {
+                map.insert(*chord, *action);
+            }
+        }
+        Self { map }
+    }
+
+    /// Build the keymap from the optional `keybindings` config, layered
+    /// over the defaults. Returns the keymap plus any warnings (invalid
+    /// chord / unknown command) for the UI to surface. A command of
+    /// `none` / `unbind` removes the chord (so a user can disable a
+    /// default binding).
+    pub fn from_config(bindings: Option<&[KeybindingConfig]>) -> (Self, Vec<String>) {
+        let mut km = Self::defaults();
+        let mut warnings = Vec::new();
+        for b in bindings.unwrap_or(&[]) {
+            let Some(chord) = parse_chord(&b.key) else {
+                warnings.push(format!("keybindings: unrecognized key {:?}", b.key));
+                continue;
+            };
+            let cmd = b.command.trim().to_ascii_lowercase().replace('-', "_");
+            if matches!(cmd.as_str(), "none" | "noop" | "unbind" | "") {
+                km.map.remove(&chord);
+                continue;
+            }
+            match KeyAction::from_command(&cmd) {
+                Some(action) => {
+                    km.map.insert(chord, action);
+                }
+                None => warnings.push(format!(
+                    "keybindings: unknown command {:?} for key {:?} (valid: {})",
+                    b.command,
+                    b.key,
+                    KeyAction::command_list()
+                )),
+            }
+        }
+        (km, warnings)
+    }
+
+    /// The action bound to `key`, if any. Matches modifiers exactly.
+    pub fn resolve(&self, key: &KeyEvent) -> Option<KeyAction> {
+        self.map.get(&(key.code, key.modifiers)).copied()
+    }
+}
+
+/// Parse a chord string like `ctrl-r`, `pageup`, `ctrl-shift-x`,
+/// `home`, `f5` into a `(KeyCode, KeyModifiers)`. Case-insensitive,
+/// `-`-separated, modifiers before the key. Returns `None` on a
+/// malformed spec. (A standalone copy of the plugin chord grammar so
+/// this module stays available without the `plugin` feature.)
+pub fn parse_chord(spec: &str) -> Option<(KeyCode, KeyModifiers)> {
+    let spec = spec.trim().to_ascii_lowercase();
+    if spec.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = spec.split(['-', '+']).filter(|s| !s.is_empty()).collect();
+    let (key_part, mod_parts) = parts.split_last()?;
+    let mut modifiers = KeyModifiers::NONE;
+    for m in mod_parts {
+        match *m {
+            "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+            "alt" | "meta" | "option" => modifiers |= KeyModifiers::ALT,
+            "shift" => modifiers |= KeyModifiers::SHIFT,
+            _ => return None,
+        }
+    }
+    let code = match *key_part {
+        "enter" | "return" => KeyCode::Enter,
+        "esc" | "escape" => KeyCode::Esc,
+        "tab" => KeyCode::Tab,
+        "backspace" => KeyCode::Backspace,
+        "delete" | "del" => KeyCode::Delete,
+        "insert" | "ins" => KeyCode::Insert,
+        "space" => KeyCode::Char(' '),
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "pageup" | "pgup" => KeyCode::PageUp,
+        "pagedown" | "pgdn" | "pagedn" => KeyCode::PageDown,
+        f if f.starts_with('f') && f.len() >= 2 && f[1..].chars().all(|c| c.is_ascii_digit()) => {
+            let n: u8 = f[1..].parse().ok()?;
+            if (1..=12).contains(&n) {
+                KeyCode::F(n)
+            } else {
+                return None;
+            }
+        }
+        s if s.chars().count() == 1 => KeyCode::Char(s.chars().next().unwrap()),
+        _ => return None,
+    };
+    Some((code, modifiers))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(key: &str, command: &str) -> KeybindingConfig {
+        KeybindingConfig {
+            key: key.to_string(),
+            command: command.to_string(),
+        }
+    }
+    fn ev(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    #[test]
+    fn defaults_resolve() {
+        let km = Keymap::defaults();
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            Some(KeyAction::ToggleReasoning)
+        );
+        assert_eq!(
+            km.resolve(&ev(KeyCode::PageUp, KeyModifiers::NONE)),
+            Some(KeyAction::ScrollPageUp)
+        );
+        // A plain char / unbound chord resolves to nothing.
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('a'), KeyModifiers::NONE)),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_chord_forms() {
+        assert_eq!(
+            parse_chord("ctrl-r"),
+            Some((KeyCode::Char('r'), KeyModifiers::CONTROL))
+        );
+        assert_eq!(
+            parse_chord("Ctrl+T"),
+            Some((KeyCode::Char('t'), KeyModifiers::CONTROL))
+        );
+        assert_eq!(
+            parse_chord("pageup"),
+            Some((KeyCode::PageUp, KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_chord("ctrl-shift-x"),
+            Some((
+                KeyCode::Char('x'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            ))
+        );
+        assert_eq!(parse_chord("f5"), Some((KeyCode::F(5), KeyModifiers::NONE)));
+        assert_eq!(parse_chord("boguskey"), None);
+        assert_eq!(parse_chord("ctrl-"), None);
+        assert_eq!(parse_chord("f99"), None);
+    }
+
+    #[test]
+    fn override_rebinds_and_keeps_other_defaults() {
+        // Rebind toggle-reasoning to Ctrl+T.
+        let (km, warns) = Keymap::from_config(Some(&[cfg("ctrl-t", "toggle_reasoning")]));
+        assert!(warns.is_empty(), "{warns:?}");
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+            Some(KeyAction::ToggleReasoning)
+        );
+        // The default Ctrl+R still toggles (adding a binding doesn't drop
+        // the default), and an unrelated default is intact.
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            Some(KeyAction::ToggleReasoning)
+        );
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('n'), KeyModifiers::CONTROL)),
+            Some(KeyAction::NextChat)
+        );
+    }
+
+    #[test]
+    fn override_on_an_occupied_chord_replaces_it() {
+        // Binding Ctrl+R to next_chat takes Ctrl+R away from toggle.
+        let (km, warns) = Keymap::from_config(Some(&[cfg("ctrl-r", "next_chat")]));
+        assert!(warns.is_empty(), "{warns:?}");
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            Some(KeyAction::NextChat)
+        );
+    }
+
+    #[test]
+    fn unbind_removes_a_default() {
+        let (km, _) = Keymap::from_config(Some(&[cfg("ctrl-r", "none")]));
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            None
+        );
+    }
+
+    #[test]
+    fn invalid_chord_and_unknown_command_warn() {
+        let (_, warns) = Keymap::from_config(Some(&[
+            cfg("kaboom", "toggle_reasoning"),
+            cfg("ctrl-y", "do_a_barrel_roll"),
+        ]));
+        assert_eq!(warns.len(), 2, "{warns:?}");
+        assert!(warns[0].contains("unrecognized key"));
+        assert!(warns[1].contains("unknown command"));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ mod events;
 pub(crate) mod gitstatus;
 mod highlight;
 pub(crate) mod input;
+pub(crate) mod keymap;
 mod markdown;
 pub(crate) mod notifications;
 pub(crate) mod panel_data;
@@ -72,6 +73,7 @@ use crate::ui::chat_state::{ChatUiState, load_chat_ui_state, save_chat_ui_state}
 use crate::ui::colors::{c_agent, c_error, c_perm, c_tool, resolve_color};
 use crate::ui::events::{render_session, sanitize_output};
 use crate::ui::input::InputEditor;
+use crate::ui::keymap::{KeyAction, Keymap};
 use crate::ui::panel_render::{build_left_panel_info, build_panel_data};
 use crate::ui::picker::ListPicker;
 use crate::ui::renderer::{LineEntry, Renderer};
@@ -176,6 +178,12 @@ pub async fn run_interactive(
     // and a ring of the most recent tool actions for the [ACTIVITY]
     // ticker. Both feed `build_left_panel_info` each loop tick.
     let gitstat = crate::ui::gitstatus::spawn_poller(std::time::Duration::from_secs(3));
+    // Configurable global key bindings (VSCode-style): defaults layered
+    // with the user's `keybindings` config. Surface any parse warnings.
+    let (keymap, keymap_warnings) = Keymap::from_config(cfg.keybindings.as_deref());
+    for w in &keymap_warnings {
+        eprintln!("warning: {w}");
+    }
     const TOOL_ACTIVITY_CAP: usize = 8;
     let mut tool_activity: std::collections::VecDeque<String> =
         std::collections::VecDeque::with_capacity(TOOL_ACTIVITY_CAP);
@@ -825,6 +833,11 @@ pub async fn run_interactive(
                         continue;
                     }
                     UserEvent::Key(key) => {
+                        // Resolve the key to a rebindable global command
+                        // (config-overridable). `None` for everything else
+                        // (typing, input-editor keys, the Ctrl+C/D/Esc
+                        // cancel gesture), which flows through unchanged.
+                        let action = keymap.resolve(&key);
                         let is_ctrl_c = key.code == KeyCode::Char('c')
                             && key.modifiers.contains(KeyModifiers::CONTROL);
                         let is_ctrl_d = key.code == KeyCode::Char('d')
@@ -1040,9 +1053,7 @@ pub async fn run_interactive(
                             last_esc = None;
                         }
 
-                        let ctrl_r = key.code == KeyCode::Char('r')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        if ctrl_r {
+                        if action == Some(KeyAction::ToggleReasoning) {
                             show_reasoning = !show_reasoning;
                             renderer.write_line(
                                 &format!("reasoning visibility: {}", if show_reasoning { "on" } else { "off" }),
@@ -1056,13 +1067,13 @@ pub async fn run_interactive(
                             continue;
                         }
 
-                        let ctrl_n = key.code == KeyCode::Char('n')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        let ctrl_p = key.code == KeyCode::Char('p')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        let ctrl_x = key.code == KeyCode::Char('x')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        if (ctrl_n || ctrl_p || ctrl_x) && renderer.chat_count() > 1 {
+                        let ctrl_p = action == Some(KeyAction::PrevChat);
+                        let ctrl_x = action == Some(KeyAction::CloseChat);
+                        if matches!(
+                            action,
+                            Some(KeyAction::NextChat | KeyAction::PrevChat | KeyAction::CloseChat)
+                        ) && renderer.chat_count() > 1
+                        {
                             let old_active = renderer.active_chat();
                             save_chat_ui_state(
                                 &mut chat_ui_states[old_active],
@@ -1131,9 +1142,7 @@ pub async fn run_interactive(
                         // focused tab (if any). Only fires when the
                         // input buffer is empty so it doesn't shadow
                         // ordinary character input.
-                        let ctrl_k = key.code == KeyCode::Char('k')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        if ctrl_k && input.expanded().is_empty() {
+                        if action == Some(KeyAction::KillSubagent) && input.expanded().is_empty() {
                             let active = renderer.active_chat();
                             if let Some(sub_id) = chat_idx_to_subagent.get(&active).cloned() {
                                 use crate::agent::tools::task::{KillOutcome, kill_subagent};
@@ -1181,8 +1190,8 @@ pub async fn run_interactive(
                             }
                         }
 
-                        match key.code {
-                            KeyCode::PageUp => {
+                        match action {
+                            Some(KeyAction::ScrollPageUp) => {
                                 renderer.scroll_page_up();
                                 renderer.render_viewport()?;
                                 renderer.draw_bottom(
@@ -1192,7 +1201,7 @@ pub async fn run_interactive(
                                 )?;
                                 continue;
                             }
-                            KeyCode::PageDown => {
+                            Some(KeyAction::ScrollPageDown) => {
                                 renderer.scroll_page_down();
                                 renderer.render_viewport()?;
                                 renderer.draw_bottom(
@@ -1202,7 +1211,7 @@ pub async fn run_interactive(
                                 )?;
                                 continue;
                             }
-                            KeyCode::Home => {
+                            Some(KeyAction::ScrollToTop) => {
                                 renderer.scroll_to_top();
                                 renderer.render_viewport()?;
                                 renderer.draw_bottom(
@@ -1212,7 +1221,7 @@ pub async fn run_interactive(
                                 )?;
                                 continue;
                             }
-                            KeyCode::End => {
+                            Some(KeyAction::ScrollToBottom) => {
                                 renderer.scroll_to_bottom()?;
                                 renderer.draw_bottom(
                                     &input,


### PR DESCRIPTION
Adds a `keybindings` config — an array of `{ "key": "<chord>", "command": "<command>" }` that overrides the built-in global command keys, like a VSCode `keybindings.json`.

```json
{
  "keybindings": [
    { "key": "ctrl-t", "command": "toggle_reasoning" },
    { "key": "ctrl-r", "command": "none" }
  ]
}
```

## Design
- **New `ui::keymap`** — a `KeyAction` set (toggle_reasoning, scroll_page_up/down, scroll_to_top/bottom, next/prev/close_chat, kill_subagent) with default chords, a self-contained chord parser (`ctrl-t`, `pageup`, `ctrl-shift-x`, `f5`, named keys; no `plugin`-feature dependency), and a `Keymap` that layers config over the defaults.
- **Semantics (VSCode-like):** binding a new chord *adds* it (defaults kept); binding an occupied chord *replaces* it; command `none`/`unbind` *disables* the default on that chord. Invalid chords / unknown commands warn at startup and are skipped (rest of config still loads).
- **Low-risk integration:** the event loop resolves each key to a `KeyAction` once, and the four affected arms (toggle reasoning, chat nav, kill-subagent, scroll) swap from hardcoded chord tests to action tests. The delicate handler bodies are untouched — a condition swap, not an event-loop rewrite. The input-editor overlap (Ctrl+N/P/K) is preserved by the existing guards (`chat_count > 1`, empty-buffer).

## Scope (confirmed)
Global/command keys only. **Not** rebindable, by design: the input-editor's text-editing keys (Ctrl+A/E/W, kill-ring, word motion, history) and the universal cancel/interrupt gesture (Ctrl+C / Ctrl+D / Esc — the panic button).

## Docs & tests
- A "Key bindings" section in `docs/config.md` (schema, chord grammar, command table, add/replace/unbind semantics) + a pointer from `docs/tui.md`.
- Unit tests: defaults resolve, chord-parse forms, add-vs-replace override, unbind, invalid-chord/unknown-command warnings.
- Full feature-matrix suite green at `-D warnings` (2182 passed).
