### PR TITLE
chore(provider): per-role one-shot LLM telemetry label + MODIFIED panel regression test

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2071,7 +2071,17 @@ fn build_critic_fn(
         let model_name = model_name.clone();
         Box::pin(async move {
             let model = client.completion_model(model_name);
-            summarize::summarize_with_model(model, prompt).await
+            // dirge-0g6i: distinct retry/telemetry label so the critic's
+            // calls aren't conflated with the summarizer's. (Same preamble
+            // as the summarizer path — the critic's instructions live in
+            // the prompt body.)
+            summarize::oneshot_with_model(
+                model,
+                "critic",
+                "You are a conversation summarizer.",
+                prompt,
+            )
+            .await
         })
             as std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<String>> + Send>>
     }))
@@ -2103,7 +2113,8 @@ pub fn build_approval_fn(
         Box::pin(async move {
             let model = client.completion_model(model_name);
             let prompt = build_evaluator_prompt(&req);
-            let raw = summarize::oneshot_with_model(model, EVALUATOR_PREAMBLE, prompt).await?;
+            let raw = summarize::oneshot_with_model(model, "approval", EVALUATOR_PREAMBLE, prompt)
+                .await?;
             Ok::<ApprovalDecision, anyhow::Error>(parse_decision(&raw))
         })
             as std::pin::Pin<

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -69,17 +69,26 @@ pub(crate) async fn summarize_with_model(
     model: super::AnyModel,
     prompt: String,
 ) -> anyhow::Result<String> {
-    oneshot_with_model(model, "You are a conversation summarizer.", prompt).await
+    oneshot_with_model(
+        model,
+        "summarizer",
+        "You are a conversation summarizer.",
+        prompt,
+    )
+    .await
 }
 
 /// Generic one-shot LLM call over any `AnyModel` variant with a caller-
 /// supplied system preamble. Factored out of `summarize_with_model` so
 /// every side-LLM role (summarizer, critic, approval evaluator) shares
 /// the same dispatch + retry/stream-drain path instead of duplicating
-/// the 8-arm variant match. The summarizer-sized prompt budget is
-/// applied here too (a no-op for the tiny approval/critic prompts).
+/// the 8-arm variant match. `label` keeps each role distinct in
+/// retry/backoff telemetry (`run_with_retry`). The summarizer-sized
+/// prompt budget is applied here too (a no-op for the tiny
+/// approval/critic prompts).
 pub(crate) async fn oneshot_with_model(
     model: super::AnyModel,
+    label: &'static str,
     preamble: &'static str,
     mut prompt: String,
 ) -> anyhow::Result<String> {
@@ -88,14 +97,14 @@ pub(crate) async fn oneshot_with_model(
         prompt = head_tail_truncate(&prompt, ONESHOT_PROMPT_BUDGET_BYTES);
     }
     match model {
-        super::AnyModel::OpenRouter(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::OpenAI(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::Anthropic(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::Gemini(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::DeepSeek(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::Glm(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::Ollama(m) => run_oneshot(m, preamble, prompt).await,
-        super::AnyModel::Custom(m) => run_oneshot(m, preamble, prompt).await,
+        super::AnyModel::OpenRouter(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::OpenAI(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::Anthropic(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::Gemini(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::DeepSeek(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::Glm(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::Ollama(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::Custom(m) => run_oneshot(m, label, preamble, prompt).await,
     }
 }
 
@@ -145,7 +154,12 @@ pub(crate) fn head_tail_truncate(prompt: &str, budget: usize) -> String {
     )
 }
 
-async fn run_oneshot<M>(model: M, preamble: &'static str, prompt: String) -> anyhow::Result<String>
+async fn run_oneshot<M>(
+    model: M,
+    label: &'static str,
+    preamble: &'static str,
+    prompt: String,
+) -> anyhow::Result<String>
 where
     M: rig::completion::CompletionModel + Clone + 'static,
     M::StreamingResponse: Send + Sync + Unpin + Clone + 'static,
@@ -158,7 +172,7 @@ where
     // stream error as `Err(String)` so the helper can classify it; an
     // empty-but-clean response is returned as `Ok(String::new())` and
     // rejected (non-retryable) below.
-    let response = run_with_retry(&policy, "oneshot-llm", || {
+    let response = run_with_retry(&policy, label, || {
         let model = model.clone();
         let prompt = prompt.clone();
         async move {

--- a/src/ui/tui/panels.rs
+++ b/src/ui/tui/panels.rs
@@ -1016,6 +1016,45 @@ mod tests {
         );
     }
 
+    /// dirge-sb2n: with N files the MODIFIED box is content-sized — 2
+    /// borders + one row per file — NOT pane-filling. Complements
+    /// `modified_box_paints_three_rows_when_empty` (the empty case) and
+    /// pins the user-visible symptom from the report: 4 files paint a
+    /// 6-row box on a tall panel.
+    #[test]
+    fn modified_box_grows_to_content_height_with_files() {
+        let mut data = PanelData::default();
+        data.modified = vec![
+            "src/verify.ts".into(),
+            "test/todatests.test.ts".into(),
+            "src/graph.ts".into(),
+            "src/interpreter.ts".into(),
+        ];
+        let layout = Layout::new(160, 40, 1);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| f.render_widget(RightPanel::new(&data), layout.right_panel))
+            .unwrap();
+        let backend = terminal.backend().clone();
+        let row = |y: u16| -> String {
+            (layout.right_panel.x..layout.right_panel.x + layout.right_panel.width)
+                .map(|x| backend.buffer().cell((x, y)).unwrap().symbol().to_string())
+                .collect()
+        };
+        let title_y = (layout.right_panel.y..layout.right_panel.y + layout.right_panel.height)
+            .find(|&y| row(y).contains("[MODIFIED]"))
+            .expect("MODIFIED title");
+        let bottom_y = (title_y + 1..layout.right_panel.y + layout.right_panel.height)
+            .find(|&y| row(y).contains('╰'))
+            .expect("MODIFIED bottom border");
+        assert_eq!(
+            bottom_y - title_y,
+            5,
+            "4 files → 6-row box (2 borders + 4 rows), not pane-filling"
+        );
+    }
+
     /// CPU/MEM bar formatting.
     #[test]
     fn bar_formatting() {


### PR DESCRIPTION
Two small follow-ups from the final review:

1. **Telemetry label (requested).** The summarizer one-shot was generalized into `oneshot_with_model`, which collapsed the per-role retry label to a shared one. This threads a `label` param through to `run_with_retry`, restoring distinct labels: `summarizer`, `critic`, `approval` (critic now gets its own label too, which it didn't have before — it had been inheriting `summarizer`).

2. **MODIFIED panel regression test.** A user screenshot showed the MODIFIED box pane-filling with 4 files. Investigation: the content-sizing fix (dirge-sb2n / #264) is on `main` and **verified correct** — measured a 6-row box for 4 files (2 borders + 4 rows). The screenshot was from a binary predating #264. This adds a permanent regression test pinning the with-files height, complementing the existing empty-case test.

Full suite: 2322 passed.