### PR TITLE
feat(critic): give the critic a role-appropriate system preamble

### DIFF
--- a/src/agent/agent_loop/critic.rs
+++ b/src/agent/agent_loop/critic.rs
@@ -27,21 +27,32 @@ pub type CriticFn = Arc<
     dyn Fn(String) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>> + Send + Sync,
 >;
 
-/// System/instruction preamble for the critic. Asks for a strict,
-/// parseable verdict so we can act on it deterministically.
-const CRITIC_INSTRUCTIONS: &str = "\
-You are a strict code-review critic. You are given a user's request and a transcript of what an \
-assistant just did to satisfy it. Judge ONLY whether the task is actually complete and correct — \
-not style. Be skeptical: unverified claims, partial work, ignored edge cases, and \"done\" without \
-evidence are NOT complete.\n\n\
+/// System preamble for the critic: establishes its role and the strict,
+/// skeptical stance. Passed as the LLM system prompt by `build_critic_fn`
+/// (replacing the stray "conversation summarizer" preamble) so the model
+/// knows what it is BEFORE it sees the transcript. The exact response
+/// FORMAT lives in [`build_prompt`] instead — right next to the material
+/// being judged.
+pub const CRITIC_PREAMBLE: &str = "\
+You are a strict code-review critic for an autonomous coding agent. You are given a user's request \
+and a transcript of what the assistant just did to satisfy it. Judge ONLY whether the task is \
+actually complete and correct — not style. Be skeptical: unverified claims, partial work, ignored \
+edge cases, and \"done\" without evidence are NOT complete. If you are genuinely unsure, pass — do \
+not block on speculation.";
+
+/// Response-format instruction. Kept in the user prompt (not the system
+/// preamble) so the strict verdict shape sits directly beside the
+/// transcript the critic is judging.
+const CRITIC_FORMAT: &str = "\
 Respond in EXACTLY this format and nothing else:\n\
 On the first line, either `VERDICT: COMPLETE` or `VERDICT: INCOMPLETE`.\n\
-If INCOMPLETE, follow with a short bullet list of the specific, concrete issues to fix.\n\
-If you are unsure, answer COMPLETE (do not block on speculation).";
+If INCOMPLETE, follow with a short bullet list of the specific, concrete issues to fix.";
 
-/// Build the critic prompt from a transcript of the run.
+/// Build the critic prompt from a transcript of the run. The role lives
+/// in [`CRITIC_PREAMBLE`] (the system slot); this carries the format +
+/// the transcript.
 pub fn build_prompt(transcript: &str) -> String {
-    format!("{CRITIC_INSTRUCTIONS}\n\n--- transcript ---\n{transcript}\n--- end transcript ---")
+    format!("{CRITIC_FORMAT}\n\n--- transcript ---\n{transcript}\n--- end transcript ---")
 }
 
 /// Parse the critic's raw response into a verdict. `Some(issues)` means
@@ -127,6 +138,21 @@ mod tests {
         assert!(p.contains("VERDICT: COMPLETE"));
         assert!(p.contains("VERDICT: INCOMPLETE"));
         assert!(p.contains("edited foo.rs"));
+    }
+
+    /// The system preamble states the critic's ROLE (not the summarizer's),
+    /// and the response FORMAT is kept out of it (it lives in the prompt).
+    #[test]
+    fn preamble_establishes_critic_role_without_format() {
+        let lower = CRITIC_PREAMBLE.to_ascii_lowercase();
+        assert!(lower.contains("critic"), "preamble must name the role");
+        assert!(
+            !lower.contains("summarizer"),
+            "preamble must not be the summarizer's"
+        );
+        // Format lives in the prompt, not the system preamble.
+        assert!(!CRITIC_PREAMBLE.contains("VERDICT:"));
+        assert!(build_prompt("t").contains("VERDICT:"));
     }
 
     #[tokio::test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2054,8 +2054,9 @@ fn build_escalation_stream_fn(
 
 /// F6 tier 3: build the bounded-critic callback. Constructs a fresh
 /// client for the critic alias and returns a [`CriticFn`] that runs one
-/// completion (via `summarize_with_model`) per call. No tools — the
-/// critic only reads a transcript and returns a verdict.
+/// completion (via `summarize::oneshot_with_model`, with the critic's own
+/// role preamble + telemetry label) per call. No tools — the critic only
+/// reads a transcript and returns a verdict.
 fn build_critic_fn(
     alias: &str,
     entry: &ProviderEntry,
@@ -2071,14 +2072,13 @@ fn build_critic_fn(
         let model_name = model_name.clone();
         Box::pin(async move {
             let model = client.completion_model(model_name);
-            // dirge-0g6i: distinct retry/telemetry label so the critic's
-            // calls aren't conflated with the summarizer's. (Same preamble
-            // as the summarizer path — the critic's instructions live in
-            // the prompt body.)
+            // Distinct retry/telemetry label + a role-appropriate system
+            // preamble (the critic's response FORMAT still rides in the
+            // prompt body, next to the transcript).
             summarize::oneshot_with_model(
                 model,
                 "critic",
-                "You are a conversation summarizer.",
+                crate::agent::agent_loop::critic::CRITIC_PREAMBLE,
                 prompt,
             )
             .await


### PR DESCRIPTION
Follow-up to the telemetry-label change. The critic had been inheriting the summarizer's `You are a conversation summarizer.` **system** preamble — its actual instructions only rode in the prompt body.

This splits it cleanly:
- **`CRITIC_PREAMBLE`** (new, system slot) — states the role + the strict, skeptical stance, so the model knows what it is *before* the transcript.
- **`CRITIC_FORMAT`** (user prompt, via `build_prompt`) — the exact `VERDICT: COMPLETE/INCOMPLETE` response shape, kept next to the transcript it's judging.

`build_critic_fn` now passes `CRITIC_PREAMBLE`. New test pins that the preamble names the critic role (not the summarizer) and that the verdict format lives in the prompt, not the preamble. Full suite: 2323 passed.