### PR TITLE
fix(stability): round 3 — LSP slot leak, edit overlaps, memory drift & lock staleness

### DIFF
--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -205,12 +205,16 @@ impl Tool for EditTool {
             )));
         }
 
+        // dirge-nj6d: the fuzzy fallback matchers can return OVERLAPPING
+        // byte ranges (e.g. the whitespace-normalized matcher tries block
+        // sizes up to +5, so two different start lines can cover the same
+        // region). Splicing overlapping ranges — even in reverse — corrupts
+        // the buffer or panics at a non-char boundary inside
+        // `replace_range`. Keep only a disjoint set so every downstream
+        // consumer (ambiguity count + replace_all splice) is safe.
+        let match_ranges: Vec<(usize, usize)> = keep_disjoint_ranges(match_positions);
         // Reduce to start positions for backwards compat with the
         // downstream ambiguity-reporting and replacement logic.
-        // Each "position" still refers to the START of a match;
-        // the actual matched length is captured via the byte range
-        // for replacement below.
-        let match_ranges: Vec<(usize, usize)> = match_positions;
         let match_positions: Vec<usize> = match_ranges.iter().map(|(s, _)| *s).collect();
 
         let do_replace_all = args.replace_all.unwrap_or(false);
@@ -399,6 +403,25 @@ impl Tool for EditTool {
 // end_byte) byte ranges in `content` that match `find` under the
 // helper's normalization. Empty Vec = no matches. The cascade
 // tries each in priority order in the call site above.
+
+/// dirge-nj6d: reduce a set of (start, end) byte ranges to a disjoint
+/// subset. Sorts by start and greedily keeps a range only if it begins
+/// at or after the previously-kept range's end; overlapping ranges are
+/// dropped. This protects the reverse-order `replace_range` splice from
+/// corruption / non-char-boundary panics when the fuzzy matchers emit
+/// overlapping candidates. Stable preference: the earliest-starting
+/// range of any overlapping cluster wins.
+fn keep_disjoint_ranges(mut ranges: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    ranges.sort_by_key(|r| r.0);
+    let mut disjoint: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        match disjoint.last() {
+            Some(&(_, last_end)) if start < last_end => {} // overlaps kept → drop
+            _ => disjoint.push((start, end)),
+        }
+    }
+    disjoint
+}
 
 /// Line-trimmed match. Match each logical block of N lines where
 /// each line's .trim() equals the corresponding find line's
@@ -630,5 +653,56 @@ mod fuzzy_tests {
         assert_eq!(m.len(), 1);
         let (s, e) = m[0];
         assert_eq!(&content[s..e], "        let x = 1;\n        let y = 2;");
+    }
+
+    // ── dirge-nj6d: overlapping-range dedup for replace_all ──
+
+    #[test]
+    fn keep_disjoint_drops_overlaps_keeps_earliest() {
+        // Two overlapping clusters; earliest-starting range of each wins.
+        let input = vec![(0, 10), (5, 15), (12, 20), (20, 25)];
+        assert_eq!(
+            keep_disjoint_ranges(input),
+            vec![(0, 10), (12, 20), (20, 25)],
+        );
+    }
+
+    #[test]
+    fn keep_disjoint_sorts_unsorted_input() {
+        // Unsorted input with a nested range fully inside an earlier one.
+        let input = vec![(20, 25), (0, 30), (5, 8)];
+        // After sort: (0,30),(5,8),(20,25). (5,8) and (20,25) both inside
+        // (0,30) → dropped.
+        assert_eq!(keep_disjoint_ranges(input), vec![(0, 30)]);
+    }
+
+    #[test]
+    fn keep_disjoint_adjacent_ranges_are_kept() {
+        // end-exclusive: (0,5) and (5,10) touch but don't overlap.
+        let input = vec![(0, 5), (5, 10)];
+        assert_eq!(keep_disjoint_ranges(input), vec![(0, 5), (5, 10)]);
+    }
+
+    #[test]
+    fn keep_disjoint_empty() {
+        assert!(keep_disjoint_ranges(Vec::new()).is_empty());
+    }
+
+    /// Mirrors the call-site reverse-order `replace_range` splice over a
+    /// set that originated as OVERLAPPING matcher output. Without
+    /// `keep_disjoint_ranges` this corrupts the buffer (and can panic at a
+    /// non-char boundary); with it, the splice is safe and correct.
+    #[test]
+    fn replace_all_reverse_splice_over_deduped_ranges_is_safe() {
+        let content = "aXbXc".to_string();
+        // (1,3) and (1,2) overlap; (3,4) is disjoint.
+        let overlapping = vec![(1, 3), (1, 2), (3, 4)];
+        let ranges = keep_disjoint_ranges(overlapping);
+        assert_eq!(ranges, vec![(1, 3), (3, 4)]);
+        let mut out = content.clone();
+        for (s, e) in ranges.into_iter().rev() {
+            out.replace_range(s..e, "_");
+        }
+        assert_eq!(out, "a__c");
     }
 }

--- a/src/extras/memory_store.rs
+++ b/src/extras/memory_store.rs
@@ -371,23 +371,42 @@ impl MemoryStore {
         let disk_entries = split_entries(&on_disk);
         let disk_entries = deduplicate_entries(disk_entries);
 
-        // Detect drift: if our in-memory entries don't match what's
-        // on disk (and the snapshot isn't the same either), someone
-        // modified the file externally.
-        if self.entries != disk_entries && self.snapshot != disk_entries {
-            // Snapshot the corrupted file and refuse.
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            let bak = self.file_path.with_extension(format!("bak.{}", ts));
-            std::fs::rename(&self.file_path, &bak)
-                .map_err(|e| format!("External drift detected but failed to snapshot: {e}"))?;
+        // Detect drift: distinguish a benign concurrent append (another
+        // dirge process in the same project added entries) from a genuine
+        // external edit (a user hand-editing or corrupting the file).
+        //
+        // dirge-cdik: the old check (`entries != disk && snapshot != disk`)
+        // flagged ANY disk mismatch as corruption — so two sessions in one
+        // project made each other's legitimate appends look like external
+        // tampering, renaming MEMORY.md to .bak and refusing the write.
+        //
+        // New rule: treat disk as COMPATIBLE (accept it as truth) as long as
+        // every entry we already knew about — our load-time snapshot AND our
+        // current in-memory entries — is still present on disk. That covers
+        // concurrent appends. Only when disk has DROPPED or REWRITTEN an
+        // entry we knew about do we treat it as a real external edit worth
+        // preserving. (Limitation: a concurrent dirge REMOVE by another
+        // session looks like divergence and is conservatively preserved to
+        // .bak — no data is lost, just an extra backup.)
+        if self.entries != disk_entries {
+            let disk_set: std::collections::HashSet<&String> = disk_entries.iter().collect();
+            let snapshot_preserved = self.snapshot.iter().all(|e| disk_set.contains(e));
+            let entries_preserved = self.entries.iter().all(|e| disk_set.contains(e));
+            if !snapshot_preserved || !entries_preserved {
+                // Genuine external divergence — snapshot the file and refuse.
+                let ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let bak = self.file_path.with_extension(format!("bak.{}", ts));
+                std::fs::rename(&self.file_path, &bak)
+                    .map_err(|e| format!("External drift detected but failed to snapshot: {e}"))?;
 
-            return Err(format!(
-                "External drift detected — file was modified outside dirge. Original saved to {}.",
-                bak.display()
-            ));
+                return Err(format!(
+                    "External drift detected — file was modified outside dirge. Original saved to {}.",
+                    bak.display()
+                ));
+            }
         }
 
         // Accept disk state as truth.
@@ -593,7 +612,7 @@ impl FileLock {
         // staleness detection. If the process crashes, the lock
         // file remains — we detect this by checking whether the
         // PID in the lock file is still alive.
-        for attempt in 0..50 {
+        for _ in 0..50 {
             match std::fs::OpenOptions::new()
                 .read(true)
                 .write(true)
@@ -607,10 +626,16 @@ impl FileLock {
                     return Ok(FileLock { path: path.clone() });
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                    // Check if the lock holder is still alive.
-                    if attempt == 0 && Self::is_lock_stale(path) {
+                    // dirge-3mx6: re-check staleness on EVERY attempt, not just
+                    // the first. The holder may crash AFTER we begin waiting;
+                    // the old `attempt == 0` gate meant the remaining 49 tries
+                    // never re-checked, so we'd time out against an orphan lock
+                    // left by a dead process. `is_lock_stale` only reports true
+                    // when the recorded PID is genuinely gone, so a live holder
+                    // is never stolen from.
+                    if Self::is_lock_stale(path) {
                         let _ = std::fs::remove_file(path);
-                        continue; // Retry immediately.
+                        continue; // Retry immediately to claim it.
                     }
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
@@ -835,6 +860,122 @@ mod tests {
 
         let err = store.remove("nonexistent").unwrap_err();
         assert!(err.contains("No entry found"), "got: {err}");
+    }
+
+    /// dirge-cdik: two dirge sessions in one project. A legitimate
+    /// concurrent append by session B must NOT make session A's next write
+    /// see the file as externally corrupted — no `.bak`, no refusal.
+    #[test]
+    fn concurrent_append_by_another_session_is_not_drift() {
+        let (paths, _dir) = temp_project();
+        // Seed disk with one entry.
+        {
+            let mut seed = MemoryStore::load_memory(&paths).unwrap();
+            seed.add("entry one").unwrap();
+        }
+        // Two sessions load the same project independently.
+        let mut session_a = MemoryStore::load_memory(&paths).unwrap();
+        let mut session_b = MemoryStore::load_memory(&paths).unwrap();
+
+        // Session B appends — a legitimate concurrent write.
+        session_b.add("entry two from B").unwrap();
+
+        // Session A now appends. The old code saw disk=[one,two] ≠ its
+        // snapshot/entries=[one], renamed MEMORY.md to .bak, and refused.
+        // With the fix it accepts the compatible superset and appends.
+        session_a
+            .add("entry three from A")
+            .expect("concurrent append must not be treated as drift");
+
+        let dir = paths.memory_dir();
+        let baks: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".bak"))
+            .collect();
+        assert!(
+            baks.is_empty(),
+            "no .bak should be created on a concurrent append, found {baks:?}"
+        );
+
+        let on_disk = std::fs::read_to_string(paths.memory_file("MEMORY.md")).unwrap();
+        assert!(on_disk.contains("entry one"));
+        assert!(on_disk.contains("entry two from B"));
+        assert!(on_disk.contains("entry three from A"));
+    }
+
+    /// dirge-cdik: a genuinely destructive external edit (a known entry
+    /// removed / rewritten by hand) is still detected as drift and the file
+    /// preserved to a `.bak`.
+    #[test]
+    fn genuine_external_edit_still_detected_as_drift() {
+        let (paths, _dir) = temp_project();
+        {
+            let mut seed = MemoryStore::load_memory(&paths).unwrap();
+            seed.add("original entry").unwrap();
+        }
+        let mut session = MemoryStore::load_memory(&paths).unwrap();
+
+        // A user hand-edits the file, REPLACING the known entry.
+        crate::fs_atomic::atomic_write_sync(
+            &paths.memory_file("MEMORY.md"),
+            "totally different hand-written note\n".as_bytes(),
+        )
+        .unwrap();
+
+        let err = session.add("new entry").unwrap_err();
+        assert!(err.contains("External drift"), "got: {err}");
+
+        let dir = paths.memory_dir();
+        let has_bak = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".bak"));
+        assert!(
+            has_bak,
+            "destructive external edit must be snapshotted to .bak"
+        );
+    }
+
+    /// dirge-3mx6: a lock holder that crashes AFTER we start waiting must
+    /// still be reclaimed. We seed the lock with our own (live) PID so the
+    /// first attempt sees it as held, then a background thread rewrites it
+    /// with a genuinely-dead PID mid-wait. The old `attempt == 0`-only
+    /// staleness check would never re-inspect and would time out; the
+    /// per-attempt check reclaims it.
+    #[cfg(unix)]
+    #[test]
+    fn stale_lock_is_reclaimed_after_attempt_zero() {
+        let (_paths, dir) = temp_project();
+        let lock_path = dir.join("reclaim.lock");
+
+        // Attempt 0: lock holds THIS (live) process's PID → not stale.
+        std::fs::write(&lock_path, std::process::id().to_string()).unwrap();
+
+        // A genuinely-dead PID: spawn a child, then reap it.
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn helper process");
+        let dead_pid = child.id();
+        child.wait().unwrap(); // reaped → PID no longer alive
+
+        // Mid-wait, replace the live PID with the dead one (holder crash).
+        let lp = lock_path.clone();
+        let swapper = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            std::fs::write(&lp, dead_pid.to_string()).unwrap();
+        });
+
+        // Must NOT time out: once the lock goes stale, the per-attempt
+        // re-check clears it and we claim the lock.
+        let lock =
+            FileLock::acquire(&lock_path).expect("stale lock must be reclaimed, not time out");
+        swapper.join().unwrap();
+        drop(lock); // Drop removes the lock file.
+        assert!(
+            !lock_path.exists(),
+            "lock file should be cleaned up on drop"
+        );
     }
 
     #[test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -270,9 +270,13 @@ impl LspManager {
         root: &Path,
         key: &(PathBuf, String),
     ) -> Option<Arc<ClientEntry>> {
-        // If another caller is already spawning this key, wait for them
-        // instead of racing.
-        let wait_for: Option<Arc<Notify>> = {
+        // Decide our role under the lock, then RELEASE it before any await
+        // (the MutexGuard is not Send and must not cross `.await`).
+        enum Slot {
+            Wait(Arc<Notify>),
+            Spawn(Arc<Notify>),
+        }
+        let slot = {
             let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
             // Re-check cache under the lock — could have landed between
             // the fast-path miss and now.
@@ -283,30 +287,49 @@ impl LspManager {
                 return None;
             }
             if let Some(notify) = state.spawning.get(key) {
-                Some(Arc::clone(notify))
+                Slot::Wait(Arc::clone(notify))
             } else {
-                // We're the spawner. Mark in-flight.
+                // We're the spawner. Mark in-flight and keep the handle.
                 let notify = Arc::new(Notify::new());
                 state.spawning.insert(key.clone(), Arc::clone(&notify));
-                None
+                Slot::Spawn(notify)
             }
         };
 
-        if let Some(notify) = wait_for {
-            // Safety timeout in case we subscribed after `notify_waiters` fired
-            // (Notify doesn't save permits for late subscribers). The cache is
-            // authoritative either way — re-check after the wait, regardless
-            // of how it terminated.
-            let _ = tokio::time::timeout(Duration::from_secs(60), notify.notified()).await;
-            let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(entry) = state.clients.get(key) {
-                return Some(Arc::clone(entry));
+        // If another caller is already spawning this key, wait for them
+        // instead of racing.
+        let spawn_notify = match slot {
+            Slot::Wait(notify) => {
+                // Safety timeout in case we subscribed after `notify_waiters`
+                // fired (Notify doesn't save permits for late subscribers).
+                // The cache is authoritative either way — re-check after the
+                // wait, regardless of how it terminated.
+                let _ = tokio::time::timeout(Duration::from_secs(60), notify.notified()).await;
+                let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                if let Some(entry) = state.clients.get(key) {
+                    return Some(Arc::clone(entry));
+                }
+                return None;
             }
-            return None;
-        }
+            Slot::Spawn(notify) => notify,
+        };
+
+        // dirge-gt8c: arm a Drop guard so a cancelled future (Ctrl-C during a
+        // cold spawn) releases the slot + wakes waiters instead of orphaning
+        // it. The normal completion path below disarms it.
+        let mut slot_guard = SpawnSlotGuard {
+            state: Arc::clone(&self.state),
+            key: key.clone(),
+            notify: Arc::clone(&spawn_notify),
+            armed: true,
+        };
 
         // We're responsible for the spawn.
         let result = self.do_spawn(server, root).await;
+
+        // Reached completion under our own control — disarm; the two-phase
+        // cleanup below removes the slot and notifies waiters itself.
+        slot_guard.armed = false;
 
         // Two-phase: update state under the lock, then log + signal outside.
         // Slot-disappeared warning is captured for emit after lock release.
@@ -757,6 +780,37 @@ enum SpawnOutcome {
     },
 }
 
+/// dirge-gt8c: RAII guard held by the caller responsible for a spawn.
+/// If that caller's future is dropped mid-spawn (e.g. Ctrl-C during a
+/// cold rust-analyzer / jdtls startup), the in-flight `spawning` slot
+/// would otherwise be orphaned — every later caller then blocks on the
+/// stale `Notify`, times out, and gets `None`, leaving the server
+/// permanently unspawnable for the session. On drop the guard removes
+/// the slot and wakes any waiters so the next request re-attempts the
+/// spawn. The normal completion path disarms the guard (`armed = false`)
+/// because it removes + notifies the slot itself.
+struct SpawnSlotGuard {
+    state: Arc<Mutex<ManagerState>>,
+    key: (PathBuf, String),
+    notify: Arc<Notify>,
+    armed: bool,
+}
+
+impl Drop for SpawnSlotGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.spawning.remove(&self.key);
+        }
+        // Wake waiters AFTER releasing the lock — they re-check the cache,
+        // find no client, and one of them becomes the new spawner.
+        self.notify.notify_waiters();
+    }
+}
+
 impl ClientEntry {
     #[allow(dead_code)]
     pub fn server_id(&self) -> &str {
@@ -792,8 +846,9 @@ mod tests {
         spawn_calls: StdArc<AtomicUsize>,
         fail_keys: std::sync::Mutex<std::collections::HashSet<(String, PathBuf)>>,
         /// Delay each spawn by this much so concurrent calls have a chance
-        /// to collide on the dedupe path.
-        delay_ms: u64,
+        /// to collide on the dedupe path. Atomic so tests can lengthen it
+        /// (to park a spawn for cancellation) then shorten it for a retry.
+        delay_ms: std::sync::atomic::AtomicU64,
     }
 
     impl CountingSpawner {
@@ -801,11 +856,14 @@ mod tests {
             Self {
                 spawn_calls: StdArc::new(AtomicUsize::new(0)),
                 fail_keys: std::sync::Mutex::new(std::collections::HashSet::new()),
-                delay_ms,
+                delay_ms: std::sync::atomic::AtomicU64::new(delay_ms),
             }
         }
         fn count(&self) -> usize {
             self.spawn_calls.load(Ordering::SeqCst)
+        }
+        fn set_delay(&self, ms: u64) {
+            self.delay_ms.store(ms, Ordering::SeqCst);
         }
         fn fail_for(&self, server_id: &str, root: &Path) {
             self.fail_keys
@@ -826,8 +884,9 @@ mod tests {
         ) -> BoxFuture<'a, std::io::Result<Spawned>> {
             Box::pin(async move {
                 self.spawn_calls.fetch_add(1, Ordering::SeqCst);
-                if self.delay_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+                let delay = self.delay_ms.load(Ordering::SeqCst);
+                if delay > 0 {
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
                 }
                 if self
                     .fail_keys
@@ -917,6 +976,57 @@ mod tests {
         let clients2 = manager.get_clients(&file).await;
         assert_eq!(clients2.len(), 1);
         assert_eq!(spawner.count(), 1);
+
+        std::fs::remove_dir_all(&tree).ok();
+    }
+
+    /// dirge-gt8c: if the spawner's future is dropped mid-spawn (Ctrl-C
+    /// during a cold rust-analyzer/jdtls startup), the in-flight slot must
+    /// be released and waiters woken — otherwise that server is
+    /// permanently unspawnable for the session. Asserts (1) the slot is
+    /// freed after cancellation and (2) a subsequent call re-spawns and
+    /// succeeds rather than hanging on the orphaned `Notify`.
+    #[tokio::test]
+    async fn cancelled_spawn_releases_slot_for_retry() {
+        let tree = cargo_tree("cancel-retry");
+        // Long cold-spawn delay so we can cancel while it's in-flight.
+        let spawner = StdArc::new(CountingSpawner::new(10_000));
+        let manager = LspManager::new(spawner.clone(), tree.clone());
+        let file = tree.join("src/lib.rs");
+
+        // Start the spawn, drive it until it parks in the slow do_spawn
+        // await, then drop the future (simulating an abort).
+        {
+            let fut = manager.get_clients(&file);
+            tokio::pin!(fut);
+            let _ = tokio::time::timeout(Duration::from_millis(250), &mut fut).await;
+            // `fut` dropped at end of block → SpawnSlotGuard fires.
+        }
+        // Let the guard's lock/notify settle.
+        tokio::task::yield_now().await;
+        assert_eq!(spawner.count(), 1, "first spawn should have been attempted");
+
+        // The in-flight slot must be gone.
+        {
+            let state = manager.state.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(
+                state.spawning.is_empty(),
+                "cancelled spawn must release its in-flight slot, got {:?}",
+                state.spawning.keys().collect::<Vec<_>>()
+            );
+            assert!(
+                state.broken.is_empty(),
+                "a cancelled (not failed) spawn must not mark the server broken",
+            );
+        }
+
+        // A retry must actually re-spawn and succeed — proving the server
+        // is NOT permanently disabled. Shorten the delay so it completes.
+        spawner.set_delay(0);
+        let clients = manager.get_clients(&file).await;
+        assert_eq!(clients.len(), 1, "retry after cancellation must succeed");
+        assert_eq!(clients[0].server_id(), "rust");
+        assert_eq!(spawner.count(), 2, "retry must spawn afresh");
 
         std::fs::remove_dir_all(&tree).ok();
     }


### PR DESCRIPTION
Third batch from the systemic review. Four confirmed bugs, each TDD-fixed and wired up.

## Fixes
- **dirge-gt8c** (P1) — a cancelled `get_or_spawn` future (Ctrl-C during a cold rust-analyzer/jdtls spawn) orphaned the in-flight `spawning` slot, leaving that LSP server permanently unspawnable for the session. Adds a `SpawnSlotGuard` (RAII) that releases the slot and wakes waiters on drop; the normal completion path disarms it. Also restructures the wait path so the `MutexGuard` never crosses an `.await`.
- **dirge-nj6d** (P1) — fuzzy fallback matchers can return OVERLAPPING byte ranges; the reverse-order `replace_all` splice then corrupts the buffer or panics at a non-char boundary. Adds `keep_disjoint_ranges` to keep a sorted, disjoint set before both the ambiguity count and the splice.
- **dirge-cdik** (P2) — two dirge sessions in one project made each other's legitimate appends look like external corruption (MEMORY.md renamed to `.bak`, write refused). Now accepts disk as truth when it's a compatible superset of our snapshot + in-memory entries; only DROPPED/REWRITTEN known entries count as genuine drift.
- **dirge-3mx6** (P3) — `FileLock::acquire` only checked staleness on attempt 0, so a holder that crashed mid-wait left an orphan lock that timed us out. Re-checks staleness on every attempt.

## Verification
- `cargo test` (default): 2347 passed.
- New tests: `cancelled_spawn_releases_slot_for_retry`, `keep_disjoint_*` + reverse-splice safety, `concurrent_append_by_another_session_is_not_drift` / `genuine_external_edit_still_detected_as_drift`, `stale_lock_is_reclaimed_after_attempt_zero`.
- `cargo fmt` clean; no new clippy warnings (both feature configs).