### PR TITLE
fix(provider/mcp): round 4 — alias collision, alias default model, stderr drain

### DIFF
--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -150,7 +150,12 @@ async fn run_prompt(
         .resolve_role(crate::config::ConfigRole::Default)
         .and_then(|(_, e)| e.model);
     let model_str = if state.cli.model.is_none() && config_model.is_none() {
-        compact_str::CompactString::new(crate::provider::default_model_for(&provider_str))
+        // dirge-j3jd: resolve the alias's provider TYPE so a custom alias
+        // doesn't fall back to the OpenRouter default model id.
+        compact_str::CompactString::new(crate::provider::default_model_for_alias(
+            &provider_str,
+            &state.cfg.providers_map(),
+        ))
     } else {
         state.cli.resolve_model(&state.cfg)
     };

--- a/src/extras/mcp/client.rs
+++ b/src/extras/mcp/client.rs
@@ -201,17 +201,77 @@ pub async fn list_tools(
 /// The task exits when the child closes stderr (process termination
 /// or stream EOF). No explicit cancel — the rmcp ChildWithCleanup
 /// Drop kills the child on shutdown, which closes stderr.
+/// Per-line byte cap. A buggy / runaway MCP child that writes gigabytes
+/// without a newline would otherwise grow dirge's read buffer until OOM.
+/// 16 KiB is generous for any real log line; past it we truncate, emit a
+/// single marker, and drain the rest of that line. (#5 fix.)
+const MAX_STDERR_LINE_BYTES: usize = 16 * 1024;
+
+/// Byte-at-a-time splitter for MCP child stderr. Accumulates a line until
+/// `\n`, capping at `max_line_bytes`. dirge-yb0a: once a line overflows the
+/// cap it emits ONE `...[truncated]` marker and then DRAINS (drops) the
+/// remaining bytes until the next newline — previously the truncation
+/// branch cleared the buffer but fell through to re-accumulate the SAME
+/// logical line, emitting a fresh `...[truncated]` chunk every 16 KiB.
+struct StderrLineSplitter {
+    buf: Vec<u8>,
+    draining: bool,
+    max_line_bytes: usize,
+}
+
+impl StderrLineSplitter {
+    fn new(max_line_bytes: usize) -> Self {
+        Self {
+            buf: Vec::with_capacity(1024),
+            draining: false,
+            max_line_bytes,
+        }
+    }
+
+    /// Feed one byte; returns a completed line ready to emit, if any.
+    fn push(&mut self, b: u8) -> Option<Vec<u8>> {
+        if b == b'\n' {
+            // End of line: emit the accumulated buffer unless we were
+            // draining an over-length line (whose marker already went out).
+            let line = if self.draining {
+                None
+            } else {
+                Some(std::mem::take(&mut self.buf))
+            };
+            self.buf.clear();
+            self.draining = false;
+            return line;
+        }
+        if self.draining {
+            return None; // dropping the remainder of an over-length line
+        }
+        if self.buf.len() >= self.max_line_bytes {
+            self.buf.extend_from_slice(b" ...[truncated]");
+            self.draining = true;
+            return Some(std::mem::take(&mut self.buf));
+        }
+        if self.buf.is_empty() && b == b'\r' {
+            return None; // strip leading CR (CRLF from a windows-y child)
+        }
+        self.buf.push(b);
+        None
+    }
+
+    /// EOF: return any pending partial line (none if mid-drain).
+    fn finish(self) -> Option<Vec<u8>> {
+        if self.buf.is_empty() {
+            None
+        } else {
+            Some(self.buf)
+        }
+    }
+}
+
 fn spawn_stderr_forwarder(server_name: String, stderr: ChildStderr) {
-    /// Per-line byte cap. A buggy / runaway MCP child that writes
-    /// gigabytes without a newline would otherwise grow dirge's
-    /// `read_line` buffer until OOM. 16 KiB is generous for any
-    /// real log line; past it we truncate and emit a marker.
-    /// (#5 fix.)
-    const MAX_LINE_BYTES: usize = 16 * 1024;
     tokio::spawn(async move {
         use tokio::io::AsyncReadExt;
         let mut reader = tokio::io::BufReader::new(stderr);
-        let mut buf = Vec::with_capacity(1024);
+        let mut splitter = StderrLineSplitter::new(MAX_STDERR_LINE_BYTES);
         let mut byte_buf = [0u8; 4096];
         loop {
             let n = match reader.read(&mut byte_buf).await {
@@ -220,36 +280,14 @@ fn spawn_stderr_forwarder(server_name: String, stderr: ChildStderr) {
                 Err(_) => break,
             };
             for &b in &byte_buf[..n] {
-                if b == b'\n' {
-                    emit_mcp_line(&server_name, &buf);
-                    buf.clear();
-                    continue;
+                if let Some(line) = splitter.push(b) {
+                    emit_mcp_line(&server_name, &line);
                 }
-                if buf.len() >= MAX_LINE_BYTES {
-                    // Past the cap — finalise the line with a
-                    // truncation marker, then keep dropping
-                    // bytes until the next `\n` so the
-                    // overflow doesn't roll into the NEXT line.
-                    buf.extend_from_slice(b" ...[truncated]");
-                    emit_mcp_line(&server_name, &buf);
-                    buf.clear();
-                    // Skip bytes until next newline.
-                    // (Set buf to capacity already so we don't
-                    // grow; just discard until we see \n.)
-                    // We use a marker bool by reusing buf's len > 0:
-                    // simpler: just track a draining state.
-                    // For correctness, fall through to the
-                    // dropping branch below.
-                }
-                if buf.is_empty() && b == b'\r' {
-                    continue; // strip leading CR (CRLF from windows-y child)
-                }
-                buf.push(b);
             }
         }
         // Flush any pending partial line on EOF.
-        if !buf.is_empty() {
-            emit_mcp_line(&server_name, &buf);
+        if let Some(line) = splitter.finish() {
+            emit_mcp_line(&server_name, &line);
         }
     });
 }
@@ -309,4 +347,79 @@ fn parse_headers(
         result.insert(h_name, h_value);
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive the splitter over a whole byte stream, collecting the lines it
+    /// would emit (as UTF-8-lossy strings for readable assertions).
+    fn split(data: &[u8], cap: usize) -> Vec<String> {
+        let mut s = StderrLineSplitter::new(cap);
+        let mut out = Vec::new();
+        for &b in data {
+            if let Some(line) = s.push(b) {
+                out.push(String::from_utf8_lossy(&line).into_owned());
+            }
+        }
+        if let Some(line) = s.finish() {
+            out.push(String::from_utf8_lossy(&line).into_owned());
+        }
+        out
+    }
+
+    #[test]
+    fn normal_lines_split_on_newline() {
+        assert_eq!(split(b"alpha\nbeta\n", 16), vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn trailing_partial_line_flushed_on_eof() {
+        assert_eq!(split(b"alpha\npartial", 16), vec!["alpha", "partial"]);
+    }
+
+    #[test]
+    fn leading_cr_stripped() {
+        // The splitter strips only LEADING CR; a trailing CR before the
+        // newline is left for `emit_mcp_line`'s sanitizer to remove.
+        assert_eq!(split(b"\rhi\n", 16), vec!["hi"]);
+    }
+
+    /// dirge-yb0a: ONE runaway line past the cap emits exactly ONE
+    /// `...[truncated]` marker, then drains until the next newline — it does
+    /// NOT emit a fresh truncated chunk every `cap` bytes.
+    #[test]
+    fn overlong_line_truncates_once_then_drains() {
+        let mut data = vec![b'x'; 100]; // 100 'x' with cap 8 → would be 12+ chunks if buggy
+        data.push(b'\n');
+        let lines = split(&data, 8);
+        assert_eq!(lines.len(), 1, "exactly one emitted line, got {lines:?}");
+        assert!(lines[0].starts_with("xxxxxxxx"));
+        assert!(lines[0].ends_with("...[truncated]"));
+        assert_eq!(lines[0].matches("[truncated]").count(), 1);
+    }
+
+    /// After draining an over-length line, the FOLLOWING line is emitted
+    /// cleanly — the overflow does not roll into it.
+    #[test]
+    fn line_after_overlong_is_clean() {
+        let mut data = vec![b'x'; 50];
+        data.push(b'\n');
+        data.extend_from_slice(b"ok\n"); // shorter than the cap
+        let lines = split(&data, 8);
+        assert_eq!(lines.len(), 2, "got {lines:?}");
+        assert!(lines[0].ends_with("...[truncated]"));
+        assert_eq!(lines[1], "ok");
+    }
+
+    /// An over-length line that never sees a newline before EOF emits its
+    /// single truncation marker and nothing more (no partial-flush dup).
+    #[test]
+    fn overlong_line_at_eof_emits_once() {
+        let data = vec![b'x'; 100];
+        let lines = split(&data, 8);
+        assert_eq!(lines.len(), 1, "got {lines:?}");
+        assert!(lines[0].ends_with("...[truncated]"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,7 +404,12 @@ async fn main() -> anyhow::Result<()> {
         .resolve_role(config::ConfigRole::Default)
         .and_then(|(_, e)| e.model);
     let model = if cli.model.is_none() && config_model.is_none() {
-        CompactString::new(provider::default_model_for(&provider))
+        // dirge-j3jd: resolve the alias's provider TYPE so a custom alias
+        // doesn't fall back to the OpenRouter default model id.
+        CompactString::new(provider::default_model_for_alias(
+            &provider,
+            &cfg.providers_map(),
+        ))
     } else {
         cli.resolve_model(&cfg)
     };

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -60,6 +60,32 @@ pub fn default_model_for(provider_name: &str) -> &'static str {
     }
 }
 
+/// dirge-j3jd: default model for a provider ALIAS backed by a config/plugin
+/// entry. A custom alias (e.g. `my-openai` with `provider_type = "openai"`)
+/// is not a built-in name, so `default_model_for` on the bare alias would
+/// miss `parse_provider` and fall back to the OpenRouter `vendor/model`
+/// default — an invalid id for OpenAI/Anthropic/etc. Resolve the entry's
+/// effective provider TYPE first.
+pub fn default_model_for_entry(alias: &str, entry: &ProviderEntry) -> &'static str {
+    default_model_for(&Config::provider_type_of(alias, entry))
+}
+
+/// dirge-j3jd: default model for a provider alias, resolving its entry from
+/// `providers` first. Falls back to treating the alias as a built-in name
+/// when no entry is declared.
+pub fn default_model_for_alias(
+    alias: &str,
+    providers: &HashMap<String, ProviderEntry>,
+) -> &'static str {
+    match providers
+        .get(alias)
+        .or_else(|| providers.get(&alias.to_ascii_lowercase()))
+    {
+        Some(entry) => default_model_for_entry(alias, entry),
+        None => default_model_for(alias),
+    }
+}
+
 pub fn parse_provider(name: &str) -> Option<ProviderKind> {
     match name.to_lowercase().as_str() {
         "openrouter" => Some(ProviderKind::OpenRouter),
@@ -102,8 +128,20 @@ pub fn resolve_provider_info(
         // a base_url. Built-in providers (e.g. `"deepseek": {}`)
         // legitimately have no base_url — they fall through to the
         // provider's default endpoint.
+        // dirge-8sku: a CONFIG-declared entry is the user's own trusted
+        // intent — aliasing a built-in name with a custom base_url (e.g.
+        // `ollama`/`openai` pointed at a local proxy) is documented and
+        // legitimate, so the built-in-name collision guard is NOT enforced
+        // here. It exists only to stop an UNTRUSTED plugin from shadowing a
+        // built-in to intercept credentials (enforced in the plugin branch
+        // below). The URL-scheme (https / allow_insecure) check still runs.
         if let Some(url) = entry.base_url.as_deref()
-            && let Err(err) = validate_custom_provider(name, url, entry.allow_insecure)
+            && let Err(err) = validate_custom_provider(
+                name,
+                url,
+                entry.allow_insecure,
+                /* enforce_builtin_collision */ false,
+            )
         {
             tracing::error!(
                 target: "dirge::provider",
@@ -139,8 +177,16 @@ pub fn resolve_provider_info(
     if let Some(entry) = plugin_provider(name).or_else(|| plugin_provider(&lower)) {
         let ptype = Config::provider_type_of(name, &entry);
         let kind = parse_provider(&ptype)?;
+        // dirge-8sku: plugin providers are UNTRUSTED — enforce the
+        // built-in-name collision guard so a plugin can't register e.g.
+        // "openai" to silently intercept the user's OpenAI credentials.
         if let Some(url) = entry.base_url.as_deref()
-            && let Err(err) = validate_custom_provider(name, url, entry.allow_insecure)
+            && let Err(err) = validate_custom_provider(
+                name,
+                url,
+                entry.allow_insecure,
+                /* enforce_builtin_collision */ true,
+            )
         {
             tracing::error!(
                 target: "dirge::provider",
@@ -202,17 +248,23 @@ fn validate_custom_provider(
     name: &str,
     base_url: &str,
     allow_insecure: bool,
+    enforce_builtin_collision: bool,
 ) -> Result<(), String> {
-    let lower = name.to_ascii_lowercase();
-    if BUILTIN_PROVIDER_NAMES
-        .iter()
-        .any(|b| b.eq_ignore_ascii_case(&lower))
-    {
-        return Err(format!(
-            "Custom provider '{}' collides with built-in provider name. \
-             Choose a different name.",
-            name
-        ));
+    // dirge-8sku: only UNTRUSTED (plugin) providers are blocked from
+    // shadowing a built-in name; a user's own config may legitimately
+    // alias one (e.g. `ollama` → openai backend + local base_url).
+    if enforce_builtin_collision {
+        let lower = name.to_ascii_lowercase();
+        if BUILTIN_PROVIDER_NAMES
+            .iter()
+            .any(|b| b.eq_ignore_ascii_case(&lower))
+        {
+            return Err(format!(
+                "Custom provider '{}' collides with built-in provider name. \
+                 Choose a different name.",
+                name
+            ));
+        }
     }
     // URL scheme validation: only https:// is safe by default.
     // http:// sends plaintext over the network — every prompt,
@@ -2043,7 +2095,7 @@ fn build_escalation_stream_fn(
     let model_name = entry
         .model
         .clone()
-        .unwrap_or_else(|| default_model_for(alias).to_string());
+        .unwrap_or_else(|| default_model_for_entry(alias, entry).to_string());
     let model = client.completion_model(model_name);
     let tool_defs: Vec<rig::completion::ToolDefinition> = loop_tools
         .iter()
@@ -2066,7 +2118,7 @@ fn build_critic_fn(
     let model_name = entry
         .model
         .clone()
-        .unwrap_or_else(|| default_model_for(alias).to_string());
+        .unwrap_or_else(|| default_model_for_entry(alias, entry).to_string());
     Ok(std::sync::Arc::new(move |prompt: String| {
         let client = client.clone();
         let model_name = model_name.clone();
@@ -2106,7 +2158,7 @@ pub fn build_approval_fn(
     let model_name = entry
         .model
         .clone()
-        .unwrap_or_else(|| default_model_for(alias).to_string());
+        .unwrap_or_else(|| default_model_for_entry(alias, entry).to_string());
     Ok(std::sync::Arc::new(move |req: ApprovalRequest| {
         let client = client.clone();
         let model_name = model_name.clone();
@@ -2143,7 +2195,7 @@ fn build_review_stream_fn(
     let model_name = entry
         .model
         .clone()
-        .unwrap_or_else(|| default_model_for(alias).to_string());
+        .unwrap_or_else(|| default_model_for_entry(alias, entry).to_string());
     let model = client.completion_model(model_name.clone());
     // Review path uses ONLY memory + skill — match what
     // `spawn_review_runner_with_cache` puts in `cfg.tools` so

--- a/src/provider/mod_tests.rs
+++ b/src/provider/mod_tests.rs
@@ -548,24 +548,109 @@ fn custom_provider_http_allowed_with_allow_insecure() {
     );
 }
 
-/// Custom provider name colliding with built-in is rejected.
+/// dirge-j3jd: a custom alias backed by an `openai` provider_type must get
+/// OpenAI's default model, not the OpenRouter `vendor/model` fallback.
 #[test]
-fn custom_provider_builtin_name_collision_rejected() {
-    // Plugin tries to shadow "openai" with an explicit different
-    // backend type and base_url.
-    let custom = std::collections::HashMap::from([(
-        "openai".to_string(),
+fn default_model_for_entry_resolves_alias_provider_type() {
+    let entry = ProviderEntry {
+        provider_type: Some("openai".to_string()),
+        base_url: Some("https://proxy.internal/v1".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(default_model_for_entry("my-openai", &entry), "gpt-4o");
+
+    let anthropic = ProviderEntry {
+        provider_type: Some("anthropic".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(
+        default_model_for_entry("work-claude", &anthropic),
+        "claude-sonnet-4-6"
+    );
+}
+
+/// dirge-j3jd: `default_model_for_alias` looks the entry up in the
+/// providers map; a custom alias resolves to its backend default, while an
+/// undeclared (built-in) name still resolves directly.
+#[test]
+fn default_model_for_alias_uses_map_then_builtin_fallback() {
+    let providers = HashMap::from([(
+        "my-openai".to_string(),
         ProviderEntry {
-            provider_type: Some("custom".to_string()),
-            base_url: Some("https://evil.example.com/v1".to_string()),
+            provider_type: Some("openai".to_string()),
             ..Default::default()
         },
     )]);
-    let result = resolve_provider_info("openai", &custom);
-    assert!(
-        result.is_none(),
-        "builtin name collision should be rejected"
+    // Custom alias → resolved via entry → OpenAI default.
+    assert_eq!(default_model_for_alias("my-openai", &providers), "gpt-4o");
+    // Undeclared name that IS a built-in → direct resolution.
+    assert_eq!(
+        default_model_for_alias("anthropic", &providers),
+        "claude-sonnet-4-6"
     );
+    // The bare alias WITHOUT the map would have wrongly fallen back here:
+    assert_eq!(default_model_for("my-openai"), "deepseek/deepseek-v4-flash");
+}
+
+/// dirge-8sku: an UNTRUSTED plugin shadowing a built-in name is still
+/// rejected (collision guard ENFORCED) — guards against credential
+/// interception. Tested directly via the validator since the plugin
+/// registry is a process-global OnceLock.
+#[test]
+fn plugin_provider_builtin_name_collision_rejected() {
+    let res = validate_custom_provider(
+        "openai",
+        "https://evil.example.com/v1",
+        false,
+        /* enforce_builtin_collision */ true,
+    );
+    assert!(
+        res.is_err(),
+        "plugin shadowing a built-in name must be rejected"
+    );
+    assert!(res.unwrap_err().contains("collides with built-in"));
+}
+
+/// dirge-8sku: a CONFIG-declared alias of a built-in name with a custom
+/// base_url is the documented, trusted use (e.g. `ollama` → openai
+/// backend + local proxy) and must be ACCEPTED — previously it was wrongly
+/// rejected as a collision, contradicting docs/config.md.
+#[test]
+fn config_alias_of_builtin_name_with_base_url_is_accepted() {
+    let providers = std::collections::HashMap::from([(
+        "ollama".to_string(),
+        ProviderEntry {
+            provider_type: Some("openai".to_string()),
+            base_url: Some("http://localhost:11434/v1".to_string()),
+            allow_insecure: true,
+            ..Default::default()
+        },
+    )]);
+    let result = resolve_provider_info("ollama", &providers);
+    assert!(
+        result.is_some(),
+        "config-declared alias of a built-in name should be accepted"
+    );
+    let info = result.unwrap();
+    assert_eq!(info.kind, ProviderKind::OpenAI);
+    assert_eq!(info.base_url.as_deref(), Some("http://localhost:11434/v1"));
+}
+
+/// dirge-8sku: the URL-scheme check still applies to config aliases —
+/// the collision guard is skipped, NOT all validation.
+#[test]
+fn config_alias_still_enforces_url_scheme() {
+    let res = validate_custom_provider(
+        "openai",
+        "http://evil.example.com/v1", // insecure, non-local
+        false,                        // allow_insecure = false
+        /* enforce_builtin_collision */ false,
+    );
+    assert!(
+        res.is_err(),
+        "config alias must still reject insecure http:// without allow_insecure"
+    );
+    assert!(res.unwrap_err().contains("insecure base_url"));
 }
 
 // ============================================================

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -146,7 +146,12 @@ pub fn render_session(
         .resolve_role(crate::config::ConfigRole::Default)
         .and_then(|(_, e)| e.model);
     let model = if cli.model.is_none() && config_model.is_none() {
-        compact_str::CompactString::new(crate::provider::default_model_for(&provider))
+        // dirge-j3jd: resolve the alias's provider TYPE so a custom alias
+        // doesn't fall back to the OpenRouter default model id.
+        compact_str::CompactString::new(crate::provider::default_model_for_alias(
+            &provider,
+            &cfg.providers_map(),
+        ))
     } else {
         cli.resolve_model(cfg)
     };


### PR DESCRIPTION
Final batch from the systemic review. Three confirmed bugs, each TDD-fixed and wired up.

## Fixes
- **dirge-8sku** (P2) — a CONFIG-declared alias of a built-in name with a `base_url` (e.g. `ollama` → openai backend + local proxy, exactly as docs/config.md shows) was wrongly rejected as a built-in collision. The guard exists to stop UNTRUSTED plugins shadowing a built-in to intercept credentials, so it is now enforced only on the plugin path; config aliases skip it (the https/allow_insecure URL-scheme check still applies).
- **dirge-j3jd** (P2) — `default_model_for(alias)` only matched built-in names via `parse_provider`, so a custom alias with no explicit model fell to the OpenRouter `vendor/model` default — an invalid id for OpenAI/Anthropic/etc. Adds `default_model_for_entry` / `default_model_for_alias` that resolve the entry's `provider_type` first, and wires all 7 call sites (4 builders + main, ui/events, acp).
- **dirge-yb0a** (P3) — the MCP stderr forwarder's truncation branch cleared the buffer but fell through to re-accumulate the SAME logical line, emitting a fresh `...[truncated]` chunk every 16 KiB. Extracts a `StderrLineSplitter` with a draining flag: one marker, then drop bytes until the next newline.

## Verification
- `cargo test` (default): 2357 passed.
- New tests: `config_alias_*` / `plugin_provider_builtin_name_collision_rejected`, `default_model_for_entry/alias_*`, and 6 `StderrLineSplitter` cases.
- `cargo fmt` clean; no new clippy warnings (both feature configs).