### PR TITLE
refactor(ui): extract Reasoning + Token streaming arms (dirge-4y4l stage 2)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -67,8 +67,7 @@ use crate::shell;
 #[cfg(feature = "plugin")]
 use crate::ui::agent_io::render_plugin_entry;
 use crate::ui::agent_io::{
-    RENDER_FRAME, apply_subagent_panel_event, capture_partial_on_abort, render_agent_stream,
-    should_render_token,
+    apply_subagent_panel_event, capture_partial_on_abort, render_agent_stream,
 };
 use crate::ui::chat_state::{ChatUiState, load_chat_ui_state, save_chat_ui_state};
 use crate::ui::colors::{c_agent, c_error, c_perm, c_tool, resolve_color};
@@ -1845,97 +1844,33 @@ pub async fn run_interactive(
                         if !show_reasoning {
                             continue;
                         }
-                        let safe = sanitize_output(&text);
-                        reasoning_buf.push_str(&safe);
-                        // Shared pipeline with Token. DarkMagenta as
-                        // the base color signals "thinking" voice;
-                        // markdown highlights (bold / italic / inline
-                        // code / headings / blockquotes) still render
-                        // via theme accessors so the visual
-                        // hierarchy reads consistently across both
-                        // streams.
-                        render_agent_stream(
-                            &reasoning_buf,
-                            &mut reasoning_start_line,
-                            Color::DarkMagenta,
-                            &mut renderer,
+                        let mut ctx = make_run_ctx!();
+                        run_handlers::streaming::handle_reasoning(
+                            &mut ctx,
+                            &text,
+                            &mut was_reasoning,
                         )?;
-                        agent_line_started = true;
-                        was_reasoning = true;
                     }
                     AgentEvent::Token(text) => {
-                        renderer.set_avatar_state(avatar::AvatarState::Speaking);
-                        if was_reasoning {
-                            renderer.write_line("", Color::White)?;
-                            was_reasoning = false;
-                            response_buf.clear();
-                            response_start_line = None;
-                            // End-of-reasoning marker. Keep the
-                            // reasoning rendered in the scroll
-                            // (committed via the Reasoning handler's
-                            // render_viewport); just stop tracking it
-                            // so the next reasoning burst (if any)
-                            // anchors at a fresh buffer position
-                            // below the content about to stream.
-                            // `agent_line_started` is reset to true
-                            // by `render_agent_stream` below.
-                            reasoning_buf.clear();
-                            reasoning_start_line = None;
-                        }
-                        let safe = sanitize_output(&text);
-                        response_buf.push_str(&safe);
-
-                        // Stream this token into the per-turn batcher
-                        // and accumulator. When the batcher crosses its
-                        // threshold, dispatch `on-message-update` with
-                        // the cumulative text so far. The batcher's
-                        // batch covers only the *new* tokens since the
-                        // last update; current_turn_text is the *full*
-                        // turn text for the closing on-turn-end event.
-                        #[cfg(feature = "plugin")]
-                        if let Some(pm) = plugin_manager {
-                            current_turn_text.push_str(&text);
-                            if token_batcher.push(&text).is_some() {
-                                let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
-                                let _ = mgr.dispatch(
-                                    "on-message-update",
-                                    &format!(
-                                        "@{{:index {} :partial \"{}\"}}",
-                                        current_turn_index,
-                                        crate::plugin::escape_janet_string(&current_turn_text),
-                                    ),
-                                );
-                            }
-                        }
-
-                        // Shared pipeline with Reasoning. theme::agent()
-                        // as the base color — switching themes shifts
-                        // the agent's voice in one place; markdown
-                        // highlights (headings, code, accent) ride on
-                        // their own theme accessors so they remain
-                        // visible against any chosen base.
-                        //
-                        // dirge-ufe0: coalesce repaints. A burst of
-                        // buffered tokens (the agent->UI channel holds up
-                        // to 256) would otherwise repaint once per token.
-                        // Paint only when caught up to the last queued
-                        // event (so the final token of a burst always
-                        // lands) or a frame interval elapsed (so a long
-                        // burst still streams visibly). The ToolCall/Done
-                        // arms flush response_buf, so a coalesced trailing
-                        // token still renders before the buffer clears.
+                        // Caught-up check for the render coalescer, computed
+                        // before ctx borrows the render state (dirge-ufe0).
                         let pending = agent_rx.as_ref().map_or(0, |rx| rx.len());
-                        let since = last_token_render.map_or(RENDER_FRAME, |t| t.elapsed());
-                        if should_render_token(pending, since, RENDER_FRAME) {
-                            render_agent_stream(
-                                &response_buf,
-                                &mut response_start_line,
-                                c_agent(),
-                                &mut renderer,
-                            )?;
-                            last_token_render = Some(std::time::Instant::now());
-                        }
-                        agent_line_started = true;
+                        let mut ctx = make_run_ctx!();
+                        run_handlers::streaming::handle_token(
+                            &mut ctx,
+                            &text,
+                            &mut was_reasoning,
+                            &mut last_token_render,
+                            pending,
+                            #[cfg(feature = "plugin")]
+                            plugin_manager,
+                            #[cfg(feature = "plugin")]
+                            &mut token_batcher,
+                            #[cfg(feature = "plugin")]
+                            &mut current_turn_text,
+                            #[cfg(feature = "plugin")]
+                            current_turn_index,
+                        )?;
                     }
                     AgentEvent::ToolCall { id, name, args } => {
                         // Feed the left-panel [ACTIVITY] ticker (newest last,

--- a/src/ui/run_handlers/mod.rs
+++ b/src/ui/run_handlers/mod.rs
@@ -34,6 +34,7 @@ pub(super) mod done;
 pub(super) mod error;
 pub(super) mod interjected;
 pub(super) mod notices;
+pub(super) mod streaming;
 pub(super) mod tool_result;
 
 // dirge-5h5: isolated repro harness for the parallel-read chamber

--- a/src/ui/run_handlers/streaming.rs
+++ b/src/ui/run_handlers/streaming.rs
@@ -1,0 +1,117 @@
+//! Streaming `AgentEvent` arms (`Reasoning`, `Token`) extracted from
+//! `run_interactive`. Both feed the shared `render_agent_stream` pipeline;
+//! `Token` additionally drives the plugin per-turn batcher and the
+//! dirge-ufe0 render coalescer. The caller keeps the loop-control guards
+//! (`Reasoning`'s `show_reasoning` skip, the avatar-state set) inline.
+//! Behavior is identical to the inline code; pure refactor (dirge-4y4l).
+
+use std::time::Instant;
+
+use crossterm::style::Color;
+
+use crate::ui::agent_io::{RENDER_FRAME, render_agent_stream, should_render_token};
+use crate::ui::avatar;
+use crate::ui::colors::c_agent;
+use crate::ui::events::sanitize_output;
+use crate::ui::run_handlers::RunCtx;
+
+#[cfg(feature = "plugin")]
+use crate::plugin::PluginManager;
+#[cfg(feature = "plugin")]
+use crate::ui::streaming::TokenBatcher;
+#[cfg(feature = "plugin")]
+use std::sync::{Arc, Mutex};
+
+/// `AgentEvent::Reasoning` body (after the caller's avatar-state set +
+/// `show_reasoning` guard): accumulate the thinking text and repaint it in
+/// the DarkMagenta "thinking" register.
+pub(crate) fn handle_reasoning(
+    ctx: &mut RunCtx<'_>,
+    text: &str,
+    was_reasoning: &mut bool,
+) -> anyhow::Result<()> {
+    let safe = sanitize_output(text);
+    ctx.reasoning_buf.push_str(&safe);
+    // Shared pipeline with Token. DarkMagenta base color signals the
+    // "thinking" voice; markdown highlights still ride the theme accessors.
+    render_agent_stream(
+        ctx.reasoning_buf,
+        ctx.reasoning_start_line,
+        Color::DarkMagenta,
+        ctx.renderer,
+    )?;
+    *ctx.agent_line_started = true;
+    *was_reasoning = true;
+    Ok(())
+}
+
+/// `AgentEvent::Token` body: accumulate the assistant token, feed the
+/// plugin per-turn batcher (`on-message-update`), and coalesce repaints
+/// (dirge-ufe0) so a burst paints at most once per frame. `pending` is the
+/// caller's `agent_rx.len()` — when 0 we're caught up to the last queued
+/// event, so the final token of a burst always lands.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_token(
+    ctx: &mut RunCtx<'_>,
+    text: &str,
+    was_reasoning: &mut bool,
+    last_token_render: &mut Option<Instant>,
+    pending: usize,
+    #[cfg(feature = "plugin")] plugin_manager: Option<&Arc<Mutex<PluginManager>>>,
+    #[cfg(feature = "plugin")] token_batcher: &mut TokenBatcher,
+    #[cfg(feature = "plugin")] current_turn_text: &mut String,
+    #[cfg(feature = "plugin")] current_turn_index: u32,
+) -> anyhow::Result<()> {
+    ctx.renderer.set_avatar_state(avatar::AvatarState::Speaking);
+    if *was_reasoning {
+        ctx.renderer.write_line("", Color::White)?;
+        *was_reasoning = false;
+        ctx.response_buf.clear();
+        *ctx.response_start_line = None;
+        // End-of-reasoning marker. The reasoning stays rendered in the
+        // scroll; we just stop tracking it so the next reasoning burst
+        // anchors at a fresh buffer position below the streamed content.
+        ctx.reasoning_buf.clear();
+        *ctx.reasoning_start_line = None;
+    }
+    let safe = sanitize_output(text);
+    ctx.response_buf.push_str(&safe);
+
+    // Stream the token into the per-turn batcher + accumulator. When the
+    // batcher crosses its threshold, dispatch `on-message-update` with the
+    // cumulative text so far. `current_turn_text` is the full turn text for
+    // the closing `on-turn-end` event.
+    #[cfg(feature = "plugin")]
+    if let Some(pm) = plugin_manager {
+        current_turn_text.push_str(text);
+        if token_batcher.push(text).is_some() {
+            let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
+            let _ = mgr.dispatch(
+                "on-message-update",
+                &format!(
+                    "@{{:index {} :partial \"{}\"}}",
+                    current_turn_index,
+                    crate::plugin::escape_janet_string(current_turn_text),
+                ),
+            );
+        }
+    }
+
+    // dirge-ufe0: coalesce repaints. Paint only when caught up to the last
+    // queued event (pending == 0, so the final token of a burst lands) or a
+    // frame interval elapsed (so a long burst still streams visibly). The
+    // ToolCall/Done/Error arms flush response_buf, so a coalesced trailing
+    // token still renders before the buffer clears.
+    let since = last_token_render.map_or(RENDER_FRAME, |t| t.elapsed());
+    if should_render_token(pending, since, RENDER_FRAME) {
+        render_agent_stream(
+            ctx.response_buf,
+            ctx.response_start_line,
+            c_agent(),
+            ctx.renderer,
+        )?;
+        *last_token_render = Some(Instant::now());
+    }
+    *ctx.agent_line_started = true;
+    Ok(())
+}


### PR DESCRIPTION
Stage 2 of the architectural sweep (dirge-4y4l). Behavior-preserving; 2374 tests green, `-D warnings` clean.

Extracts the two streaming `select!` arms from `run_interactive` into `run_handlers::streaming`:
- `handle_reasoning` — accumulate + repaint thinking text (DarkMagenta register)
- `handle_token` — accumulate assistant token, drive the plugin per-turn batcher (`on-message-update`), and coalesce repaints (dirge-ufe0)

Loop-control guards stay inline (Reasoning's `show_reasoning` skip + the avatar-state set; Token's `pending = agent_rx.len()` computed before `ctx` borrows render state). `ui/mod.rs`: 3963 → 3898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)