### PR TITLE
refactor(ui): extract TurnStart/TurnEnd arms (dirge-4y4l stage 4)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2019,82 +2019,24 @@ pub async fn run_interactive(
                     }
                     AgentEvent::TurnStart { index } => {
                         #[cfg(feature = "plugin")]
-                        {
-                            // New turn — reset per-turn streaming state.
-                            // Without the reset, current_turn_text would
-                            // accumulate across all turns and the index
-                            // tracked here would drift from the runner's.
-                            token_batcher.reset();
-                            current_turn_text.clear();
-                            current_turn_index = index;
-                            if let Some(pm) = plugin_manager {
-                                let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
-                                let _ = mgr.dispatch(
-                                    "on-turn-start",
-                                    &format!("@{{:index {}}}", index),
-                                );
-                                // Clear tool-hook slots after the turn
-                                // hook runs so a `(harness/block ...)`
-                                // call inside on-turn-start can't bleed
-                                // into the *first* tool of the next
-                                // turn. `dispatch_tool_hook` clears
-                                // slots before tool hooks, but turn
-                                // hooks bypass that path.
-                                let _ = mgr.eval(
-                                    "(do (set harness-block nil) \
-                                         (set harness-mutate-input nil) \
-                                         (set harness-replace-result nil))",
-                                );
-                            }
-                        }
+                        run_handlers::turn::handle_turn_start(
+                            plugin_manager,
+                            &mut token_batcher,
+                            &mut current_turn_text,
+                            &mut current_turn_index,
+                            index,
+                        );
                         #[cfg(not(feature = "plugin"))]
                         let _ = index;
                     }
                     AgentEvent::TurnEnd { index } => {
                         #[cfg(feature = "plugin")]
-                        {
-                            if let Some(pm) = plugin_manager {
-                                // Flush any tokens that didn't reach the
-                                // batcher threshold so the final partial
-                                // update gets delivered.
-                                if let Some(tail) = token_batcher.flush_remaining() {
-                                    // tail is the *new* tokens since the
-                                    // last update; current_turn_text now
-                                    // covers them since we pushed at the
-                                    // same time as the batcher.
-                                    let _ = tail;
-                                    let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
-                                    let _ = mgr.dispatch(
-                                        "on-message-update",
-                                        &format!(
-                                            "@{{:index {} :partial \"{}\"}}",
-                                            index,
-                                            crate::plugin::escape_janet_string(
-                                                &current_turn_text
-                                            ),
-                                        ),
-                                    );
-                                }
-                                let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
-                                let _ = mgr.dispatch(
-                                    "on-turn-end",
-                                    &format!(
-                                        "@{{:index {} :message \"{}\"}}",
-                                        index,
-                                        crate::plugin::escape_janet_string(&current_turn_text),
-                                    ),
-                                );
-                                // Same defense as on-turn-start: clear
-                                // tool-hook slots so turn-end can't
-                                // leak block/mutate/replace into the
-                                // next tool call.
-                                let _ = mgr.eval(
-                                    "(do (set harness-block nil) \
-                                         (set harness-mutate-input nil) \
-                                         (set harness-replace-result nil))",
-                                );
-                            }
-                        }
+                        run_handlers::turn::handle_turn_end(
+                            plugin_manager,
+                            &mut token_batcher,
+                            &current_turn_text,
+                            index,
+                        );
                         #[cfg(not(feature = "plugin"))]
                         let _ = index;
                     }

--- a/src/ui/run_handlers/mod.rs
+++ b/src/ui/run_handlers/mod.rs
@@ -37,6 +37,8 @@ pub(super) mod notices;
 pub(super) mod streaming;
 pub(super) mod tool_call;
 pub(super) mod tool_result;
+#[cfg(feature = "plugin")]
+pub(super) mod turn;
 
 // dirge-5h5: isolated repro harness for the parallel-read chamber
 // race. Drives the chamber state machine directly without the

--- a/src/ui/run_handlers/turn.rs
+++ b/src/ui/run_handlers/turn.rs
@@ -1,0 +1,78 @@
+//! `AgentEvent::TurnStart` / `TurnEnd` arms extracted from
+//! `run_interactive`. Both are entirely plugin-gated — they drive the
+//! per-turn token batcher and the `on-turn-start` / `on-turn-end` plugin
+//! hooks — so the whole module is `cfg(feature = "plugin")`. Behavior is
+//! identical to the inline code; pure refactor (dirge-4y4l).
+
+use std::sync::{Arc, Mutex};
+
+use crate::plugin::PluginManager;
+use crate::ui::streaming::TokenBatcher;
+
+/// Clears tool-hook slots (`harness-block` / `-mutate-input` /
+/// `-replace-result`) so a turn hook can't bleed block/mutate/replace into
+/// the next tool call — turn hooks bypass `dispatch_tool_hook`'s own clear.
+fn clear_tool_hook_slots(mgr: &mut PluginManager) {
+    let _ = mgr.eval(
+        "(do (set harness-block nil) \
+             (set harness-mutate-input nil) \
+             (set harness-replace-result nil))",
+    );
+}
+
+/// New turn: reset the per-turn batcher + accumulator (else `current_turn_text`
+/// accumulates across turns and the tracked index drifts from the runner's),
+/// record the runner's turn index, fire `on-turn-start`, clear hook slots.
+pub(crate) fn handle_turn_start(
+    plugin_manager: Option<&Arc<Mutex<PluginManager>>>,
+    token_batcher: &mut TokenBatcher,
+    current_turn_text: &mut String,
+    current_turn_index: &mut u32,
+    index: u32,
+) {
+    token_batcher.reset();
+    current_turn_text.clear();
+    *current_turn_index = index;
+    if let Some(pm) = plugin_manager {
+        let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = mgr.dispatch("on-turn-start", &format!("@{{:index {}}}", index));
+        clear_tool_hook_slots(&mut mgr);
+    }
+}
+
+/// Turn end: flush any sub-threshold batched tokens as a final
+/// `on-message-update`, fire `on-turn-end` with the full turn text, clear
+/// hook slots.
+pub(crate) fn handle_turn_end(
+    plugin_manager: Option<&Arc<Mutex<PluginManager>>>,
+    token_batcher: &mut TokenBatcher,
+    current_turn_text: &str,
+    index: u32,
+) {
+    if let Some(pm) = plugin_manager {
+        // Flush tokens that didn't reach the batcher threshold so the final
+        // partial update lands. `current_turn_text` already covers them
+        // (pushed in lockstep with the batcher).
+        if token_batcher.flush_remaining().is_some() {
+            let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
+            let _ = mgr.dispatch(
+                "on-message-update",
+                &format!(
+                    "@{{:index {} :partial \"{}\"}}",
+                    index,
+                    crate::plugin::escape_janet_string(current_turn_text),
+                ),
+            );
+        }
+        let mut mgr = pm.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = mgr.dispatch(
+            "on-turn-end",
+            &format!(
+                "@{{:index {} :message \"{}\"}}",
+                index,
+                crate::plugin::escape_janet_string(current_turn_text),
+            ),
+        );
+        clear_tool_hook_slots(&mut mgr);
+    }
+}


### PR DESCRIPTION
Stage 4 of the architectural sweep (dirge-4y4l). Behavior-preserving; default + no-plugin both `-D warnings` clean, 2374 tests green.

Extracts the two plugin-gated turn arms into a `cfg(feature="plugin")` `run_handlers::turn` module (per-turn batcher reset/flush + `on-turn-start`/`on-turn-end` hooks; tool-hook-slot clear deduped into a helper). This completes the `AgentEvent` arm extraction for `run_interactive` — all heavy/streaming/lifecycle arms now live in `run_handlers/`. `ui/mod.rs`: 3770 → 3712 (from 4170 at the start of the sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)