### PR TITLE
fix(critic): constraint-aware context + distinct <critic> role (dirge-bedj, dirge-vg9e)

### DIFF
--- a/src/agent/agent_loop/critic.rs
+++ b/src/agent/agent_loop/critic.rs
@@ -27,32 +27,70 @@ pub type CriticFn = Arc<
     dyn Fn(String) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send>> + Send + Sync,
 >;
 
-/// System preamble for the critic: establishes its role and the strict,
-/// skeptical stance. Passed as the LLM system prompt by `build_critic_fn`
-/// (replacing the stray "conversation summarizer" preamble) so the model
-/// knows what it is BEFORE it sees the transcript. The exact response
-/// FORMAT lives in [`build_prompt`] instead — right next to the material
-/// being judged.
+/// Tag prefixed onto the critic's injected follow-up message. The agent
+/// loop re-enters it as a user-role message (so the model acts on it); the
+/// UI keys on this tag to render it under a distinct `<critic>` handle and
+/// color instead of the user's. Shared so producer and renderer agree.
+pub const CRITIC_TAG: &str = "[critic]";
+
+/// System preamble for the critic: establishes its role and a calibrated —
+/// not trigger-happy — stance. Passed as the LLM system prompt by
+/// `build_critic_fn` so the model knows what it is BEFORE it sees the
+/// transcript. The response FORMAT lives in [`build_prompt`] instead —
+/// right next to the material being judged.
+///
+/// dirge-bedj: the stance was over-aggressive ("be skeptical", everything
+/// "NOT complete") and constraint-blind, so it demanded actions the agent
+/// was explicitly told not to take (e.g. pushing). It now (a) respects the
+/// agent's own instructions and (b) blocks only on concrete, in-scope gaps.
 pub const CRITIC_PREAMBLE: &str = "\
-You are a strict code-review critic for an autonomous coding agent. You are given a user's request \
-and a transcript of what the assistant just did to satisfy it. Judge ONLY whether the task is \
-actually complete and correct — not style. Be skeptical: unverified claims, partial work, ignored \
-edge cases, and \"done\" without evidence are NOT complete. If you are genuinely unsure, pass — do \
-not block on speculation.";
+You are a code-review critic for an autonomous coding agent. You are given the instructions and \
+constraints the assistant operates under, plus a transcript of what it just did to satisfy the \
+user's request. Judge ONLY whether the task is actually complete and correct within those \
+constraints — not style.\n\
+\n\
+Hard rules:\n\
+- RESPECT the assistant's instructions. NEVER flag the absence of an action the instructions \
+forbid or defer (e.g. if it was told not to push/commit/deploy, do NOT ask it to). Treat anything \
+the instructions place out of scope as correctly omitted.\n\
+- Block only on CONCRETE, in-scope incompleteness with evidence (e.g. the user asked for X and X \
+is missing; a change was made but never built/tested when verification was expected).\n\
+- Do NOT invent new requirements, scope, or \"nice to haves\". If you are unsure, PASS — a false \
+block wastes a whole turn.";
 
 /// Response-format instruction. Kept in the user prompt (not the system
-/// preamble) so the strict verdict shape sits directly beside the
-/// transcript the critic is judging.
+/// preamble) so the verdict shape sits directly beside the transcript.
 const CRITIC_FORMAT: &str = "\
 Respond in EXACTLY this format and nothing else:\n\
 On the first line, either `VERDICT: COMPLETE` or `VERDICT: INCOMPLETE`.\n\
-If INCOMPLETE, follow with a short bullet list of the specific, concrete issues to fix.";
+If INCOMPLETE, follow with a short bullet list of the specific, concrete, in-scope issues to fix.";
 
-/// Build the critic prompt from a transcript of the run. The role lives
-/// in [`CRITIC_PREAMBLE`] (the system slot); this carries the format +
-/// the transcript.
-pub fn build_prompt(transcript: &str) -> String {
-    format!("{CRITIC_FORMAT}\n\n--- transcript ---\n{transcript}\n--- end transcript ---")
+/// Cap on the instructions/constraints block fed to the critic, so a large
+/// system prompt (tool docs + project context) doesn't balloon the critic
+/// call. Generous — the constraints that matter (AGENTS.md, prompt-mode
+/// rules) sit early; a truncation note tells the critic more was elided.
+const MAX_RULES_CHARS: usize = 16_000;
+
+/// Build the critic prompt. `rules` is the assistant's own system prompt /
+/// instructions (so the critic judges against the SAME constraints the
+/// agent had — dirge-bedj); `transcript` is what the agent did. The role
+/// lives in [`CRITIC_PREAMBLE`]; this carries the format + both bodies.
+pub fn build_prompt(rules: &str, transcript: &str) -> String {
+    let rules = rules.trim();
+    let rules_block = if rules.is_empty() {
+        "(no special constraints provided)".to_string()
+    } else if rules.len() > MAX_RULES_CHARS {
+        let head: String = rules.chars().take(MAX_RULES_CHARS).collect();
+        format!("{head}\n…(instructions truncated)")
+    } else {
+        rules.to_string()
+    };
+    format!(
+        "{CRITIC_FORMAT}\n\n\
+         --- assistant instructions & constraints (judge within these; never demand a \
+         forbidden/out-of-scope action) ---\n{rules_block}\n--- end instructions ---\n\n\
+         --- transcript ---\n{transcript}\n--- end transcript ---"
+    )
 }
 
 /// Parse the critic's raw response into a verdict. `Some(issues)` means
@@ -83,12 +121,14 @@ pub fn parse_verdict(response: &str) -> Option<String> {
     }
 }
 
-/// Run the critic over a run transcript. Returns a one-element vec with a
-/// `[critic]`-tagged follow-up message when the critic judged the work
-/// incomplete; empty otherwise (complete, or the call errored — fail
-/// open). Never panics on a critic error.
-pub async fn run_critic(critic: &CriticFn, transcript: &str) -> Vec<LoopMessage> {
-    let prompt = build_prompt(transcript);
+/// Run the critic over a run transcript. `rules` is the assistant's own
+/// system prompt / instructions, passed so the critic judges within the
+/// SAME constraints the agent had (dirge-bedj). Returns a one-element vec
+/// with a [`CRITIC_TAG`]-prefixed follow-up message when the critic judged
+/// the work incomplete; empty otherwise (complete, or the call errored —
+/// fail open). Never panics on a critic error.
+pub async fn run_critic(critic: &CriticFn, rules: &str, transcript: &str) -> Vec<LoopMessage> {
+    let prompt = build_prompt(rules, transcript);
     let response = match critic(prompt).await {
         Ok(r) => r,
         Err(e) => {
@@ -99,8 +139,9 @@ pub async fn run_critic(critic: &CriticFn, transcript: &str) -> Vec<LoopMessage>
     match parse_verdict(&response) {
         Some(issues) => vec![LoopMessage::User(UserMessage {
             content: format!(
-                "[critic] A review of your work found it isn't done yet. Address these before \
-                 reporting complete, or explain why they don't apply:\n{issues}"
+                "{CRITIC_TAG} A review of your work found it may not be done yet. Address these \
+                 before reporting complete, or explain why they don't apply (e.g. they're out of \
+                 scope or something you were told not to do):\n{issues}"
             ),
         })],
         None => Vec::new(),
@@ -133,26 +174,59 @@ mod tests {
     }
 
     #[test]
-    fn prompt_embeds_transcript_and_format() {
-        let p = build_prompt("user asked X; assistant edited foo.rs");
+    fn prompt_embeds_transcript_format_and_rules() {
+        let p = build_prompt(
+            "RULE: never push to remote.",
+            "user asked X; assistant edited foo.rs",
+        );
         assert!(p.contains("VERDICT: COMPLETE"));
         assert!(p.contains("VERDICT: INCOMPLETE"));
         assert!(p.contains("edited foo.rs"));
+        // dirge-bedj: the agent's own constraints are included so the
+        // critic judges within them.
+        assert!(p.contains("never push to remote"), "rules must be embedded");
+        assert!(
+            p.to_lowercase().contains("forbidden") || p.to_lowercase().contains("out-of-scope"),
+            "prompt must instruct the critic to respect constraints",
+        );
     }
 
-    /// The system preamble states the critic's ROLE (not the summarizer's),
-    /// and the response FORMAT is kept out of it (it lives in the prompt).
     #[test]
-    fn preamble_establishes_critic_role_without_format() {
+    fn empty_rules_render_a_placeholder_not_blank() {
+        let p = build_prompt("", "did stuff");
+        assert!(p.contains("no special constraints"));
+    }
+
+    #[test]
+    fn build_prompt_caps_large_rules() {
+        let huge = "x".repeat(MAX_RULES_CHARS + 5_000);
+        let p = build_prompt(&huge, "t");
+        assert!(p.contains("instructions truncated"));
+        // The rules block is bounded (cap + the transcript/format scaffold,
+        // well under the untruncated size).
+        assert!(p.len() < MAX_RULES_CHARS + 4_000);
+    }
+
+    /// The system preamble states the critic's ROLE, keeps FORMAT out, and
+    /// (dirge-bedj) instructs it to respect the agent's constraints.
+    #[test]
+    fn preamble_is_calibrated_and_constraint_aware() {
         let lower = CRITIC_PREAMBLE.to_ascii_lowercase();
         assert!(lower.contains("critic"), "preamble must name the role");
-        assert!(
-            !lower.contains("summarizer"),
-            "preamble must not be the summarizer's"
-        );
+        assert!(!lower.contains("summarizer"));
         // Format lives in the prompt, not the system preamble.
         assert!(!CRITIC_PREAMBLE.contains("VERDICT:"));
-        assert!(build_prompt("t").contains("VERDICT:"));
+        assert!(build_prompt("", "t").contains("VERDICT:"));
+        // Must not demand forbidden actions, and must respect instructions.
+        assert!(
+            lower.contains("respect"),
+            "must say to respect instructions"
+        );
+        assert!(
+            lower.contains("never flag the absence") || lower.contains("forbid"),
+            "must forbid demanding disallowed actions",
+        );
+        assert!(lower.contains("unsure"), "must keep the fail-open guidance");
     }
 
     #[tokio::test]
@@ -160,28 +234,44 @@ mod tests {
         let critic: CriticFn = Arc::new(|_prompt| {
             Box::pin(async { Ok("VERDICT: INCOMPLETE\n- the test was never run".to_string()) })
         });
-        let msgs = run_critic(&critic, "did stuff").await;
+        let msgs = run_critic(&critic, "rules", "did stuff").await;
         assert_eq!(msgs.len(), 1);
         let content = match &msgs[0] {
             LoopMessage::User(u) => &u.content,
             _ => panic!("expected user message"),
         };
-        assert!(content.contains("[critic]"));
+        assert!(content.starts_with(CRITIC_TAG));
         assert!(content.contains("test was never run"));
+    }
+
+    #[tokio::test]
+    async fn run_critic_passes_rules_into_prompt() {
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let seen2 = seen.clone();
+        let critic: CriticFn = Arc::new(move |prompt: String| {
+            *seen2.lock().unwrap() = prompt;
+            Box::pin(async { Ok("VERDICT: COMPLETE".to_string()) })
+        });
+        let _ = run_critic(&critic, "RULE: do not deploy", "did stuff").await;
+        assert!(
+            seen.lock().unwrap().contains("do not deploy"),
+            "the agent's constraints must reach the critic prompt",
+        );
     }
 
     #[tokio::test]
     async fn run_critic_silent_when_complete() {
         let critic: CriticFn =
             Arc::new(|_p| Box::pin(async { Ok("VERDICT: COMPLETE".to_string()) }));
-        assert!(run_critic(&critic, "did stuff").await.is_empty());
+        assert!(run_critic(&critic, "rules", "did stuff").await.is_empty());
     }
 
     #[tokio::test]
     async fn run_critic_fails_open_on_error() {
         let critic: CriticFn = Arc::new(|_p| Box::pin(async { anyhow::bail!("provider down") }));
         assert!(
-            run_critic(&critic, "did stuff").await.is_empty(),
+            run_critic(&critic, "rules", "did stuff").await.is_empty(),
             "a critic error must not block finalization"
         );
     }

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -1340,7 +1340,12 @@ pub async fn run_loop(
             critic_done = true;
             if let Some(critic) = &config.critic_fn {
                 let transcript = build_critic_transcript(&new_messages);
-                follow_up = super::critic::run_critic(critic, &transcript).await;
+                // dirge-bedj: pass the agent's own system prompt as the
+                // constraint set so the critic judges within the same rules
+                // the agent had (and never demands a forbidden action).
+                follow_up =
+                    super::critic::run_critic(critic, &current_context.system_prompt, &transcript)
+                        .await;
             }
         }
         if !follow_up.is_empty() {

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -187,10 +187,33 @@ pub fn render_session(
         // to 8 columns so multi-role chats stay visually aligned.
         // Continuation lines are indented to that same width so the
         // handle isn't repeated on every wrap.
-        let (handle, line_color) = match msg.role {
-            MessageRole::User => ("<you> ", theme::user()),
-            MessageRole::Assistant => ("<dirge> ", theme::agent()),
-            MessageRole::System => ("<sys> ", theme::system()),
+        // dirge-vg9e: a persisted critic follow-up is a User-role message
+        // tagged with `[critic]`; render it under its own handle/color in
+        // scrollback too, matching the live view.
+        let is_critic = msg.role == MessageRole::User
+            && msg
+                .content
+                .trim_start()
+                .starts_with(crate::agent::agent_loop::critic::CRITIC_TAG);
+        let (handle, line_color) = if is_critic {
+            ("<critic> ", theme::critic())
+        } else {
+            match msg.role {
+                MessageRole::User => ("<you> ", theme::user()),
+                MessageRole::Assistant => ("<dirge> ", theme::agent()),
+                MessageRole::System => ("<sys> ", theme::system()),
+            }
+        };
+        // Strip the `[critic]` tag from the displayed body (the handle
+        // already conveys the role).
+        let body: &str = if is_critic {
+            msg.content
+                .trim_start()
+                .strip_prefix(crate::agent::agent_loop::critic::CRITIC_TAG)
+                .map(str::trim_start)
+                .unwrap_or(&msg.content)
+        } else {
+            &msg.content
         };
         let cont_indent = " ".repeat(handle.chars().count());
 
@@ -214,7 +237,7 @@ pub fn render_session(
                 renderer.write_line(&entry.text, entry.color)?;
             }
         } else {
-            for (i, line) in msg.content.lines().enumerate() {
+            for (i, line) in body.lines().enumerate() {
                 let prefix = if i == 0 {
                     handle.to_string()
                 } else {

--- a/src/ui/run_handlers/notices.rs
+++ b/src/ui/run_handlers/notices.rs
@@ -9,7 +9,9 @@ use crossterm::style::Color;
 use crate::agent::agent_loop::message::EscalationReason;
 use crate::agent::agent_loop::tool_input_repair::RepairStatsSnapshot;
 use crate::ui::renderer::Renderer;
-use crate::ui::text_output::{strip_leading_system_reminder, write_system_lines, write_user_lines};
+use crate::ui::text_output::{
+    strip_leading_system_reminder, write_critic_lines, write_system_lines, write_user_lines,
+};
 use crate::ui::theme;
 
 /// `AgentEvent::UserMessage` — the literal prompt sent to the LLM. Strips
@@ -19,6 +21,13 @@ use crate::ui::theme;
 /// to the session at submit time.
 pub(crate) fn handle_user_message(renderer: &mut Renderer, content: &str) -> std::io::Result<()> {
     let visible = strip_leading_system_reminder(content);
+    // dirge-vg9e: the in-loop critic re-enters as a user-role message so the
+    // model acts on it; surface it under a distinct `<critic>` handle/color
+    // rather than the user's `<you>`. The tag is stripped from the display.
+    if let Some(body) = visible.strip_prefix(crate::agent::agent_loop::critic::CRITIC_TAG) {
+        write_critic_lines(renderer, body.trim_start())?;
+        return renderer.write_line("", Color::White);
+    }
     write_user_lines(renderer, visible)?;
     renderer.write_line("", Color::White)
 }

--- a/src/ui/text_output.rs
+++ b/src/ui/text_output.rs
@@ -117,6 +117,13 @@ pub(crate) fn write_user_lines(renderer: &mut Renderer, text: &str) -> std::io::
     write_prefixed_lines(renderer, "<you> ", theme::user(), text)
 }
 
+/// Print the in-loop critic's review under a distinct `<critic> ` prefix in
+/// the critic color, so it reads as a separate reviewing voice rather than
+/// the user's own message (dirge-vg9e). See `write_prefixed_lines`.
+pub(crate) fn write_critic_lines(renderer: &mut Renderer, text: &str) -> std::io::Result<()> {
+    write_prefixed_lines(renderer, "<critic> ", theme::critic(), text)
+}
+
 /// Print a dirge-originated log/notice (e.g. the max-agent-turns cap) to
 /// the chat log with a `<system> ` prefix in the *warning* color so it
 /// reads as a transient runtime notice that stands out from the user's

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -56,6 +56,9 @@ pub struct Theme {
     pub perm: Color,
     /// Secondary result text (slash command output, tool stdout dim).
     pub result: Color,
+    /// In-loop critic's review voice. Distinct from `user` so critic
+    /// follow-ups aren't mistaken for the user's own messages.
+    pub critic: Color,
     /// Hard errors. Always red-family; theme can choose the exact red
     /// but must keep it semantically distinct from everything else.
     pub error: Color,
@@ -98,6 +101,10 @@ impl Theme {
             tool: Color::Green,
             perm: Color::Yellow,
             result: Color::DarkGreen,
+            // Magenta reads distinct from the green/cyan axis — the critic
+            // is a separate reviewing voice. (Freed up now that thinking no
+            // longer monopolizes the magenta register.)
+            critic: Color::Magenta,
             error: Color::Red,
             warn: Color::Yellow,
             accent: Color::Green,
@@ -120,6 +127,8 @@ impl Theme {
             tool: Color::Yellow,
             perm: Color::Magenta,
             result: Color::DarkGrey,
+            // Blue — distinct from plain's Magenta(perm)/Green(user)/Cyan(accent).
+            critic: Color::Blue,
             error: Color::Red,
             warn: Color::Yellow,
             accent: Color::Cyan,
@@ -146,6 +155,7 @@ struct ThemeJson {
     tool: Option<ColorValue>,
     perm: Option<ColorValue>,
     result: Option<ColorValue>,
+    critic: Option<ColorValue>,
     error: Option<ColorValue>,
     warn: Option<ColorValue>,
     accent: Option<ColorValue>,
@@ -251,6 +261,7 @@ impl ThemeJson {
             tool: pick(self.tool, base.tool),
             perm: pick(self.perm, base.perm),
             result: pick(self.result, base.result),
+            critic: pick(self.critic, base.critic),
             error: pick(self.error, base.error),
             warn: pick(self.warn, base.warn),
             accent: pick(self.accent, base.accent),
@@ -346,6 +357,9 @@ pub fn perm() -> Color {
 }
 pub fn result() -> Color {
     current().result
+}
+pub fn critic() -> Color {
+    current().critic
 }
 pub fn error() -> Color {
     current().error


### PR DESCRIPTION
## Problems

1. **Critic is over-aggressive and constraint-blind.** `build_prompt` only received a transcript, so the critic judged "complete" without knowing the agent's rules — and demanded forbidden actions (e.g. "push to remote" when the agent was explicitly told not to). The preamble's "be skeptical / everything is NOT complete" stance compounded the over-blocking.
2. **Critic feedback borrowed the user's identity.** It re-enters the loop as a user-role message and rendered under the `<you>` handle/color — indistinguishable from the user.

## Fixes

- **Context (`dirge-bedj`):** the critic now receives the agent's own system prompt / constraints (`current_context.system_prompt`) and is instructed to judge *within* them and never demand a forbidden/out-of-scope action. `CRITIC_PREAMBLE` recalibrated: respect the instructions; block only on concrete, in-scope gaps with evidence; if unsure, pass. Rules block capped at 16k chars.
- **Role (`dirge-vg9e`):** new `Theme.critic` color (phosphor: Magenta, plain: Blue; custom-theme field + accessor) and a shared `CRITIC_TAG`. The live renderer and scrollback detect the tag and render critic feedback under a `<critic>` handle in its own color (tag stripped from the body).

## Tests

7 new/updated critic tests (rules embedded, constraint instruction present, rules cap, calibrated preamble, rules reach the prompt) + updated signatures.

- [x] `-D warnings` clean default + windows-default
- [x] `cargo test --bin dirge` — 2395 passed, 0 failed
- [x] `cargo fmt --check` clean

Refs dirge-bedj, dirge-vg9e