### PR TITLE
tweak(ui): agent prose to bright phosphor green, not near-white

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -93,14 +93,16 @@ impl Theme {
     /// monochrome monitor.
     pub const fn phosphor() -> Self {
         Theme {
-            // The AI's prose is the focal point — push it close to white
-            // (high brightness, low saturation) so the eye lands there
-            // first, while the green chrome (tool/header/accent) recedes
-            // around it. A faint green tint keeps the phosphor identity.
+            // The AI's prose is the focal point: a bright phosphor green —
+            // a modern take on the 80s CRT look. Light and green-forward so
+            // the eye lands here first and it reads unmistakably as the
+            // green-terminal voice, while the more-saturated/darker green
+            // chrome (tool/header/accent) recedes around it. Not near-white
+            // (loses the CRT character) and not neon (#00ff00 is harsh).
             agent: Color::Rgb {
-                r: 222,
-                g: 248,
-                b: 226,
+                r: 138,
+                g: 232,
+                b: 156,
             },
             // Cyan complements phosphor green without breaking the
             // CRT aesthetic — classic CRTs shipped with green OR


### PR DESCRIPTION
Follow-up to #316: the near-white agent prose read as too white and lost the 80s CRT character. Swap it for a bright, green-forward phosphor tone (`rgb 138,232,156`) — a modern take on the green-terminal look: still the brightest/focal element (lighter than the saturated green chrome) but unmistakably green, and softer than neon `#00ff00`.

- [x] `-D warnings` clean; theme tests green

Refs dirge-redp