### PR TITLE
docs+test(theme): document critic/thinking as config-themeable

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -46,6 +46,8 @@ A fully-custom palette:
   "tool":   "darkcyan",
   "perm":   "yellow",
   "result": "darkgray",
+  "critic":   "#c9a9ff",
+  "thinking": "#8a9c90",
   "error":  "red",
   "warn":   "yellow",
   "accent": "#ff66cc",
@@ -85,6 +87,8 @@ Each color field accepts three forms:
 | `tool` | Tool chamber headers (`╭─ BASH ─ …`) |
 | `perm` | Permission prompts (loud — yellow/red recommended) |
 | `result` | Secondary result text (slash output, dim tool stdout) |
+| `critic` | In-loop critic's review voice (`<critic>`) |
+| `thinking` | Agent reasoning / "thinking" register (placeholder, Ctrl+O expand, Ctrl+R stream) |
 | `error` | Hard errors (red recommended; keeps semantic urgency) |
 | `warn` | Warnings (yellow recommended) |
 | `accent` | Headers, focused picker rows, banner accent |

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -694,6 +694,8 @@ mod tests {
             "tool": "blue",
             "perm": "magenta",
             "result": "cyan",
+            "critic": "blue",
+            "thinking": "darkgrey",
             "error": "darkred",
             "warn": "darkyellow",
             "accent": "white",
@@ -709,6 +711,9 @@ mod tests {
         assert!(matches!(theme.agent, Color::Red));
         assert!(matches!(theme.error, Color::DarkRed));
         assert!(matches!(theme.banner_primary, Color::DarkBlue));
+        // The newer roles (critic, thinking) are config-themeable too.
+        assert!(matches!(theme.critic, Color::Blue));
+        assert!(matches!(theme.thinking, Color::DarkGrey));
         assert_eq!(theme.label, "MIDNIGHT");
     }
 


### PR DESCRIPTION
Follow-up to the palette work: confirm the new roles are overridable via custom themes.

`critic` and `thinking` were already wired through `ThemeJson` + `merge_into` (verified all 16 color fields are present in `Theme`, `ThemeJson`, *and* `merge_into`), so `~/.config/dirge/<name>.theme.json` can override them with named/hex/256-index colors — they just weren't documented or guarded.

- **docs/themes.md**: add `critic` and `thinking` to the field reference table + the full sample theme.
- **`theme_json_full_override_replaces_all_fields`**: include + assert `critic` and `thinking`, so dropping either from the override path fails CI.

No behavior change.

- [x] `-D warnings` clean default + windows-default
- [x] `cargo test --bin dirge` — 2400 passed