### PR TITLE
refactor(runner): hoist AbortRunnerOnDrop + summarize_actions (R2)

### DIFF
--- a/src/agent/phased_orchestrator.rs
+++ b/src/agent/phased_orchestrator.rs
@@ -16,7 +16,7 @@
 use crate::agent::plan_workflow::{
     PhaseOutput, REVIEWER_TOOLS, ReviewStep, next_review_step, reviewer_prompt,
 };
-use crate::agent::runner::AgentRunner;
+use crate::agent::runner::{AbortRunnerOnDrop, AgentRunner};
 use crate::event::AgentEvent;
 use crate::provider::AnyAgent;
 
@@ -38,24 +38,6 @@ pub(crate) struct PlanKickoff {
     pub impl_prompt: String,
     /// Becomes the live [`ActivePlan`] when the implement run launches.
     pub active: ActivePlan,
-}
-
-/// Drop guard so a cancelled `collect_runner_text` future (an orchestrator
-/// timeout or a caller abort) actually stops the forked runner rather than
-/// orphaning a task that keeps calling the model in the background. Mirrors
-/// the background-review guard in `review.rs`.
-struct AbortRunnerOnDrop {
-    task: tokio::task::JoinHandle<()>,
-    cancel_tx: tokio::sync::mpsc::Sender<()>,
-}
-
-impl Drop for AbortRunnerOnDrop {
-    fn drop(&mut self) {
-        // Cooperative cancel first (lets an in-flight consumer surface a clean
-        // cancelled event), then hard abort at the next `.await`.
-        let _ = self.cancel_tx.try_send(());
-        self.task.abort();
-    }
 }
 
 /// Drain a forked phase runner to completion and return its final assistant

--- a/src/agent/review.rs
+++ b/src/agent/review.rs
@@ -19,6 +19,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::agent::runner::{AbortRunnerOnDrop, summarize_actions};
 use crate::extras::dirge_paths::ProjectPaths;
 use crate::provider::AnyAgent;
 
@@ -102,38 +103,13 @@ Target shape of the library: CLASS-LEVEL skills with a rich SKILL.md. Not a long
 
 "Nothing to save." is valid but should NOT be the default. Most coding sessions produce at least one learning."#;
 
-/// dirge-ba0m: RAII guard that hard-aborts a forked runner's task
-/// on drop. The forked review/curator runners are SEPARATE tokio
-/// tasks; a core that only holds the runner's `event_rx` channel
-/// does NOT stop the runner when its own future is cancelled —
-/// dropping the channel just makes the runner's event sends no-op
-/// (`let _ = .send`), and its `loop_future` (the live LLM call +
-/// tool execution writing MEMORY.md / .usage.json / skills) keeps
-/// running to completion in the background.
-///
-/// Without this guard, the post-session orchestrator's per-stage
-/// `tokio::time::timeout` firing on a hung provider would abandon
-/// the stage future but leave its runner orphaned and writing
-/// files CONCURRENTLY with the next stage — re-introducing the
-/// exact cross-pass races the orchestrator exists to eliminate
-/// (dirge-ba0m review HIGH). Holding `task` + `cancel_tx` in this
-/// guard means any cancellation path (timeout, future drop, panic)
-/// stops the runner. On normal completion the task is already
-/// finished, so `abort()` is a harmless no-op.
-struct AbortRunnerOnDrop {
-    task: tokio::task::JoinHandle<()>,
-    cancel_tx: tokio::sync::mpsc::Sender<()>,
-}
-
-impl Drop for AbortRunnerOnDrop {
-    fn drop(&mut self) {
-        // Cooperative cancel first (lets an in-flight consumer
-        // surface a clean cancelled-event), then hard abort at the
-        // next .await. Mirrors the UI's Ctrl+C handling.
-        let _ = self.cancel_tx.try_send(());
-        self.task.abort();
-    }
-}
+// dirge-ba0m: the abort-on-drop guard for these forked review/curator
+// runners now lives in `agent::runner` ([`AbortRunnerOnDrop`]) so the
+// cancel-safety contract is shared with the phased-workflow forks. Without
+// it, the post-session orchestrator's per-stage `tokio::time::timeout` firing
+// on a hung provider would abandon the stage future but leave its runner
+// orphaned and writing MEMORY.md / .usage.json / skills CONCURRENTLY with the
+// next stage — the exact cross-pass races the orchestrator exists to prevent.
 
 /// dirge-ba0m: awaitable core of the background review pass.
 /// Runs to completion — claims the rate-limit slot, drains the
@@ -216,16 +192,7 @@ pub(crate) async fn run_background_review(
 
     if !had_error && !tool_actions.is_empty() {
         // Surface action summary so the user knows what was learned.
-        // Port of Hermes's `_safe_print` (background_review.py:514-516).
-        let summary = tool_actions
-            .iter()
-            .fold(Vec::<&str>::new(), |mut acc, a| {
-                if !acc.contains(&a.as_str()) {
-                    acc.push(a.as_str());
-                }
-                acc
-            })
-            .join(" · ");
+        let summary = summarize_actions(&tool_actions);
         tracing::info!(
             target: "dirge::review",
             actions = %summary,
@@ -320,15 +287,7 @@ pub(crate) async fn run_curator_review(
     }
 
     if error_msg.is_none() && !tool_actions.is_empty() {
-        let summary = tool_actions
-            .iter()
-            .fold(Vec::<&str>::new(), |mut acc, a| {
-                if !acc.contains(&a.as_str()) {
-                    acc.push(a.as_str());
-                }
-                acc
-            })
-            .join(" · ");
+        let summary = summarize_actions(&tool_actions);
         tracing::info!(
             target: "dirge::curator",
             actions = %summary,
@@ -457,15 +416,7 @@ pub(crate) async fn run_memory_curator_review(
         let summary = if tool_actions.is_empty() {
             "no-op".to_string()
         } else {
-            tool_actions
-                .iter()
-                .fold(Vec::<&str>::new(), |mut acc, a| {
-                    if !acc.contains(&a.as_str()) {
-                        acc.push(a.as_str());
-                    }
-                    acc
-                })
-                .join(" · ")
+            summarize_actions(&tool_actions)
         };
         tracing::info!(
             target: "dirge::memory_curator",

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -35,6 +35,42 @@ pub struct AgentRunner {
     pub cancel_tx: mpsc::Sender<()>,
 }
 
+/// Abort-on-drop guard for a forked [`AgentRunner`]. Holding it while draining
+/// the runner's events ensures a cancelled/early-returning drain actually stops
+/// the fork — cooperative `cancel_tx` first (so an in-flight consumer can
+/// surface a clean cancelled event), then a hard `task.abort()` at the next
+/// `.await` — rather than orphaning a task that keeps calling the model.
+///
+/// Shared by every forked-runner consumer (`agent::review` background passes,
+/// `agent::phased_orchestrator` phase forks) so the cancel-safety contract
+/// lives in exactly one place.
+pub(crate) struct AbortRunnerOnDrop {
+    pub task: JoinHandle<()>,
+    pub cancel_tx: mpsc::Sender<()>,
+}
+
+impl Drop for AbortRunnerOnDrop {
+    fn drop(&mut self) {
+        let _ = self.cancel_tx.try_send(());
+        self.task.abort();
+    }
+}
+
+/// Summarize a forked runner's tool-call names into a compact, de-duplicated
+/// ` · `-joined line (first-occurrence order preserved). Port of Hermes's
+/// action summary (`background_review.py`); shared by the review/curator passes.
+pub(crate) fn summarize_actions(actions: &[String]) -> String {
+    actions
+        .iter()
+        .fold(Vec::<&str>::new(), |mut acc, a| {
+            if !acc.contains(&a.as_str()) {
+                acc.push(a.as_str());
+            }
+            acc
+        })
+        .join(" · ")
+}
+
 pub fn convert_history(session: &Session) -> Vec<Message> {
     use rig::OneOrMany;
     use rig::completion::message::AssistantContent;
@@ -320,6 +356,20 @@ mod plugin_hook_tests {
         let mut mgr = PluginManager::try_new().unwrap();
         let out = resolve_prompt_with_hooks("just this", &mut mgr);
         assert_eq!(out, "just this");
+    }
+
+    #[test]
+    fn summarize_actions_dedups_preserving_first_occurrence_order() {
+        let actions = [
+            "read".to_string(),
+            "grep".to_string(),
+            "read".to_string(),
+            "bash".to_string(),
+            "grep".to_string(),
+        ];
+        assert_eq!(summarize_actions(&actions), "read · grep · bash");
+        assert_eq!(summarize_actions(&[]), "");
+        assert_eq!(summarize_actions(&["edit".to_string()]), "edit");
     }
 
     /// on-response can mutate the final response via


### PR DESCRIPTION
**Round 2 of the vix-port cleanup** (epic dirge-g298). Partially closes dirge-5oxu (F3); F4 split out (see below).

The vix port introduced a verbatim copy of `AbortRunnerOnDrop` (the abort-on-drop guard) in `phased_orchestrator.rs`, duplicating the one in `review.rs`. The tool-action dedup-fold was also copy-pasted **3×** across the review/curator passes. Both now live in `agent::runner` next to `AgentRunner`:

- **`AbortRunnerOnDrop`** (`pub(crate)`) — shared by the 4 `review.rs` forked-runner drains + `phased_orchestrator`'s `collect_runner_text`. The safety-critical cancel contract (cooperative cancel → hard abort; prevents orphaned background runners writing files concurrently — dirge-ba0m) now has exactly one definition.
- **`summarize_actions(&[String])`** — replaces the 3× identical `fold(Vec<&str>).join(" · ")` with one tested helper.

Behavior-preserving — per-site logging targets/messages untouched. Net **−55 LOC** + a unit test for `summarize_actions`.

### Scope note
The original R2 also bundled **F4** — a `launch_run` helper for the "spawn_runner + set the four `agent_*` mutables + `is_running`" block. On inspection that pattern repeats across **10 sites in the core UI loop** (6 in `ui/mod.rs` + 4 in `done.rs`), not just the vix code, and the interactive loop has no integration tests. I've split it into its own focused PR (R2b) so the high-blast-radius change is reviewable in isolation rather than riding along with this contained dedup.

2452 tests pass; clean under `-D warnings`.