### PR TITLE
refactor(ui): extract /plan reviewer loop into plan_review.rs (R3)

### DIFF
--- a/src/ui/run_handlers/done.rs
+++ b/src/ui/run_handlers/done.rs
@@ -5,9 +5,11 @@
 //! `on-complete` / `prepare-next-run` chain (with optional model
 //! swap), auto-compacts when the session crossed the threshold,
 //! decides via `decide_post_done_action` whether to launch a
-//! follow-up / loop iteration / stop, spawns a background review +
-//! curator pass when idle, handles git-worktree return, and finally
-//! drains any user interjections queued during the run.
+//! follow-up / loop iteration / stop, hands off to `plan_review` when a
+//! phased `/plan` implement turn just finished (the reviewer-runs-code
+//! loop), spawns a background review + curator pass when idle, handles
+//! git-worktree return, and finally drains any user interjections queued
+//! during the run.
 //!
 //! Behavior is identical to the original inline body; only the
 //! lexical home moved.
@@ -527,68 +529,20 @@ pub(crate) async fn handle_done(
 
     // Phased `/plan` reviewer loop (P3e-b). If this `Done` closed a plan-driven
     // implement run and nothing else (plugin follow-up / loop iteration) claimed
-    // the next turn, fork a write-disabled reviewer to *run the code* and act on
-    // its verdict. Driven event-by-event (not via `run_review_loop`) because the
-    // implement run streams through this UI loop and can't be awaited inline.
-    if !*is_running && let Some(active) = ctx.active_plan.take() {
-        // Transcript reflects the just-committed implement turn (the assistant
-        // response was added to the session earlier in this handler).
-        let transcript = crate::agent::review::build_transcript(ctx.session);
-        ctx.renderer
-            .write_line("Phase: Review — reviewer runs the code…", c_agent())?;
-        match crate::agent::phased_orchestrator::review_once(
-            agent,
-            &active.plan,
-            transcript,
-            active.cycles_left,
-        )
-        .await
-        {
-            Ok(crate::agent::plan_workflow::ReviewStep::Approved) => {
-                ctx.renderer
-                    .write_line("Phase: Review — ✓ reviewer approved", c_agent())?;
-            }
-            Ok(crate::agent::plan_workflow::ReviewStep::Exhausted) => {
-                ctx.renderer.write_line(
-                    "Phase: Review — fix-cycle budget spent; stopping. Continue manually if needed.",
-                    c_agent(),
-                )?;
-            }
-            Ok(crate::agent::plan_workflow::ReviewStep::Retry { feedback }) => {
-                ctx.renderer.write_line(
-                    "Phase: Review — changes needed; re-implementing…",
-                    c_agent(),
-                )?;
-                let retry_prompt = crate::agent::plan_workflow::implement_retry_prompt(&feedback);
-                ctx.last_user_prompt.clone_from(&retry_prompt);
-                ctx.session.add_message(MessageRole::User, &retry_prompt);
-                let runner = agent.clone().spawn_runner(
-                    crate::agent::tools::background::prepend_pending_notifications(
-                        &retry_prompt,
-                        bg_store.as_ref(),
-                    ),
-                    crate::agent::runner::convert_history(ctx.session),
-                    Some(interjection_queue.clone()),
-                );
-                *agent_rx = Some(runner.event_rx);
-                *agent_abort = Some(runner.task);
-                *agent_interject = Some(runner.interject_tx);
-                *agent_cancel = Some(runner.cancel_tx);
-                *is_running = true;
-                // One cycle consumed; the next `Done` reviews again.
-                *ctx.active_plan = Some(crate::agent::phased_orchestrator::ActivePlan {
-                    plan: active.plan,
-                    cycles_left: active.cycles_left - 1,
-                });
-            }
-            Err(e) => {
-                ctx.renderer.write_line(
-                    &format!("Phase: Review — reviewer error: {e}; stopping"),
-                    c_error(),
-                )?;
-            }
-        }
-    }
+    // the next turn, a write-disabled reviewer runs the code and either approves
+    // or relaunches the implement run with the punch-list. See `plan_review`.
+    super::plan_review::drive_plan_review(
+        ctx,
+        agent,
+        bg_store,
+        interjection_queue,
+        agent_rx,
+        agent_abort,
+        agent_interject,
+        agent_cancel,
+        is_running,
+    )
+    .await?;
 
     // Phase 4: spawn background review when the
     // session is truly idle (no plugin followup,

--- a/src/ui/run_handlers/mod.rs
+++ b/src/ui/run_handlers/mod.rs
@@ -34,6 +34,7 @@ pub(super) mod done;
 pub(super) mod error;
 pub(super) mod interjected;
 pub(super) mod notices;
+pub(super) mod plan_review;
 pub(super) mod streaming;
 pub(super) mod tool_call;
 pub(super) mod tool_result;

--- a/src/ui/run_handlers/plan_review.rs
+++ b/src/ui/run_handlers/plan_review.rs
@@ -1,0 +1,102 @@
+//! Phased `/plan` reviewer loop (P3e-b), extracted from `handle_done`.
+//!
+//! After a plan-driven implement turn finishes, this forks a *write-disabled*
+//! reviewer that independently runs the code and emits a verdict
+//! ([`crate::agent::phased_orchestrator::review_once`]). `DONE` ends the
+//! workflow; `NEEDS_FIX` feeds the punch-list back into another streamed
+//! implement turn, bounded by the cycle budget. The policy decision lives in
+//! [`crate::agent::plan_workflow::next_review_step`]; this module is the UI-side
+//! orchestration (render phase lines, relaunch the implement run) that
+//! `handle_done` calls once it knows no plugin follow-up / loop iteration
+//! claimed the next turn.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use crate::agent::phased_orchestrator::{ActivePlan, review_once};
+use crate::agent::plan_workflow::{ReviewStep, implement_retry_prompt};
+use crate::agent::tools::background::{BackgroundStore, prepend_pending_notifications};
+use crate::event::AgentEvent;
+use crate::provider::AnyAgent;
+use crate::session::MessageRole;
+use crate::ui::colors::{c_agent, c_error};
+use crate::ui::run_handlers::RunCtx;
+
+/// Drive one reviewer pass for an in-flight `/plan` workflow. No-op unless the
+/// run just went idle (`!is_running`) and a plan is active. On `NEEDS_FIX`
+/// (within budget) it relaunches the implement run — taking over the run-state
+/// slots and re-arming `ctx.active_plan` with one fewer cycle so the next
+/// `Done` reviews again.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn drive_plan_review(
+    ctx: &mut RunCtx<'_>,
+    agent: &mut AnyAgent,
+    bg_store: &Option<BackgroundStore>,
+    interjection_queue: &Arc<Mutex<VecDeque<String>>>,
+    agent_rx: &mut Option<mpsc::Receiver<AgentEvent>>,
+    agent_abort: &mut Option<JoinHandle<()>>,
+    agent_interject: &mut Option<mpsc::Sender<()>>,
+    agent_cancel: &mut Option<mpsc::Sender<()>>,
+    is_running: &mut bool,
+) -> anyhow::Result<()> {
+    // Only when this `Done` left the run idle and a plan is mid-flight.
+    if *is_running {
+        return Ok(());
+    }
+    let Some(active) = ctx.active_plan.take() else {
+        return Ok(());
+    };
+
+    // Transcript reflects the just-committed implement turn (the assistant
+    // response was added to the session earlier in `handle_done`).
+    let transcript = crate::agent::review::build_transcript(ctx.session);
+    ctx.renderer
+        .write_line("Phase: Review — reviewer runs the code…", c_agent())?;
+
+    match review_once(agent, &active.plan, transcript, active.cycles_left).await {
+        Ok(ReviewStep::Approved) => {
+            ctx.renderer
+                .write_line("Phase: Review — ✓ reviewer approved", c_agent())?;
+        }
+        Ok(ReviewStep::Exhausted) => {
+            ctx.renderer.write_line(
+                "Phase: Review — fix-cycle budget spent; stopping. Continue manually if needed.",
+                c_agent(),
+            )?;
+        }
+        Ok(ReviewStep::Retry { feedback }) => {
+            ctx.renderer.write_line(
+                "Phase: Review — changes needed; re-implementing…",
+                c_agent(),
+            )?;
+            let retry_prompt = implement_retry_prompt(&feedback);
+            ctx.last_user_prompt.clone_from(&retry_prompt);
+            ctx.session.add_message(MessageRole::User, &retry_prompt);
+            let runner = agent.clone().spawn_runner(
+                prepend_pending_notifications(&retry_prompt, bg_store.as_ref()),
+                crate::agent::runner::convert_history(ctx.session),
+                Some(interjection_queue.clone()),
+            );
+            *agent_rx = Some(runner.event_rx);
+            *agent_abort = Some(runner.task);
+            *agent_interject = Some(runner.interject_tx);
+            *agent_cancel = Some(runner.cancel_tx);
+            *is_running = true;
+            // One cycle consumed; the next `Done` reviews again.
+            *ctx.active_plan = Some(ActivePlan {
+                plan: active.plan,
+                cycles_left: active.cycles_left - 1,
+            });
+        }
+        Err(e) => {
+            ctx.renderer.write_line(
+                &format!("Phase: Review — reviewer error: {e}; stopping"),
+                c_error(),
+            )?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
**Round 3 of the vix-port cleanup** (epic dirge-g298). Closes dirge-aho0.

The phased reviewer loop was a ~63-line inline block at the bottom of the **718-line** `handle_done` — undiscoverable (the module header listed nine responsibilities and didn't mention it) and inseparable from the whole UI loop. Moved into its own focused handler module `run_handlers/plan_review.rs` (`drive_plan_review(...)`), called as a one-liner from `handle_done`. The `done.rs` `//!` now names the handoff.

Pure code move — behavior unchanged. The review *policy* still lives in `plan_workflow::next_review_step`; this module is just the UI-side orchestration (render phase lines, relaunch the implement run). 2452 tests pass; clean under `-D warnings`.