### PR TITLE
docs: fix stale src paths after module→directory splits

### DIFF
--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -132,7 +132,7 @@ The agent loop lives in `src/agent/agent_loop/`:
 | `retry.rs` | `retrying_stream_fn` — transient-error recovery around a `StreamFn` |
 | `steering.rs` | `steering_from_queue` — shared queue → `GetSteeringMessagesFn` |
 | `plugin_hooks.rs` | Factories that adapt Janet plugin hooks to the loop hook surface |
-| `tool_input_repair.rs` | Validate-then-repair pass for malformed tool-call arguments |
+| `tool_input_repair/` | Validate-then-repair pass for malformed tool-call arguments |
 | `context_manager.rs` | Compaction policy and dispatch for `transform_context` |
 
 ## Production wiring

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -184,7 +184,7 @@ debug run_to_cursor { file: "src/auth.py", line: 87 }
 
 ```
 debug set_breakpoints {
-  file: "src/loop.rs",
+  file: "src/extras/loop/transcript.rs",
   line: 128,
   condition: "i > 1000"
 }

--- a/docs/storyboards/02-permission-ask.md
+++ b/docs/storyboards/02-permission-ask.md
@@ -22,9 +22,9 @@ short-circuits before the prompt fires.
 
 ## Implementation
 
-- `src/agent/tools/bash.rs::BashTool::call` — splits the command into
+- `src/agent/tools/bash/mod.rs::BashTool::call` — splits the command into
   segments and submits each to `check_bash_segments`.
-- `src/agent/tools/bash.rs::check_bash_segments` — calls `enforce`
+- `src/agent/tools/bash/check.rs::check_bash_segments` — calls `enforce`
   per segment and per extracted mutation path.
 - `src/agent/tools/mod.rs::enforce` — public entry point; runs
   `PermissionChecker::check` / `check_path` and routes `Ask`
@@ -38,7 +38,7 @@ short-circuits before the prompt fires.
 - `src/permission/checker.rs::track_doom_loop` — per-key counter
   via `repeat_counts`.
 - `src/permission/ask.rs` — `AskRequest`, `UserDecision`, key bindings.
-- `src/permission/engine.rs` — high-risk-tool list that Accept mode
+- `src/permission/engine/classify.rs` — high-risk-tool list that Accept mode
   still asks for (bash, webfetch, task, memory, skill, apply_patch).
 
 ## Edge cases

--- a/docs/tool-input-repair.md
+++ b/docs/tool-input-repair.md
@@ -113,7 +113,7 @@ When all repairs fail, the raw `serde_json::Error` is not surfaced to the model.
 
 ## Where it lives
 
-The repair layer lives in `src/agent/agent_loop/tool_input_repair.rs`:
+The repair layer lives in `src/agent/agent_loop/tool_input_repair/`:
 
 | Symbol | Role |
 |---|---|


### PR DESCRIPTION
While auditing whether docs are current, found 4 pre-existing stale path references (unrelated to the vix port) — modules that grew from a single `.rs` into a directory but whose doc references weren't updated:

- `tool_input_repair.rs` → `tool_input_repair/` (tool-input-repair.md, agent-loop.md)
- `tools/bash.rs` → `tools/bash/mod.rs` + `tools/bash/check.rs` (storyboards/02)
- `permission/engine.rs` → `permission/engine/classify.rs` (storyboards/02)
- `src/loop.rs` → `src/extras/loop/transcript.rs` (dap.md breakpoint example)

**The new-feature docs were already in sync** — the `/plan` workflow, minify, read-gate, watchdog, reason fields, and todo nudge are documented (features.md, config.md, agent-loop.md, CHANGELOG, README ack), and the R4/5 `agent/plan/` module move was reflected in agent-loop.md. Docs-only.