### PR TITLE
refactor: short_id helper + spawn tool_defs_for/model_name_opt

### DIFF
--- a/src/provider/spawn.rs
+++ b/src/provider/spawn.rs
@@ -30,6 +30,31 @@ pub(crate) fn filter_loop_tools(
 }
 
 impl AnyAgent {
+    /// Map a tool slice to rig `ToolDefinition`s for the per-turn request
+    /// builder. Shared by the main (`spawn_runner`) and fork
+    /// (`spawn_filtered_runner_with_cache`) builders, which built this
+    /// identically.
+    fn tool_defs_for(
+        tools: &[std::sync::Arc<dyn crate::agent::agent_loop::LoopTool>],
+    ) -> Vec<rig::completion::ToolDefinition> {
+        tools
+            .iter()
+            .map(|t| crate::agent::agent_loop::loop_tool_to_rig_definition(t.as_ref()))
+            .collect()
+    }
+
+    /// `model_name` as an `Option`, treating empty as "unset" — the
+    /// normalization both spawn builders need for `LoopSpawnConfig.model_name`.
+    /// Takes the field by ref (not `&self`) so it's callable after `self` is
+    /// partially moved (`cfg.tools = self.loop_tools`).
+    fn model_name_opt(model_name: &str) -> Option<String> {
+        if model_name.is_empty() {
+            None
+        } else {
+            Some(model_name.to_string())
+        }
+    }
+
     pub fn spawn_runner(
         self,
         prompt: String,
@@ -39,8 +64,8 @@ impl AnyAgent {
         >,
     ) -> AgentRunner {
         use crate::agent::agent_loop::{
-            LoopSpawnConfig, loop_tool_to_rig_definition, retrying_stream_fn,
-            rig_history_system_prompt, rig_history_to_loop_messages, spawn_loop_runner,
+            LoopSpawnConfig, retrying_stream_fn, rig_history_system_prompt,
+            rig_history_to_loop_messages, spawn_loop_runner,
         };
         use crate::agent::recovery::RecoveryPolicy;
 
@@ -51,11 +76,7 @@ impl AnyAgent {
         // Convert tool registry → rig ToolDefinitions for the
         // request builder, and keep the registry itself for the
         // loop's dispatch.
-        let tool_defs: Vec<rig::completion::ToolDefinition> = self
-            .loop_tools
-            .iter()
-            .map(|t| loop_tool_to_rig_definition(t.as_ref()))
-            .collect();
+        let tool_defs = Self::tool_defs_for(&self.loop_tools);
 
         // Phase-3: per-session loaded-tool set was allocated at
         // `build_agent` time (when `dynamic_tool_search` is on)
@@ -126,11 +147,7 @@ impl AnyAgent {
         cfg.history = loop_history;
         cfg.tools = self.loop_tools;
         cfg.provider_name = Some(provider_name);
-        cfg.model_name = if self.model_name.is_empty() {
-            None
-        } else {
-            Some(self.model_name.clone())
-        };
+        cfg.model_name = Self::model_name_opt(&self.model_name);
         cfg.steering_queue = steering_queue;
         cfg.tool_def_filter = tool_def_filter;
         cfg.dynamic_tool_search = self.dynamic_tool_search;
@@ -291,9 +308,7 @@ impl AnyAgent {
         review_cache: ToolCache,
         allowed_tools: &[&str],
     ) -> (crate::agent::runner::AgentRunner, ToolCache) {
-        use crate::agent::agent_loop::{
-            LoopSpawnConfig, loop_tool_to_rig_definition, retrying_stream_fn, spawn_loop_runner,
-        };
+        use crate::agent::agent_loop::{LoopSpawnConfig, retrying_stream_fn, spawn_loop_runner};
         use crate::agent::recovery::RecoveryPolicy;
 
         // Hard guard against accidental sharing: if a caller
@@ -308,10 +323,7 @@ impl AnyAgent {
         // Filter to the caller-supplied allow-list (shared, tested helper).
         let review_tools = filter_loop_tools(&self.loop_tools, allowed_tools);
 
-        let tool_defs: Vec<rig::completion::ToolDefinition> = review_tools
-            .iter()
-            .map(|t| loop_tool_to_rig_definition(t.as_ref()))
-            .collect();
+        let tool_defs = Self::tool_defs_for(&review_tools);
 
         // dirge-z73i: prefer the explicit review_stream_fn when the
         // user configured `review_provider` to point at a different
@@ -331,11 +343,7 @@ impl AnyAgent {
                 (
                     self.build_stream_fn(tool_defs),
                     self.provider_name().to_string(),
-                    if self.model_name.is_empty() {
-                        None
-                    } else {
-                        Some(self.model_name.clone())
-                    },
+                    Self::model_name_opt(&self.model_name),
                 )
             };
         let stream_fn = retrying_stream_fn(inner_stream_fn, RecoveryPolicy::default());

--- a/src/text.rs
+++ b/src/text.rs
@@ -29,6 +29,14 @@ pub(crate) fn tail(s: &str, max_bytes: usize) -> &str {
     &s[start..]
 }
 
+/// Short display prefix of an id — its first 8 characters. Used across the UI
+/// to compact session / subagent / notification / plugin ids for display.
+/// Char-based (UTF-8 safe) and consistent everywhere, replacing the ~9
+/// scattered `id.chars().take(8).collect()` copies.
+pub(crate) fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/agent_io.rs
+++ b/src/ui/agent_io.rs
@@ -218,10 +218,7 @@ pub(crate) fn persist_turn_to_db(
         }
     };
     let now = chrono::Utc::now().to_rfc3339();
-    let sid = format!(
-        "dirge-{}",
-        session.id.as_str().chars().take(8).collect::<String>()
-    );
+    let sid = format!("dirge-{}", crate::text::short_id(session.id.as_str()));
     let _ = db.insert_session(&sid, "cli", &session.model, &session.provider, &now);
 
     if !user_prompt.is_empty() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1166,7 +1166,7 @@ pub async fn run_interactive(
                                             active,
                                             &format!(
                                                 "(/kill triggered — aborting {})",
-                                                id.chars().take(8).collect::<String>()
+                                                crate::text::short_id(&id)
                                             ),
                                             theme::dim(),
                                         );
@@ -2684,11 +2684,11 @@ pub async fn run_interactive(
                 };
                 let (label, color) = match &lifecycle_evt {
                     LifecycleEvent::Started { id } => {
-                        let short: String = id.chars().take(8).collect();
+                        let short = crate::text::short_id(&id);
                         (format!("[task {} started]", short), c_tool())
                     }
                     LifecycleEvent::Finished(notif) => {
-                        let short: String = notif.id.chars().take(8).collect();
+                        let short = crate::text::short_id(&notif.id);
                         match &notif.state {
                             TS::Completed(_) => {
                                 (format!("[task {} completed]", short), Color::Green)
@@ -2798,7 +2798,7 @@ pub async fn run_interactive(
                             .take(40)
                             .collect();
                         let name = if short.is_empty() {
-                            format!("subagent {}", id.chars().take(8).collect::<String>())
+                            format!("subagent {}", crate::text::short_id(&id))
                         } else {
                             format!("task: {}", short)
                         };

--- a/src/ui/plugin_tree.rs
+++ b/src/ui/plugin_tree.rs
@@ -210,7 +210,7 @@ pub fn apply_tree_op(
 }
 
 fn short(s: &str) -> String {
-    s.chars().take(8).collect()
+    crate::text::short_id(s)
 }
 
 #[cfg(test)]

--- a/src/ui/run_handlers/context_compacted.rs
+++ b/src/ui/run_handlers/context_compacted.rs
@@ -48,10 +48,7 @@ pub(crate) async fn handle_context_compacted(
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let paths = crate::extras::dirge_paths::ProjectPaths::new(&cwd);
     if let Ok(db) = crate::extras::session_db::SessionDb::open(&paths.session_db_path()) {
-        let old_sid = format!(
-            "dirge-{}",
-            ctx.session.id.as_str().chars().take(8).collect::<String>()
-        );
+        let old_sid = format!("dirge-{}", crate::text::short_id(ctx.session.id.as_str()));
         let _ = db.end_session(&old_sid, "compression");
         let now = chrono::Utc::now().to_rfc3339();
         let _ = db.insert_session(

--- a/src/ui/tree.rs
+++ b/src/ui/tree.rs
@@ -11,7 +11,7 @@ use crate::session::{MessageRole, Session, TreeNode};
 /// noisy in chat output; the prefix is uniquely-identifiable in any
 /// realistic session size.
 pub fn short_id(id: &CompactString) -> String {
-    id.chars().take(8).collect()
+    crate::text::short_id(id)
 }
 
 /// Resolve a short id prefix the user typed (e.g. "abc12345") to a
@@ -164,7 +164,7 @@ mod tests {
         let mut s = Session::new("p", "m", 0);
         s.add_message(MessageRole::User, "msg");
         let full_id = s.messages[0].id.clone();
-        let prefix: String = full_id.chars().take(8).collect();
+        let prefix = crate::text::short_id(&full_id);
         let resolved = resolve_id_prefix(&s, &prefix).unwrap();
         assert_eq!(resolved, full_id);
     }


### PR DESCRIPTION
Round A part 2 of the duplication consolidation (epic dirge-9l12, dirge-ftmo). Follows #353 (find_callees).

**#10 `short_id`** — the `id.chars().take(8)` display-prefix idiom was hand-rolled at 9 sites, two of them already-duplicated local fns (`ui/tree.rs`, `ui/plugin_tree.rs`). Hoisted to `crate::text::short_id`; the 2 local wrappers delegate, the 7 inline sites call it directly.

**#9 spawn.rs** — the main (`spawn_runner`) and fork (`spawn_filtered_runner_with_cache`) builders assembled `tool_defs` and `model_name` identically. Extracted private `AnyAgent::tool_defs_for(tools)` + `::model_name_opt(model_name)` (takes the field by ref so it survives the partial move of `self.loop_tools`).

**#5 `ext_of` dropped** — the audit counted 8 sites but only 2 (`read_minified`/`edit_minified`) actually match the `&str → &str` shape; the rest take `&Path` and/or add `.to_lowercase()`/`format!`, so one helper doesn't fit. Not worth it for 2 sites — an honest correction of the audit.

2455 tests pass; clean under `-D warnings --all-features`. Round A complete; next: the security-relevant ANSI/perm merges (Round B).