### PR TITLE
feat(theme): configurable terminal background; phosphor #222

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -97,6 +97,7 @@ Each color field accepts three forms:
 | `divider` | Horizontal divider line |
 | `banner_primary` | Welcome banner primary stroke |
 | `banner_secondary` | Welcome banner border / decorations |
+| `background` | Terminal background fill, painted behind every cell (foregrounds preserved). Use `"reset"` to keep the terminal's own background — that's the `plain` default; `phosphor` uses a near-black `#222222`. |
 | `label` | Human-readable name shown in the banner |
 
 ### Activating

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -677,6 +677,7 @@ impl Renderer {
             show_left_panel,
             show_right_panel,
             frame_color,
+            background: crate::ui::theme::background(),
             right_panel_mode: *right_panel_mode,
             #[cfg(feature = "dap")]
             debug_panel_data: self.debug_panel_data.as_ref(),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -82,6 +82,11 @@ pub struct Theme {
     pub banner_primary: Color,
     /// Welcome-banner secondary stroke (border, decorations).
     pub banner_secondary: Color,
+    /// Terminal background fill. Painted behind every cell (foregrounds
+    /// preserved). `Color::Reset` keeps the terminal's own default background
+    /// (no fill) — the right choice for `plain` and for users on a custom
+    /// terminal palette who don't want dirge overriding it.
+    pub background: Color,
     /// Human-readable name surfaced in the banner ("PHOSPHOR", "PLAIN").
     pub label: &'static str,
 }
@@ -208,6 +213,13 @@ impl Theme {
                 g: 116,
                 b: 96,
             },
+            // Near-black charcoal (#222) instead of pure terminal black — gives
+            // the phosphor green a touch of CRT-bezel depth without washing out.
+            background: Color::Rgb {
+                r: 0x22,
+                g: 0x22,
+                b: 0x22,
+            },
             label: "PHOSPHOR",
         }
     }
@@ -238,6 +250,8 @@ impl Theme {
             divider: Color::DarkGrey,
             banner_primary: Color::Cyan,
             banner_secondary: Color::DarkGrey,
+            // Keep the terminal's own background — `plain` shouldn't override it.
+            background: Color::Reset,
             label: "PLAIN",
         }
     }
@@ -266,6 +280,7 @@ struct ThemeJson {
     divider: Option<ColorValue>,
     banner_primary: Option<ColorValue>,
     banner_secondary: Option<ColorValue>,
+    background: Option<ColorValue>,
     label: Option<String>,
 }
 
@@ -373,6 +388,7 @@ impl ThemeJson {
             divider: pick(self.divider, base.divider),
             banner_primary: pick(self.banner_primary, base.banner_primary),
             banner_secondary: pick(self.banner_secondary, base.banner_secondary),
+            background: pick(self.background, base.background),
             label,
         })
     }
@@ -490,6 +506,9 @@ pub fn banner_primary() -> Color {
 }
 pub fn banner_secondary() -> Color {
     current().banner_secondary
+}
+pub fn background() -> Color {
+    current().background
 }
 
 /// Whether the given color should render with the Bold attribute to

--- a/src/ui/tui/scene.rs
+++ b/src/ui/tui/scene.rs
@@ -72,6 +72,9 @@ pub struct Scene<'a> {
     pub show_right_panel: bool,
     /// Header / frame color.
     pub frame_color: crossterm::style::Color,
+    /// Terminal background fill (theme-configurable). `Color::Reset` = no fill
+    /// (keep the terminal's own background).
+    pub background: crossterm::style::Color,
 }
 
 /// Paint the entire UI into `f`. Computes layout from the frame's
@@ -150,6 +153,18 @@ pub fn render_frame(scene: &Scene, f: &mut Frame<'_>) {
         });
     }
     f.render_widget(strip, area);
+
+    // Theme background fill. Every widget above sets foreground only (selection
+    // uses the REVERSED modifier, never an explicit bg), so patching the whole
+    // area with `bg` sets each cell's background while leaving foregrounds — and
+    // REVERSED swaps — intact. `Color::Reset` (plain theme / opt-out) skips the
+    // fill so the terminal's own background shows through.
+    if scene.background != crossterm::style::Color::Reset {
+        f.buffer_mut().set_style(
+            area,
+            Style::default().bg(crossterm_to_ratatui(scene.background)),
+        );
+    }
 
     // Show the hardware cursor at the editor's (row, col). The
     // terminal blinks it naturally.
@@ -231,6 +246,7 @@ pub fn empty_scene<'a>(
         show_left_panel: true,
         show_right_panel: true,
         frame_color: crossterm::style::Color::Green,
+        background: crossterm::style::Color::Reset,
     }
 }
 
@@ -301,6 +317,40 @@ mod tests {
         assert!(status_row.starts_with("ready"));
     }
 
+    /// A configured (non-Reset) theme background fills every cell's bg;
+    /// `Color::Reset` leaves the terminal default untouched.
+    #[test]
+    fn theme_background_fills_cells_only_when_set() {
+        let buf: Vec<LineEntry> = Vec::new();
+        let pd = PanelData::default();
+        let info = LeftPanelInfo::default();
+        let subs: Vec<SubagentStatusRow> = Vec::new();
+        let mut scene = empty_scene(&buf, &pd, &info, &subs, "ready");
+
+        let bg = crossterm::style::Color::Rgb {
+            r: 0x22,
+            g: 0x22,
+            b: 0x22,
+        };
+        scene.background = bg;
+        let mut t = Terminal::new(TestBackend::new(160, 30)).unwrap();
+        t.draw(|f| render_frame(&scene, f)).unwrap();
+        assert_eq!(
+            t.backend().buffer().cell((5, 5)).unwrap().bg,
+            crossterm_to_ratatui(bg),
+            "configured background must fill cells",
+        );
+
+        scene.background = crossterm::style::Color::Reset;
+        let mut t2 = Terminal::new(TestBackend::new(160, 30)).unwrap();
+        t2.draw(|f| render_frame(&scene, f)).unwrap();
+        assert_eq!(
+            t2.backend().buffer().cell((5, 5)).unwrap().bg,
+            RColor::Reset,
+            "Reset background must NOT fill — terminal default shows through",
+        );
+    }
+
     /// When an overlay is active, the editor is REPLACED inside
     /// the bottom frame — no second box anywhere.
     #[test]
@@ -335,6 +385,7 @@ mod tests {
             show_left_panel: true,
             show_right_panel: true,
             frame_color: crossterm::style::Color::Green,
+            background: crossterm::style::Color::Reset,
         };
 
         let mut backend = TestBackend::new(160, 30);
@@ -523,6 +574,7 @@ mod tests {
             show_left_panel: true,
             show_right_panel: true,
             frame_color: crossterm::style::Color::Green,
+            background: crossterm::style::Color::Reset,
         };
         terminal.draw(|f| render_frame(&s1, f)).unwrap();
 
@@ -553,6 +605,7 @@ mod tests {
             show_left_panel: true,
             show_right_panel: true,
             frame_color: crossterm::style::Color::Green,
+            background: crossterm::style::Color::Reset,
         };
         terminal.draw(|f| render_frame(&s2, f)).unwrap();
         backend = terminal.backend().clone();


### PR DESCRIPTION
Adds a theme-configurable terminal **background** color, and sets phosphor's to a near-black `#222222` (CRT-bezel depth instead of pure terminal black).

**Mechanism (clean, ratatui-native):** `render_frame` patches the whole frame area with `Style::default().bg(..)` *after* all widgets. ratatui's style-patch only overrides the `Some` fields, so foregrounds — and selection's `REVERSED` modifier (no cell sets an explicit bg anywhere) — stay intact. `Color::Reset` skips the fill entirely, so `plain` (and anyone opting out) keeps the terminal's own background.

**Wiring:** `Theme.background` field + both presets (phosphor `#222`, plain `Reset`) + `ThemeJson` key + `merge_into` + `theme::background()` accessor; `Scene` carries it; the renderer reads `theme::background()` when building the scene.

**Themes can configure it** — any `<name>.theme.json` can set `"background": "#1a1b26"` (or `"reset"` to opt out), documented in docs/themes.md.

+ scene test (fills cells when set / no-op on `Reset`). Builds clean; 18 theme/scene tests pass.