### PR TITLE
fix(ui): /plan shows the standard busy indicator + clears the input box

### DIFF
--- a/src/ui/slash/cmd_plan.rs
+++ b/src/ui/slash/cmd_plan.rs
@@ -10,7 +10,40 @@
 use super::SlashCtx;
 use crate::agent::plan::runtime::{ActivePlan, PlanKickoff, collect_runner_text};
 use crate::agent::plan::workflow::{READONLY_PHASE_TOOLS, explore_prompt, plan_prompt};
+use crate::ui::avatar::AvatarState;
 use crate::ui::colors::{c_agent, c_error};
+
+/// Switch the bottom bar between the busy and idle presentations and repaint.
+///
+/// The standard busy indicator is keyed off a single `is_running` flag that the
+/// prompt glyph (`░▌` vs `> `), the status word (`running`/`ready`), and the
+/// avatar all read. Blocking slash handlers (the `/plan` explore/plan forks
+/// here) run with the UI event loop parked, so the indicator only updates if
+/// the handler repaints — without this, `/plan` deceptively looks idle and the
+/// just-submitted command still appears in the (already-cleared) input box.
+/// Flipping `is_running` + repainting here makes a blocking phase look exactly
+/// as busy as a normal streamed run, and blanks the stale input text.
+fn set_busy(ctx: &mut SlashCtx<'_>, busy: bool) -> anyhow::Result<()> {
+    *ctx.is_running = busy;
+    ctx.renderer.set_avatar_state(if busy {
+        AvatarState::Thinking
+    } else {
+        AvatarState::Idle
+    });
+    let status = crate::ui::status::StatusLine::render(
+        ctx.session,
+        busy,
+        0,
+        None,
+        ctx.context.current_prompt_name.as_deref(),
+        None,
+        ctx.bg_store.as_ref(),
+        None,
+    );
+    ctx.renderer.draw_bottom(ctx.input, &status, busy)?;
+    ctx.renderer.render_viewport()?;
+    Ok(())
+}
 
 pub(super) async fn cmd_plan(
     ctx: &mut SlashCtx<'_>,
@@ -32,6 +65,24 @@ pub(super) async fn cmd_plan(
         return Ok(());
     }
 
+    // Enter the busy state up front: the explore/plan forks below block the UI
+    // event loop, so without an immediate repaint the bar would stay idle and
+    // the typed `/plan …` line would linger in the box. `run_phases` drops back
+    // to idle on any abort; on success the kickoff hands off to the loop, which
+    // keeps the run busy through the implement phase.
+    set_busy(ctx, true)?;
+
+    match run_phases(ctx, &request).await? {
+        Some(kickoff) => *ctx.plan_kickoff = Some(kickoff),
+        None => set_busy(ctx, false)?, // aborted — release the busy indicator
+    }
+    Ok(())
+}
+
+/// Run the explore → plan forks. Returns the kickoff on success, or `None` when
+/// a phase aborts (having already printed why). Split out so `cmd_plan` can
+/// bracket it with the busy-indicator transitions.
+async fn run_phases(ctx: &mut SlashCtx<'_>, request: &str) -> anyhow::Result<Option<PlanKickoff>> {
     // A frozen snapshot of the conversation so far — the same view every phase
     // fork explores from.
     let transcript = crate::agent::review::build_transcript(ctx.session);
@@ -42,7 +93,7 @@ pub(super) async fn cmd_plan(
         c_agent(),
     )?;
     let explore_runner = ctx.agent.spawn_phase_runner(
-        explore_prompt(&request),
+        explore_prompt(request),
         transcript.clone(),
         READONLY_PHASE_TOOLS,
     );
@@ -51,12 +102,12 @@ pub(super) async fn cmd_plan(
         Ok(_) => {
             ctx.renderer
                 .write_line("Phase: Explore — produced no findings; aborting", c_error())?;
-            return Ok(());
+            return Ok(None);
         }
         Err(e) => {
             ctx.renderer
                 .write_line(&format!("Phase: Explore — error: {e}; aborting"), c_error())?;
-            return Ok(());
+            return Ok(None);
         }
     };
 
@@ -67,7 +118,7 @@ pub(super) async fn cmd_plan(
         c_agent(),
     )?;
     let plan_runner = ctx.agent.spawn_phase_runner(
-        plan_prompt(&request, &findings),
+        plan_prompt(request, &findings),
         transcript,
         READONLY_PHASE_TOOLS,
     );
@@ -76,12 +127,12 @@ pub(super) async fn cmd_plan(
         Ok(_) => {
             ctx.renderer
                 .write_line("Phase: Plan — produced no plan; aborting", c_error())?;
-            return Ok(());
+            return Ok(None);
         }
         Err(e) => {
             ctx.renderer
                 .write_line(&format!("Phase: Plan — error: {e}; aborting"), c_error())?;
-            return Ok(());
+            return Ok(None);
         }
     };
 
@@ -96,12 +147,11 @@ pub(super) async fn cmd_plan(
         "Phase: Implement — executing the plan (you'll watch it run)…",
         c_agent(),
     )?;
-    *ctx.plan_kickoff = Some(PlanKickoff {
+    Ok(Some(PlanKickoff {
         impl_prompt,
         active: ActivePlan {
             plan,
             cycles_left: cycles,
         },
-    });
-    Ok(())
+    }))
 }


### PR DESCRIPTION
Two coupled `/plan` UX bugs, both from the explore/plan forks running **inline** (blocking the UI event loop):

1. **The input box kept showing the typed `/plan …` text.** The buffer *is* cleared on Enter, but the loop doesn't repaint before `cmd_plan` blocks on the forks — so the stale line lingered on screen for the whole (multi-second) explore+plan phase.
2. **The UI looked idle while working.** During the forks `is_running` stayed `false`, so the prompt glyph (`> ` not `░▌`), the status word (`ready` not `running`), and the avatar all showed idle.

`is_running` is the **single busy flag** that all three indicators read — that's the standard busy indicator. The forks just bypassed it. `cmd_plan` now flips it on and repaints (`set_busy`) *before* the blocking forks, so a blocking phase presents **exactly** like a normal streamed run (busy glyph + `running` status + thinking avatar), and the now-empty input is painted (stale text gone). On any phase abort it releases back to idle; on success the kickoff hands off to the loop, which keeps it busy through the implement phase.

Refactor: the forks moved into `run_phases()` so `cmd_plan` cleanly brackets them with the busy→idle transitions. 2459 tests pass; clean under `-D warnings`.

(`/compress` is the other inline blocking handler with the same latent issue, but it's on a different non-`SlashCtx` call path — noted as a follow-up rather than bundled here.)