### PR TITLE
feat(ui): typing or Down snaps the scrolled-up chat to the bottom

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1290,6 +1290,36 @@ pub async fn run_interactive(
                                 continue;
                             }
 
+                        // Snap the chat back to the newest content the instant
+                        // the user starts interacting with the input — typing a
+                        // character or pressing Down — so they don't have to
+                        // hand-scroll all the way down from deep in the history.
+                        // (Picker / plugin-shortcut / scroll keys were already
+                        // handled-and-`continue`d above, so anything here is
+                        // headed for the input editor.)
+                        if renderer.is_scrolled_up() {
+                            match scroll_snap_for(&key) {
+                                Some(ScrollSnap::Jump) => {
+                                    // The jump IS the action — snap to the
+                                    // bottom and consume the key (don't also
+                                    // move the input cursor).
+                                    renderer.scroll_to_bottom()?;
+                                    renderer.draw_bottom(
+                                        &input,
+                                        &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), bg_store.as_ref(), shell_store.as_ref()), interjection_queue.lock().unwrap().len()),
+                                        is_running,
+                                    )?;
+                                    continue;
+                                }
+                                Some(ScrollSnap::TypeThrough) => {
+                                    // Snap to the bottom, then fall through so
+                                    // the editor still inserts the character.
+                                    renderer.scroll_to_bottom()?;
+                                }
+                                None => {}
+                            }
+                        }
+
                         // Keep the editor's wrap width in sync with the
                         // rendered box so Up/Down move by wrapped display
                         // rows (dirge-5w9v).
@@ -3676,6 +3706,37 @@ fn is_safe_during_agent(text: &str) -> bool {
         ("/memory", Some("list")) | ("/skill", Some("list"))
     );
     always_safe || safe_when_no_arg || safe_when_list
+}
+
+/// When the chat is scrolled up off the newest content, what a key that's about
+/// to reach the input editor should do to the scroll position. `None` leaves
+/// the scroll alone.
+#[derive(Debug, PartialEq, Eq)]
+enum ScrollSnap {
+    /// Down was pressed — snap to the bottom and CONSUME the key (the jump is
+    /// the whole action; don't also move the input cursor).
+    Jump,
+    /// A character was typed — snap to the bottom but still let the editor
+    /// insert the character.
+    TypeThrough,
+}
+
+/// Decide the scroll-snap behavior for a key headed to the input editor. Plain
+/// typing and a plain Down snap back to the newest content; modified combos
+/// (Ctrl/Alt/Super — those are commands) and every other key leave the scroll
+/// where it is. Pure so the modifier rules are unit-testable.
+fn scroll_snap_for(key: &crossterm::event::KeyEvent) -> Option<ScrollSnap> {
+    let modified = key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER);
+    if modified {
+        return None;
+    }
+    match key.code {
+        KeyCode::Down => Some(ScrollSnap::Jump),
+        KeyCode::Char(_) => Some(ScrollSnap::TypeThrough),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/mod_tests.rs
+++ b/src/ui/mod_tests.rs
@@ -620,3 +620,41 @@ fn memory_skill_list_safe_during_agent() {
     assert!(!is_safe_during_agent("/memory add key value"));
     assert!(!is_safe_during_agent("/skill load foo"));
 }
+
+// ============================================================
+// scroll_snap_for — typing / Down jump the scrolled-up chat to bottom
+// ============================================================
+
+#[test]
+fn scroll_snap_typing_and_down_snap_but_command_combos_dont() {
+    use crossterm::event::KeyEvent;
+    let none = KeyModifiers::NONE;
+
+    // Plain typing → snap to bottom AND still insert the char.
+    assert_eq!(
+        scroll_snap_for(&KeyEvent::new(KeyCode::Char('a'), none)),
+        Some(ScrollSnap::TypeThrough)
+    );
+    // Shift+char (a capital) is still typing.
+    assert_eq!(
+        scroll_snap_for(&KeyEvent::new(KeyCode::Char('A'), KeyModifiers::SHIFT)),
+        Some(ScrollSnap::TypeThrough)
+    );
+    // Plain Down → jump to bottom and consume the key.
+    assert_eq!(
+        scroll_snap_for(&KeyEvent::new(KeyCode::Down, none)),
+        Some(ScrollSnap::Jump)
+    );
+
+    // Command combos (Ctrl/Alt/Super) and other keys leave the scroll alone.
+    assert_eq!(
+        scroll_snap_for(&KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        None
+    );
+    assert_eq!(
+        scroll_snap_for(&KeyEvent::new(KeyCode::Down, KeyModifiers::ALT)),
+        None
+    );
+    assert_eq!(scroll_snap_for(&KeyEvent::new(KeyCode::Up, none)), None);
+    assert_eq!(scroll_snap_for(&KeyEvent::new(KeyCode::Enter, none)), None);
+}

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1422,6 +1422,13 @@ impl Renderer {
         }
     }
 
+    /// True when the chat is scrolled up off the newest content
+    /// (`scroll_offset > 0`). Lets the input loop snap back to the bottom the
+    /// moment the user starts interacting with the input.
+    pub fn is_scrolled_up(&self) -> bool {
+        self.scroll_offset > 0
+    }
+
     pub fn scroll_page_up(&mut self) {
         let visible = self.visible_lines();
         let page = visible.saturating_sub(2).max(1);


### PR DESCRIPTION
When you scroll up into the chat history and then want back to the newest content, you currently have to scroll all the way down by hand — which can be a lot when you're deep in scrollback.

Now the chat **snaps to the bottom the moment you start interacting with the input**:
- **Typing a character** → snap to bottom, *and still insert the character*.
- **Down arrow** → snap to bottom (consumes the key — the jump is the whole action).
- **Command combos** (Ctrl/Alt/Super) and every other key → leave the scroll where it is.

The snap only fires when actually scrolled up (`is_scrolled_up()`), and only for keys headed to the input editor — picker navigation, plugin shortcuts, and the existing scroll keys (PageUp/Down, Ctrl+Home/End) are matched-and-handled earlier, so they're unaffected.

The key decision is a pure `scroll_snap_for(key) -> Option<ScrollSnap>` (`Jump` / `TypeThrough` / `None`) so the modifier rules are unit-tested (typing + Shift+char + Down snap; Ctrl+c / Alt+Down / Up / Enter don't). 2461 tests pass; clean under `-D warnings`.