### PR TITLE
fix(ui): attribute todo/verifier nudges to <critic>, not <you> [dirge-i75f]

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -133,12 +133,18 @@ enum FollowUpSource {
     None,
 }
 
+/// Display tag prefixing the unfinished-todo nudge. The UI keys on this to
+/// attribute the message to the system/critic rather than the user — it's
+/// injected as a user-role message so the model responds, but it isn't user
+/// input [dirge-i75f].
+pub(crate) const TODO_NUDGE_TAG: &str = "[todo]";
+
 /// The unfinished-todo nudge message. Pure (no globals) so the singular/plural
 /// wording is unit-testable independent of the todo store.
 fn todo_nudge_message(unfinished: usize) -> LoopMessage {
     LoopMessage::User(super::message::UserMessage {
         content: format!(
-            "You still have {unfinished} unfinished todo{} (pending or in progress). \
+            "{TODO_NUDGE_TAG} You still have {unfinished} unfinished todo{} (pending or in progress). \
              Finish the remaining work, or if it's genuinely done or no longer needed, \
              update the todo list (mark items completed/cancelled) before stopping.",
             if unfinished == 1 { "" } else { "s" }

--- a/src/agent/agent_loop/verifier.rs
+++ b/src/agent/agent_loop/verifier.rs
@@ -23,6 +23,12 @@ use std::sync::{Arc, Mutex};
 use super::message::{LoopMessage, UserMessage};
 use super::result::LoopToolResult;
 
+/// Display tag prefixing both verifier nudges. The UI keys on this to attribute
+/// the message to the system/critic rather than the user (it's injected as a
+/// user-role message so the model responds) [dirge-i75f]. The `*_NUDGE`
+/// constants below embed it literally.
+pub const VERIFY_TAG: &str = "[verify-before-done]";
+
 /// Nudge when code was edited but no build/test command ran.
 const VERIFY_NUDGE: &str = "[verify-before-done] You changed code this run but didn't run the tests or build to check it. Verify it works before reporting done — or, if there's nothing to run or you verified another way, say so briefly and finish. Don't re-edit just to look busy.";
 

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -133,6 +133,20 @@ pub fn format_time(rfc3339: &str) -> CompactString {
     }
 }
 
+/// Internal finalization nudges (critic / verifier / todo) are injected as
+/// user-role messages so the model acts on them, but they are NOT the user's
+/// input. If `content` is one of these tagged nudges, return its body with the
+/// tag stripped (to be shown under the `<critic>` handle); otherwise `None`.
+/// Single source of truth for both the live view (`run_handlers::notices`) and
+/// scrollback (`render_session`) [dirge-i75f].
+pub(crate) fn finalization_nudge_body(content: &str) -> Option<&str> {
+    use crate::agent::agent_loop::{critic::CRITIC_TAG, run::TODO_NUDGE_TAG, verifier::VERIFY_TAG};
+    let trimmed = content.trim_start();
+    [CRITIC_TAG, VERIFY_TAG, TODO_NUDGE_TAG]
+        .into_iter()
+        .find_map(|tag| trimmed.strip_prefix(tag).map(str::trim_start))
+}
+
 pub fn render_session(
     renderer: &mut Renderer,
     session: &Session,
@@ -187,15 +201,16 @@ pub fn render_session(
         // to 8 columns so multi-role chats stay visually aligned.
         // Continuation lines are indented to that same width so the
         // handle isn't repeated on every wrap.
-        // dirge-vg9e: a persisted critic follow-up is a User-role message
-        // tagged with `[critic]`; render it under its own handle/color in
-        // scrollback too, matching the live view.
-        let is_critic = msg.role == MessageRole::User
-            && msg
-                .content
-                .trim_start()
-                .starts_with(crate::agent::agent_loop::critic::CRITIC_TAG);
-        let (handle, line_color) = if is_critic {
+        // dirge-i75f: the finalization nudges (critic / verifier / todo) are
+        // persisted as User-role messages so the model acts on them, but
+        // they're system steering, not user input — render them under the
+        // `<critic>` handle/color in scrollback too, matching the live view.
+        let nudge_body = if msg.role == MessageRole::User {
+            finalization_nudge_body(&msg.content)
+        } else {
+            None
+        };
+        let (handle, line_color) = if nudge_body.is_some() {
             ("<critic> ", theme::critic())
         } else {
             match msg.role {
@@ -204,17 +219,8 @@ pub fn render_session(
                 MessageRole::System => ("<sys> ", theme::system()),
             }
         };
-        // Strip the `[critic]` tag from the displayed body (the handle
-        // already conveys the role).
-        let body: &str = if is_critic {
-            msg.content
-                .trim_start()
-                .strip_prefix(crate::agent::agent_loop::critic::CRITIC_TAG)
-                .map(str::trim_start)
-                .unwrap_or(&msg.content)
-        } else {
-            &msg.content
-        };
+        // Strip the tag from the displayed body (the handle conveys the role).
+        let body: &str = nudge_body.unwrap_or(&msg.content);
         let cont_indent = " ".repeat(handle.chars().count());
 
         if msg.role == MessageRole::Assistant {
@@ -406,6 +412,34 @@ fn strip_orphan_mouse_reports(text: &str) -> String {
 mod tests {
     use super::*;
     use crate::session::{MessageRole, Session};
+
+    /// All three finalization nudges (critic / verifier / todo) are recognized
+    /// and their tags stripped; a genuine user message is left as-is so it
+    /// still renders under `<you>` [dirge-i75f].
+    #[test]
+    fn finalization_nudge_body_recognizes_all_tags() {
+        use crate::agent::agent_loop::{
+            critic::CRITIC_TAG, run::TODO_NUDGE_TAG, verifier::VERIFY_TAG,
+        };
+        assert_eq!(
+            finalization_nudge_body(&format!("{CRITIC_TAG} not done yet")),
+            Some("not done yet")
+        );
+        assert_eq!(
+            finalization_nudge_body(&format!("{VERIFY_TAG} run the tests")),
+            Some("run the tests")
+        );
+        assert_eq!(
+            finalization_nudge_body(&format!(
+                "{TODO_NUDGE_TAG} You still have 6 unfinished todos"
+            )),
+            Some("You still have 6 unfinished todos")
+        );
+        // Genuine user input is not a nudge.
+        assert_eq!(finalization_nudge_body("fix the parser bug"), None);
+        // A bracketed-but-unknown prefix is not a nudge either.
+        assert_eq!(finalization_nudge_body("[note] just a note"), None);
+    }
 
     fn make_session() -> Session {
         Session::new("openrouter", "gpt-5", 200_000)

--- a/src/ui/run_handlers/notices.rs
+++ b/src/ui/run_handlers/notices.rs
@@ -21,11 +21,12 @@ use crate::ui::theme;
 /// to the session at submit time.
 pub(crate) fn handle_user_message(renderer: &mut Renderer, content: &str) -> std::io::Result<()> {
     let visible = strip_leading_system_reminder(content);
-    // dirge-vg9e: the in-loop critic re-enters as a user-role message so the
-    // model acts on it; surface it under a distinct `<critic>` handle/color
-    // rather than the user's `<you>`. The tag is stripped from the display.
-    if let Some(body) = visible.strip_prefix(crate::agent::agent_loop::critic::CRITIC_TAG) {
-        write_critic_lines(renderer, body.trim_start())?;
+    // dirge-i75f: the in-loop finalization nudges (critic / verifier / todo)
+    // re-enter as user-role messages so the model acts on them; surface them
+    // under the `<critic>` handle/color rather than the user's `<you>`. The tag
+    // is stripped from the display.
+    if let Some(body) = crate::ui::events::finalization_nudge_body(visible) {
+        write_critic_lines(renderer, body)?;
         return renderer.write_line("", Color::White);
     }
     write_user_lines(renderer, visible)?;


### PR DESCRIPTION
The finalization nudges are injected as `LoopMessage::User` so the model responds to them — but the UI rendered the **todo** and **verifier** nudges under the `<you>` handle, attributing system steering to the user:

> `<you>` You still have 6 unfinished todos (pending or in progress)...

Only the critic was attributed correctly, because it carried a `[critic]` tag the UI special-cased. The verifier had a `[verify-before-done]` tag the UI **didn't check**, and the todo nudge had **no tag at all**.

- Add `VERIFY_TAG` (verifier, already embedded in the nudge strings) and a new `[todo]` tag (todo nudge).
- Add one `finalization_nudge_body()` helper — single source of truth — that strips any of the three tags.
- Both the live view (`run_handlers::notices`) and scrollback (`events::render_session`) route all three through it and render under the `<critic>` handle/color (matching the user's framing of these as the agent's self-review). The tag is stripped from the body; genuine user input is untouched.

Helper test covers all three tags + real user input + unknown bracketed prefixes. 2472 default + 2566 all-features tests pass; clean under `-D warnings`.

Closes dirge-i75f.