### PR TITLE
chore(ui): remove vestigial monochrome fields/setters [dirge-zh7q]

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -224,7 +224,6 @@ pub struct InputEditor {
     /// the live buffer IS the draft (not navigating history).
     history_draft: Option<(CompactString, usize)>,
     pub picker: Option<FilePicker>,
-    monochrome: bool,
     kill_ring: Vec<CompactString>,
     last_action_was_kill: bool,
     yank_state: Option<YankState>,
@@ -393,7 +392,6 @@ impl InputEditor {
             history_pos: None,
             history_draft: None,
             picker: None,
-            monochrome: false,
             kill_ring: Vec::new(),
             last_action_was_kill: false,
             yank_state: None,
@@ -650,16 +648,8 @@ impl InputEditor {
         (out, display_cursor)
     }
 
-    pub fn set_monochrome(&mut self, monochrome: bool) {
-        self.monochrome = monochrome;
-        if let Some(picker) = self.picker.as_mut() {
-            picker.set_monochrome(monochrome);
-        }
-    }
-
     pub fn start_picker(&mut self) {
         let picker = self.picker.get_or_insert_with(FilePicker::new);
-        picker.set_monochrome(self.monochrome);
         picker.activate();
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -187,7 +187,6 @@ pub async fn run_interactive(
     let _guard = TerminalGuard::new()?;
 
     let mut renderer = Renderer::new()?;
-    renderer.set_monochrome(cli.no_color);
     // Apply the preferred pane layout from config (`display`). An invalid
     // spec is surfaced as a warning and ignored (panels keep their
     // automatic width-based default); the `/display` command overrides
@@ -199,7 +198,6 @@ pub async fn run_interactive(
         }
     }
     let mut input = InputEditor::new();
-    input.set_monochrome(cli.no_color);
     // Left-panel vitals: a background git-status poller (follows `/cd`)
     // and a ring of the most recent tool actions for the [ACTIVITY]
     // ticker. Both feed `build_left_panel_info` each loop tick.
@@ -425,7 +423,6 @@ pub async fn run_interactive(
     #[cfg(feature = "git-worktree")]
     let mut wt_return_path: Option<String> = None;
     let mut rewind_picker = ListPicker::new();
-    rewind_picker.set_monochrome(cli.no_color);
     let mut last_esc: Option<std::time::Instant> = None;
 
     // Snapshot plugin-registered shortcuts (P9c). Seeded at UI

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -25,7 +25,6 @@ pub struct ListPicker {
     pub items: Vec<String>,
     pub selected: usize,
     prompt: String,
-    monochrome: bool,
 }
 
 impl ListPicker {
@@ -35,12 +34,7 @@ impl ListPicker {
             items: Vec::new(),
             selected: 0,
             prompt: String::new(),
-            monochrome: false,
         }
-    }
-
-    pub fn set_monochrome(&mut self, monochrome: bool) {
-        self.monochrome = monochrome;
     }
 
     pub fn activate(&mut self, prompt: &str, items: Vec<String>) {
@@ -105,7 +99,6 @@ pub struct FilePicker {
     pub matches: Vec<PathBuf>,
     pub selected: usize,
     file_cache: Arc<Mutex<Vec<PathBuf>>>,
-    monochrome: bool,
 }
 
 impl FilePicker {
@@ -117,12 +110,7 @@ impl FilePicker {
             matches: Vec::new(),
             selected: 0,
             file_cache: Arc::new(Mutex::new(Vec::new())),
-            monochrome: false,
         }
-    }
-
-    pub fn set_monochrome(&mut self, monochrome: bool) {
-        self.monochrome = monochrome;
     }
 
     pub fn activate(&mut self) {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -305,7 +305,6 @@ pub struct Renderer {
     /// up to MAX_INPUT_VISIBLE_LINES as the user adds newlines or types past
     /// the wrap width). The chat viewport shrinks by the same amount.
     input_rows: u16,
-    monochrome: bool,
     pub selection_active: bool,
     /// Selection anchor as `(buffer_line_index, char_offset_in_line)`.
     /// Char offset is in *chars* (not bytes) so multi-byte UTF-8 glyphs
@@ -463,7 +462,6 @@ impl Renderer {
             chats: vec![ChatSnapshot::empty("main")],
             active_chat: 0,
             input_rows: 1,
-            monochrome: false,
             selection_active: false,
             selection_start: None,
             selection_end: None,
@@ -1118,10 +1116,6 @@ impl Renderer {
 
     pub fn right_panel_visible(&self) -> bool {
         self.side_panel_visible(self.right_panel_mode)
-    }
-
-    pub fn set_monochrome(&mut self, monochrome: bool) {
-        self.monochrome = monochrome;
     }
 
     fn terminal_size(&self) -> (u16, u16) {


### PR DESCRIPTION
Investigation of whether `--no-color` is wired through the ratatui path:

**Finding 1 — the per-struct `monochrome` fields are dead.** `Renderer::monochrome`, `InputEditor::monochrome`, and the two pickers' `monochrome` fields were all **write-only**: `set_monochrome(cli.no_color)` ran at startup, but nothing ever *read* the fields. (The pickers' became dead when picker rendering moved into the scene in #371; the renderer's was never read.) The actual `--no-color` application is `resolve_color(color, cli.no_color)`, which reads `cli.no_color` directly — independent of this plumbing.

→ Removed the dead fields, their `set_monochrome` setters, and the three startup callers. No behavior change.

**Finding 2 — `--no-color` is barely wired in the TUI** (filed as follow-up **dirge-zrda**, not fixed here). It's resolved at only **two** `write_line` sites; the main scene (chat, panels, status, avatar, frames) gets raw theme colors and there's no global desaturation. The real fix needs a design choice (global no-color theme flag vs. per-cell resolution) and must keep errors/warnings visible — out of scope for this cleanup.

2473 tests pass; clean under `-D warnings` (default + all-features).

Closes dirge-zh7q.