### PR TITLE
feat(ui): run /plan explore→plan forks off the event loop [dirge-vuzz]

### DIFF
--- a/src/agent/plan/runtime.rs
+++ b/src/agent/plan/runtime.rs
@@ -40,6 +40,27 @@ pub(crate) struct PlanKickoff {
     pub active: ActivePlan,
 }
 
+/// Events emitted by the async explore→plan task and drained by the UI loop, so
+/// the (minutes-long) forks no longer park the event loop [dirge-vuzz]. The
+/// loop renders `Progress` lines, launches the implement run on `Ready`, and
+/// drops the busy state on `Aborted`.
+pub(crate) enum PlanPhaseEvent {
+    /// A status line to render. `error` selects the color.
+    Progress { text: String, error: bool },
+    /// Both forks succeeded — launch the streamed implement run from this.
+    Ready(Box<PlanKickoff>),
+    /// A phase produced nothing or errored (a `Progress` line already said why).
+    Aborted,
+}
+
+/// Handle to the spawned explore→plan task: the event stream the UI loop drains
+/// plus the task itself, so Ctrl+C can `abort()` it (which drops the in-flight
+/// `collect_runner_text` guard and cancels the inner phase runner too).
+pub(crate) struct PlanPhaseHandle {
+    pub rx: tokio::sync::mpsc::Receiver<PlanPhaseEvent>,
+    pub task: tokio::task::JoinHandle<()>,
+}
+
 /// Drain a forked phase runner to completion and return its final assistant
 /// text. `Token`s accumulate; the authoritative `Done { response }` payload is
 /// preferred once it arrives (but an empty `Done` keeps the streamed text); the

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -4,7 +4,7 @@
 //!
 //! NOTE: this is NOT the phased `/plan` workflow (explore→plan→implement→
 //! review) — that lives in [`crate::agent::plan`]. Unrelated feature, similar
-//! name; don't cross the wires (`plan_tx` here vs `plan_kickoff`/`active_plan`
+//! name; don't cross the wires (`plan_tx` here vs `plan_phase`/`active_plan`
 //! there). For how this relates to the phased workflow, the `write_todo_list`
 //! checklist, and background `task`s, see the canonical map of all four
 //! work-tracking concepts in [`crate::agent::plan`].

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -261,12 +261,13 @@ pub async fn run_interactive(
     // and surface a clean "cancelled" event before the task is
     // killed at its next `.await`.
     let mut agent_cancel: Option<mpsc::Sender<()>> = None;
-    // Phased `/plan` workflow (P3e-b). `plan_kickoff` is set by the `/plan`
-    // slash command after its explore→plan forks finish; the loop drains it to
-    // launch the streamed implement run. `active_plan` then holds the reviewer
-    // loop state across `Done` events until the reviewer approves or the
-    // fix-cycle budget is spent.
-    let mut plan_kickoff: Option<crate::agent::plan::runtime::PlanKickoff> = None;
+    // Phased `/plan` workflow (P3e-b). `plan_phase` holds the handle to the
+    // spawned explore→plan task; the loop drains its events in a `select!` arm
+    // (so the forks don't park the loop — dirge-vuzz), launching the streamed
+    // implement run on `Ready`. `active_plan` then holds the reviewer loop state
+    // across `Done` events until the reviewer approves or the fix-cycle budget
+    // is spent.
+    let mut plan_phase: Option<crate::agent::plan::runtime::PlanPhaseHandle> = None;
     let mut active_plan: Option<crate::agent::plan::runtime::ActivePlan> = None;
     let mut agent_line_started = false;
     let mut response_buf = String::new();
@@ -839,6 +840,14 @@ pub async fn run_interactive(
                             }
                             if is_running {
                                 is_running = false;
+                                // Abort an in-flight phased `/plan` explore/plan
+                                // task. Aborting it drops the in-flight
+                                // `collect_runner_text` future, whose
+                                // `AbortRunnerOnDrop` guard cancels the inner
+                                // phase runner too (dirge-vuzz).
+                                if let Some(ph) = plan_phase.take() {
+                                    ph.task.abort();
+                                }
                                 // Cooperative cancel first: lets the
                                 // retry loop and rig stream observe
                                 // `signal.is_cancelled()` and exit
@@ -946,6 +955,10 @@ pub async fn run_interactive(
                                 continue;
                             }
                             is_running = false;
+                            // Abort an in-flight phased `/plan` task too (dirge-vuzz).
+                            if let Some(ph) = plan_phase.take() {
+                                ph.task.abort();
+                            }
                             if let Some(tx) = agent_cancel.take() {
                                 let _ = tx.try_send(());
                             }
@@ -1487,7 +1500,7 @@ pub async fn run_interactive(
                                 // /help) have no UserMessage event, so we keep the echo.
                                 write_user_lines(&mut renderer, &text)?;
                                 renderer.write_line("", Color::White)?;
-                                let result = handle_slash(&text, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut todo_tools_enabled, &bg_store, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut plan_kickoff).await;
+                                let result = handle_slash(&text, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut show_reasoning, &mut is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut todo_tools_enabled, &bg_store, &sandbox, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut plan_phase).await;
                                 match result {
                                 Err(e) if e.to_string().starts_with("DEFER_COMPRESS:") => {
                                     let err_msg = e.to_string();
@@ -1640,24 +1653,10 @@ pub async fn run_interactive(
                                         c_error(),
                                     )?;
                                 }
-                                // Phased `/plan` kickoff: the slash handler ran
-                                // its explore→plan forks and stashed the implement
-                                // prompt + reviewer-loop budget. Launch the streamed
-                                // implement run here (slash handlers can't touch
-                                // agent_rx / is_running) and arm the reviewer loop.
-                                if let Some(kickoff) = plan_kickoff.take() {
-                                    session.add_message(MessageRole::User, &kickoff.impl_prompt);
-                                    last_user_prompt.clone_from(&kickoff.impl_prompt);
-                                    let history = crate::agent::runner::convert_history(session);
-                                    renderer.set_avatar_state(avatar::AvatarState::Idle);
-                                    let runner = agent.clone().spawn_runner(
-                                        crate::agent::tools::background::prepend_pending_notifications(&kickoff.impl_prompt, bg_store.as_ref()),
-                                        history,
-                                        Some(interjection_queue.clone()),
-                                    );
-                                    runner.install_into(&mut agent_rx, &mut agent_abort, &mut agent_interject, &mut agent_cancel, &mut is_running);
-                                    active_plan = Some(kickoff.active);
-                                }
+                                // The phased `/plan` kickoff is no longer consumed
+                                // here: cmd_plan spawns the explore→plan forks on a
+                                // task and the `plan_phase` select! arm launches the
+                                // implement run on `Ready` (dirge-vuzz).
                             } else if is_running {
                                 // Agent busy — queue the message. The loop polls
                                 // the steering queue at turn boundaries and injects
@@ -2133,6 +2132,62 @@ pub async fn run_interactive(
                     &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), bg_store.as_ref(), shell_store.as_ref()), interjection_queue.lock().unwrap().len()),
                     is_running,
                 )?;
+            }
+            // Phased `/plan` explore→plan task events. Drained here so the forks
+            // run off the event loop (dirge-vuzz): progress lines paint as they
+            // arrive, `Ready` launches the implement run, `Aborted`/channel-close
+            // drops the busy state. Binds the `Option` directly (not `Some(..)`)
+            // so a closed channel is handled instead of busy-looping the select.
+            ev = async {
+                if let Some(ph) = &mut plan_phase {
+                    ph.rx.recv().await
+                } else {
+                    std::future::pending().await
+                }
+            } => {
+                use crate::agent::plan::runtime::PlanPhaseEvent;
+                match ev {
+                    Some(PlanPhaseEvent::Progress { text, error }) => {
+                        renderer.write_line(&text, if error { c_error() } else { c_agent() })?;
+                        renderer.render_viewport()?;
+                        renderer.draw_bottom(
+                            &input,
+                            &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), bg_store.as_ref(), shell_store.as_ref()), interjection_queue.lock().unwrap().len()),
+                            is_running,
+                        )?;
+                    }
+                    Some(PlanPhaseEvent::Ready(kickoff)) => {
+                        // explore→plan finished: launch the streamed implement run
+                        // and arm the reviewer loop (the old inline kickoff path,
+                        // now event-driven so the loop stayed responsive).
+                        plan_phase = None;
+                        let kickoff = *kickoff;
+                        session.add_message(MessageRole::User, &kickoff.impl_prompt);
+                        last_user_prompt.clone_from(&kickoff.impl_prompt);
+                        let history = crate::agent::runner::convert_history(session);
+                        renderer.set_avatar_state(avatar::AvatarState::Idle);
+                        let runner = agent.clone().spawn_runner(
+                            crate::agent::tools::background::prepend_pending_notifications(&kickoff.impl_prompt, bg_store.as_ref()),
+                            history,
+                            Some(interjection_queue.clone()),
+                        );
+                        runner.install_into(&mut agent_rx, &mut agent_abort, &mut agent_interject, &mut agent_cancel, &mut is_running);
+                        active_plan = Some(kickoff.active);
+                    }
+                    Some(PlanPhaseEvent::Aborted) | None => {
+                        // A phase produced nothing / errored (a Progress line said
+                        // why), or the task ended without a terminal event. Release
+                        // the busy state.
+                        plan_phase = None;
+                        is_running = false;
+                        renderer.set_avatar_state(avatar::AvatarState::Idle);
+                        renderer.draw_bottom(
+                            &input,
+                            &with_queue(StatusLine::render(session, is_running, 0, loop_label.as_deref(), context.current_prompt_name.as_deref(), perm_mode().as_deref(), bg_store.as_ref(), shell_store.as_ref()), interjection_queue.lock().unwrap().len()),
+                            is_running,
+                        )?;
+                    }
+                }
             }
             Some(ask_req) = async {
                 if let Some(rx) = &mut ask_rx {

--- a/src/ui/slash/cmd_plan.rs
+++ b/src/ui/slash/cmd_plan.rs
@@ -1,28 +1,32 @@
 //! `/plan <request>` — the phased plan workflow entry (vix port, P3e-b).
 //!
-//! Runs the two read-only forks (explore → plan) inline here, exactly like
-//! `/compress` does its heavy work in the slash handler, then hands a
-//! [`PlanKickoff`] back to the UI loop, which launches the *streamed* implement
-//! run and seeds the reviewer loop (driven in `run_handlers/done.rs`). The
-//! phases are separate forks → genuine context resets, per the chosen
-//! "separate-agent phases" model.
+//! The two read-only forks (explore → plan) run on a SPAWNED task, not inline,
+//! so the UI event loop stays responsive (paints, scrolls, Ctrl+C) while the
+//! minutes-long LLM calls run [dirge-vuzz]. The task streams
+//! [`PlanPhaseEvent`]s back over a channel; the UI loop renders progress lines,
+//! launches the streamed implement run on `Ready`, and seeds the reviewer loop
+//! (driven in `run_handlers/done.rs`). The phases are separate forks → genuine
+//! context resets, per the chosen "separate-agent phases" model.
+
+use tokio::sync::mpsc;
 
 use super::SlashCtx;
-use crate::agent::plan::runtime::{ActivePlan, PlanKickoff, collect_runner_text};
+use crate::agent::plan::runtime::{
+    ActivePlan, PlanKickoff, PlanPhaseEvent, PlanPhaseHandle, collect_runner_text,
+};
 use crate::agent::plan::workflow::{READONLY_PHASE_TOOLS, explore_prompt, plan_prompt};
+use crate::provider::AnyAgent;
 use crate::ui::avatar::AvatarState;
-use crate::ui::colors::{c_agent, c_error};
+use crate::ui::colors::c_error;
 
-/// Switch the bottom bar between the busy and idle presentations and repaint.
+/// Switch the bottom bar into the busy presentation and repaint.
 ///
-/// The standard busy indicator is keyed off a single `is_running` flag that the
-/// prompt glyph (`░▌` vs `> `), the status word (`running`/`ready`), and the
-/// avatar all read. Blocking slash handlers (the `/plan` explore/plan forks
-/// here) run with the UI event loop parked, so the indicator only updates if
-/// the handler repaints — without this, `/plan` deceptively looks idle and the
-/// just-submitted command still appears in the (already-cleared) input box.
-/// Flipping `is_running` + repainting here makes a blocking phase look exactly
-/// as busy as a normal streamed run, and blanks the stale input text.
+/// The standard busy indicator is keyed off the single `is_running` flag that
+/// the prompt glyph (`░▌` vs `> `), the status word (`running`/`ready`), and
+/// the avatar read. We flip it on here (and blank the just-submitted `/plan …`
+/// line) the instant the phases are spawned; the UI loop flips it back off when
+/// the phase task reports `Aborted`, or keeps it on through the implement run on
+/// `Ready`.
 fn set_busy(ctx: &mut SlashCtx<'_>, busy: bool) -> anyhow::Result<()> {
     ctx.renderer.set_avatar_state(if busy {
         AvatarState::Thinking
@@ -41,8 +45,6 @@ fn set_busy(ctx: &mut SlashCtx<'_>, busy: bool) -> anyhow::Result<()> {
     );
     ctx.renderer.draw_bottom(ctx.input, &status, busy)?;
     ctx.renderer.render_viewport()?;
-    // Flip the flag only after the paint succeeded, so a failed draw can't
-    // strand the UI in a busy state the user can't get out of.
     *ctx.is_running = busy;
     Ok(())
 }
@@ -67,101 +69,130 @@ pub(super) async fn cmd_plan(
         return Ok(());
     }
 
-    // Enter the busy state up front: the explore/plan forks below block the UI
-    // event loop, so without an immediate repaint the bar would stay idle and
-    // the typed `/plan …` line would linger in the box. `run_phases` drops back
-    // to idle on any abort; on success the kickoff hands off to the loop, which
-    // keeps the run busy through the implement phase.
-    set_busy(ctx, true)?;
+    // Snapshot everything the forks need OFF the UI thread: a frozen transcript,
+    // the review-cycle budget, and a cheap clone of the agent (Arc bumps). The
+    // session/renderer/config stay on the UI thread.
+    let transcript = crate::agent::review::build_transcript(ctx.session);
+    let cycles = ctx.cfg.resolve_phased_workflow_max_review_cycles();
+    let agent = ctx.agent.clone();
 
-    // Reset the busy indicator on EVERY exit except a successful kickoff (where
-    // the loop keeps the run busy). Crucially that includes the error path: a
-    // bubbled io error must not strand the UI showing "running" with no run
-    // active — the user would then have their typing silently queued forever.
-    match run_phases(ctx, &request).await {
-        Ok(Some(kickoff)) => *ctx.plan_kickoff = Some(kickoff),
-        Ok(None) => set_busy(ctx, false)?, // aborted — release the busy indicator
-        Err(e) => {
-            let _ = set_busy(ctx, false);
-            return Err(e);
-        }
+    // Channel capacity is small — the task emits a handful of progress lines
+    // plus one terminal event; the UI loop drains it promptly.
+    let (tx, rx) = mpsc::channel::<PlanPhaseEvent>(8);
+    let task = tokio::spawn(run_phases_task(agent, request, transcript, cycles, tx));
+
+    // Show busy immediately (the typed line is already cleared), then hand the
+    // handle to the loop, which drives the rest from its `select!`. Defensive:
+    // abort any prior phase task we're replacing so it can't keep running
+    // orphaned (shouldn't happen — /plan is gated while a run is active).
+    set_busy(ctx, true)?;
+    if let Some(old) = ctx.plan_phase.take() {
+        old.task.abort();
     }
+    *ctx.plan_phase = Some(PlanPhaseHandle { rx, task });
     Ok(())
 }
 
-/// Run the explore → plan forks. Returns the kickoff on success, or `None` when
-/// a phase aborts (having already printed why). Split out so `cmd_plan` can
-/// bracket it with the busy-indicator transitions.
-async fn run_phases(ctx: &mut SlashCtx<'_>, request: &str) -> anyhow::Result<Option<PlanKickoff>> {
-    // A frozen snapshot of the conversation so far — the same view every phase
-    // fork explores from.
-    let transcript = crate::agent::review::build_transcript(ctx.session);
+/// Send a progress line; returns `false` (caller should bail) if the UI loop
+/// dropped the receiver (e.g. Ctrl+C aborted the phases).
+async fn progress(tx: &mpsc::Sender<PlanPhaseEvent>, text: impl Into<String>, error: bool) -> bool {
+    tx.send(PlanPhaseEvent::Progress {
+        text: text.into(),
+        error,
+    })
+    .await
+    .is_ok()
+}
 
+/// The explore → plan forks, run on a spawned task. Streams progress lines and a
+/// terminal `Ready`/`Aborted` back over `tx`. Aborting the task (Ctrl+C) drops
+/// the in-flight `collect_runner_text` future, whose `AbortRunnerOnDrop` guard
+/// cancels the inner phase runner too — so no orphaned LLM call survives.
+async fn run_phases_task(
+    agent: AnyAgent,
+    request: String,
+    transcript: String,
+    cycles: usize,
+    tx: mpsc::Sender<PlanPhaseEvent>,
+) {
     // Phase 1: Explore (read-only fork, fresh context).
-    ctx.renderer.write_line(
+    if !progress(
+        &tx,
         "Phase: Explore — mapping the codebase (read-only)…",
-        c_agent(),
-    )?;
-    let explore_runner = ctx.agent.spawn_phase_runner(
-        explore_prompt(request),
+        false,
+    )
+    .await
+    {
+        return;
+    }
+    let explore_runner = agent.spawn_phase_runner(
+        explore_prompt(&request),
         transcript.clone(),
         READONLY_PHASE_TOOLS,
     );
     let findings = match collect_runner_text(explore_runner).await {
         Ok(t) if !t.trim().is_empty() => t,
         Ok(_) => {
-            ctx.renderer
-                .write_line("Phase: Explore — produced no findings; aborting", c_error())?;
-            return Ok(None);
+            progress(&tx, "Phase: Explore — produced no findings; aborting", true).await;
+            let _ = tx.send(PlanPhaseEvent::Aborted).await;
+            return;
         }
         Err(e) => {
-            ctx.renderer
-                .write_line(&format!("Phase: Explore — error: {e}; aborting"), c_error())?;
-            return Ok(None);
+            progress(&tx, format!("Phase: Explore — error: {e}; aborting"), true).await;
+            let _ = tx.send(PlanPhaseEvent::Aborted).await;
+            return;
         }
     };
 
-    // Phase 2: Plan (read-only fork; the ONLY thing carried over is the
-    // findings report — a true context reset between phases).
-    ctx.renderer.write_line(
+    // Phase 2: Plan (read-only fork; the ONLY thing carried over is the findings
+    // report — a true context reset between phases).
+    if !progress(
+        &tx,
         "Phase: Plan — turning findings into an implementation plan…",
-        c_agent(),
-    )?;
-    let plan_runner = ctx.agent.spawn_phase_runner(
-        plan_prompt(request, &findings),
+        false,
+    )
+    .await
+    {
+        return;
+    }
+    let plan_runner = agent.spawn_phase_runner(
+        plan_prompt(&request, &findings),
         transcript,
         READONLY_PHASE_TOOLS,
     );
     let plan = match collect_runner_text(plan_runner).await {
         Ok(t) if !t.trim().is_empty() => t,
         Ok(_) => {
-            ctx.renderer
-                .write_line("Phase: Plan — produced no plan; aborting", c_error())?;
-            return Ok(None);
+            progress(&tx, "Phase: Plan — produced no plan; aborting", true).await;
+            let _ = tx.send(PlanPhaseEvent::Aborted).await;
+            return;
         }
         Err(e) => {
-            ctx.renderer
-                .write_line(&format!("Phase: Plan — error: {e}; aborting"), c_error())?;
-            return Ok(None);
+            progress(&tx, format!("Phase: Plan — error: {e}; aborting"), true).await;
+            let _ = tx.send(PlanPhaseEvent::Aborted).await;
+            return;
         }
     };
 
-    // Hand off to the UI loop: it launches the streamed implement run and
-    // arms the reviewer loop.
-    let cycles = ctx.cfg.resolve_phased_workflow_max_review_cycles();
+    // Hand off to the UI loop: it launches the streamed implement run and arms
+    // the reviewer loop.
     let impl_prompt = format!(
         "{request}\n\n--- Implementation plan (from the planning phase) ---\n{plan}\n\n\
          Implement this plan now. Make the edits and run the build/tests to verify.",
     );
-    ctx.renderer.write_line(
+    progress(
+        &tx,
         "Phase: Implement — executing the plan (you'll watch it run)…",
-        c_agent(),
-    )?;
-    Ok(Some(PlanKickoff {
-        impl_prompt,
-        active: ActivePlan {
-            plan,
-            cycles_left: cycles,
-        },
-    }))
+        false,
+    )
+    .await;
+    let _ = tx
+        .send(PlanPhaseEvent::Ready(Box::new(PlanKickoff {
+            impl_prompt,
+            active: ActivePlan {
+                plan,
+                cycles_left: cycles,
+            },
+        })))
+        .await;
 }

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -70,10 +70,11 @@ pub(super) struct SlashCtx<'a> {
     pub semantic_manager: Option<&'a SemanticManager>,
     #[cfg(feature = "lsp")]
     pub lsp_manager: Option<&'a std::sync::Arc<crate::lsp::manager::LspManager>>,
-    /// `/plan` writes its post-fork kickoff here; the UI loop launches the
-    /// streamed implement run from it (slash handlers can't touch the loop's
-    /// `agent_rx`/`is_running` directly).
-    pub plan_kickoff: &'a mut Option<crate::agent::plan::runtime::PlanKickoff>,
+    /// `/plan` spawns its explore→plan forks on a task and writes the handle
+    /// here; the UI loop drains its events, launches the streamed implement run
+    /// on `Ready`, and can Ctrl+C-abort it (slash handlers can't touch the
+    /// loop's `agent_rx`/`is_running`/`select!` directly) [dirge-vuzz].
+    pub plan_phase: &'a mut Option<crate::agent::plan::runtime::PlanPhaseHandle>,
 }
 
 /// Walk `cut_idx` forward until the message at that index is a
@@ -428,7 +429,7 @@ pub async fn handle_slash(
     // build_agent. The user lost LSP silently after the first such
     // command. Thread the actual manager through.
     #[cfg(feature = "lsp")] lsp_manager: Option<&std::sync::Arc<crate::lsp::manager::LspManager>>,
-    plan_kickoff: &mut Option<crate::agent::plan::runtime::PlanKickoff>,
+    plan_phase: &mut Option<crate::agent::plan::runtime::PlanPhaseHandle>,
 ) -> anyhow::Result<()> {
     let parts: SmallVec<[&str; 3]> = split_command_parts(text);
     let mut ctx = SlashCtx {
@@ -457,7 +458,7 @@ pub async fn handle_slash(
         semantic_manager,
         #[cfg(feature = "lsp")]
         lsp_manager,
-        plan_kickoff,
+        plan_phase,
     };
     match parts[0] {
         "/model" => cmd_model::cmd_model(&mut ctx, &parts).await?,


### PR DESCRIPTION
The second, larger half of the UI-hang issue (the status-line git-branch cache was #374). The phased `/plan` command ran its two read-only LLM forks (explore → plan) **inline** on the UI event loop — `collect_runner_text(...).await` parked the whole loop for the minutes those calls take, so the TUI froze (no paint, scroll, or Ctrl+C) until planning finished.

### Change — spawn the forks, stream events
- `cmd_plan` snapshots the transcript + clones the agent (cheap Arc bumps), spawns `run_phases_task`, sets the busy indicator, and hands a `PlanPhaseHandle` to the loop via `SlashCtx` (`plan_kickoff` → `plan_phase`).
- A new `select!` arm drains the channel: **Progress** lines paint as they arrive, **Ready** launches the streamed implement run + arms the reviewer loop (the old inline kickoff path, now event-driven), **Aborted**/channel-close releases the busy state. The arm binds the `Option` directly so a closed channel is handled instead of busy-looping the select.
- **Ctrl+C and Esc-while-running abort the phase task.** Aborting it drops the in-flight `collect_runner_text` future, whose `AbortRunnerOnDrop` guard cancels the inner phase runner too — so no orphaned LLM call survives.

The UI now stays fully responsive during `/plan`. Behavior preserved: same prompts, same abort conditions, same kickoff payload. 2474 default + 2568 all-features tests pass; clean under `-D warnings`.

Closes dirge-vuzz.