### PR TITLE
chore(beads): union-merge driver for .beads/issues.jsonl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Beads issue tracker export.
+#
+# `.beads/issues.jsonl` is beads' git-native sync artifact: one JSON object per
+# issue, re-serialized by the `pre-commit` hook on every commit and reconciled
+# back into the local Dolt DB by the `post-merge` hook (`bd import`, upsert
+# semantics) after a pull/merge.
+#
+# Use git's built-in `union` merge driver so concurrent edits on different
+# branches COMBINE both sides' lines instead of producing conflict markers
+# (which block the merge and the post-merge import). Because `bd import` upserts
+# by issue id and Dolt holds the authoritative three-way-merged history (synced
+# via `bd dolt push`/`pull`), taking both sides at the git layer is safe — the
+# importer dedups/reconciles. This removes the recurring text-merge conflicts on
+# this file without dropping git-native issue tracking.
+.beads/issues.jsonl merge=union


### PR DESCRIPTION
Resolves the recurring `.beads/issues.jsonl` merge conflicts that dogged this session's PRs — **without** dropping git-native issue tracking (the file is beads' intended git sync artifact, not vestigial).

### Root cause
`issues.jsonl` is re-serialized by beads' `pre-commit` hook on every commit and reconciled by the `post-merge` hook (`bd import`, upsert). With **no merge driver configured**, git did a naive text merge on it, so concurrent issue edits across branches conflicted.

### Fix
Register git's **built-in `union`** merge driver via `.gitattributes`:
```
.beads/issues.jsonl merge=union
```
Concurrent edits combine both sides' lines instead of producing conflict markers. Safe because `bd import` upserts by issue id and Dolt holds the authoritative three-way-merged history (`bd dolt push/pull`) — the importer dedups/reconciles and the next `bd export` rewrites a canonical file. `union` is a git built-in, so **no per-clone git config** is needed — fully portable.

### Verified
In an isolated throwaway repo, a merge that *would* conflict (one branch adds an issue, the other edits a different issue + adds another) now resolves automatically with **zero conflict markers**; both sides' issues are preserved, and a same-issue edit collapses to a duplicate line that the post-merge import reconciles.

Config-only; no code change.