### PR TITLE
compression: robust head+tail truncation + git diff off-by-one fix

### DIFF
--- a/plugins/compression/05-util.janet
+++ b/plugins/compression/05-util.janet
@@ -1,0 +1,37 @@
+# Shared output-truncation helpers for the compression plugin.
+# Loaded after 00-regex.janet, before the per-tool compressors
+# (alphabetical sort), so every compressor can call these.
+#
+# Principle: NEVER silently drop the tail of output. When a list is
+# too long to keep whole, show a HEAD and a TAIL with an explicit,
+# unambiguous marker stating exactly how many lines are hidden — and
+# that what's shown is a head+tail sample, not a relevance ranking.
+# Errors, summaries, and totals usually live at the END of command
+# output, so head-only truncation is the dangerous kind.
+
+(defn truncate-lines
+  ``Keep the first `head-n` and last `tail-n` of `lines` (an indexed
+  collection of strings) when the list exceeds head-n+tail-n, with a
+  clear marker in between. `label` names the unit for the hidden count
+  (e.g. "matches", "results", "lines"). Returns a string. When the
+  list already fits, returns every line joined, unchanged.``
+  [lines head-n tail-n label]
+  (def n (length lines))
+  (if (<= n (+ head-n tail-n))
+    (string/join lines "\n")
+    (let [head (take head-n lines)
+          tail (take tail-n (drop (- n tail-n) lines))
+          hidden (- n head-n tail-n)]
+      (string
+        (string/join head "\n")
+        "\n… [" hidden " of " n " " label
+        " hidden — showing first " head-n " + last " tail-n "] …\n"
+        (string/join tail "\n")))))
+
+(defn nonblank-lines
+  "Split `text` on newlines and drop blank/whitespace-only lines."
+  [text]
+  (filter (fn [l] (not (empty? (string/trim l))))
+          (string/split "\n" text)))
+
+nil

--- a/plugins/compression/10-git.janet
+++ b/plugins/compression/10-git.janet
@@ -172,8 +172,12 @@
   (each [i line] (pairs lines)
     (if (string/has-prefix? "diff --git" line)
       (do
+        # `i` (not `dec i`) is the exclusive slice end: file content
+        # runs [file-start, i) — the line at i-1 is this file's last
+        # line. The old `dec i` dropped the last line of every file
+        # except the last in a multi-file diff.
         (when (not (nil? file-start))
-          (array/push file-ranges [file-start (dec i) file-name]))
+          (array/push file-ranges [file-start i file-name]))
         (set file-start i)
         (def parts (string/split " b/" line))
         (set file-name (if (> (length parts) 1) (in parts 1) "?")))))
@@ -183,15 +187,12 @@
   (def result @[])
   (each [start end name] file-ranges
     (def file-lines (tuple/slice lines start end))
-    (if (<= (length file-lines) 250)
-      (each l file-lines (array/push result l))
-      (do
-        (each l (take 200 file-lines) (array/push result l))
-        (array/push result (string "[WARNING: diff truncated ("
-                                 (- (length file-lines) 250)
-                                 " lines hidden)]"))
-        (each l (take 50 (drop (- (length file-lines) 50) file-lines))
-          (array/push result l)))))
+    # Per-file head+tail via the shared helper, so the marker matches
+    # every other compressor and names the file. Keeps the first 200
+    # and last 50 lines of an over-long file diff (the tail often
+    # holds the most recent / most relevant hunks).
+    (array/push result
+                (truncate-lines file-lines 200 50 (string "diff lines in " name))))
   (string/join result "\n"))
 
 # ---------------------------------------------------------------------------

--- a/plugins/compression/50-misc.janet
+++ b/plugins/compression/50-misc.janet
@@ -32,10 +32,10 @@
 (defn- compress-grep-output [output]
   (def lines (string/split "\n" output))
   (if (<= (length lines) 30) (break output))
-  (def match-count (length (filter (fn [l] (not (empty? (string/trim l)))) lines)))
-  (let [sample (take 20 lines)]
-    (string (string/join sample "\n")
-            "\n... (" match-count " matches, " (- (length lines) 20) " lines omitted)")))
+  # Head+tail: grep emits matches in file order, so the LAST matches
+  # are as load-bearing as the first. Head-only truncation hid the
+  # tail entirely (the regression this refactor fixes).
+  (truncate-lines lines 18 8 "matching lines"))
 
 (defn grep-compress [command output]
   (if (not (or (string/find "grep " command) (string/has-prefix? "grep" command)
@@ -48,13 +48,14 @@
 # ---------------------------------------------------------------------------
 
 (defn- compress-find-output [output]
-  (def lines (filter (fn [l] (not (empty? (string/trim l)))) (string/split "\n" output)))
+  (def lines (nonblank-lines output))
   (if (<= (length lines) 20) (break (string/join lines "\n")))
-  (def dirs (filter (fn [l] (not (string/find "." (last (string/split "/" l))))) lines))
-  (def files (- (length lines) (length dirs)))
-  (def sample (take 15 lines))
-  (string (string/join sample "\n")
-          "\n... (" (length lines) " results: " files " files, " (length dirs) " dirs)"))
+  # Show actual paths head+tail. The previous version guessed
+  # file-vs-dir from "does the basename contain a dot" — which
+  # miscounts (Makefile/README → "dir", .git → "file"). `find`
+  # output is just paths; there's no reliable file/dir signal in the
+  # string, so we report the honest total instead of a wrong split.
+  (truncate-lines lines 12 6 "paths"))
 
 (defn find-compress [command output]
   (if (not (or (string/find "find " command) (string/find "fd " command))) (break nil))
@@ -65,14 +66,13 @@
 # ---------------------------------------------------------------------------
 
 (defn- compress-ls-output [output]
-  (def lines (filter (fn [l] (not (empty? (string/trim l)))) (string/split "\n" output)))
+  (def lines (nonblank-lines output))
   (if (<= (length lines) 30) (break (string/join lines "\n")))
-  (def dirs (filter (fn [l]
-                      (let [t (string/trim l)]
-                        (or (string/has-prefix? "d" t) (string/has-prefix? "total" t))))
-                    lines))
-  (def files (- (length lines) (length dirs)))
-  (string (length lines) " entries (" files " files, " (length dirs) " dirs)"))
+  # Show actual entry names head+tail rather than collapsing to a bare
+  # count — the model usually re-runs `ls` to learn WHICH files exist,
+  # so a names-less "N entries" was nearly useless. (The old file/dir
+  # split only worked for `ls -l`; dropped as unreliable.)
+  (truncate-lines lines 18 6 "entries"))
 
 (defn ls-compress [command output]
   (if (not (or (string/has-prefix? "ls" command) (string/find " ls " command) (string/find "/ls" command))) (break nil))
@@ -85,13 +85,9 @@
 (defn- compress-curl-output [output]
   (def trimmed (string/trim output))
   (when (empty? trimmed) (break "ok"))
-  (def lines (string/split "\n" trimmed))
-  (if (<= (length lines) 20) (break trimmed))
-  (def head (take 10 lines))
-  (def tail (take 10 (drop (- (length lines) 10) lines)))
-  (string (string/join head "\n")
-          "\n... (" (- (length lines) 20) " lines omitted)\n"
-          (string/join tail "\n")))
+  # Already head+tail; route through the shared helper so the marker
+  # matches every other compressor.
+  (truncate-lines (string/split "\n" trimmed) 10 10 "lines"))
 
 (defn curl-compress [command output]
   (if (not (or (string/find "curl " command) (string/has-prefix? "curl" command)))

--- a/plugins/compression/README.md
+++ b/plugins/compression/README.md
@@ -75,6 +75,7 @@ The plugin loads as a single shared Janet environment. Files are eval'd in alpha
 - **Structural extraction** — `git status` pulls branch name, ahead/behind count, and changed file lists into `branch↑N staged: ... unstaged: ...` format.
 - **Deduplication** — `kubectl logs` and `docker logs` collapse repeated lines with `(xN)` suffixes.
 - **Stat extraction** — `git merge`/`pull`/`cherry-pick` extract `N files, +M/-K` from the trailing summary line.
+- **Head+tail truncation** — when a list is too long to keep whole (`grep`/`find`/`ls`/`curl`/large `git diff`), `truncate-lines` (in `05-util.janet`) keeps the FIRST and LAST lines with an explicit marker — `… [N of M matches hidden — showing first H + last T] …`. Never head-only: errors, totals, and summaries usually sit at the *end* of output, so dropping the tail is the dangerous kind. The marker also makes clear the shown lines are a head+tail sample, not a relevance ranking.
 - **Passthrough** — commands with ≤10 lines of output or that don't match any pattern pass through unchanged. Already-terse output (like `git diff --stat` or small `curl` responses) is left alone.
 
 ## Files
@@ -82,6 +83,7 @@ The plugin loads as a single shared Janet environment. Files are eval'd in alpha
 ```
 .dirge/plugins/compression/
 ├── 00-regex.janet       Vendored spork/regex (MIT) — regex→PEG compiler
+├── 05-util.janet        Shared truncation helpers (head+tail with markers)
 ├── 10-git.janet         git (19 subcommands: status, log, diff, branch, ...)
 ├── 20-cargo.janet       cargo (10 subcommands: build, test, clippy, ...)
 ├── 30-docker.janet      docker + compose (12 subcommands: ps, images, build, ...)
@@ -91,19 +93,19 @@ The plugin loads as a single shared Janet environment. Files are eval'd in alpha
 ├── init.janet           ANSI strip, generic noise removal, on-tool-end hook,
 │                        main dispatch routing
 └── tests/
-    ├── bench.janet      A/B compression benchmark with realistic samples
-    └── test.janet       Unit tests for each compressor + tool-gate tests
+    └── test.janet       Runnable truncation checks (head+tail invariants)
 ```
 
 ## Running the tests
 
 ```bash
-# Unit tests (23 tests, all compressors + tool gate)
+# Truncation invariants (head+tail, markers, off-by-one regressions)
 janet .dirge/plugins/compression/tests/test.janet
-
-# A/B benchmark (17 realistic samples, threshold checks)
-janet .dirge/plugins/compression/tests/bench.janet
 ```
+
+These run in the Janet worker, not under `cargo test`, so they're a
+runnable local artifact rather than a CI gate — run them after editing
+any compressor.
 
 ## Porting from lean-ctx
 

--- a/plugins/compression/tests/test.janet
+++ b/plugins/compression/tests/test.janet
@@ -1,0 +1,114 @@
+# Runnable checks for the compression plugin's truncation behavior.
+#
+#   janet plugins/compression/tests/test.janet   (from repo root)
+#
+# Lives in tests/ so the plugin loader (which scans only top-level
+# *.janet files in the plugin dir) doesn't load it as plugin code.
+# Loads the plugin files in the host's load order into one env (no
+# `harness/*` needed — the compressor functions are pure), then asserts
+# the head+tail truncation invariants. Not a cargo test (these run in
+# the Janet worker, not Rust), but keeps the behavior pinned and
+# locally verifiable. The PR that added compression shipped its tests
+# in an external gist; this brings coverage in-repo.
+
+(def here (string (os/cwd) "/plugins/compression"))
+(defn load-plugin [name] (dofile (string here "/" name) :env (curenv)))
+
+(load-plugin "00-regex.janet")
+(load-plugin "05-util.janet")
+(load-plugin "10-git.janet")
+(load-plugin "50-misc.janet")
+
+(var failures 0)
+(defn check [name cond]
+  (if cond
+    (print "ok   - " name)
+    (do (set failures (+ failures 1)) (print "FAIL - " name))))
+
+(defn lines-of [s] (string/split "\n" s))
+
+# ── truncate-lines: the core invariant ──────────────────────────────
+
+(let [small (map string (range 5))]
+  (check "short input is unchanged"
+         (= (truncate-lines small 18 8 "x") (string/join small "\n"))))
+
+(let [big (map string (range 100))
+      out (truncate-lines big 18 8 "matching lines")]
+  (check "long input keeps the HEAD" (string/has-prefix? "0\n1\n2" out))
+  (check "long input keeps the TAIL (never silently dropped)"
+         (string/find "\n99" out))
+  (check "marker states hidden count + head/tail sizes"
+         (and (string/find "74 of 100 matching lines hidden" out)
+              (string/find "first 18 + last 8" out)))
+  (check "exactly head+tail+1 marker line"
+         (= (length (lines-of out)) (+ 18 8 1))))
+
+# Boundary: head+tail == n → no truncation.
+(let [exact (map string (range 26))]
+  (check "head+tail == n is not truncated"
+         (= (truncate-lines exact 18 8 "x") (string/join exact "\n"))))
+
+# ── grep: head AND tail, both ends visible ──────────────────────────
+
+(let [g (string/join (map (fn [i] (string "src/f" i ".rs:1:hit")) (range 50)) "\n")
+      out (compress-grep-output g)]
+  (check "grep shows the first match" (string/find "src/f0.rs" out))
+  (check "grep shows the LAST match (regression fix)" (string/find "src/f49.rs" out))
+  (check "grep marks hidden matches" (string/find "matching lines hidden" out)))
+
+(let [tiny (string/join (map (fn [i] (string "m" i)) (range 10)) "\n")]
+  (check "grep under threshold passes through" (= (compress-grep-output tiny) tiny)))
+
+# ── find: honest total, no bogus file/dir split ─────────────────────
+
+(let [paths (string/join (map (fn [i] (string "./a/b" i "/Makefile")) (range 40)) "\n")
+      out (compress-find-output paths)]
+  (check "find shows head paths" (string/find "./a/b0/Makefile" out))
+  (check "find shows tail paths" (string/find "./a/b39/Makefile" out))
+  (check "find reports paths-hidden, not a guessed file/dir count"
+         (and (string/find "paths hidden" out)
+              (not (string/find "dirs" out)))))
+
+# ── ls: actual names head+tail, not a bare count ────────────────────
+
+(let [entries (string/join (map (fn [i] (string "file" i ".txt")) (range 60)) "\n")
+      out (compress-ls-output entries)]
+  (check "ls shows real entry names (not just a count)"
+         (and (string/find "file0.txt" out) (string/find "file59.txt" out)))
+  (check "ls marks hidden entries" (string/find "entries hidden" out)))
+
+# ── curl: head+tail unchanged in spirit, shared marker ──────────────
+
+(let [body (string/join (map (fn [i] (string "{\"k\":" i "}")) (range 40)) "\n")
+      out (compress-curl-output body)]
+  (check "curl keeps head and tail"
+         (and (string/find "\"k\":0" out) (string/find "\"k\":39" out)))
+  (check "curl uses the shared marker" (string/find "lines hidden" out)))
+
+# ── git diff: multi-file truncation keeps both ends of EVERY file ───
+
+(let [mk (fn [name n] (string "diff --git a/" name " b/" name "\n"
+                              (string/join (map (fn [i] (string "+" name i)) (range n)) "\n")))
+      # 300 lines/file × 2 = 600 (>500 total, each file >250) → per-file
+      # head+tail truncation path.
+      out (git-compress "git diff" (string (mk "x" 300) "\n" (mk "y" 300)))]
+  (check "git diff keeps first file head" (string/find "+x0" out))
+  (check "git diff keeps first file's LAST line (off-by-one fix)"
+         (string/find "+x299" out))
+  (check "git diff keeps second file's last line" (string/find "+y299" out))
+  (check "git diff marker names each file"
+         (and (string/find "diff lines in x" out)
+              (string/find "diff lines in y" out))))
+
+# A small multi-file diff (<500 total) must pass through with every
+# line of every file intact.
+(let [mk (fn [name] (string "diff --git a/" name " b/" name "\n+" name "0\n+" name "1\n+" name "2"))
+      out (git-compress "git diff" (string (mk "p") "\n" (mk "q")))]
+  (check "small git diff keeps all of first file" (string/find "+p2" out))
+  (check "small git diff keeps all of second file" (string/find "+q2" out)))
+
+(print)
+(if (= failures 0)
+  (print "all checks passed")
+  (do (print failures " check(s) FAILED") (os/exit 1)))


### PR DESCRIPTION
Follow-up to #391's compression plugin. The review of that PR flagged the misc compressors as truncating head-only — silently dropping the tail of `grep`/`find`/`ls` output, which is where later-file matches and summaries live. This makes truncation robust.

- **Shared `truncate-lines` helper** (`05-util.janet`): keeps the FIRST and LAST lines with an explicit marker — `… [N of M matches hidden — showing first H + last T] …`. Never head-only; the marker also signals the shown lines are a head+tail sample, not a relevance ranking.
- **grep**: head+tail (was head-only-20) so the last matches stay visible.
- **find**: dropped the file/dir split — it guessed type from "does the basename contain a dot", miscounting `Makefile`/`README` as dirs and `.git` as a file. Reports the honest total; shows real paths.
- **ls**: shows actual entry names head+tail instead of collapsing to a bare count (the model re-runs `ls` to learn *which* files exist). Dropped the `d`-prefix dir count that only worked for `ls -l`.
- **curl + git diff**: routed through the same helper for a consistent, file-naming marker.
- **git diff multi-file off-by-one** (pre-existing): each file's range used `(dec i)` as an exclusive slice end, dropping the last line of every file except the last. Fixed.

Also brings tests in-repo — `tests/test.janet`, 23 runnable Janet checks (the original PR's tests were in an external gist) — and fixes the README's file tree + test instructions, which referenced a never-committed `bench.janet`/`test.janet`.

Verified: `janet plugins/compression/tests/test.janet` → all 23 pass; full sequential load of all plugin files evals clean; Rust `plugin` suite unaffected (188 pass).