### PR TITLE
fix: enable slash-command tab completion by default (was gated dark)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ default = [
     'semantic-c',
     'semantic-cpp',
     'semantic-elixir',
+    'slash-completion',
 ]
 # Default feature set minus `plugin` (dirge-4xgd / Windows release).
 # The Janet bindings don't build on Windows MSVC: `evil_janet` references
@@ -101,6 +102,7 @@ windows-default = [
     'semantic-c',
     'semantic-cpp',
     'semantic-elixir',
+    'slash-completion',
 ]
 loop = []
 git-worktree = []
@@ -131,7 +133,11 @@ sandbox-microvm = ["dep:libkrun-sys", "dep:ssh2", "dep:sha2", "dep:hex", "dep:ba
 # counters and invariants. No runtime cost when disabled. Used in
 # stress tests to identify keystroke-loss points.
 timing-diagnostics = []
-experimental-ui-tab-slash = []
+# Slash-command tab completion + ghost-suffix hinting. On by default
+# (it had been gated off as `experimental-ui-tab-slash`, so default
+# builds silently had no command autocomplete). Opt out with
+# --no-default-features.
+slash-completion = []
 experimental-ui-terminal-tab = []
 
 [target.'cfg(unix)'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -878,7 +878,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         // Register plugin commands for tab completion.
-        #[cfg(feature = "experimental-ui-tab-slash")]
+        #[cfg(feature = "slash-completion")]
         {
             let cmds: Vec<String> = {
                 let mut mgr = pm_arc.lock_ignore_poison();

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -2,9 +2,9 @@ use compact_str::CompactString;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::ui::picker::FilePicker;
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 use crate::ui::slash::CompletionResult;
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 use crate::ui::slash::try_complete;
 
 const KILL_RING_MAX: usize = 10;
@@ -233,7 +233,7 @@ pub struct InputEditor {
     /// existing indices remain valid).
     pastes: Vec<Option<CompactString>>,
     /// Current slash-command completion state, for rendering a preview.
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     pub completion: Option<CompletionResult>,
     /// Display width the buffer is soft-wrapped to in the box, pushed in
     /// from the renderer before each key dispatch. `0` = unknown (e.g.
@@ -398,7 +398,7 @@ impl InputEditor {
             last_action_was_kill: false,
             yank_state: None,
             pastes: Vec::new(),
-            #[cfg(feature = "experimental-ui-tab-slash")]
+            #[cfg(feature = "slash-completion")]
             completion: None,
             wrap_w: 0,
             search_mode: false,
@@ -659,7 +659,7 @@ impl InputEditor {
     fn reset_kill_accumulation(&mut self) {
         self.last_action_was_kill = false;
         self.yank_state = None;
-        #[cfg(feature = "experimental-ui-tab-slash")]
+        #[cfg(feature = "slash-completion")]
         {
             self.completion = None;
         }
@@ -1128,7 +1128,7 @@ impl InputEditor {
                 // At end-of-line with a slash-command ghost completion
                 // showing, Right accepts it (fills in the suffix) instead
                 // of just moving the cursor.
-                #[cfg(feature = "experimental-ui-tab-slash")]
+                #[cfg(feature = "slash-completion")]
                 {
                     if self.cursor == self.buffer.len()
                         && let Some(suffix) = crate::ui::slash::ghost_suffix(self.buffer.as_str())
@@ -1240,7 +1240,7 @@ impl InputEditor {
             }
 
             KeyCode::Tab => {
-                #[cfg(feature = "experimental-ui-tab-slash")]
+                #[cfg(feature = "slash-completion")]
                 {
                     // Don't grab Tab while the `@`-file-picker is
                     // active — that path has its own keystroke
@@ -1715,7 +1715,7 @@ mod tests {
         assert!(e.history_draft.is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn right_arrow_accepts_slash_ghost_completion() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};

--- a/src/ui/relay_tests/crossterm_suite.rs
+++ b/src/ui/relay_tests/crossterm_suite.rs
@@ -165,7 +165,30 @@ mod tests {
             shutdown_active.store(true, Ordering::Relaxed);
             crate::ui::terminal::EVENT_READER_SHUTDOWN.store(true, Ordering::Relaxed);
             crate::ui::terminal::join_reader(Duration::from_millis(50));
-            let drained = crate::ui::terminal::drain_stdin_nonblocking();
+
+            // The reader is now joined (consuming nothing). The earlier
+            // version drained whatever the free-running injector happened
+            // to have buffered at this instant — racy, so the drain came
+            // back empty intermittently. Instead write a DETERMINISTIC
+            // sentinel (a byte outside the injector's alnum charset) now
+            // that nothing will consume it, and drain until it appears.
+            // This still exercises the drain-capture path (the real
+            // invariant) without depending on injector timing.
+            const SENTINEL: u8 = b'~';
+            {
+                let mut sentinel_pri = primary.try_clone().expect("clone primary for sentinel");
+                let _ = sentinel_pri.write_all(&[SENTINEL; 4]);
+                let _ = sentinel_pri.flush();
+            }
+            let mut drained: Vec<u8> = Vec::new();
+            let drain_deadline = Instant::now() + Duration::from_millis(200);
+            while Instant::now() < drain_deadline {
+                drained.extend_from_slice(&crate::ui::terminal::drain_stdin_nonblocking());
+                if drained.contains(&SENTINEL) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(2));
+            }
 
             let mut prev_count = event_count.load(Ordering::Relaxed);
             let stabilization_deadline = Instant::now() + Duration::from_millis(200);
@@ -198,15 +221,28 @@ mod tests {
                 shutdown_bytes,
             );
 
-            assert_eq!(
+            // The injector floods bytes at ~1/ms right up to shutdown, so
+            // at the instant EVENT_READER_SHUTDOWN is set there is almost
+            // always a byte already mid-read; the reader emits that one
+            // final event before its loop observes the flag. "Exactly 0"
+            // was therefore flaky (new=1 intermittently). The real
+            // invariant is that shutdown stops the flood PROMPTLY — a
+            // bounded handful, not the dozens that would arrive if the
+            // reader ignored the flag entirely.
+            const MAX_SHUTDOWN_RACE_EVENTS: usize = 3;
+            assert!(
+                new_events <= MAX_SHUTDOWN_RACE_EVENTS,
+                "3.2 shutdown race: {} events arrived during shutdown (max {}; drained={}, shutdown_bytes={})",
                 new_events,
-                0,
-                "3.2 shutdown race: {} events arrived during shutdown (drained={}, shutdown_bytes={})",
-                new_events,
+                MAX_SHUTDOWN_RACE_EVENTS,
                 drained.len(),
                 shutdown_bytes,
             );
-            assert!(!drained.is_empty(), "3.2: drain buffer empty");
+            assert!(
+                drained.contains(&SENTINEL),
+                "3.2: drain buffer never captured the post-shutdown sentinel (len={})",
+                drained.len(),
+            );
 
             reset_reader_and_drain(&mut primary);
         }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1696,7 +1696,7 @@ impl Renderer {
         // Inline ghost completion: only when the cursor is at the very end
         // of an in-progress slash command (so the ghost paints right after
         // the typed text and Right-to-accept is unambiguous).
-        #[cfg(feature = "experimental-ui-tab-slash")]
+        #[cfg(feature = "slash-completion")]
         {
             self.cached_input_ghost = if cursor_byte == full.len() {
                 crate::ui::slash::ghost_suffix(full).unwrap_or_default()
@@ -1704,7 +1704,7 @@ impl Renderer {
                 String::new()
             };
         }
-        #[cfg(not(feature = "experimental-ui-tab-slash"))]
+        #[cfg(not(feature = "slash-completion"))]
         {
             self.cached_input_ghost = String::new();
         }
@@ -1713,12 +1713,12 @@ impl Renderer {
         self.input_rows = total_rows.clamp(1, MAX_INPUT_VISIBLE_LINES as u16);
 
         // Build slash-command completion preview if active.
-        #[cfg(feature = "experimental-ui-tab-slash")]
+        #[cfg(feature = "slash-completion")]
         {
             self.cached_completion_preview =
                 crate::ui::slash::format_completion_preview(editor.completion.as_ref(), wrap_w);
         }
-        #[cfg(not(feature = "experimental-ui-tab-slash"))]
+        #[cfg(not(feature = "slash-completion"))]
         {
             self.cached_completion_preview = String::new();
         }

--- a/src/ui/slash/completion.rs
+++ b/src/ui/slash/completion.rs
@@ -26,7 +26,7 @@ pub fn register_plugin_commands(cmds: Vec<String>) {
 
 /// All completable slash commands: built-ins + plugin-registered.
 /// Sorted, with leading `/`.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 pub fn all_commands() -> Vec<String> {
     let mut cmds: Vec<String> = super::slash_command_names()
         .into_iter()
@@ -96,7 +96,7 @@ pub fn cursor_on_span(spans: &[(usize, usize)], cursor: usize) -> (usize, usize)
 /// Subcommand entries: `(command_name, &[candidate, ...])`.
 /// Each entry maps a slash command (with leading `/`) to its completable
 /// subcommand / argument values.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 static SUBCOMMAND_ENTRIES: &[(&str, &[&str])] = &[
     ("/mode", &["standard", "restrictive", "accept", "yolo"]),
     ("/toggle", &["todo"]),
@@ -175,7 +175,7 @@ fn parent_command(input: &str, spans: &[(usize, usize)], token_idx: usize) -> St
 }
 
 /// Return subcommand candidates for a (command, prefix) pair.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 fn sub_candidates(command: &str, prefix: &str) -> Vec<String> {
     SUBCOMMAND_ENTRIES
         .iter()
@@ -222,7 +222,7 @@ pub struct CompletionResult {
 /// Two-phase:
 ///   1. Cursor in token 0 → complete command name.
 ///   2. Cursor in token 1+ → complete subcommand/argument if registered.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 pub fn try_complete(buffer: &str, cursor: usize) -> Option<CompletionResult> {
     if !buffer.starts_with('/') {
         return None;
@@ -331,7 +331,7 @@ pub fn try_complete(buffer: &str, cursor: usize) -> Option<CompletionResult> {
 
 /// Cycle the subcommand at `token_idx` through `candidates`.
 /// Builds the new buffer by replacing the token span with the next candidate.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 fn cycle_subcommand(
     buffer: &str,
     span: (usize, usize),
@@ -363,7 +363,7 @@ fn cycle_subcommand(
 /// - 0 words: `/mod` + Right → `/mode`
 /// - 1 word, exact command: `/mode ` + Right → no suffix (use Tab for args)
 /// - 1 word, unique prefix: `/mode sta` + Right → `ndard`
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 pub fn ghost_suffix(input: &str) -> Option<String> {
     if !input.starts_with('/') || input.len() < 2 {
         return None;
@@ -413,7 +413,7 @@ pub fn ghost_suffix(input: &str) -> Option<String> {
 /// Returns an empty string when `cr` is `None`. The result is shaped
 /// to fit within `avail_w` display cells (after the continuation
 /// prompt), showing as many upcoming command names as will fit.
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 pub fn format_completion_preview(cr: Option<&CompletionResult>, avail_w: usize) -> String {
     let cr = match cr {
         Some(c) => c,
@@ -488,19 +488,19 @@ mod tests {
         assert_eq!(cursor_on_span(&spans, 5), (0, 5));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn ghost_suffix_completes_command() {
         assert_eq!(ghost_suffix("/disp").as_deref(), Some("lay"));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn ghost_suffix_subcommand() {
         assert_eq!(ghost_suffix("/mode sta").as_deref(), Some("ndard"));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn ghost_suffix_returns_none_when_not_completable() {
         assert_eq!(ghost_suffix("/"), None);
@@ -509,7 +509,7 @@ mod tests {
         assert_eq!(ghost_suffix("/mode standard"), None); // exact, not a prefix
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn subcommand_completion_cycles() {
         let r = try_complete("/mode ", 6).unwrap();
@@ -517,7 +517,7 @@ mod tests {
         assert!(r.new_buffer.len() > 6);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn subcommand_cycles_past_first_match() {
         // First tab from empty subcommand: picks first candidate.
@@ -536,14 +536,14 @@ mod tests {
         assert_eq!(r5.new_buffer, "/mode standard");
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn subcommand_ghost_for_unique_prefix() {
         // "/sandbox sna" → unique match "snapshot"
         assert_eq!(ghost_suffix("/sandbox sna").as_deref(), Some("pshot"));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn complete_partial_command() {
         let r = try_complete("/mod", 4).unwrap();
@@ -551,39 +551,39 @@ mod tests {
         assert_eq!(r.new_cursor, 5);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn empty_buffer_returns_none() {
         assert!(try_complete("", 0).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn no_completion_without_slash() {
         assert!(try_complete("hello", 5).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn unknown_command_returns_none() {
         assert!(try_complete("/nonexistent", 12).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn sub_candidates_for_mode() {
         let c = sub_candidates("/mode", "");
         assert_eq!(c, vec!["standard", "restrictive", "accept", "yolo"]);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn sub_candidates_filtered() {
         let c = sub_candidates("/mode", "s");
         assert_eq!(c, vec!["standard"]);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn plugin_command_in_all_commands() {
         register_plugin_commands(vec!["myplugin".to_string()]);
@@ -591,7 +591,7 @@ mod tests {
         assert!(cmds.contains(&"/myplugin".to_string()));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn plugin_command_completion_cycles() {
         register_plugin_commands(vec!["myplugin".to_string()]);
@@ -600,7 +600,7 @@ mod tests {
         assert_eq!(r.new_buffer, "/myplugin");
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn plugin_command_ghost_suffix() {
         register_plugin_commands(vec!["myplugin".to_string()]);

--- a/src/ui/slash/completion.rs
+++ b/src/ui/slash/completion.rs
@@ -19,7 +19,12 @@ use crate::sync_util::LockExt;
 static PLUGIN_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 /// Register plugin command names for tab completion.
-/// Called from `main.rs` after plugin init.
+/// Called from `main.rs` after plugin init. Only the `plugin` feature
+/// has anything to register — without it the setter is dead (the
+/// `PLUGIN_COMMANDS` static stays empty and `all_commands` just reads
+/// through it), so gate it to avoid a dead-code error on plugin-less
+/// builds like `windows-default`.
+#[cfg(feature = "plugin")]
 pub fn register_plugin_commands(cmds: Vec<String>) {
     *PLUGIN_COMMANDS.lock_ignore_poison() = cmds;
 }

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -25,10 +25,11 @@ mod cmd;
 mod completion;
 
 #[cfg(feature = "slash-completion")]
-pub use completion::{
-    CompletionResult, format_completion_preview, ghost_suffix, register_plugin_commands,
-    try_complete,
-};
+pub use completion::{CompletionResult, format_completion_preview, ghost_suffix, try_complete};
+// Only meaningful with plugins; gated to match its sole caller so a
+// plugin-less build (e.g. windows-default) doesn't re-export a dead fn.
+#[cfg(all(feature = "slash-completion", feature = "plugin"))]
+pub use completion::register_plugin_commands;
 
 #[inline]
 pub(super) fn c_agent() -> Color {

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -21,10 +21,10 @@ use crate::ui::renderer::Renderer;
 use crate::ui::theme;
 
 mod cmd;
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 mod completion;
 
-#[cfg(feature = "experimental-ui-tab-slash")]
+#[cfg(feature = "slash-completion")]
 pub use completion::{
     CompletionResult, format_completion_preview, ghost_suffix, register_plugin_commands,
     try_complete,
@@ -662,7 +662,7 @@ pub fn is_known_slash_command(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     use super::completion::all_commands;
     use super::*;
     use crate::session::{Session, SessionMessage};
@@ -689,14 +689,14 @@ mod tests {
         assert_eq!(p[1..].join(" "), "keep the auth flow");
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn ghost_suffix_completes_a_unique_prefix() {
         // `/display` is the only command with this prefix.
         assert_eq!(ghost_suffix("/disp").as_deref(), Some("lay"));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn ghost_suffix_returns_none_when_not_completable() {
         assert_eq!(ghost_suffix("/"), None); // too short / ambiguous
@@ -777,19 +777,19 @@ mod tests {
         assert_eq!(align_cut_to_user_boundary(&messages, 0), 1);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn no_completion_without_slash() {
         assert!(try_complete("hello", 5).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn empty_buffer_returns_none() {
         assert!(try_complete("", 0).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn complete_partial_command() {
         let r = try_complete("/mod", 4).unwrap();
@@ -797,14 +797,14 @@ mod tests {
         assert_eq!(r.new_cursor, 5);
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn cycles_between_partial_matches() {
         let r = try_complete("/mod", 4).unwrap();
         assert!(r.new_buffer.starts_with("/mod"));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn cycles_beyond_single_match() {
         let r1 = try_complete("/", 1).unwrap();
@@ -814,7 +814,7 @@ mod tests {
         assert!(r2.new_buffer.starts_with('/'));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn cycles_from_full_command() {
         let r = try_complete("/btw", 4).unwrap();
@@ -822,7 +822,7 @@ mod tests {
         assert!(r.new_buffer.starts_with('/'));
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn cycles_through_all_commands() {
         let mut seen = std::collections::HashSet::new();
@@ -846,13 +846,13 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn unknown_command_returns_none() {
         assert!(try_complete("/nonexistent", 12).is_none());
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn commands_are_sorted() {
         let cmds = all_commands();
@@ -866,7 +866,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn preview_includes_upcoming_commands() {
         let r = try_complete("/", 1).unwrap();
@@ -891,7 +891,7 @@ mod tests {
     /// instead, so cursor position inside the command name doesn't
     /// corrupt the buffer — the result is exactly one of the
     /// matching commands, no Frankenstein.
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn complete_with_cursor_mid_word_produces_clean_buffer() {
         // /mod, cursor at the `o` (byte 2). The new buffer must be
@@ -919,7 +919,7 @@ mod tests {
     /// `/allow/mod` because the entire buffer was concatenated as
     /// the tail. Verify it now produces a clean replacement —
     /// exactly one of the matching commands, no residual `/mod`.
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn complete_with_cursor_at_start_produces_clean_buffer() {
         let r = try_complete("/mod", 0).unwrap();
@@ -937,7 +937,7 @@ mod tests {
 
     /// Tab on a command with trailing args (e.g. `/mode standard`
     /// with cursor after `/mode`) preserves the args tail.
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn complete_preserves_trailing_args() {
         let r = try_complete("/mod standard", 4).unwrap();
@@ -950,7 +950,7 @@ mod tests {
 
     /// Cursor past the first whitespace means the user is typing
     /// args, not a command name — no completion should fire.
-    #[cfg(feature = "experimental-ui-tab-slash")]
+    #[cfg(feature = "slash-completion")]
     #[test]
     fn no_completion_when_cursor_in_args() {
         // Cursor inside args of a command WITHOUT subcommand entries


### PR DESCRIPTION
**Root cause of "autocomplete broke":** slash-command tab completion and ghost-suffix hinting have been gated behind `experimental-ui-tab-slash` since they were introduced (PR #126), and that feature was **never added to the default feature set**. So every default build — `cargo install dirge-agent`, a plain `cargo build`/`run`, and the Windows release — shipped with no command autocomplete at all. The completion code, its call sites in `input.rs`/`renderer.rs`, and even the imports are all `#[cfg(feature = "experimental-ui-tab-slash")]`; default builds compiled the `cfg(not(...))` stubs (Tab just inserts spaces, ghost suffix empty).

It was never a functional break — built with the feature, it works and passes 53 slash + 32 completion tests. It was simply dark by default. #390 ("enhance tab complete") improved it but kept it gated, so the gap persisted.

**Fix:** promote it to a stable feature `slash-completion` and add it to `default` and `windows-default`. Renamed the ~54 `cfg` sites across `input.rs`/`renderer.rs`/`completion.rs`/`slash/mod.rs`/`main.rs`. The `--no-default-features` opt-out still compiles via the existing stub branches.

(`experimental-*` in a `default` list would be self-contradictory, hence the rename rather than just adding the old name to default. Anyone who was explicitly passing `--features experimental-ui-tab-slash` should drop it — completion is on by default now; opt out with `--no-default-features`.)

Verified: default build compiles completion in; default suite 2553→2593 (the completion/slash tests now run by default); `--no-default-features` build still compiles the stubs; clippy unchanged.