### PR TITLE
fix(ui): repaint throttled frames when idle (scroll stall)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3355,6 +3355,13 @@ pub async fn run_interactive(
                 // itself). The status line is built once by `render_frame!`.
                 renderer.request_repaint();
             }
+            // A dirty frame the 8ms paint throttle deferred (the tail of a fast
+            // wheel-scroll / PageUp burst) would otherwise sit unpainted: while
+            // the agent is idle there's no other timer to wake the loop, so the
+            // scrolled position stalls until the next unrelated event. Wake just
+            // past the throttle window and let the loop-top `render_frame!` flush
+            // it (no body needed — needs_paint is already set).
+            _ = tokio::time::sleep(tokio::time::Duration::from_millis(16)), if renderer.needs_paint() => {}
             else => {
                 tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1790,6 +1790,15 @@ impl Renderer {
         self.needs_paint = true;
     }
 
+    /// Whether a frame is marked dirty but not yet painted — e.g. the
+    /// `tui_redraw` paint throttle deferred it. The event loop polls
+    /// this so a throttled frame (the tail of a fast wheel/PageUp scroll
+    /// burst) gets flushed shortly instead of being stranded until the
+    /// next unrelated event.
+    pub fn needs_paint(&self) -> bool {
+        self.needs_paint
+    }
+
     /// #387: the single paint per event. Performs one `tui_redraw` iff the
     /// frame is dirty. The flag is cleared inside `tui_redraw` only
     /// after a successful `terminal.draw()`, so a throttled paint or


### PR DESCRIPTION
## Symptom
Scrolling the main pane (mouse wheel / trackpad, and held PageUp) appears broken: the content stalls and doesn't track the scroll while the agent is idle. A single slow tick repaints fine, which is what made it look half-broken.

## Root cause
Not the scroll math (offset/clamp/slice are all consistent). It's a dropped frame:

1. The loop paints once at the top of each iteration (`render_frame!` → `flush` → `tui_redraw`), then blocks in `tokio::select!` for the next event (the #387 "single paint per event" model).
2. `tui_redraw` has an 8ms paint throttle that `return`s early **without clearing `needs_paint`**, expecting a retry on the next loop iteration.
3. The only periodic timer arm is gated `if ui.is_running` — so **when the agent is idle there's no timer**, and `select!` just blocks on events.

So a fast scroll burst advances `scroll_offset`, every frame after the first is throttle-dropped, and the final position never paints until an unrelated event arrives.

## Fix
Add a `select!` arm that wakes ~16ms (just past the 8ms throttle) while a frame is still dirty, so the loop-top `render_frame!` flushes it even when idle:

```rust
_ = tokio::time::sleep(Duration::from_millis(16)), if renderer.needs_paint() => {}
```

Once it paints, `needs_paint` clears and the arm disarms — no busy loop. Adds a `needs_paint()` accessor for the guard.

## Verification
Confirmed by hand in a real terminal: wheel/trackpad scrolling now tracks smoothly when idle. Build clean; all 436 `ui::` tests pass. (The live `tokio::select!` loop can't be exercised at unit-test level, hence the manual check.)