### PR TITLE
fix(headless): resume session history in -p; better MCP files_changed

### DIFF
--- a/src/extras/mcp_server.rs
+++ b/src/extras/mcp_server.rs
@@ -322,29 +322,68 @@ async fn run_delegation(
 
 /// `git status --porcelain` as a set of `"XY path"` lines. Empty (not an
 /// error) when the project isn't a git repo or git is unavailable.
-fn git_status_set(dir: &Path) -> std::collections::HashSet<String> {
+/// Signature for the path under each `git status --porcelain` entry:
+/// `path -> (size, mtime-nanos)`. Empty when the dir isn't a git repo.
+///
+/// We key on a content signature, not just the porcelain line, so a file
+/// that was ALREADY dirty before a delegation (e.g. created untracked by
+/// an earlier delegation in the same session) and is edited again is still
+/// attributed — a plain porcelain-line diff misses that, since `?? path`
+/// is identical before and after.
+fn git_status_set(dir: &Path) -> std::collections::HashMap<String, (u64, i128)> {
     let out = std::process::Command::new("git")
         .current_dir(dir)
         .args(["status", "--porcelain"])
         .output();
-    match out {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
-            .lines()
-            .map(|l| l.to_string())
-            .collect(),
-        _ => std::collections::HashSet::new(),
+    let mut map = std::collections::HashMap::new();
+    if let Ok(o) = out
+        && o.status.success()
+    {
+        for line in String::from_utf8_lossy(&o.stdout).lines() {
+            let path = porcelain_path(line);
+            if path.is_empty() {
+                continue;
+            }
+            let sig = std::fs::metadata(dir.join(&path))
+                .ok()
+                .map(|m| (m.len(), mtime_nanos(&m)))
+                .unwrap_or((0, 0));
+            map.insert(path, sig);
+        }
+    }
+    map
+}
+
+/// The path from a porcelain line: strip the 3-char `XY ` status prefix,
+/// and for a rename/copy (`old -> new`) attribute the change to `new`.
+fn porcelain_path(line: &str) -> String {
+    let p = line.get(3..).unwrap_or("").trim();
+    match p.find(" -> ") {
+        Some(i) => p[i + 4..].to_string(),
+        None => p.to_string(),
     }
 }
 
-/// Paths that changed during the run: porcelain lines present after but
-/// not before. Strips the 3-char `XY ` status prefix to bare paths.
+fn mtime_nanos(m: &std::fs::Metadata) -> i128 {
+    m.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as i128)
+        .unwrap_or(0)
+}
+
+/// Paths dirge touched during the run: dirty afterward AND either newly
+/// dirty or with a changed `(size, mtime)` signature vs before — so edits
+/// to an already-dirty file are caught, while the caller's pre-existing
+/// untouched changes are not falsely attributed.
 fn changed_paths(
-    before: &std::collections::HashSet<String>,
-    after: &std::collections::HashSet<String>,
+    before: &std::collections::HashMap<String, (u64, i128)>,
+    after: &std::collections::HashMap<String, (u64, i128)>,
 ) -> Vec<String> {
     let mut v: Vec<String> = after
-        .difference(before)
-        .map(|l| l.get(3..).unwrap_or(l).trim().to_string())
+        .iter()
+        .filter(|(path, sig)| before.get(*path) != Some(*sig))
+        .map(|(path, _)| path.clone())
         .collect();
     v.sort();
     v.dedup();
@@ -432,18 +471,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn changed_paths_reports_new_entries_and_strips_status() {
-        let before: std::collections::HashSet<String> = [" M src/a.rs".to_string()].into();
-        let after: std::collections::HashSet<String> = [
-            " M src/a.rs".to_string(),
-            "?? src/b.rs".to_string(),
-            "A  c.rs".to_string(),
+    fn changed_paths_detects_new_and_modified_not_untouched() {
+        use std::collections::HashMap;
+        // src/a.rs dirty before with sig (10,1). After: a.rs unchanged,
+        // b.rs newly dirty, c.rs already dirty but its signature changed
+        // (further edited — the case the old line-diff missed).
+        let before: HashMap<String, (u64, i128)> =
+            [("src/a.rs".into(), (10, 1)), ("c.rs".into(), (5, 1))].into();
+        let after: HashMap<String, (u64, i128)> = [
+            ("src/a.rs".into(), (10, 1)), // untouched → not reported
+            ("src/b.rs".into(), (3, 2)),  // new → reported
+            ("c.rs".into(), (8, 9)),      // sig changed → reported
         ]
         .into();
         let changed = changed_paths(&before, &after);
-        // a.rs unchanged between snapshots → not reported; new ones are,
-        // with the 3-char `XY ` porcelain prefix stripped.
         assert_eq!(changed, vec!["c.rs".to_string(), "src/b.rs".to_string()]);
+    }
+
+    #[test]
+    fn porcelain_path_strips_status_and_handles_rename() {
+        assert_eq!(porcelain_path("?? src/b.rs"), "src/b.rs");
+        assert_eq!(porcelain_path(" M src/a.rs"), "src/a.rs");
+        assert_eq!(porcelain_path("R  old.rs -> new.rs"), "new.rs");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1157,8 +1157,18 @@ async fn main() -> anyhow::Result<()> {
         )
         .await;
         let msg = cli.message.join(" ");
+        // Resume the loaded session's prior conversation so `--session <id>`
+        // continues with context instead of running the model cold each time.
+        // `session` here is the session `--session` resolved (loaded or fresh);
+        // its messages are the prior turns, the new prompt is appended after.
+        let history = crate::agent::runner::convert_history(&session);
         let response = agent
-            .run_print(&msg, cli.resolve_max_agent_turns(&cfg), cli.output_format)
+            .run_print(
+                &msg,
+                cli.resolve_max_agent_turns(&cfg),
+                cli.output_format,
+                history,
+            )
             .await?;
         // A plugin may have called `harness/set-next-model` during
         // `prepare-next-run`. `--print` is single-shot so we can't
@@ -1564,6 +1574,9 @@ async fn run_headless_loop(
                 &iteration_prompt,
                 cli.resolve_max_agent_turns(cfg),
                 cli.output_format,
+                // The loop drives its own prompt sequence (from LOOP_PLAN),
+                // not a resumed chat history.
+                Vec::new(),
             )
             .await
         {

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -60,6 +60,11 @@ impl AnyAgent {
         prompt: &str,
         max_turns: usize,
         output_format: crate::cli::OutputFormat,
+        // Prior conversation to resume into the model's context. Empty for a
+        // fresh run; for `--session <id>` the caller passes the loaded
+        // session's history (via `convert_history`) so a headless run
+        // continues where it left off instead of starting cold each time.
+        history: Vec<rig::completion::Message>,
     ) -> anyhow::Result<String> {
         // dirge-nqr: honor the cap explicitly even if the agent was
         // built with a different one. `run_print` is the headless
@@ -109,7 +114,7 @@ impl AnyAgent {
         // — Arc internals + refcounts), spawn a runner, and drain the
         // event channel collecting text. Use the max_turns-stamped
         // `agent` from above so the cap is honored.
-        let runner = agent.spawn_runner(effective_prompt.clone(), Vec::new(), None);
+        let runner = agent.spawn_runner(effective_prompt.clone(), history, None);
         let task = runner.task;
         let mut event_rx = runner.event_rx;
 


### PR DESCRIPTION
Two bugs found while testing the `dirge mcp` delegation loop end-to-end.

## 1. `dirge -p --session <id>` didn't resume history
The headless print path **persisted** the session (so `message_count` grew) but never **resumed** it: `run_print` passed `Vec::new()` as the model history regardless of `--session`, so every headless run started cold. Through the MCP server this meant a follow-up `delegate` ("fix the thing you just did") had no memory of the prior turn — it replied *"I haven't created any file in this session."*

Fix: the print path now threads `convert_history(&session)` (the resolved session's prior turns) into `run_print`. The `--loop` caller still passes `Vec::new()` (it drives its own prompt sequence). This is a general headless bug, not MCP-specific.

**Verified live** through the MCP server: in a fresh session, delegate #1 creates a file, delegate #2 ("append a line to the file you just created") now correctly finds and edits it.

## 2. MCP `files_changed` missed edits to already-dirty files
The server computed `files_changed` as a `git status --porcelain` **line** diff, which can't see a content edit to a file that was already dirty before the delegation — exactly the multi-delegation case (file created untracked in #1, edited in #2: `?? path` is identical before and after). Switched to a `(size, mtime)` signature per dirty path, so further edits are attributed while the caller's pre-existing untouched changes aren't.

Unit-tested. Note: this runs in the long-lived `dirge mcp` server process, so it needs a Claude Code restart (respawns the server with the new binary) to take effect live.

## Tests
4 `mcp_server` unit tests (signature diff + porcelain path/rename parsing), `run_print` tests, full suite 2612 pass.