### PR TITLE
fix(headless): persist tool calls on -p --session (resume cutoff); mermaid validation

### DIFF
--- a/plugins/mermaid_diagram.janet
+++ b/plugins/mermaid_diagram.janet
@@ -12,7 +12,7 @@
 (var phase :idle)
 (var diagram nil)
 (var attempt 0)
-(var max-retries 3)
+(def max-retries 3)
 (var original-task nil)
 
 # --- Prompts (arXiv 2604.00171: diagrams as intermediate representations) ---
@@ -84,18 +84,26 @@
   (unless (or has-flowchart has-seq has-class has-state has-er)
     (array/push errors "Missing diagram type header — add e.g. 'flowchart TD' or 'sequenceDiagram'"))
 
-  (def has-edge (or (string/find "-->" text)
+  # Cover the common mermaid connectors across diagram types: flowchart
+  # (--> --- -.-> ==>), sequence (->> -->>), and er/class/state, which use
+  # `--`-based links. The old check only matched --> / ->> / --- and so
+  # falsely rejected valid er/classDiagrams (and flowchart -.-> / ==>).
+  (def has-edge (or (string/find "--" text)
                     (string/find "->>" text)
-                    (string/find "---" text)))
+                    (string/find "==>" text)
+                    (string/find "-.-" text)))
   (unless has-edge
     (array/push errors "No connections between nodes — add edges like 'A --> B' or 'A->>B'"))
 
   (def bracket-diff (- (count-char text "[") (count-char text "]")))
   (def paren-diff (- (count-char text "(") (count-char text ")")))
+  (def brace-diff (- (count-char text "{") (count-char text "}")))
   (when (not= bracket-diff 0)
-    (array/push errors (string "Unbalanced square brackets [" bracket-diff " — check node labels")))
+    (array/push errors (string "Unbalanced square brackets " bracket-diff " — check node labels")))
   (when (not= paren-diff 0)
     (array/push errors (string "Unbalanced parentheses " paren-diff " — check node labels")))
+  (when (not= brace-diff 0)
+    (array/push errors (string "Unbalanced braces " brace-diff " — check {decision}/{{hexagon}} nodes")))
 
   {:valid (empty? errors) :errors errors})
 

--- a/plugins/mermaid_diagram.janet
+++ b/plugins/mermaid_diagram.janet
@@ -1,0 +1,190 @@
+# Mermaid diagram plugin — generates architecture diagrams as intermediate
+# representations before implementation. Based on findings from arXiv
+# 2604.00171 (diagrams-as-IR improves generation quality), VisDocSketcher
+# 2509.11942 (multi-agent decomposition beats single-agent), and 2605.15184v1
+# (inline delivery beats file-based routing).
+#
+# Flow: /diagram <task> → model generates Mermaid → validate → inject
+# blueprint into context → implement phase follows the blueprint.
+
+(def hooks ["on-init" "on-response"])
+
+(var phase :idle)
+(var diagram nil)
+(var attempt 0)
+(var max-retries 3)
+(var original-task nil)
+
+# --- Prompts (arXiv 2604.00171: diagrams as intermediate representations) ---
+
+(defn- generation-prompt [task]
+  (string
+    "ARCHITECTURE PLANNING — produce a Mermaid diagram as an intermediate "
+    "representation before any code is written.\n\n"
+    "This diagram will serve as the DEFINITIVE architectural blueprint for "
+    "implementation. It bridges the gap between the problem statement and "
+    "the code — make it complete and internally consistent.\n\n"
+    "1. Identify all components/modules involved and their responsibilities\n"
+    "2. Map every data and control flow edge between them\n"
+    "3. List files to create or modify\n"
+    "4. Output the architecture as a Mermaid diagram inside a code fence:\n\n"
+    "```mermaid\n"
+    "flowchart TD\n"
+    "    A[Component] -->|data flow| B[Component]\n"
+    "    ...\n"
+    "```\n\n"
+    "Use flowchart for structural architecture or sequenceDiagram for API flows. "
+    "Every node must have a label. Every edge must have a direction. "
+    "Keep it focused — at most 20 nodes.\n\n"
+    "Task: " task))
+
+(defn- implementation-prompt []
+  (string
+    "IMPLEMENT the architecture shown in the blueprint above.\n"
+    "The diagram is the definitive reference for component structure, "
+    "data flow, and file layout. Follow it.\n\n"
+    "Use TDD: write failing tests first, then minimal implementation "
+    "to make them pass. Refer to the diagram for relationships between "
+    "components."))
+
+(defn- retry-feedback [task errors]
+  (string
+    "Your previous Mermaid diagram had issues:\n"
+    (string/join (map (fn [e] (string "- " e)) errors) "\n")
+    "\nFix these and regenerate the diagram for:\n" task))
+
+# --- Extraction and validation ---
+
+(defn- extract-mermaid [text]
+  (def start (string/find "```mermaid" text))
+  (if (nil? start)
+    nil
+    (let [body-start (+ start 10)
+          end (string/find "```" text body-start)]
+      (if (nil? end)
+        nil
+        (string/trim (string/slice text body-start end))))))
+
+(defn- count-char [s ch]
+  (var n 0)
+  (for i 0 (length s)
+    (if (= (string/slice s i (+ i 1)) ch)
+      (set n (+ n 1))))
+  n)
+
+(defn- validate-diagram [text]
+  (var errors @[])
+
+  (def has-flowchart (string/find "flowchart" text))
+  (def has-seq (string/find "sequenceDiagram" text))
+  (def has-class (string/find "classDiagram" text))
+  (def has-state (string/find "stateDiagram" text))
+  (def has-er (string/find "erDiagram" text))
+
+  (unless (or has-flowchart has-seq has-class has-state has-er)
+    (array/push errors "Missing diagram type header — add e.g. 'flowchart TD' or 'sequenceDiagram'"))
+
+  (def has-edge (or (string/find "-->" text)
+                    (string/find "->>" text)
+                    (string/find "---" text)))
+  (unless has-edge
+    (array/push errors "No connections between nodes — add edges like 'A --> B' or 'A->>B'"))
+
+  (def bracket-diff (- (count-char text "[") (count-char text "]")))
+  (def paren-diff (- (count-char text "(") (count-char text ")")))
+  (when (not= bracket-diff 0)
+    (array/push errors (string "Unbalanced square brackets [" bracket-diff " — check node labels")))
+  (when (not= paren-diff 0)
+    (array/push errors (string "Unbalanced parentheses " paren-diff " — check node labels")))
+
+  {:valid (empty? errors) :errors errors})
+
+# --- Hooks ---
+
+(defn mermaid_diagram-on-init [ctx]
+  (set phase :idle)
+  (set diagram nil)
+  (set attempt 0)
+  nil)
+
+(defn mermaid_diagram-on-response [ctx]
+  (if (not= phase :generating)
+    nil
+    (let [response (or (ctx :response) "")
+          mermaid (extract-mermaid response)]
+      (if (nil? mermaid)
+        (if (< attempt max-retries)
+          (do
+            (set attempt (+ attempt 1))
+            (harness/notify
+              (string "No Mermaid diagram found (attempt " attempt "/" max-retries ")")
+              :warn)
+            (harness/request-prompt
+              (string "Your response did not include a Mermaid diagram. "
+                      "Output a ```mermaid ... ``` block with a flowchart "
+                      "or sequence diagram for: " original-task))
+            nil)
+          (do
+            (set phase :idle)
+            (set attempt 0)
+            (harness/notify "Failed to get a Mermaid diagram after retries" :error)
+            nil))
+        (let [result (validate-diagram mermaid)]
+          (if (result :valid)
+            (do
+              (set diagram mermaid)
+              (set attempt 0)
+              (harness/notify "Mermaid diagram validated — injecting as architecture blueprint" :info)
+              # arXiv 2605.15184v1: inline injection beats file-based routing.
+              # Inject the diagram into the system prompt so the model sees it
+              # as a definitive intermediate representation during implementation.
+              (harness/append-system-prompt
+                (string
+                  "## Architecture Blueprint (definitive intermediate representation)\n\n"
+                  "The following Mermaid diagram was generated and validated during "
+                  "the architecture planning phase. It describes component structure, "
+                  "data flow, and file layout. Use it as the authoritative reference "
+                  "during implementation.\n\n"
+                  "```mermaid\n" diagram "\n```"))
+              # Also add as a visible custom message so it persists in the
+              # transcript across the full implementation phase.
+              (harness/add-custom-message
+                "mermaid_blueprint"
+                (string "```mermaid\n" diagram "\n```")
+                true)
+              (set phase :idle)
+              (harness/request-prompt (implementation-prompt))
+              nil)
+            (if (< attempt max-retries)
+              (do
+                (set attempt (+ attempt 1))
+                (harness/notify
+                  (string "Diagram validation failed: " (string/join (result :errors) "; "))
+                  :warn)
+                (harness/request-prompt (retry-feedback original-task (result :errors)))
+                nil)
+              (do
+                (set phase :idle)
+                (set attempt 0)
+                (harness/notify "Diagram validation failed after retries" :error)
+                nil))))))))
+
+# --- Slash command ---
+
+(defn diagram-handler [args]
+  (def task (if (string? args) (string/trim args) ""))
+  (if (empty? task)
+    (string "Usage: /diagram <task description>\n"
+            "Generates a Mermaid architecture diagram as an intermediate "
+            "representation (arXiv 2604.00171) before writing code. The "
+            "diagram is validated then injected as the implementation blueprint.")
+    (do
+      (set phase :generating)
+      (set attempt 0)
+      (set original-task task)
+      (harness/request-prompt (generation-prompt task))
+      (string "Generating architecture diagram for: " task
+              "\n(The diagram will be validated then used as an "
+              "implementation blueprint.)"))))
+
+(harness/register-command "diagram" "diagram-handler")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1162,7 +1162,7 @@ async fn main() -> anyhow::Result<()> {
         // `session` here is the session `--session` resolved (loaded or fresh);
         // its messages are the prior turns, the new prompt is appended after.
         let history = crate::agent::runner::convert_history(&session);
-        let response = agent
+        let (response, turn_tool_calls) = agent
             .run_print(
                 &msg,
                 cli.resolve_max_agent_turns(&cfg),
@@ -1199,7 +1199,10 @@ async fn main() -> anyhow::Result<()> {
         // fail without losing the lifecycle signal.
         if !cli.no_session {
             session.add_message(MessageRole::User, &msg);
-            session.add_message(MessageRole::Assistant, &response);
+            // Persist the full assistant turn — text PLUS the tool calls/
+            // results — so a resumed `--session` (e.g. an MCP delegation
+            // follow-up) sees what dirge actually did, not just a text blurb.
+            session.add_message_with_tool_calls(MessageRole::Assistant, &response, turn_tool_calls);
             crate::agent::review::maybe_fire_session_end(&agent, &session);
             if let Err(e) = session::storage::save_session(&mut session) {
                 eprintln!("warning: failed to save session: {}", e);
@@ -1580,7 +1583,7 @@ async fn run_headless_loop(
             )
             .await
         {
-            Ok(r) => r,
+            Ok((r, _tool_calls)) => r,
             Err(e) => {
                 eprintln!("[loop] error in iteration {}: {}", state.iteration, e);
                 return Ok(HeadlessLoopExit::MaxIterations);

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -65,7 +65,9 @@ impl AnyAgent {
         // session's history (via `convert_history`) so a headless run
         // continues where it left off instead of starting cold each time.
         history: Vec<rig::completion::Message>,
-    ) -> anyhow::Result<String> {
+        // Returns the final response text plus the turn's tool calls (so the
+        // caller can persist a full-fidelity assistant message).
+    ) -> anyhow::Result<(String, Vec<crate::session::ToolCallEntry>)> {
         // dirge-nqr: honor the cap explicitly even if the agent was
         // built with a different one. `run_print` is the headless
         // entry point — callers explicitly pass the cap they want.
@@ -124,9 +126,44 @@ impl AnyAgent {
         // can't claim success for a truncated or runner-died run.
         let mut completed = false;
         let mut truncated = false;
+        // Accumulate the turn's tool calls so the headless save is
+        // full-fidelity (matching the interactive path). Without this the
+        // saved assistant message carried only its final text, so a resumed
+        // `--session` lost every tool call/result — and a tool-heavy final
+        // turn saved an empty/partial message, reading as a cut-off end.
+        // Mirrors the UI's ToolCall/ToolResult accumulation
+        // (run_handlers/tool_call.rs + tool_result.rs).
+        use crate::session::{ToolCallEntry, ToolCallState};
+        let mut tool_calls: Vec<ToolCallEntry> = Vec::new();
 
         while let Some(event) = event_rx.recv().await {
             match event {
+                AgentEvent::ToolCall { id, name, args } => {
+                    // Start Interrupted; the matching ToolResult flips it to
+                    // Completed. An unanswered call stays Interrupted, which
+                    // convert_history re-emits so the model sees no orphan.
+                    tool_calls.push(ToolCallEntry {
+                        id: id.to_string(),
+                        name: name.to_string(),
+                        args,
+                        state: ToolCallState::Interrupted,
+                    });
+                }
+                AgentEvent::ToolResult { id, output, .. } => {
+                    let target = if !id.is_empty() {
+                        tool_calls.iter_mut().rev().find(|e| e.id == id.as_str())
+                    } else {
+                        tool_calls
+                            .iter_mut()
+                            .rev()
+                            .find(|e| matches!(e.state, ToolCallState::Interrupted))
+                    };
+                    if let Some(entry) = target {
+                        entry.state = ToolCallState::Completed {
+                            result: output.to_string(),
+                        };
+                    }
+                }
                 AgentEvent::Token(text) => {
                     full_response.push_str(&text);
                     if !suppress_inline {
@@ -252,7 +289,7 @@ impl AnyAgent {
                 "run ended without completing — the agent runner stopped before producing a result"
             ));
         }
-        Ok(full_response)
+        Ok((full_response, tool_calls))
     }
 }
 


### PR DESCRIPTION
## The resume "cutoff" bug
Found while testing the MCP delegation loop. `dirge -p --session <id>` saved the conversation, but the assistant message stored **only its final text** — every tool call/result was dropped (verified: a saved MCP session had `tool_calls=0` on assistant turns that actually wrote/edited files). Consequences on resume:

- A resumed `--session` (e.g. an MCP delegation follow-up) lost the *substance* of prior turns — dirge saw "I did X" but not what the tools actually did.
- A tool-heavy final turn — which often ends with little or no trailing text — saved an empty/thin assistant message, reading as a **cut-off end**.

(The companion resume fix — feeding the loaded history back to the model at all — already shipped in #406. This adds full fidelity.)

**Fix:** `run_print` now accumulates the turn's `ToolCall`/`ToolResult` events (mirroring the interactive `run_handlers/tool_call.rs` + `tool_result.rs`) and returns them; the print path saves via `add_message_with_tool_calls`, so `convert_history` re-emits the `tool_use`/`tool_result` blocks on resume. The `--loop` caller ignores them.

**Verified live:** `dirge -p --session X "create a file FOO.txt"` now saves the assistant message with `tool_calls=[write, read]` instead of `0`.

## Plugin review: `plugins/mermaid_diagram.janet`
Reviewed as requested. The structure is sound (the stem-prefixed hook names are a supported form; `request-prompt`/`append-system-prompt`/3-arg `add-custom-message` all exist). Fixed validation gaps in `validate-diagram`:
- The edge check only matched `-->` / `->>` / `---`, so valid `er`/`class`/`state` diagrams (and flowchart `-.->` / `==>`) were rejected for "no connections". Broadened to `--` / `->>` / `==>` / `-.-`.
- Added a `{}`-balance check (`{decision}` / `{{hexagon}}` nodes were unchecked).
- Dropped a stray `[` from the unbalanced-brackets error message.
- `max-retries` → `def` (never reassigned).

Parses clean (`janet parse-all`).

## Tests
Full suite 2612 pass; `run_print` signature change covered by the existing print tests + live verification.