### PR TITLE
skills: bundled workflow starter pack (debug, review-feedback, writing-skills)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -19,3 +19,12 @@ Detailed skill content here.
 Skills are auto-discovered at agent startup and listed in the `skill` tool
 description. The agent can call `skill "my-skill"` to load the full content on
 demand. Project skills override global skills by name.
+
+## Bundled starter skills
+
+The repo ships a small pack of general-purpose workflow skills under
+[`skills/`](../skills/) — `systematic-debugging`, `code-review-feedback`, and
+`writing-skills`. They are **not** installed automatically; copy the ones you
+want into a discovered location, e.g. `cp -r skills/systematic-debugging
+.dirge/skills/` (per project) or `~/.dirge/skills/` (global). See
+[skills/README.md](../skills/README.md).

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,44 @@
+# Bundled skills
+
+A small starter pack of general-purpose workflow skills. These are
+[Claude-compatible skills](../docs/skills.md): each is a directory with a
+`SKILL.md` the agent loads on demand via the `skill` tool, keyed off the
+`description` field.
+
+They are **not** installed automatically. To use one, copy its directory into a
+skills location dirge discovers — `.dirge/skills/` (or `.claude/skills/` /
+`.opencode/skills/`) in your project or home directory:
+
+```sh
+# per project
+cp -r skills/systematic-debugging .dirge/skills/
+# or globally for every project
+cp -r skills/code-review-feedback ~/.dirge/skills/
+```
+
+dirge picks them up at the next startup and lists them in the `skill` tool.
+
+## What's here
+
+| Skill | Loads when |
+|---|---|
+| [`systematic-debugging`](systematic-debugging/SKILL.md) | hitting a bug, test failure, or unexpected behavior — find root cause before fixing |
+| [`code-review-feedback`](code-review-feedback/SKILL.md) | acting on review feedback — verify and reason before implementing, no performative agreement |
+| [`writing-skills`](writing-skills/SKILL.md) | authoring or editing a skill |
+
+## Overlap with dirge's built-ins
+
+dirge already enforces several disciplines at the loop level — the verifier
+gate (verify before done), the cross-turn failure-recovery checkpoint, the
+`/plan` phased workflow, and the goal gate. These skills complement those with
+*proactive* guidance the model reaches for itself; they don't replace the
+gates.
+
+## Attribution
+
+`systematic-debugging` and `code-review-feedback` are adapted from the
+[superpowers](https://github.com/obra/superpowers) project by Jesse Vincent,
+used under the MIT License. `writing-skills` distills superpowers' skill-authoring
+guidance for dirge's skill system. The originals were vendored via
+[MiMo-Code](https://github.com/XiaomiMiMo/MiMo-Code); adapted here to dirge
+conventions (no cross-skill orchestration runtime, dirge-native tooling).

--- a/skills/code-review-feedback/SKILL.md
+++ b/skills/code-review-feedback/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: code-review-feedback
+description: Use when receiving code-review feedback, before implementing suggestions — especially when feedback seems unclear or technically questionable. Verify against the codebase and reason about each item instead of agreeing performatively or implementing blindly.
+---
+
+# Receiving Code Review
+
+## Overview
+
+Code review is a technical evaluation, not an emotional performance.
+
+**Core principle:** verify before implementing, ask before assuming, technical
+correctness over social comfort.
+
+## The response pattern
+
+```
+1. READ      — the whole review, without reacting
+2. UNDERSTAND — restate each item in your own words (or ask if unclear)
+3. VERIFY    — check it against codebase reality
+4. EVALUATE  — is it technically sound for THIS codebase?
+5. RESPOND   — technical acknowledgment, or reasoned pushback
+6. IMPLEMENT — one item at a time, test each
+```
+
+## No performative agreement
+
+Don't open with "You're absolutely right!", "Great point!", "Thanks for
+catching that!", or any gratitude/praise filler. State the fix instead, or just
+make it — the code shows you heard the feedback.
+
+- Acknowledge a correct item with the change: `Fixed — <what changed> in <where>`.
+- If you catch yourself about to type "Thanks" or "Good point," delete it and
+  state the fix.
+
+## Handle unclear feedback before implementing anything
+
+If any item is unclear, stop — don't implement the clear ones yet. Items are
+often related, and partial understanding produces the wrong implementation. Ask
+for clarification (the `question` tool), presenting your interpretations as
+options.
+
+> "I understand items 1, 2, 3, and 6. I need clarification on 4 and 5 before
+> implementing."
+
+## Evaluate external feedback skeptically
+
+Feedback from a human reviewer or an automated reviewer is a *suggestion to
+evaluate*, not an order to follow. Before implementing, check:
+
+1. Is it technically correct for **this** codebase and stack?
+2. Does it break existing functionality?
+3. Is there a reason the current implementation is the way it is?
+4. Does it hold across the platforms/versions you support?
+5. Does the reviewer have the full context?
+
+If a suggestion seems wrong, **push back with technical reasoning** — reference
+the tests/code that show it. If you can't verify it, say so: "I can't verify
+this without X — should I investigate, ask, or proceed?" If it conflicts with a
+prior decision the user made, stop and raise that first.
+
+## YAGNI check
+
+If a reviewer asks you to "implement this properly," grep for actual usage
+first. If nothing calls it: "This isn't called anywhere — remove it (YAGNI)?"
+If it is used, then implement it properly.
+
+## Implementation order
+
+1. Clarify everything unclear first.
+2. Then: blocking issues (breakage, security) → simple fixes (typos, imports) →
+   complex fixes (refactors, logic).
+3. Test each fix individually; verify no regressions.
+
+## If you pushed back and were wrong
+
+State it factually and move on — no long apology, no defending why you pushed
+back:
+
+> "You were right — I checked X and it does Y. Implementing now."
+
+## GitHub review threads
+
+When replying to inline review comments, reply *in the comment thread*
+(`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a
+top-level PR comment.
+
+## The bottom line
+
+Verify. Question. Then implement. Technical rigor over performative agreement.
+
+---
+
+*Adapted from [superpowers](https://github.com/obra/superpowers) by Jesse
+Vincent (MIT License).*

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes — find the root cause first instead of guessing at symptom patches.
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying
+issues.
+
+**Core principle:** find the root cause before attempting a fix. Symptom fixes
+are failure.
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT-CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose a fix.
+
+## When to Use
+
+Any technical issue — test failures, bugs, unexpected behavior, performance
+problems, build failures, integration issues. **Especially** when you're under
+time pressure, a "quick fix" seems obvious, you've already tried a fix that
+didn't work, or you don't fully understand the issue. Don't skip it because a
+bug "seems simple" — simple bugs have root causes too, and systematic is faster
+than thrashing.
+
+## The Four Phases
+
+Complete each phase before moving to the next.
+
+### Phase 1 — Root-cause investigation
+
+Before attempting any fix:
+
+1. **Read the error carefully.** Don't skip past it. Read the full stack trace;
+   note line numbers, paths, error codes. The exact answer is often in there.
+2. **Reproduce consistently.** Can you trigger it reliably? What are the exact
+   steps? If it's not reproducible, gather more data — don't guess.
+3. **Check recent changes.** `git diff` / recent commits, new dependencies,
+   config or environment differences. What changed that could cause this?
+4. **Instrument component boundaries** (multi-layer systems). Before proposing a
+   fix, add logging at each boundary — what data enters, what exits, whether
+   config/env propagates. Run once to see *where* it breaks, then investigate
+   that component specifically.
+5. **Trace data flow backward.** When the error is deep in the call stack, find
+   where the bad value *originates*: what passed it in, and what passed it to
+   that? Keep tracing up to the source and fix there, not at the symptom.
+
+### Phase 2 — Pattern analysis
+
+1. **Find working examples.** Locate similar code in the same codebase that
+   works.
+2. **Read references completely.** If you're following a pattern or reference
+   implementation, read every line — don't skim and adapt.
+3. **List every difference** between the working and broken cases, however
+   small. Don't assume "that can't matter."
+4. **Understand dependencies** — what config, environment, and assumptions the
+   code relies on.
+
+### Phase 3 — Hypothesis and testing
+
+1. **Form one hypothesis.** State it precisely: "I think X is the root cause
+   because Y."
+2. **Test minimally.** Make the smallest possible change to test it — one
+   variable at a time. Don't fix several things at once.
+3. **Verify before continuing.** Worked → Phase 4. Didn't → form a *new*
+   hypothesis; don't pile fixes on top.
+4. **When you don't know, say so.** Don't pretend. State what you've tried and
+   ask the user (the `question` tool) with concrete next-step options, or
+   research further.
+
+### Phase 4 — Implementation
+
+1. **Write a failing test first.** Simplest reproduction; automated if possible.
+   Have it before fixing.
+2. **Make one fix** — address the root cause, one change, no "while I'm here"
+   refactors.
+3. **Verify with fresh output.** Run the test and the surrounding suite; confirm
+   the issue is gone and nothing else broke. (dirge's verifier gate will hold
+   you to this at finalization — meet it honestly.)
+4. **If the fix doesn't work, stop and count.** Fewer than 3 attempts → return
+   to Phase 1 with the new information. **3+ failed fixes → question the
+   architecture**, don't attempt fix #4.
+
+When 3+ fixes fail and each reveals a new problem elsewhere or demands "massive
+refactoring," that's an architectural problem, not a failed hypothesis. Stop and
+raise it with the user (the `question` tool) — continue fixing vs. propose a
+refactor — rather than grinding on symptoms.
+
+## Red flags — stop and return to Phase 1
+
+If you catch yourself thinking any of these, stop:
+
+- "Quick fix for now, investigate later."
+- "Just try changing X and see if it works."
+- "Add several changes, then run the tests."
+- "It's probably X, let me fix that" (before tracing data flow).
+- "I don't fully understand this, but it might work."
+- "One more fix attempt" (after 2+ failures).
+
+## Common rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to need the process" | Simple bugs have root causes too; the process is fast for them. |
+| "Emergency, no time" | Systematic is *faster* than guess-and-check thrashing. |
+| "Try this first, investigate later" | The first fix sets the pattern. Do it right from the start. |
+| "I'll test after confirming the fix" | Untested fixes don't stick. Test first proves it. |
+| "Reference is long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it fully. |
+| "One more attempt" (after 2+ fails) | 3+ failures = architectural problem. Question the design. |
+
+## When investigation finds no root cause
+
+If the issue really is environmental, timing-dependent, or external: you've
+completed the process — document what you investigated, add appropriate handling
+(retry, timeout, clear error), and add logging for next time. But most
+"no root cause" cases are incomplete investigation.
+
+---
+
+*Adapted from [superpowers](https://github.com/obra/superpowers) by Jesse
+Vincent (MIT License).*

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: writing-skills
+description: Use when creating, editing, or reviewing a dirge skill — how to structure SKILL.md, write a description that gets the skill loaded at the right time, keep it token-efficient, and verify it actually changes behavior.
+---
+
+# Writing Skills
+
+## What a skill is
+
+A skill is an on-demand instruction bundle — a directory with a `SKILL.md` that
+the agent loads mid-session via the `skill` tool. dirge lists every skill's
+`name` + `description` up front; the agent reads the full body only when a task
+matches. Skills live in `.dirge/skills/<name>/` (project or home); project
+skills override global ones by name.
+
+**Skills are:** reusable techniques, patterns, and reference guides that apply
+across tasks.
+
+**Skills are NOT:** a narrative of how you solved one problem once.
+
+## When to create one (and when not to)
+
+Create a skill when a technique wasn't obvious, you'd reach for it again across
+projects, and it involves *judgment* (not a mechanical rule).
+
+Don't create a skill for:
+
+- **Project-specific facts or conventions** → use the `memory` tool, or
+  `AGENTS.md`/`CLAUDE.md`. Skills are for broadly-applicable know-how.
+- **One-off solutions** → not reusable.
+- **Mechanically-enforceable rules** → if a regex/validator/gate can enforce it,
+  automate it; save skills for judgment calls.
+
+## The description field is the trigger
+
+The `description` is the only thing the agent sees before deciding to load the
+skill, so it's the most important line. Write it as **triggering conditions**,
+not a workflow summary (a summary tempts the agent to act on the description
+*instead of* reading the skill).
+
+```yaml
+# weak — vague, no trigger, summarizes the process
+description: Helps with debugging by finding root causes through investigation.
+
+# strong — starts with "Use when", names the situation, no workflow
+description: Use when encountering a bug, test failure, or unexpected behavior, before proposing fixes.
+```
+
+Cover the words a future agent would actually be thinking ("test failure",
+"flaky", "race condition"), and start with **"Use when …"**. Third person, no
+first person.
+
+## SKILL.md structure
+
+```markdown
+---
+name: kebab-case-name
+description: Use when <trigger> — <one line on what it gives you>.
+---
+
+# Skill Name
+
+## Overview        — the core principle in 1–2 sentences
+## When to Use     — concrete triggering situations
+## <The content>   — the technique/pattern/checklist itself
+## Common Mistakes — the failure modes this prevents (a table works well)
+```
+
+Keep it focused on one technique. A table of "excuse → reality" or
+"mistake → fix" is a high-density way to close rationalizations.
+
+## Keep it token-efficient
+
+The body loads into context, so every line costs. Be ruthless:
+
+- **Reference, don't reproduce.** Point at `--help`, a man page, or another
+  skill instead of pasting their contents.
+- **Trim examples** to the shortest form that still teaches.
+- **Push heavy detail into supporting files** in the skill directory (e.g.
+  `reference.md`) and link them; the agent reads them only if needed.
+
+## Verify the skill changes behavior
+
+A skill that doesn't change what the agent does is dead weight. Check it the way
+you'd check a test:
+
+1. **Baseline** — give the task to a subagent (`task` tool) *without* the skill
+   and note how it goes wrong (the exact rationalizations it reaches for).
+2. **Write the skill** to address those specific failures.
+3. **Re-run** the same task with the skill loaded and confirm the behavior
+   changed.
+4. **Close loopholes** — when the agent finds a new way to rationalize around
+   the rule, name that excuse explicitly and re-check.
+
+If you skipped the baseline, you don't know whether the skill teaches the right
+thing — only that it sounds reasonable.
+
+## Lifecycle
+
+dirge's post-session skills curator manages skills over time (stale detection,
+consolidation, archiving) — so keep each skill single-purpose and well-described
+rather than bundling several concerns into one.
+
+---
+
+*Distilled from [superpowers](https://github.com/obra/superpowers) by Jesse
+Vincent (MIT License), adapted to dirge's skill system.*


### PR DESCRIPTION
Adds an opt-in starter pack of general-purpose workflow skills under `skills/`, adapted from the [superpowers](https://github.com/obra/superpowers) collection (MIT, Jesse Vincent) that [MiMo-Code](https://github.com/XiaomiMiMo/MiMo-Code) vendors.

## What's here

`.dirge/` is gitignored and dirge ships no skills today, so these live as a tracked starter pack at the repo root (mirroring `plugins/` and `prompts/`):

| Skill | Loads when |
|---|---|
| `systematic-debugging` | a bug / test failure / unexpected behavior — find root cause before fixing |
| `code-review-feedback` | acting on review feedback — verify and reason before implementing, no performative agreement |
| `writing-skills` | authoring or editing a skill |

Plus `skills/README.md` and a pointer in `docs/skills.md`.

## Adaptation (not a straight copy)

- Dropped the `compose:` names, `hidden:` field, and cross-skill references that assume MiMo's compose orchestration runtime; rewrote them to dirge-native tooling — the `question` tool, the verifier gate, the `memory` tool, the skills curator.
- Removed MiMo's autonomous-override blocks (dirge handles autonomous vs interactive at the loop level).
- Cleaned superpowers-isms ("your human partner" → "the user", easter eggs, persuasion/CSO jargon, graphviz tooling).
- Distilled `new-skill` (656 lines) into a focused ~150-line `writing-skills` matching dirge's format, description-as-trigger discovery, and the curator lifecycle.
- Kept MIT attribution to superpowers/Jesse Vincent in each file + the README.

## Install (opt-in, not auto-loaded)

```sh
cp -r skills/systematic-debugging .dirge/skills/   # per project
cp -r skills/code-review-feedback ~/.dirge/skills/  # or global
```

These complement dirge's loop-level gates (verifier, failure-recovery checkpoint, `/plan`, goal gate) rather than duplicating them, and keep the default prompt lean. Auto-discovery of the bundled `skills/` dir was deliberately not wired — loading discipline skills by default is a product decision and adds per-session prompt weight.