### PR TITLE
fix(ui): self-heal mouse capture + bracketed paste (intermittent scroll/select break)

### DIFF
--- a/src/ui/ansi.rs
+++ b/src/ui/ansi.rs
@@ -174,6 +174,94 @@ pub fn strip_escapes(s: &str, policy: StripPolicy) -> String {
     result
 }
 
+/// Strip every escape sequence EXCEPT SGR (`\x1b[…m`) — the color/style
+/// codes dirge's own markdown renderer bakes into `LineEntry::text` and
+/// that the chat painter parses back into ratatui spans. Everything else —
+/// cursor moves, scroll regions, private-mode sets/resets (`\x1b[?1000l`
+/// …), alt-screen toggles, OSC, DCS, RIS — is dropped, so a control
+/// sequence that slipped past content sanitization (a plugin custom
+/// message, an unsanitized writer) can never reach a terminal cell and
+/// corrupt global terminal state. Defense-in-depth behind the startup
+/// mode-set and the paint-loop re-assert.
+///
+/// Returns the input borrowed when it has no ESC at all — the common case
+/// — so plain lines allocate nothing.
+pub fn strip_non_sgr_escapes(s: &str) -> std::borrow::Cow<'_, str> {
+    if !s.contains('\x1b') {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                // CSI: collect through the final byte (0x40..=0x7e); keep
+                // the whole sequence only when it's SGR (final byte `m`).
+                let mut seq = String::from("\x1b[");
+                let mut sgr = false;
+                let mut n = 0;
+                for next in &mut chars {
+                    seq.push(next);
+                    if (0x40..=0x7e).contains(&(next as u32)) {
+                        sgr = next == 'm';
+                        break;
+                    }
+                    n += 1;
+                    if n >= 256 {
+                        break;
+                    }
+                }
+                if sgr {
+                    out.push_str(&seq);
+                }
+            }
+            Some(']') => {
+                // OSC: drop through BEL or ST (ESC \). Mirrors strip_escapes.
+                let mut n = 0;
+                while let Some(next) = chars.next() {
+                    if next == '\x07' {
+                        break;
+                    }
+                    if next == '\x1b' {
+                        let mut peek = chars.clone();
+                        if peek.next() == Some('\\') {
+                            chars = peek;
+                            break;
+                        }
+                    }
+                    n += 1;
+                    if n >= 256 {
+                        break;
+                    }
+                }
+            }
+            Some('P') | Some('X') | Some('^') | Some('_') => {
+                // DCS / SOS / PM / APC: drop through ST (ESC \).
+                let mut prev = '\0';
+                let mut n = 0;
+                for next in &mut chars {
+                    if prev == '\x1b' && next == '\\' {
+                        break;
+                    }
+                    prev = next;
+                    n += 1;
+                    if n >= 4096 {
+                        break;
+                    }
+                }
+            }
+            // Single-byte ESC sequence (incl. RIS `\x1bc`): drop both.
+            Some(_) => {}
+            None => break,
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 /// Strip ANSI CSI escape sequences (`\x1b[…m` and friends) from `s`,
 /// returning a clean printable string. Used by clipboard / selection
 /// paths: the renderer bakes SGR codes into `LineEntry::text` for
@@ -389,5 +477,34 @@ mod tests {
         let s = "a\x1b]0;payload\x1b[2J\x07b";
         let out = strip_escapes(s, StripPolicy::STRICT);
         assert_eq!(out, "ab");
+    }
+
+    #[test]
+    fn non_sgr_strip_keeps_sgr_drops_the_rest() {
+        // SGR (color/bold/reset) is preserved verbatim so markdown styling
+        // still parses; everything else is removed.
+        let s = "\x1b[1mbold\x1b[0m plain \x1b[31mred\x1b[m";
+        assert_eq!(strip_non_sgr_escapes(s), s, "pure SGR is untouched");
+
+        // The leak that breaks mouse: a private-mode reset embedded in text.
+        assert_eq!(
+            strip_non_sgr_escapes("before\x1b[?1000lafter"),
+            "beforeafter"
+        );
+        // Alt-screen toggle, cursor move, RIS, OSC title — all dropped,
+        // surrounding text + SGR kept.
+        assert_eq!(
+            strip_non_sgr_escapes("\x1b[?1049h\x1b[Hx\x1bc\x1b]0;t\x07\x1b[32mok\x1b[0m"),
+            "x\x1b[32mok\x1b[0m"
+        );
+    }
+
+    #[test]
+    fn non_sgr_strip_borrows_when_no_escape() {
+        // No ESC → no allocation (Cow::Borrowed).
+        assert!(matches!(
+            strip_non_sgr_escapes("plain text"),
+            std::borrow::Cow::Borrowed(_)
+        ));
     }
 }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -107,6 +107,44 @@ pub const CHAT_FRAME_ROWS: u16 = 2;
 /// gate always bound first — and the README's "≥100 cols" was wrong.
 const PANEL_AUTO_MIN_COLS: u16 = 152;
 
+/// Global terminal modes dirge owns and must keep asserted for its whole
+/// session: SGR mouse capture (`?1000`/`?1002`/`?1003`/`?1006`) so wheel +
+/// click reach the app, and bracketed paste (`?2004`). These are set once
+/// at startup ([`crate::ui::terminal::TerminalGuard::new`]); this is the
+/// exact same set, re-emitted periodically so a mid-session reset can't
+/// leave them off permanently. Both are idempotent with no visual effect
+/// when already enabled, so re-emitting on a throttle is safe. Notably this
+/// does NOT include the alternate screen (`?1049h`) — re-entering it can
+/// clear/flicker on some terminals — nor cursor visibility (managed per
+/// frame by `draw_bottom`).
+const TERMINAL_MODE_REASSERT: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h";
+
+/// How often [`tui_redraw`](Renderer::tui_redraw) re-asserts the terminal
+/// modes. Long enough that the extra `/dev/tty` write is negligible, short
+/// enough that a leaked reset self-heals before it's annoying.
+const MODE_REASSERT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Decide whether the terminal modes are due for re-assertion, returning
+/// the bytes to emit (or `None` when the throttle hasn't elapsed). Pure so
+/// the throttle + payload are unit-testable without a live terminal: a
+/// `None` `last` (first paint) always re-asserts; otherwise it waits
+/// [`MODE_REASSERT_INTERVAL`]. `saturating_duration_since` guards against a
+/// non-monotonic clock.
+fn mode_reassert_payload(
+    last: Option<std::time::Instant>,
+    now: std::time::Instant,
+) -> Option<&'static [u8]> {
+    let due = match last {
+        None => true,
+        Some(t) => now.saturating_duration_since(t) >= MODE_REASSERT_INTERVAL,
+    };
+    if due {
+        Some(TERMINAL_MODE_REASSERT)
+    } else {
+        None
+    }
+}
+
 #[cfg(feature = "experimental-ui-terminal-tab")]
 fn format_terminal_title(state: crate::ui::avatar::AvatarState, tool_name: Option<&str>) -> String {
     use crate::ui::avatar::AvatarState;
@@ -299,6 +337,15 @@ pub struct Renderer {
     /// 8ms repaint throttle to prevent /dev/tty write contention between
     /// keystroke-driven repaints — the root cause of typing stutter.
     last_paint: Option<std::time::Instant>,
+    /// Timestamp of the last terminal-mode re-assertion (SGR mouse capture
+    /// + bracketed paste). Those modes are enabled once at startup, but a
+    /// child program run via the bash tool (a pager / TUI) can reset them
+    /// mid-session by emitting `?1000l`/`?2004l` on exit — and there's no
+    /// other path that turns them back on, so the loss is permanent (wheel
+    /// scroll falls through to the terminal, selection stops reaching the
+    /// app). `tui_redraw` re-emits them on a throttle so dirge self-heals
+    /// within one interval of any such leak. `None` until the first paint.
+    last_mode_reassert: Option<std::time::Instant>,
     buffer: Vec<LineEntry>,
     partial: CompactString,
     partial_color: Color,
@@ -456,6 +503,7 @@ impl Renderer {
             spinner_tick: false,
             needs_paint: false,
             last_paint: None,
+            last_mode_reassert: None,
             buffer: Vec::new(),
             partial: CompactString::new(""),
             partial_color: Color::White,
@@ -523,6 +571,27 @@ impl Renderer {
         use crate::ui::avatar;
         use crate::ui::tui::bottom::{AvatarSpec, BottomBody};
         use crate::ui::tui::scene::{Scene, render_frame};
+
+        // Self-heal the global terminal modes (SGR mouse capture + bracketed
+        // paste). They're enabled once at startup, but a child program run
+        // through the bash tool — a pager or TUI (`git log` → `less`, `fzf`,
+        // `vim`, …) — opens /dev/tty and on exit emits `?1000l`/`?2004l` to
+        // restore ITS state, silently turning dirge's off. With no other
+        // re-enable path the loss is permanent: wheel scroll falls through to
+        // the terminal (the whole UI scrolls) and click/drag selection stops
+        // reaching the app. Re-emitting on a throttle (writing to a fresh
+        // /dev/tty, the same sink the guard's setup uses) heals it within one
+        // interval. Done before the 8ms paint throttle below so it keeps
+        // firing even while paints are coalesced.
+        if let Some(bytes) =
+            mode_reassert_payload(self.last_mode_reassert, std::time::Instant::now())
+        {
+            if let Some(mut tty) = crate::ui::terminal::open_tty_for_write() {
+                let _ = tty.write_all(bytes);
+                let _ = tty.flush();
+            }
+            self.last_mode_reassert = Some(std::time::Instant::now());
+        }
 
         // Re-clamp the scroll offset to the CURRENT geometry every frame. The
         // scroll mutators clamp at mutation time, but a terminal RESIZE changes

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -983,3 +983,54 @@ fn footer_shows_both_directions_when_scrolled() {
         "scrolled footer should mention BOTH directions; got:\n{scrolled}"
     );
 }
+
+// ── terminal-mode self-healing (fix/mouse-capture-self-heal) ──────────
+
+/// The re-assert payload re-enables exactly the modes dirge owns and that a
+/// child program can clobber: SGR mouse capture (so wheel + click reach the
+/// app) and bracketed paste. This is what heals "the whole UI scrolls off"
+/// — a leaked `?1000l` is undone by the next due paint re-emitting `?1000h`.
+#[test]
+fn mode_reassert_payload_re_enables_mouse_and_paste() {
+    let now = std::time::Instant::now();
+    let bytes = super::mode_reassert_payload(None, now).expect("first paint always re-asserts");
+    let s = std::str::from_utf8(bytes).unwrap();
+    assert!(
+        s.contains("\x1b[?1000h"),
+        "must re-enable basic mouse tracking"
+    );
+    assert!(
+        s.contains("\x1b[?1006h"),
+        "must re-enable SGR mouse encoding"
+    );
+    assert!(s.contains("\x1b[?2004h"), "must re-enable bracketed paste");
+    // Must NOT re-enter the alternate screen (would risk a per-second
+    // clear/flicker) or toggle cursor visibility (managed per frame).
+    assert!(!s.contains("\x1b[?1049h"), "must not re-enter alt screen");
+    assert!(!s.contains("\x1b[?25"), "must not touch cursor visibility");
+}
+
+/// The throttle: re-assert on the first paint, then suppress until the
+/// interval elapses, then re-assert again. A leak that lands between paints
+/// is healed within one interval.
+#[test]
+fn mode_reassert_payload_is_throttled() {
+    let t0 = std::time::Instant::now();
+    assert!(
+        super::mode_reassert_payload(None, t0).is_some(),
+        "first paint (no prior assert) re-asserts"
+    );
+    assert!(
+        super::mode_reassert_payload(Some(t0), t0).is_none(),
+        "same instant → not due"
+    );
+    assert!(
+        super::mode_reassert_payload(Some(t0), t0 + std::time::Duration::from_millis(100))
+            .is_none(),
+        "100ms later → still throttled"
+    );
+    assert!(
+        super::mode_reassert_payload(Some(t0), t0 + super::MODE_REASSERT_INTERVAL).is_some(),
+        "after the interval → re-asserts (self-heal)"
+    );
+}

--- a/src/ui/tui/chat.rs
+++ b/src/ui/tui/chat.rs
@@ -199,12 +199,20 @@ fn paint_line(buf: &mut Buffer, x: u16, y: u16, width: u16, entry: &LineEntry) {
     }
     let base_style = Style::default().fg(crossterm_to_ratatui(entry.color));
 
+    // Defense-in-depth: drop any non-SGR escape before it reaches a cell.
+    // SGR (color/bold) is kept so `into_text` can style markdown; a leaked
+    // control sequence (mouse/alt-screen/cursor/RIS) that slipped past
+    // content sanitization would otherwise be written raw to the terminal
+    // and corrupt global state. Borrowed (no alloc) for the common
+    // no-escape line.
+    let text = crate::ui::ansi::strip_non_sgr_escapes(&entry.text);
+
     // Try to parse SGR escapes. On parse error (malformed input)
     // fall back to plain set_stringn — better to show raw text
     // than to drop the line silently.
-    match entry.text.as_str().into_text() {
-        Ok(text) => {
-            if let Some(line) = text.lines.into_iter().next() {
+    match text.as_ref().into_text() {
+        Ok(parsed) => {
+            if let Some(line) = parsed.lines.into_iter().next() {
                 // Apply base style — Spans without their own fg
                 // inherit it; spans with fg keep theirs (patch is
                 // a merge, not an override).
@@ -214,7 +222,7 @@ fn paint_line(buf: &mut Buffer, x: u16, y: u16, width: u16, entry: &LineEntry) {
             }
         }
         Err(_) => {
-            buf.set_stringn(x, y, entry.text.as_str(), width as usize, base_style);
+            buf.set_stringn(x, y, text.as_ref(), width as usize, base_style);
         }
     }
 }


### PR DESCRIPTION
## Symptom

Intermittent in iTerm2 (and any native terminal): scroll and click-select work most of the time, then "something" breaks them — the wheel scrolls the whole UI off instead of the chat pane, and selection stops registering. Recovered only by restarting dirge.

## Root cause

Mouse capture (`?1000/1002/1003/1006`) and bracketed paste (`?2004`) are enabled **once at startup** (`TerminalGuard::new`) and never re-asserted. A child program run through the bash tool — a pager or TUI (`git log` → `less`, `fzf`, `vim`, `delta`, `htop`, …) — opens `/dev/tty` even when its stdout is captured, enables its own modes, and on exit emits `?1000l`/`?2004l`/`?1049l` to restore **its** state. That turns dirge's still-needed modes off, and there's no code path that turns them back on, so the loss is permanent until restart. Intermittent because only terminal-touching commands trigger it.

Verified the rest of the pipeline is correct (capture emitted at startup and never disabled by dirge; scroll/selection handlers fire on injected events; teardown restores modes) — the defect is specifically the *single-shot, never-re-asserted* modes.

## Fix (commit 1) — self-heal the modes

`tui_redraw` re-emits the SGR mouse + bracketed-paste DECSETs on a **1s throttle**, writing to a fresh `/dev/tty` (the same sink the guard's setup uses), so dirge self-heals within one interval of any leaked reset — regardless of source. Both sequences are idempotent with no visual effect when already set.

Deliberately scoped:
- **Excludes the alternate screen** (`?1049h`) — re-entering it can clear/flicker on some terminals.
- **Excludes cursor visibility** — managed per frame by `draw_bottom`.

Generalizes the existing one-off re-assert in the sandbox-attach path (`attach.rs:207-208`).

## Hardening (commit 2) — stop the leak at the source

`paint_line` now runs each chat line through `strip_non_sgr_escapes` before `into_text`/`set_stringn`. SGR (color/bold) is preserved so markdown still styles; every other escape — mouse toggles, alt-screen, cursor moves, RIS, OSC — is dropped, so a control sequence that slips past content sanitization (a plugin custom message, an unsanitized writer) can't reach a terminal cell and corrupt global state in the first place. Borrowed/no-alloc for the common no-escape line.

Together: commit 2 keeps escapes from leaking via the chat buffer; commit 1 heals the terminal regardless of what (else) leaks.

## Tests

- `mode_reassert_payload` — pure throttle+payload fn: first paint asserts, then throttled; payload re-enables `?1000h`/`?1006h`/`?2004h`, doesn't touch alt-screen/cursor.
- `strip_non_sgr_escapes` — keeps pure SGR verbatim; drops `?1000l`, alt-screen, cursor, RIS, OSC while keeping surrounding text + SGR; borrows when no ESC.
- PTY-verified end-to-end: `?1000h` re-emitted periodically during paints (5× over ~3s) instead of once at startup.
- Full suite green (2651).