### PR TITLE
fix(ui): review follow-ups for the mouse-capture (#412) and expand-toggle (#413) merges

### DIFF
--- a/src/ui/ansi.rs
+++ b/src/ui/ansi.rs
@@ -274,37 +274,78 @@ pub fn strip_non_sgr_escapes(s: &str) -> std::borrow::Cow<'_, str> {
 /// scroll regions) also strip cleanly — anything a misbehaving
 /// producer might leave behind in the buffer.
 pub fn strip_ansi(s: &str) -> String {
-    let bytes = s.as_bytes();
+    if !s.contains('\x1b') {
+        return s.to_string();
+    }
     let mut out = String::with_capacity(s.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
-            // CSI introducer. Skip to (and past) the final byte in
-            // the 0x40..=0x7E range.
-            let mut j = i + 2;
-            while j < bytes.len() && !(0x40..=0x7e).contains(&bytes[j]) {
-                j += 1;
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        // Drop the WHOLE escape sequence (including SGR) so the result is
+        // the exact set of glyphs the chat painter shows: `paint_line`
+        // runs `strip_non_sgr_escapes` (drops every non-SGR sequence) then
+        // `into_text` (consumes the kept SGR into styling), leaving the
+        // same fully-stripped text. Keeping the two in lockstep is what
+        // makes mouse selection / clipboard map to the right cells; the
+        // old version kept OSC/DCS/RIS payloads that the painter dropped,
+        // which mis-mapped selection on any line with such an escape.
+        match chars.next() {
+            Some('[') => {
+                // CSI: drop through the final byte (0x40..=0x7e).
+                let mut n = 0;
+                for next in &mut chars {
+                    if (0x40..=0x7e).contains(&(next as u32)) {
+                        break;
+                    }
+                    n += 1;
+                    if n >= 256 {
+                        break;
+                    }
+                }
             }
-            i = j.saturating_add(1).min(bytes.len());
-            continue;
+            Some(']') => {
+                // OSC: drop through BEL or ST (ESC \).
+                let mut n = 0;
+                while let Some(next) = chars.next() {
+                    if next == '\x07' {
+                        break;
+                    }
+                    if next == '\x1b' {
+                        let mut peek = chars.clone();
+                        if peek.next() == Some('\\') {
+                            chars = peek;
+                            break;
+                        }
+                    }
+                    n += 1;
+                    if n >= 256 {
+                        break;
+                    }
+                }
+            }
+            Some('P') | Some('X') | Some('^') | Some('_') => {
+                // DCS / SOS / PM / APC: drop through ST (ESC \).
+                let mut prev = '\0';
+                let mut n = 0;
+                for next in &mut chars {
+                    if prev == '\x1b' && next == '\\' {
+                        break;
+                    }
+                    prev = next;
+                    n += 1;
+                    if n >= 4096 {
+                        break;
+                    }
+                }
+            }
+            // Two-byte ESC sequence (RIS `\x1bc`, index, save/restore, …):
+            // drop both bytes.
+            Some(_) => {}
+            None => break,
         }
-        // Single ESC not followed by `[` — drop it alone to be
-        // safe (could be an OSC/DCS start; better not to copy).
-        if bytes[i] == 0x1b {
-            i += 1;
-            continue;
-        }
-        // UTF-8 step.
-        let step = match bytes[i] {
-            b if b < 0x80 => 1,
-            b if b < 0xC0 => 1,
-            b if b < 0xE0 => 2,
-            b if b < 0xF0 => 3,
-            _ => 4,
-        };
-        let end = (i + step).min(bytes.len());
-        out.push_str(&s[i..end]);
-        i = end;
     }
     out
 }
@@ -379,11 +420,40 @@ mod tests {
     }
 
     #[test]
-    fn strip_ansi_drops_lone_esc() {
-        // ESC not followed by `[` — drop it on its own to keep the
-        // clipboard payload safe (could be the head of an OSC/DCS).
-        let s = "a\x1bb";
-        assert_eq!(strip_ansi(s), "ab");
+    fn strip_ansi_drops_two_byte_esc_sequence() {
+        // ESC + a byte is a two-byte escape (RIS `\x1bc`, index `\x1bD`, …);
+        // drop both so the result matches what the painter renders.
+        assert_eq!(strip_ansi("a\x1bcb"), "ab");
+    }
+
+    #[test]
+    fn strip_ansi_drops_osc_and_dcs_fully() {
+        // OSC (title) and DCS payloads are dropped whole — not left as
+        // residue — so they don't desync the selection char model from the
+        // painted glyphs.
+        assert_eq!(strip_ansi("a\x1b]0;title\x07b"), "ab");
+        assert_eq!(strip_ansi("a\x1bPq...data\x1b\\b"), "ab");
+        // The mouse-break escape and an SGR around plain text.
+        assert_eq!(strip_ansi("x\x1b[?1000l\x1b[32mok\x1b[0m"), "xok");
+    }
+
+    /// Selection maps over `strip_ansi`; the painter shows
+    /// `strip_non_sgr_escapes` then SGR-parsed-away. The two must produce
+    /// the same visible glyphs for any escape, or click-select mis-maps.
+    #[test]
+    fn strip_ansi_matches_painter_glyphs() {
+        for s in [
+            "plain",
+            "a\x1b[31mred\x1b[0mb",
+            "a\x1b]0;t\x07b", // OSC
+            "a\x1bcb",        // RIS
+            "a\x1b[?1000lb",  // private-mode reset
+            "a\x1b[2;5Hb",    // cursor move
+        ] {
+            // painter residue = drop non-SGR, then drop the kept SGR.
+            let painter = strip_ansi(&strip_non_sgr_escapes(s));
+            assert_eq!(strip_ansi(s), painter, "mismatch for {s:?}");
+        }
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1544,17 +1544,24 @@ pub async fn run_interactive(
                                 ExpandToggle::Collapse {
                                     start,
                                     expected_len,
+                                    eviction_gen,
                                 } => {
-                                    // Only truncate if the expansion is still
-                                    // the tail (nothing streamed / evicted
-                                    // since) — otherwise leave it as history.
-                                    if renderer.buffer_len() == expected_len {
+                                    // Truncate back to the expansion only if it
+                                    // is still the tail AND no front-eviction
+                                    // shifted indices since (a length match
+                                    // alone can coincide after eviction and
+                                    // delete live content). Otherwise just drop
+                                    // the anchor and leave it as history.
+                                    if renderer.buffer_len() == expected_len
+                                        && renderer.eviction_generation() == eviction_gen
+                                    {
                                         renderer.replace_from(start, Vec::new());
                                     }
                                     ui.expansion_anchor = None;
                                 }
                                 ExpandToggle::Expand => {
                                     let start = renderer.buffer_len();
+                                    let gen_before = renderer.eviction_generation();
                                     match crate::ui::state::select_expand_source(
                                         live,
                                         ui.expand_target,
@@ -1583,8 +1590,16 @@ pub async fn run_interactive(
                                         ExpandSource::None => {}
                                     }
                                     let end = renderer.buffer_len();
-                                    if end > start {
-                                        ui.expansion_anchor = Some((start, end));
+                                    // Record the anchor only if the append
+                                    // didn't trip eviction (which would have
+                                    // shifted `start`). If it did, the block
+                                    // stays as history and can't be collapsed —
+                                    // benign, and far better than a stale index.
+                                    if end > start
+                                        && renderer.eviction_generation() == gen_before
+                                    {
+                                        ui.expansion_anchor =
+                                            Some((start, end, renderer.eviction_generation()));
                                     }
                                 }
                                 ExpandToggle::Nothing => {}

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -346,6 +346,13 @@ pub struct Renderer {
     /// app). `tui_redraw` re-emits them on a throttle so dirge self-heals
     /// within one interval of any such leak. `None` until the first paint.
     last_mode_reassert: Option<std::time::Instant>,
+    /// Bumped each time scrollback eviction drains lines from the FRONT of
+    /// `buffer`, which shifts every absolute line index down. Consumers
+    /// holding an absolute index across appends (the Ctrl+O expansion
+    /// anchor) capture this and bail if it changed — a buffer-length
+    /// coincidence alone can't tell whether an eviction invalidated the
+    /// index.
+    eviction_generation: u64,
     buffer: Vec<LineEntry>,
     partial: CompactString,
     partial_color: Color,
@@ -504,6 +511,7 @@ impl Renderer {
             needs_paint: false,
             last_paint: None,
             last_mode_reassert: None,
+            eviction_generation: 0,
             buffer: Vec::new(),
             partial: CompactString::new(""),
             partial_color: Color::White,
@@ -1256,6 +1264,12 @@ impl Renderer {
         self.buffer.len()
     }
 
+    /// Counter of front-eviction events. A held absolute line index is
+    /// only valid while this is unchanged (see `eviction_generation`).
+    pub fn eviction_generation(&self) -> u64 {
+        self.eviction_generation
+    }
+
     #[allow(dead_code)]
     pub fn buffer_lines(&self) -> Vec<&str> {
         self.buffer.iter().map(|e| e.text.as_str()).collect()
@@ -1507,6 +1521,9 @@ impl Renderer {
         if self.buffer.len() > MAX_SCROLLBACK {
             let drop_n = DRAIN_CHUNK;
             self.buffer.drain(..drop_n);
+            // Front eviction shifts every absolute index down — invalidate
+            // any held line anchor (see `eviction_generation`).
+            self.eviction_generation = self.eviction_generation.wrapping_add(1);
             // Adjust absolute line indices used by selection +
             // scrolling. `lines` field tracks the same counter
             // used by selection_indices_stay_absolute_under_streaming_appends

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -583,14 +583,13 @@ impl Renderer {
         // /dev/tty, the same sink the guard's setup uses) heals it within one
         // interval. Done before the 8ms paint throttle below so it keeps
         // firing even while paints are coalesced.
-        if let Some(bytes) =
-            mode_reassert_payload(self.last_mode_reassert, std::time::Instant::now())
-        {
+        let now = std::time::Instant::now();
+        if let Some(bytes) = mode_reassert_payload(self.last_mode_reassert, now) {
             if let Some(mut tty) = crate::ui::terminal::open_tty_for_write() {
                 let _ = tty.write_all(bytes);
                 let _ = tty.flush();
             }
-            self.last_mode_reassert = Some(std::time::Instant::now());
+            self.last_mode_reassert = Some(now);
         }
 
         // Re-clamp the scroll offset to the CURRENT geometry every frame. The

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1034,3 +1034,20 @@ fn mode_reassert_payload_is_throttled() {
         "after the interval → re-asserts (self-heal)"
     );
 }
+
+/// Scrollback eviction (front drain past MAX_SCROLLBACK) bumps the
+/// eviction generation — the counter the Ctrl+O collapse guard relies on
+/// to know an absolute line anchor has been invalidated.
+#[test]
+fn eviction_generation_bumps_when_scrollback_overflows() {
+    let mut r = Renderer::new().expect("renderer");
+    assert_eq!(r.eviction_generation(), 0);
+    // MAX_SCROLLBACK is 20_000; push enough to trigger at least one drain.
+    for i in 0..20_050 {
+        let _ = r.write_line(&format!("l{i}"), Color::White);
+    }
+    assert!(
+        r.eviction_generation() >= 1,
+        "front eviction must bump the generation"
+    );
+}

--- a/src/ui/run_handlers/dirge_5h5_repro.rs
+++ b/src/ui/run_handlers/dirge_5h5_repro.rs
@@ -222,7 +222,7 @@ struct State {
     last_collapsed: Option<crate::ui::tool_display::CollapsedToolResult>,
     last_thinking: Option<String>,
     expand_target: crate::ui::state::ExpandTarget,
-    expansion_anchor: Option<(usize, usize)>,
+    expansion_anchor: Option<(usize, usize, u64)>,
     last_user_prompt: String,
     active_plan: Option<crate::agent::plan::runtime::ActivePlan>,
 }

--- a/src/ui/run_handlers/mod.rs
+++ b/src/ui/run_handlers/mod.rs
@@ -86,7 +86,7 @@ pub(super) struct RunCtx<'a> {
     /// burst before clearing `reasoning_buf`.
     pub last_thinking: &'a mut Option<String>,
     pub expand_target: &'a mut crate::ui::state::ExpandTarget,
-    pub expansion_anchor: &'a mut Option<(usize, usize)>,
+    pub expansion_anchor: &'a mut Option<(usize, usize, u64)>,
     pub last_user_prompt: &'a mut String,
     pub cli: &'a Cli,
     pub cfg: &'a Config,

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -55,9 +55,17 @@ pub(crate) enum ExpandTarget {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExpandToggle {
     /// An expansion is showing — collapse it. `start` is where it was
-    /// appended; `expected_len` is the buffer length recorded at expand
-    /// time (truncate only if the buffer still matches).
-    Collapse { start: usize, expected_len: usize },
+    /// appended, `expected_len` the buffer length recorded at expand time,
+    /// and `eviction_gen` the renderer's eviction counter then. The handler
+    /// truncates back to `start` only if BOTH the length still matches AND
+    /// the eviction counter is unchanged — so a front-eviction that shifted
+    /// indices (even if the length coincidentally returns) can't truncate
+    /// live content.
+    Collapse {
+        start: usize,
+        expected_len: usize,
+        eviction_gen: u64,
+    },
     /// Collapsed with something to show — expand it.
     Expand,
     /// Nothing has been truncated yet — no-op.
@@ -66,11 +74,12 @@ pub(crate) enum ExpandToggle {
 
 /// Decide the toggle action from the current anchor and whether any
 /// expandable source exists.
-pub(crate) fn expand_toggle(anchor: Option<(usize, usize)>, has_source: bool) -> ExpandToggle {
+pub(crate) fn expand_toggle(anchor: Option<(usize, usize, u64)>, has_source: bool) -> ExpandToggle {
     match anchor {
-        Some((start, expected_len)) => ExpandToggle::Collapse {
+        Some((start, expected_len, eviction_gen)) => ExpandToggle::Collapse {
             start,
             expected_len,
+            eviction_gen,
         },
         None if has_source => ExpandToggle::Expand,
         None => ExpandToggle::Nothing,
@@ -162,13 +171,13 @@ pub(crate) struct UiState {
     /// thinking burst (`last_thinking`) and tool output (`last_collapsed`).
     pub(crate) expand_target: ExpandTarget,
     /// Drives the expand ↔ collapse toggle. `None` when collapsed. When
-    /// expanded, holds `(start, expected_len)`: the buffer index where the
-    /// full block was appended, and the buffer length right after. Collapse
-    /// truncates back to `start` only if the buffer is still that length
-    /// (i.e. the expansion is still the tail) — so streamed output or
-    /// buffer-cap eviction after expanding can't make collapse delete real
-    /// content.
-    pub(crate) expansion_anchor: Option<(usize, usize)>,
+    /// expanded, holds `(start, expected_len, eviction_gen)`: the buffer
+    /// index where the full block was appended, the buffer length right
+    /// after, and the renderer's front-eviction counter then. Collapse
+    /// truncates back to `start` only if the length still matches AND the
+    /// eviction counter is unchanged — so streamed output or buffer-cap
+    /// eviction after expanding can't make collapse delete real content.
+    pub(crate) expansion_anchor: Option<(usize, usize, u64)>,
 
     // ── User toggles ─────────────────────────────────────────────────
     pub(crate) show_reasoning: bool,
@@ -401,10 +410,11 @@ mod tests {
     #[test]
     fn toggle_collapses_when_shown() {
         assert_eq!(
-            expand_toggle(Some((10, 18)), true),
+            expand_toggle(Some((10, 18, 3)), true),
             ExpandToggle::Collapse {
                 start: 10,
-                expected_len: 18
+                expected_len: 18,
+                eviction_gen: 3,
             }
         );
     }


### PR DESCRIPTION
Two real bugs found while reviewing the merged #412 and #413. Both features are already in main (squash-merged), so these fixes target main directly.

## 1. strip_ansi vs the painter — selection/clipboard mis-map (from #412)

#412's hardening made `paint_line` drop every non-SGR escape before rendering, but the selection/clipboard path still mapped over `strip_ansi`, which only consumed CSI and **kept OSC/DCS/RIS payloads**. On a line containing such an escape the painter showed fewer glyphs than the selection model counted, so click-drag highlighted the wrong cells and copy grabbed bytes the user never saw — on exactly the unsanitized-escape inputs the strip exists to defend against.

`strip_ansi` now consumes **every** escape sequence (CSI incl. SGR, OSC, DCS/PM/APC/SOS, two-byte ESC like RIS), so its output equals the painter's visible glyphs. A test asserts the two agree across OSC/RIS/CSI/SGR inputs. (Also binds `Instant::now()` once in the mode re-assert — cosmetic.)

## 2. Ctrl+O collapse vs scrollback eviction — could truncate live content (from #413)

The expand/collapse toggle stored an absolute `(start, expected_len)` anchor and collapsed when `buffer_len() == expected_len`. That guard is unsound under scrollback eviction: a front drain shifts every index down but the anchor wasn't rebased, so if the length coincidentally returned to `expected_len` after an eviction, collapse would `replace_from(start, …)` over **live** content.

Added an `eviction_generation` counter to the renderer (bumped on every front drain). The anchor now carries the generation captured at expand time; collapse truncates only if the length matches **and** the generation is unchanged. The expand path also skips recording the anchor if the append itself tripped eviction (start already stale) — the block stays as history instead of risking a bad index.

## Tests
- `strip_ansi` fully-strips OSC/DCS/RIS; `strip_ansi_matches_painter_glyphs` asserts paint/selection agreement.
- `expand_toggle` carries the generation through `ExpandToggle::Collapse`.
- `eviction_generation_bumps_when_scrollback_overflows` covers the counter.
- Full suite green (2658).