### PR TITLE
Fast compaction, visible progress, memory-awareness feedback

### DIFF
--- a/src/agent/agent_loop/bridge.rs
+++ b/src/agent/agent_loop/bridge.rs
@@ -103,6 +103,9 @@ impl EventBridge {
             // conversion needed — the UI shows a status line when it
             // sees the event. In the future this could emit a
             // dedicated AgentEvent variant for richer UI feedback.
+            LoopEvent::CompactionStarted { tokens_before } => {
+                vec![AgentEvent::CompactionStarted { tokens_before }]
+            }
             LoopEvent::ContextCompacted {
                 ref new_session_id,
                 tokens_before,

--- a/src/agent/agent_loop/bridge_tests.rs
+++ b/src/agent/agent_loop/bridge_tests.rs
@@ -679,6 +679,7 @@ fn full_run_event_sequence_translates_correctly() {
             AgentEvent::Done { .. } => "Done",
             AgentEvent::Error(_) => "Error",
             AgentEvent::ContextOverflow { .. } => "ContextOverflow",
+            AgentEvent::CompactionStarted { .. } => "CompactionStarted",
             AgentEvent::ContextCompacted { .. } => "ContextCompacted",
             AgentEvent::CheckpointRefresh { .. } => "CheckpointRefresh",
             AgentEvent::Interjected { .. } => "Interjected",

--- a/src/agent/agent_loop/context_manager.rs
+++ b/src/agent/agent_loop/context_manager.rs
@@ -335,6 +335,26 @@ pub fn incremental_checkpoint_enabled() -> bool {
     *INCREMENTAL_CHECKPOINT.get().unwrap_or(&true)
 }
 
+/// Round 2 (memory-awareness feedback): set when background learning
+/// (post-session consolidation) has written new memories. The system-prompt
+/// memory block is baked at agent-build time, so mid-session writes wouldn't
+/// otherwise reach the running agent until restart. The loop consumes this
+/// at the next turn boundary and re-injects the refreshed memory block.
+static MEMORIES_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Mark consolidated memories as changed; the running loop re-injects the
+/// refreshed block at its next turn boundary. Called by the post-session
+/// orchestrator after its learning passes complete.
+pub fn mark_memories_dirty() {
+    MEMORIES_DIRTY.store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// Consume the memory-dirty flag — returns `true` exactly once per `mark`,
+/// resetting it. Cheap to poll every turn (a single atomic swap).
+pub fn take_memories_dirty() -> bool {
+    MEMORIES_DIRTY.swap(false, std::sync::atomic::Ordering::AcqRel)
+}
+
 /// Clamp a configured early-fold threshold into a safe range. An override
 /// may only make the NORMAL fold fire *earlier* — never later than the
 /// default and never below a floor that would fold almost immediately —

--- a/src/agent/agent_loop/h7_smoke.rs
+++ b/src/agent/agent_loop/h7_smoke.rs
@@ -154,6 +154,9 @@ fn dump_events(events: &[AgentEvent]) {
             AgentEvent::UserMessage { content } => {
                 eprintln!("\n[user_message] {content}");
             }
+            AgentEvent::CompactionStarted { .. } => {
+                eprintln!("\n[compaction_started]");
+            }
             AgentEvent::ContextCompacted { .. } => {
                 eprintln!("\n[context_compacted]");
             }

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -1224,6 +1224,7 @@ mod tests {
             AgentEvent::Interjected { .. } => "Interjected",
             AgentEvent::CustomMessage { .. } => "CustomMessage",
             AgentEvent::UserMessage { .. } => "UserMessage",
+            AgentEvent::CompactionStarted { .. } => "CompactionStarted",
             AgentEvent::ContextCompacted { .. } => "ContextCompacted",
             AgentEvent::CheckpointRefresh { .. } => "CheckpointRefresh",
             AgentEvent::RetryNotice { .. } => "RetryNotice",

--- a/src/agent/agent_loop/message.rs
+++ b/src/agent/agent_loop/message.rs
@@ -455,6 +455,12 @@ pub enum LoopEvent {
         tool_results: Vec<ToolResultMessage>,
     },
 
+    /// A destructive compaction fold is about to run its summarizer —
+    /// emitted before the (slow) LLM call so the UI can show a
+    /// "compacting…" indicator during the wait. `ContextCompacted`
+    /// follows on completion.
+    CompactionStarted { tokens_before: u64 },
+
     /// Context compression fired — middle turns were summarized
     /// and the session id rotated. The UI should show a status
     /// line. Carries the new session id for lineage tracking.
@@ -580,6 +586,7 @@ impl LoopEvent {
             LoopEvent::AgentEnd { .. } => "agent_end",
             LoopEvent::TurnStart => "turn_start",
             LoopEvent::TurnEnd { .. } => "turn_end",
+            LoopEvent::CompactionStarted { .. } => "compaction_started",
             LoopEvent::ContextCompacted { .. } => "context_compacted",
             LoopEvent::CheckpointRefresh { .. } => "checkpoint_refresh",
             LoopEvent::RetryNotice { .. } => "retry_notice",

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -373,32 +373,80 @@ fn record_compaction_outcome(failures: &mut u32, outcome: SummaryOutcome) {
     }
 }
 
+/// A background-generated running summary that the destructive fold can
+/// reuse instead of summarizing inline. The summary covers
+/// `messages[0..boundary]` of the live context; `generation` is the fold
+/// epoch it was built under. A destructive fold rebuilds the context (the
+/// message indices change), so it bumps the epoch — a checkpoint whose
+/// `generation` no longer matches the loop's is stale and won't be reused.
+#[derive(Clone)]
+struct CachedCheckpoint {
+    summary: String,
+    boundary: usize,
+    generation: u64,
+}
+
+/// Loop-owned slot holding the freshest reusable checkpoint, shared with
+/// the detached checkpoint tasks (which write it) and the fold (which reads
+/// it). `None` means no reusable summary is available — the fold falls back
+/// to an inline summarizer call.
+type CheckpointSlot = std::sync::Arc<std::sync::Mutex<Option<CachedCheckpoint>>>;
+
+/// Wall-clock ceiling on the inline compaction summarizer. A fold blocks
+/// the loop until it returns; without a bound, a provider that stalls
+/// without erroring (no chunks, stream never closes) freezes the session
+/// indefinitely. On timeout the fold keeps the pruned context (a Failed
+/// outcome) rather than hanging — the next turn retries or the breaker
+/// eventually latches.
+const COMPACTION_SUMMARY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Wall-clock ceiling on a background checkpoint summarizer call. The
+/// checkpoint is detached so it never blocks the loop, but a hung provider
+/// would otherwise leak the task forever; bound it so it gives up.
+const CHECKPOINT_SUMMARY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Spawn a background incremental checkpoint: summarize a snapshot of the
-/// current context off the loop and emit [`LoopEvent::CheckpointRefresh`]
-/// so the consumer persists it to the durable checkpoint WITHOUT folding.
-/// Best-effort — a summarizer error or invalid summary is silently dropped
-/// (the next threshold, or the eventual destructive fold, will write one).
+/// current context off the loop, store it in `slot` for the next fold to
+/// reuse, and emit [`LoopEvent::CheckpointRefresh`] so the consumer
+/// persists it to the durable checkpoint WITHOUT folding. Best-effort — a
+/// summarizer error, timeout, or invalid summary is silently dropped (the
+/// next threshold, or the eventual destructive fold, will write one).
 /// Mirrors MiMo's background checkpoint writer.
 fn spawn_incremental_checkpoint(
     sfn: crate::agent::compression::SummarizeFn,
     messages: Vec<serde_json::Value>,
     emit: mpsc::Sender<LoopEvent>,
+    slot: CheckpointSlot,
+    generation: u64,
 ) {
     tokio::spawn(async move {
         use crate::agent::compression;
         if messages.is_empty() {
             return;
         }
+        // Boundary = the snapshot length: this summary covers messages
+        // [0..boundary]. Captured before the await so it reflects exactly
+        // what was summarized, regardless of what the loop appends meanwhile.
+        let boundary = messages.len();
         let budget = compression::summary_budget(compression::estimate_messages_tokens(&messages));
         let prompt = compression::build_summary_prompt(&messages, budget, None, None);
-        if let Ok(summary) = sfn(prompt).await
+        let result = tokio::time::timeout(CHECKPOINT_SUMMARY_TIMEOUT, sfn(prompt)).await;
+        if let Ok(Ok(summary)) = result
             && compression::validate_summary(&summary)
         {
+            if let Ok(mut guard) = slot.lock() {
+                *guard = Some(CachedCheckpoint {
+                    summary: summary.clone(),
+                    boundary,
+                    generation,
+                });
+            }
             let _ = emit.send(LoopEvent::CheckpointRefresh { summary }).await;
         }
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_compaction_pass(
     current_context: &mut Context,
     summarize_fn: &Option<crate::agent::compression::SummarizeFn>,
@@ -407,6 +455,9 @@ async fn run_compaction_pass(
     memory_provider: &Option<std::sync::Arc<dyn crate::extras::memory_provider::MemoryProvider>>,
     compaction_hooks: Option<&crate::agent::agent_loop::types::CompactionHooks>,
     emit: &mpsc::Sender<LoopEvent>,
+    checkpoint_slot: &CheckpointSlot,
+    generation: &mut u64,
+    fold_target: u64,
 ) -> SummaryOutcome {
     run_compaction_pass_with_focus(
         current_context,
@@ -417,6 +468,9 @@ async fn run_compaction_pass(
         memory_provider,
         compaction_hooks,
         emit,
+        checkpoint_slot,
+        generation,
+        fold_target,
     )
     .await
 }
@@ -442,6 +496,13 @@ async fn run_compaction_pass_with_focus(
     memory_provider: &Option<std::sync::Arc<dyn crate::extras::memory_provider::MemoryProvider>>,
     compaction_hooks: Option<&crate::agent::agent_loop::types::CompactionHooks>,
     emit: &mpsc::Sender<LoopEvent>,
+    // Round 1 (fast compaction): reusable background-checkpoint slot, the
+    // current fold epoch (bumped on a successful destructive fold so
+    // pre-fold checkpoints go stale), and the token level reuse must clear
+    // to count as "fast enough" (else fall back to inline summarization).
+    checkpoint_slot: &CheckpointSlot,
+    generation: &mut u64,
+    fold_target: u64,
 ) -> SummaryOutcome {
     use crate::agent::compression;
 
@@ -488,12 +549,55 @@ async fn run_compaction_pass_with_focus(
             "compaction summarizer failed {compaction_failures} consecutive times — circuit breaker open, skipping LLM summarization",
         );
     } else if let Some(sfn) = summarize_fn {
+        // Fast path (Round 1): reuse a fresh background-checkpoint summary
+        // instead of summarizing inline. The expensive summarization already
+        // ran off the loop; here the fold is just prune + splice. Only when
+        // the checkpoint is from the current fold epoch AND reusing it
+        // actually clears `fold_target` — otherwise fall through to inline.
+        let reusable = checkpoint_slot
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .filter(|cp| cp.generation == *generation);
+        let mut reused = false;
+        if let Some(cp) = reusable
+            && let Some((new_msgs, first_kept)) = compression::apply_checkpoint_summary(
+                &current_context.messages,
+                &cp.summary,
+                cp.boundary,
+            )
+        {
+            let projected = compression::estimate_messages_tokens(&new_msgs);
+            if projected <= fold_target {
+                current_context.messages = new_msgs;
+                after_summary = projected;
+                applied_summary = cp.summary;
+                applied_first_kept = first_kept;
+                outcome = SummaryOutcome::Succeeded(first_kept);
+                reused = true;
+                tracing::info!(
+                    target: "dirge::agent_loop",
+                    boundary = cp.boundary,
+                    tokens_after = projected,
+                    "fast compaction: reused background checkpoint summary (no inline LLM call)",
+                );
+            }
+        }
+
         let (start, end) = compression::compute_compress_window(
             &current_context.messages,
             compression::PROTECT_HEAD_DEFAULT,
             protect_tail.max(compression::PROTECT_TAIL_DEFAULT),
         );
-        if start < end {
+        if !reused && start < end {
+            // Signal the UI BEFORE the multi-second summarizer call so it
+            // can show a "compacting…" indicator during the wait instead of
+            // appearing frozen. `ContextCompacted` follows on completion.
+            let _ = emit
+                .send(LoopEvent::CompactionStarted {
+                    tokens_before: before,
+                })
+                .await;
             let middle: Vec<serde_json::Value> = current_context.messages[start..end].to_vec();
             // Carry forward any previous summary body for iterative
             // re-compression (Hermes _find_latest_context_summary).
@@ -528,7 +632,16 @@ async fn run_compaction_pass_with_focus(
                         prev.as_deref(),
                         augmented_focus.as_deref(),
                     );
-                    sfn(prompt).await
+                    // Bound the inline call: a provider that stalls without
+                    // erroring would otherwise freeze the loop indefinitely.
+                    // On timeout, keep the pruned context (Failed outcome).
+                    match tokio::time::timeout(COMPACTION_SUMMARY_TIMEOUT, sfn(prompt)).await {
+                        Ok(r) => r,
+                        Err(_) => Err(anyhow::anyhow!(
+                            "compaction summarizer timed out after {}s",
+                            COMPACTION_SUMMARY_TIMEOUT.as_secs()
+                        )),
+                    }
                 }
             };
             match summary_result {
@@ -564,6 +677,18 @@ async fn run_compaction_pass_with_focus(
                     outcome = SummaryOutcome::Failed;
                 }
             }
+        }
+    }
+
+    // A successful destructive fold rebuilt the context — message indices
+    // changed. Bump the fold epoch so any in-flight or already-stored
+    // checkpoint built against the OLD indices is stale (generation mismatch
+    // → never reused), and drop the slot: its summary was just consumed, or
+    // belongs to a context that no longer exists.
+    if matches!(outcome, SummaryOutcome::Succeeded(_)) {
+        *generation = generation.wrapping_add(1);
+        if let Ok(mut guard) = checkpoint_slot.lock() {
+            *guard = None;
         }
     }
 
@@ -858,6 +983,14 @@ pub async fn run_loop(
     // after a destructive fold rebuilds the context.
     let mut checkpoint_schedule: Option<context_manager::CheckpointSchedule> = None;
 
+    // Round 1 (fast compaction): the reusable background-checkpoint slot and
+    // the fold epoch. Detached checkpoint tasks write the slot; the
+    // destructive fold reads it to skip the inline summarizer when a fresh
+    // summary is available, and bumps the epoch on success so pre-fold
+    // checkpoints go stale.
+    let checkpoint_slot: CheckpointSlot = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let mut checkpoint_generation: u64 = 0;
+
     // vix-port: don't let the model end a turn while it still has unfinished
     // todos (bounded by MAX_TODO_NUDGES; vix caps at 3, session.go:1551).
     let mut todo_nudges: u8 = 0;
@@ -951,6 +1084,9 @@ pub async fn run_loop(
                         &memory_provider,
                         config.compaction_hooks.as_ref(),
                         emit,
+                        &checkpoint_slot,
+                        &mut checkpoint_generation,
+                        (ctx_max as f64 * context_manager::HISTORY_FOLD_THRESHOLD) as u64,
                     )
                     .await;
                     if let SummaryOutcome::Succeeded(idx) = outcome {
@@ -961,6 +1097,29 @@ pub async fn run_loop(
                         compaction_recorded_this_iter = true;
                     }
                     folded_this_turn = true;
+                }
+            }
+
+            // Round 2 (memory-awareness feedback): if background
+            // consolidation wrote new memories since the last turn, re-inject
+            // the refreshed memory block here so the running agent becomes
+            // aware of them without a restart — the system-prompt memory block
+            // is baked at agent-build time and wouldn't otherwise update.
+            // Model-facing only: pushed into the live context, not into
+            // `new_messages` or persisted session history. The dirty flag is
+            // consumed (swap-to-false), so this fires at most once per
+            // consolidation.
+            if context_manager::take_memories_dirty()
+                && let Some(provider) = &memory_provider
+            {
+                let block = provider.format_for_system_prompt();
+                if !block.trim().is_empty() {
+                    current_context.messages.push(serde_json::json!({
+                        "role": "system",
+                        "content": format!(
+                            "## Updated memory (consolidated mid-session)\n{block}"
+                        ),
+                    }));
                 }
             }
 
@@ -1306,6 +1465,10 @@ pub async fn run_loop(
                                     &memory_provider,
                                     config.compaction_hooks.as_ref(),
                                     emit,
+                                    &checkpoint_slot,
+                                    &mut checkpoint_generation,
+                                    (ctx_max as f64 * context_manager::HISTORY_FOLD_THRESHOLD)
+                                        as u64,
                                 )
                                 .await;
                                 if let SummaryOutcome::Succeeded(idx) = outcome {
@@ -1345,6 +1508,9 @@ pub async fn run_loop(
                             &memory_provider,
                             config.compaction_hooks.as_ref(),
                             emit,
+                            &checkpoint_slot,
+                            &mut checkpoint_generation,
+                            (ctx_max as f64 * context_manager::HISTORY_FOLD_THRESHOLD) as u64,
                         )
                         .await;
                         if let SummaryOutcome::Succeeded(idx) = outcome {
@@ -1379,6 +1545,8 @@ pub async fn run_loop(
                                     sfn.clone(),
                                     current_context.messages.clone(),
                                     emit.clone(),
+                                    checkpoint_slot.clone(),
+                                    checkpoint_generation,
                                 );
                             }
                         }

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -12,6 +12,13 @@ use std::pin::Pin;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+/// An empty reusable-checkpoint slot for the compaction-pass tests. With no
+/// cached summary the fold always takes the inline summarizer path, so these
+/// tests exercise the same behavior they did before Round 1's fast path.
+fn empty_checkpoint_slot() -> super::CheckpointSlot {
+    std::sync::Arc::new(std::sync::Mutex::new(None))
+}
+
 /// Build a stream factory that returns canned assistant
 /// messages in sequence. Mirrors pi's typical test mock —
 /// `callIndex` increments per invocation; each call returns
@@ -24,6 +31,37 @@ fn canned_factory(responses: Vec<AssistantMessage>) -> StreamFn {
     let counter = std::sync::Arc::new(AtomicUsize::new(0));
     let responses = std::sync::Arc::new(responses);
     std::sync::Arc::new(move |_ctx, _opts| {
+        let n = counter.fetch_add(1, Ordering::SeqCst);
+        let msg = responses.get(n).cloned().unwrap_or_else(|| {
+            AssistantMessage::new(
+                vec![ContentBlock::Text {
+                    text: "end".to_string(),
+                }],
+                StopReason::Stop,
+            )
+        });
+        let reason = msg.stop_reason;
+        Box::pin(futures::stream::iter(vec![StreamEvent::Done {
+            reason,
+            message: msg,
+            usage: None,
+        }]))
+    })
+}
+
+/// Like [`canned_factory`] but records a JSON snapshot of each call's
+/// context messages into `seen`, so a test can inspect what the model was
+/// actually sent (e.g. a mid-loop memory re-injection).
+fn capturing_factory(
+    responses: Vec<AssistantMessage>,
+    seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+) -> StreamFn {
+    let counter = std::sync::Arc::new(AtomicUsize::new(0));
+    let responses = std::sync::Arc::new(responses);
+    std::sync::Arc::new(move |ctx, _opts| {
+        seen.lock()
+            .unwrap()
+            .push(serde_json::to_string(&ctx.messages).unwrap_or_default());
         let n = counter.fetch_add(1, Ordering::SeqCst);
         let msg = responses.get(n).cloned().unwrap_or_else(|| {
             AssistantMessage::new(
@@ -155,7 +193,19 @@ async fn run_compaction_pass_inserts_summary_and_rotates_session() {
         }));
 
     let (tx, mut rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, None, &tx).await;
+    super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        0,
+        &None,
+        None,
+        &tx,
+        &empty_checkpoint_slot(),
+        &mut 0,
+        u64::MAX,
+    )
+    .await;
     drop(tx);
 
     // (a) older messages dropped.
@@ -203,6 +253,270 @@ async fn run_compaction_pass_inserts_summary_and_rotates_session() {
     let received = prompt_seen.lock().unwrap().clone();
     assert!(received.contains("TURNS TO SUMMARIZE"));
     assert!(received.contains("## Active Task"));
+}
+
+/// Build a padded context with `n` alternating turns after a system +
+/// initial-user pair, for the compaction-pass tests.
+fn padded_ctx(n: usize) -> super::Context {
+    let mut ctx = empty_context();
+    ctx.messages
+        .push(serde_json::json!({"role": "system", "content": "you are an agent"}));
+    ctx.messages
+        .push(serde_json::json!({"role": "user", "content": "initial task"}));
+    for i in 0..n {
+        let role = if i % 2 == 0 { "assistant" } else { "user" };
+        ctx.messages.push(serde_json::json!({
+            "role": role,
+            "content": format!("turn {i} with some content to fill bytes"),
+        }));
+    }
+    ctx.messages
+        .push(serde_json::json!({"role": "user", "content": "latest user request"}));
+    ctx
+}
+
+/// A summarizer that records whether it was called and returns a distinct
+/// inline summary, so a test can tell the inline path from the fast path.
+fn recording_summarizer(
+    called: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> Option<crate::agent::compression::SummarizeFn> {
+    Some(std::sync::Arc::new(move |_prompt: String| {
+        let called = called.clone();
+        Box::pin(async move {
+            called.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok("## Active Task\nINLINE SUMMARY\n## Remaining Work\nx".to_string())
+        })
+    }))
+}
+
+/// A populated checkpoint slot for the fast-path tests.
+fn slot_with(summary: &str, boundary: usize, generation: u64) -> super::CheckpointSlot {
+    std::sync::Arc::new(std::sync::Mutex::new(Some(super::CachedCheckpoint {
+        summary: summary.to_string(),
+        boundary,
+        generation,
+    })))
+}
+
+/// Round 1 fast path: when the slot holds a fresh checkpoint (matching the
+/// current epoch) and reusing it clears the fold target, the fold splices it
+/// in WITHOUT calling the inline summarizer, then bumps the epoch and clears
+/// the slot.
+#[tokio::test]
+async fn run_compaction_pass_reuses_fresh_checkpoint_without_calling_summarizer() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let mut ctx = padded_ctx(20);
+    let called = std::sync::Arc::new(AtomicBool::new(false));
+    let summarize_fn = recording_summarizer(called.clone());
+    let slot = slot_with(
+        "## Active Task\nFROM CHECKPOINT\n## Remaining Work\nfinish",
+        10,
+        0,
+    );
+    let mut generation = 0u64;
+
+    let (tx, _rx) = mpsc::channel::<LoopEvent>(16);
+    let outcome = super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        0,
+        &None,
+        None,
+        &tx,
+        &slot,
+        &mut generation,
+        u64::MAX,
+    )
+    .await;
+    drop(tx);
+
+    assert!(
+        matches!(outcome, super::SummaryOutcome::Succeeded(_)),
+        "reuse should succeed"
+    );
+    assert!(
+        !called.load(Ordering::SeqCst),
+        "inline summarizer must NOT be called on the fast path"
+    );
+    let summary_msg = ctx
+        .messages
+        .iter()
+        .find_map(|m| {
+            let c = m.get("content").and_then(|v| v.as_str())?;
+            c.contains("CONTEXT COMPACTION").then_some(c)
+        })
+        .expect("a summary message should be present");
+    assert!(
+        summary_msg.contains("FROM CHECKPOINT"),
+        "the spliced summary should be the checkpoint's, not the inline one"
+    );
+    assert_eq!(generation, 1, "a successful fold bumps the epoch");
+    assert!(
+        slot.lock().unwrap().is_none(),
+        "the consumed checkpoint slot is cleared after the fold"
+    );
+}
+
+/// A checkpoint from a stale epoch (generation mismatch) is ignored — the
+/// fold falls back to the inline summarizer.
+#[tokio::test]
+async fn run_compaction_pass_ignores_stale_generation_checkpoint() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let mut ctx = padded_ctx(20);
+    let called = std::sync::Arc::new(AtomicBool::new(false));
+    let summarize_fn = recording_summarizer(called.clone());
+    // Slot built under epoch 0, but the loop is now at epoch 7.
+    let slot = slot_with(
+        "## Active Task\nFROM CHECKPOINT\n## Remaining Work\nx",
+        10,
+        0,
+    );
+    let mut generation = 7u64;
+
+    let (tx, _rx) = mpsc::channel::<LoopEvent>(16);
+    let outcome = super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        0,
+        &None,
+        None,
+        &tx,
+        &slot,
+        &mut generation,
+        u64::MAX,
+    )
+    .await;
+    drop(tx);
+
+    assert!(matches!(outcome, super::SummaryOutcome::Succeeded(_)));
+    assert!(
+        called.load(Ordering::SeqCst),
+        "stale checkpoint → inline summarizer must run"
+    );
+    let summary_msg = ctx
+        .messages
+        .iter()
+        .find_map(|m| {
+            let c = m.get("content").and_then(|v| v.as_str())?;
+            c.contains("CONTEXT COMPACTION").then_some(c)
+        })
+        .expect("a summary message should be present");
+    assert!(
+        summary_msg.contains("INLINE SUMMARY"),
+        "the inline summary should be used when the checkpoint is stale"
+    );
+}
+
+/// Serializes the two tests that touch the process-global memory-dirty flag
+/// so they don't steal each other's marks under parallel test execution.
+static DIRTY_FLAG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Round 2 flag: `mark_memories_dirty` then `take_memories_dirty` returns
+/// true exactly once, then false.
+#[test]
+fn memories_dirty_flag_is_consumed_once() {
+    use crate::agent::agent_loop::context_manager::{mark_memories_dirty, take_memories_dirty};
+    let _guard = DIRTY_FLAG_TEST_LOCK.lock().unwrap();
+    // Clear any prior state from other tests touching the global.
+    let _ = take_memories_dirty();
+    mark_memories_dirty();
+    assert!(take_memories_dirty(), "first take after mark is true");
+    assert!(!take_memories_dirty(), "second take resets to false");
+}
+
+/// Round 2 behavior: when consolidation has marked memories dirty, the loop
+/// re-injects the refreshed memory block into the model-facing context at the
+/// next turn boundary, so the agent sees it without a restart.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)] // current-thread test runtime; lock only serializes the global flag
+async fn memory_refresh_injects_block_at_turn_boundary_when_dirty() {
+    use crate::extras::memory_provider::MemoryProvider;
+    let _guard = DIRTY_FLAG_TEST_LOCK.lock().unwrap();
+
+    struct StubProvider;
+    impl MemoryProvider for StubProvider {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn format_for_system_prompt(&self) -> String {
+            "STUBMEM: prefer the fast path".to_string()
+        }
+        fn view(&self, _t: &str) -> Value {
+            serde_json::json!({})
+        }
+        fn add(&self, _: &str, _: &str, _: Option<&str>) -> Result<Value, String> {
+            Ok(serde_json::json!({}))
+        }
+        fn replace(&self, _: &str, _: &str, _: &str, _: Option<&str>) -> Result<Value, String> {
+            Ok(serde_json::json!({}))
+        }
+        fn remove(&self, _: &str, _: &str) -> Result<Value, String> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
+    let echo = std::sync::Arc::new(EchoTool::new());
+    let mut ctx = empty_context();
+    ctx.tools.push(echo.clone());
+
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    // Turn 1: a tool call (forces another loop iteration → a turn boundary).
+    // Turn 2: final text.
+    let factory = capturing_factory(
+        vec![
+            tool_use_response("call-1", "echo", serde_json::json!({"v": 1})),
+            text_response("done"),
+        ],
+        seen.clone(),
+    );
+
+    let provider: std::sync::Arc<dyn MemoryProvider> = std::sync::Arc::new(StubProvider);
+
+    // The injected refresh is a `system` message; use a converter that keeps
+    // system messages (production's does — fold summaries are system-role).
+    let mut config = build_config();
+    config.convert_to_llm = std::sync::Arc::new(|messages: &[Value]| {
+        messages
+            .iter()
+            .filter(|m| {
+                let role = m.get("role").and_then(|r| r.as_str()).unwrap_or("");
+                matches!(
+                    role,
+                    "user" | "assistant" | "tool" | "toolResult" | "system"
+                )
+            })
+            .cloned()
+            .collect()
+    });
+
+    // Simulate background consolidation completing: mark dirty just before
+    // the run so the next turn boundary consumes it.
+    crate::agent::agent_loop::context_manager::mark_memories_dirty();
+
+    let (tx, _rx) = mpsc::channel::<LoopEvent>(128);
+    let _ = run_agent_loop(
+        vec![user("echo please")],
+        ctx,
+        config,
+        AbortSignal::new(),
+        &tx,
+        &factory,
+        None,
+        Some(provider),
+    )
+    .await;
+    drop(tx);
+
+    let snapshots = seen.lock().unwrap().clone();
+    assert!(
+        snapshots.iter().any(|s| s.contains("STUBMEM")),
+        "the refreshed memory block should appear in the model-facing context \
+         after the turn boundary; snapshots={snapshots:?}"
+    );
 }
 
 /// dirge-jia8: a plugin `on-compact` hook supplying a valid summary
@@ -253,7 +567,19 @@ async fn compaction_on_compact_hook_overrides_llm_summary() {
     };
 
     let (tx, _rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, Some(&hooks), &tx).await;
+    super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        0,
+        &None,
+        Some(&hooks),
+        &tx,
+        &empty_checkpoint_slot(),
+        &mut 0,
+        u64::MAX,
+    )
+    .await;
     drop(tx);
 
     // on-before-compact observed the fold.
@@ -332,7 +658,19 @@ async fn compaction_invalid_plugin_summary_falls_through_to_llm() {
     };
 
     let (tx, _rx) = mpsc::channel::<LoopEvent>(8);
-    super::run_compaction_pass(&mut ctx, &summarize_fn, 5, 0, &None, Some(&hooks), &tx).await;
+    super::run_compaction_pass(
+        &mut ctx,
+        &summarize_fn,
+        5,
+        0,
+        &None,
+        Some(&hooks),
+        &tx,
+        &empty_checkpoint_slot(),
+        &mut 0,
+        u64::MAX,
+    )
+    .await;
     drop(tx);
 
     assert_eq!(
@@ -374,7 +712,19 @@ async fn run_compaction_pass_without_summarizer_prunes_only() {
     // Use protect_tail = 2 so the large tool result is eligible
     // for pruning (it's at index 1, end = 4 - 2 = 2, so index
     // 1 is in-range).
-    super::run_compaction_pass(&mut ctx, &None, 2, 0, &None, None, &tx).await;
+    super::run_compaction_pass(
+        &mut ctx,
+        &None,
+        2,
+        0,
+        &None,
+        None,
+        &tx,
+        &empty_checkpoint_slot(),
+        &mut 0,
+        u64::MAX,
+    )
+    .await;
     drop(tx);
 
     // No SUMMARY_PREFIX message inserted.
@@ -2235,9 +2585,19 @@ async fn compaction_circuit_breaker_skips_summarizer_after_max_failures() {
     // Sub-threshold: the summarizer IS called and reports Failed.
     for failures in 0..super::MAX_CONSECUTIVE_COMPACTION_FAILURES {
         let mut ctx = make_ctx();
-        let outcome =
-            super::run_compaction_pass(&mut ctx, &summarize_fn, 5, failures, &None, None, &tx)
-                .await;
+        let outcome = super::run_compaction_pass(
+            &mut ctx,
+            &summarize_fn,
+            5,
+            failures,
+            &None,
+            None,
+            &tx,
+            &empty_checkpoint_slot(),
+            &mut 0,
+            u64::MAX,
+        )
+        .await;
         assert_eq!(
             outcome,
             super::SummaryOutcome::Failed,
@@ -2263,6 +2623,9 @@ async fn compaction_circuit_breaker_skips_summarizer_after_max_failures() {
         &None,
         None,
         &tx,
+        &empty_checkpoint_slot(),
+        &mut 0,
+        u64::MAX,
     )
     .await;
     assert_eq!(
@@ -2305,7 +2668,19 @@ async fn context_compacted_reports_compaction_kind() {
         ctx.messages
             .push(serde_json::json!({"role":"user","content":"latest"}));
         let (tx, mut rx) = mpsc::channel::<LoopEvent>(8);
-        super::run_compaction_pass(&mut ctx, &summarize_fn, 5, failures, &None, None, &tx).await;
+        super::run_compaction_pass(
+            &mut ctx,
+            &summarize_fn,
+            5,
+            failures,
+            &None,
+            None,
+            &tx,
+            &empty_checkpoint_slot(),
+            &mut 0,
+            u64::MAX,
+        )
+        .await;
         drop(tx);
         while let Some(ev) = rx.recv().await {
             if let LoopEvent::ContextCompacted {

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -761,6 +761,41 @@ pub fn apply_summary(
     out
 }
 
+/// Fold using a precomputed running summary that already covers
+/// `messages[0..boundary]` (the background incremental checkpoint). The
+/// covered prefix is replaced with one summary marker; everything from the
+/// snapped tail-cut onward is kept verbatim. This is the FAST fold path:
+/// no inline summarizer call, because the expensive summarization already
+/// ran off the loop.
+///
+/// Returns `Some((new_messages, first_kept_index))` on success, or `None`
+/// when reuse wouldn't be safe or useful:
+/// - `boundary` is 0 or past the end (nothing to fold, or stale),
+/// - the user-boundary snap collapses the cut to 0 (no whole turn to fold).
+///
+/// The cut snaps BACKWARD to a user-message boundary so the kept tail never
+/// begins with an orphaned tool_result (which would 400 the next request).
+/// Snapping backward only ever keeps MORE verbatim than the summary covers
+/// — it never drops an un-summarized message — so it can't lose data; the
+/// few messages in `[cut..boundary]` are simply carried both in the summary
+/// and verbatim.
+pub fn apply_checkpoint_summary(
+    messages: &[Value],
+    summary: &str,
+    boundary: usize,
+) -> Option<(Vec<Value>, usize)> {
+    let n = messages.len();
+    if boundary == 0 || boundary > n {
+        return None;
+    }
+    let cut = snap_backward_to_user(messages, boundary);
+    if cut == 0 {
+        return None;
+    }
+    let out = apply_summary(messages, summary, 0, cut);
+    Some((out, cut))
+}
+
 /// Compute the boundary `(compress_start, compress_end)` for the
 /// middle section to summarize. Port of Hermes's
 /// `_protect_head_size` + `_find_tail_cut_by_tokens`.
@@ -1500,6 +1535,83 @@ mod tests {
         // Tail.
         assert_eq!(out[3]["content"].as_str().unwrap(), "recent user");
         assert_eq!(out[4]["content"].as_str().unwrap(), "recent assistant");
+    }
+
+    #[test]
+    fn checkpoint_reuse_folds_covered_prefix_and_keeps_tail() {
+        let msgs = vec![
+            serde_json::json!({"role": "user", "content": "u0"}),
+            serde_json::json!({"role": "assistant", "content": "a0"}),
+            serde_json::json!({"role": "user", "content": "u1"}),
+            serde_json::json!({"role": "assistant", "content": "a1"}),
+            // boundary = 4: checkpoint covers u0..a1; tail starts here.
+            serde_json::json!({"role": "user", "content": "u2"}),
+            serde_json::json!({"role": "assistant", "content": "a2"}),
+        ];
+        let summary = "## Active Task\nport the loop\n## Remaining Work\nwire it";
+        let (out, first_kept) = apply_checkpoint_summary(&msgs, summary, 4).unwrap();
+        // index 4 ("u2") is already a user boundary, so cut == boundary.
+        assert_eq!(first_kept, 4);
+        // [summary] + tail(u2, a2) = 3 messages.
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0]["role"].as_str().unwrap(), "system");
+        assert!(
+            out[0]["content"]
+                .as_str()
+                .unwrap()
+                .starts_with(SUMMARY_PREFIX)
+        );
+        assert!(
+            out[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("port the loop")
+        );
+        assert_eq!(out[1]["content"].as_str().unwrap(), "u2");
+        assert_eq!(out[2]["content"].as_str().unwrap(), "a2");
+    }
+
+    #[test]
+    fn checkpoint_reuse_snaps_cut_back_to_user_boundary() {
+        // boundary lands mid-turn (on an assistant/tool message); the cut
+        // must snap BACK to the preceding user turn so the kept tail never
+        // starts with an orphaned tool_result.
+        let msgs = vec![
+            serde_json::json!({"role": "user", "content": "u0"}),
+            serde_json::json!({"role": "assistant", "content": "a0"}),
+            serde_json::json!({"role": "user", "content": "u1"}),
+            serde_json::json!({"role": "assistant", "content": "a1"}),
+            serde_json::json!({"role": "tool", "content": "t1"}),
+        ];
+        let summary = "## Goal\nx";
+        // boundary = 5 (end); snap_backward finds u1 at index 2.
+        let (out, first_kept) = apply_checkpoint_summary(&msgs, summary, 5).unwrap();
+        assert_eq!(first_kept, 2, "cut snaps back to the user turn at index 2");
+        // [summary] + u1 + a1 + t1.
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[1]["content"].as_str().unwrap(), "u1");
+    }
+
+    #[test]
+    fn checkpoint_reuse_rejects_out_of_range_or_zero_boundary() {
+        let msgs = vec![
+            serde_json::json!({"role": "user", "content": "u0"}),
+            serde_json::json!({"role": "assistant", "content": "a0"}),
+        ];
+        assert!(apply_checkpoint_summary(&msgs, "## Goal\nx", 0).is_none());
+        assert!(apply_checkpoint_summary(&msgs, "## Goal\nx", 99).is_none());
+    }
+
+    #[test]
+    fn checkpoint_reuse_rejects_when_snap_collapses_to_zero() {
+        // No user turn at/before the boundary → snap_backward returns 0 →
+        // None (nothing whole to fold).
+        let msgs = vec![
+            serde_json::json!({"role": "assistant", "content": "a0"}),
+            serde_json::json!({"role": "assistant", "content": "a1"}),
+            serde_json::json!({"role": "assistant", "content": "a2"}),
+        ];
+        assert!(apply_checkpoint_summary(&msgs, "## Goal\nx", 2).is_none());
     }
 
     #[test]

--- a/src/agent/post_session.rs
+++ b/src/agent/post_session.rs
@@ -146,6 +146,12 @@ pub fn spawn_post_session(agent: AnyAgent, paths: ProjectPaths, transcript: Stri
             ),
         ];
         run_stages_sequentially(stages, STAGE_TIMEOUT).await;
+        // Round 2: the review + curator passes may have written or
+        // consolidated memories. Flag it so the running loop re-injects the
+        // refreshed memory block at its next turn boundary — the agent's
+        // baked-in system-prompt block wouldn't otherwise reflect these
+        // writes until a restart.
+        crate::agent::agent_loop::context_manager::mark_memories_dirty();
     });
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -110,6 +110,14 @@ pub enum AgentEvent {
         prompt: CompactString,
         error: CompactString,
     },
+    /// A destructive compaction fold is ABOUT to summarize the
+    /// conversation — emitted before the (multi-second) summarizer call so
+    /// the UI can show a "compacting…" indicator during the wait, rather
+    /// than appearing frozen. `ContextCompacted` follows when it finishes.
+    /// `tokens_before` is the pre-fold estimate.
+    CompactionStarted {
+        tokens_before: u64,
+    },
     /// Context was compacted mid-run — old tool results pruned,
     /// session rotated. The UI persists the split via session DB,
     /// mutates `Session::id` in-place, and calls

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -325,6 +325,7 @@ async fn run_prompt(
             }
             AgentEvent::TurnStart { .. }
             | AgentEvent::TurnEnd { .. }
+            | AgentEvent::CompactionStarted { .. }
             | AgentEvent::ContextCompacted { .. }
             | AgentEvent::CheckpointRefresh { .. }
             | AgentEvent::RetryNotice { .. }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2565,6 +2565,19 @@ pub async fn run_interactive(
                         #[cfg(not(feature = "plugin"))]
                         let _ = index;
                     }
+                    AgentEvent::CompactionStarted { tokens_before } => {
+                        // Show progress in the main pane during the
+                        // multi-second summarizer call so it's clear the
+                        // session is compacting, not hung. The result line
+                        // ("context compacted: X → Y") follows on
+                        // ContextCompacted.
+                        let approx_k = tokens_before.div_ceil(1000);
+                        renderer.write_line(
+                            &format!("  ⟳ compacting context (~{approx_k}k tokens)…"),
+                            Color::DarkGrey,
+                        )?;
+                        renderer.request_repaint();
+                    }
                     AgentEvent::ContextCompacted {
                         ref new_session_id,
                         tokens_before,


### PR DESCRIPTION
Compaction was a synchronous inline LLM call on the main loop with no timeout, defaulting to the main model when `summarization_provider` is unset. Under the 100k budget it fires often, so a slow or stalled summarizer froze the session with no UI signal.

**CompactionStarted event** — emitted before the summarizer runs so the main pane shows `⟳ compacting context…` during the wait instead of looking hung. `ContextCompacted` still follows with the result.

**Fast fold** — the background incremental checkpoint already summarizes a context snapshot off the loop. The destructive fold now reuses that precomputed summary (prune + splice, no inline LLM call) when it's from the current fold epoch and clears the fold target; otherwise it falls back to an inline summarize bounded by a 120s timeout (→ prune-only on stall). A fold-epoch counter invalidates checkpoints across folds. The background checkpoint summarizer also gets a timeout so a hung provider can't leak the task.

**Memory awareness** — the system-prompt memory block is baked at agent-build time, so memories written by background consolidation weren't visible until restart. Post-session consolidation now sets a dirty flag the loop consumes at the next turn boundary, re-injecting the refreshed block into the live context.

Tests: checkpoint-reuse helper, reuse fast-path + stale-epoch fallback, dirty-flag + turn-boundary injection. Full suite green (2669), fmt + clippy clean.