### PR TITLE
Persist panel state in session so resume survives compaction

### DIFF
--- a/src/agent/tools/todo.rs
+++ b/src/agent/tools/todo.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TodoItem {
     pub content: String,
     pub status: String,
@@ -32,6 +32,14 @@ pub static TODO_LIST: std::sync::Mutex<Vec<TodoItem>> = std::sync::Mutex::new(Ve
 /// with the conversation, mirroring `modified::clear_modified`.
 pub fn clear() {
     TODO_LIST.lock_ignore_poison().clear();
+}
+
+/// Snapshot the current todo list. `save_session` persists this with the
+/// session so a resumed session restores the TODOS panel even when a
+/// compaction has dropped the originating `write_todo_list` call from the
+/// message history.
+pub fn snapshot() -> Vec<TodoItem> {
+    TODO_LIST.lock_ignore_poison().clone()
 }
 
 /// Number of todos still `pending` or `in_progress`. Used by the agent loop

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -294,6 +294,19 @@ pub struct Session {
     /// `None` for backward compat with pre-feature session files.
     #[serde(default)]
     pub current_prompt_name: Option<String>,
+    /// Snapshot of the in-session todo list (`write_todo_list` state) taken
+    /// at save time. Persisted so a resumed session restores the TODOS panel
+    /// even past a destructive compaction, which drains the originating tool
+    /// calls out of `messages` — replaying history alone can't recover them.
+    /// Defaulted on deserialize for pre-feature files; `rehydrate` falls back
+    /// to replaying message history when this is empty.
+    #[serde(default)]
+    pub todo_list: Vec<crate::agent::tools::todo::TodoItem>,
+    /// Snapshot of the MODIFIED panel — canonical paths in recency order
+    /// (most-recent last) — taken at save time. Same rationale as
+    /// `todo_list`. Defaulted on deserialize for back-compat.
+    #[serde(default)]
+    pub modified_files: Vec<String>,
     /// Batch2-3 (audit fix): file mtime at load time. Used by
     /// `save_session` to detect concurrent writes — if the on-disk
     /// file has a newer mtime than this when we go to save, a
@@ -399,6 +412,8 @@ impl Session {
             message_store: HashMap::new(),
             branch_summaries: Vec::new(),
             current_prompt_name: None,
+            todo_list: Vec::new(),
+            modified_files: Vec::new(),
             loaded_mtime: None,
             loaded_from_newer_version: None,
         }
@@ -840,6 +855,12 @@ impl Session {
         // over implicitly.
         self.loaded_mtime = None;
         self.current_prompt_name = None;
+        // Panel snapshots are per-session — a fresh session starts with empty
+        // TODOS / MODIFIED. The process-global panel statics are cleared by
+        // the command handler (see /clear); this keeps the persisted side in
+        // step so the next save doesn't carry the prior session's snapshot.
+        self.todo_list.clear();
+        self.modified_files.clear();
         // SESS-15: reset_to_new generates a fresh id, so we own
         // the on-disk file under that id; the newer-schema flag
         // belonged to the prior id's file.

--- a/src/session/rehydrate.rs
+++ b/src/session/rehydrate.rs
@@ -8,12 +8,21 @@
 //! panels come back blank even though the work that filled them is recorded
 //! in the message history.
 //!
-//! The fix: replay the persisted tool calls and re-derive the same state.
-//! `write_todo_list` carries its full list in the args (each call replaces the
-//! whole list, so last-write-wins); `write` / `edit` / `edit_minified` /
-//! `apply_patch` each name the file they touched. We only count tool calls
-//! that actually ran to `Completed` — an interrupted or failed edit never
-//! marked the file modified live, so it shouldn't on resume either.
+//! Two sources, in priority order:
+//!
+//! 1. **The persisted snapshot** (`Session::todo_list` / `modified_files`).
+//!    `save_session` records the live globals on every save, so this survives
+//!    a destructive compaction — the common case for a long resumed session,
+//!    whose fold drains the originating tool calls out of `messages`.
+//! 2. **Replaying the message history** — the fallback for sessions written
+//!    before the snapshot fields existed. `write_todo_list` carries its full
+//!    list in the args (each call replaces the whole list, so last-write-wins);
+//!    `write` / `edit` / `edit_minified` / `apply_patch` each name the file
+//!    they touched. Only `Completed` calls count — an interrupted or failed
+//!    edit never marked the file modified live, so it shouldn't on resume.
+//!
+//! Replay can't recover state a compaction already discarded, which is why the
+//! snapshot is preferred whenever it carries anything.
 
 use std::path::PathBuf;
 
@@ -87,13 +96,20 @@ pub fn derive_panel_state(session: &Session) -> PanelState {
     PanelState { todos, modified }
 }
 
-/// Push the derived state into the process-global panel statics so a resumed
-/// session's TODOS and MODIFIED panels reflect where the previous run left
-/// off. Clears both first so the panels show exactly this session's state.
+/// Push a resumed session's panel state into the process-global statics so the
+/// TODOS and MODIFIED panels reflect where the previous run left off. Clears
+/// both first so the panels show exactly this session's state.
+///
+/// Prefers the persisted snapshot (which survives compaction); falls back to
+/// replaying the message history for sessions saved before the snapshot fields
+/// existed. "Has a snapshot" means either field is non-empty — an empty
+/// snapshot is indistinguishable from a pre-feature default, and in that case
+/// replay yields the same result (an uncompacted history agrees with the
+/// snapshot; a compacted one has nothing left to replay).
 pub fn restore_panels(session: &Session) {
     use crate::sync_util::LockExt;
 
-    let state = derive_panel_state(session);
+    let state = selected_panel_state(session);
 
     *crate::agent::tools::todo::TODO_LIST.lock_ignore_poison() = state.todos;
 
@@ -102,6 +118,20 @@ pub fn restore_panels(session: &Session) {
     crate::agent::tools::modified::clear_modified();
     for p in &state.modified {
         crate::agent::tools::modified::mark_modified(p);
+    }
+}
+
+/// Choose the panel state to restore: the persisted snapshot when it carries
+/// anything, otherwise a replay of the message history. Pure — split out so the
+/// source-selection logic is testable without touching the process globals.
+pub fn selected_panel_state(session: &Session) -> PanelState {
+    if !session.todo_list.is_empty() || !session.modified_files.is_empty() {
+        PanelState {
+            todos: session.todo_list.clone(),
+            modified: session.modified_files.iter().map(PathBuf::from).collect(),
+        }
+    } else {
+        derive_panel_state(session)
     }
 }
 
@@ -229,6 +259,68 @@ mod tests {
         let state = derive_panel_state(&session_with(vec![]));
         assert!(state.todos.is_empty());
         assert!(state.modified.is_empty());
+    }
+
+    #[test]
+    fn snapshot_is_preferred_over_history_replay() {
+        // History would derive one modified file + a one-item todo list...
+        let mut s = session_with(vec![assistant_with_calls(vec![
+            completed(
+                "write",
+                serde_json::json!({"path": "/proj/from_history.rs"}),
+            ),
+            completed(
+                "write_todo_list",
+                serde_json::json!({"todos": [
+                    {"content": "history task", "status": "pending", "priority": "low"}
+                ]}),
+            ),
+        ])]);
+        // ...but a persisted snapshot exists, so it wins.
+        s.todo_list = vec![TodoItem {
+            content: "snapshot task".into(),
+            status: "in_progress".into(),
+            priority: "high".into(),
+        }];
+        s.modified_files = vec!["/proj/from_snapshot.rs".into()];
+
+        let state = selected_panel_state(&s);
+        assert_eq!(state.todos.len(), 1);
+        assert_eq!(state.todos[0].content, "snapshot task");
+        assert_eq!(state.modified.len(), 1);
+        assert!(state.modified[0].ends_with("from_snapshot.rs"));
+    }
+
+    #[test]
+    fn snapshot_survives_compaction_that_emptied_history() {
+        // A compacted session: messages (and their tool_calls) are gone, but
+        // the snapshot persisted the panel state.
+        let mut s = session_with(vec![]);
+        s.modified_files = vec!["/proj/a.rs".into(), "/proj/b.rs".into()];
+        s.todo_list = vec![TodoItem {
+            content: "still here".into(),
+            status: "in_progress".into(),
+            priority: "high".into(),
+        }];
+
+        let state = selected_panel_state(&s);
+        assert_eq!(state.todos.len(), 1);
+        assert_eq!(state.modified.len(), 2);
+        assert!(state.modified[1].ends_with("b.rs"));
+    }
+
+    #[test]
+    fn falls_back_to_replay_when_snapshot_empty() {
+        // Pre-feature session: no snapshot, but history still has the calls.
+        let s = session_with(vec![assistant_with_calls(vec![completed(
+            "edit",
+            serde_json::json!({"path": "/proj/legacy.rs"}),
+        )])]);
+        assert!(s.todo_list.is_empty() && s.modified_files.is_empty());
+
+        let state = selected_panel_state(&s);
+        assert_eq!(state.modified.len(), 1);
+        assert!(state.modified[0].ends_with("legacy.rs"));
     }
 
     #[test]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -103,6 +103,18 @@ pub fn save_session(session: &mut Session) -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
     }
+    // Snapshot the live panel globals into the session so a resume restores
+    // the TODOS / MODIFIED panels even after a destructive compaction has
+    // drained the originating tool calls out of `messages`. `save_session`
+    // is the single persistence chokepoint and only ever runs for the main
+    // interactive session (subagents don't call it), so the process-global
+    // statics map to this session. See `session::rehydrate`.
+    session.todo_list = crate::agent::tools::todo::snapshot();
+    session.modified_files = crate::agent::tools::modified::recent(256)
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+
     let path = dir.join(format!("{}.json", session.id));
     let json = serde_json::to_string_pretty(session)?;
 


### PR DESCRIPTION
Follow-up to #418. That PR rebuilt the TODOS / MODIFIED panels on resume by
replaying the tool calls in the message history — which works until a
destructive compaction runs. The fold drains old messages out of the session
(`compact.rs` does `messages.drain(..first_kept_index)` and the summary message
it inserts carries no `tool_calls`), so a resumed `compacted-*` session had
nothing left to replay: empty TODOS, near-empty MODIFIED. Both of the repro
sessions were `compacted-*`, which is why the first fix looked like it didn't
take.

## Fix
Persist the panel state in the session instead of deriving it.

- `save_session` — the single persistence chokepoint, and only ever run for the
  main interactive session (subagents don't call it) — now snapshots
  `todo::snapshot()` and `modified::recent(256)` into the session on every save.
  The save that fires right after a compaction still sees the full globals
  (compaction touches `messages`, not the panel statics), so even compacted
  session files carry the complete snapshot.
- `restore_panels` prefers the persisted snapshot and only falls back to
  replaying history for sessions written before the fields existed.
- New `todo_list` / `modified_files` fields on `Session`, additive
  `#[serde(default)]`, no schema bump (same approach as `tool_calls` /
  `current_prompt_name`). `reset_to_new` clears them.

## Tests
`session::rehydrate` now 8 tests incl. snapshot-preferred-over-replay,
snapshot-survives-emptied-history (the compaction case), and
falls-back-to-replay-when-empty. Session/storage suite (72) green, clippy clean.

Note: 0.7.0 shipped with the replay-only fix, so this warrants a 0.7.1 once
merged.