### PR TITLE
feat: allow codex users with plan usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "base64",
+ "bytes",
  "chrono",
  "clap",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros", "sync", "time", "process", "fs", "io-util"] }
 anyhow = "1"
+bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/agent/agent_loop/h7_smoke.rs
+++ b/src/agent/agent_loop/h7_smoke.rs
@@ -94,6 +94,7 @@ fn build_stream_fn() -> Option<crate::agent::agent_loop::StreamFn> {
     let stream_fn = match any_model {
         AnyModel::OpenRouter(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::OpenAI(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
+        AnyModel::ChatGptOpenAI(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::Anthropic(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::Gemini(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::DeepSeek(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -598,7 +598,7 @@ pub fn build_provider_additional_params(
 }
 
 fn merged_request_headers(
-    provider_name: Option<&str>,
+    _provider_name: Option<&str>,
     opts: &super::stream::StreamOptions,
 ) -> std::collections::HashMap<String, String> {
     let mut headers = opts.headers.clone();
@@ -611,18 +611,6 @@ fn merged_request_headers(
         headers
             .entry("Authorization".to_string())
             .or_insert_with(|| format!("Bearer {key}"));
-    }
-    if let Some(provider) = provider_name
-        && let Some(auth) = crate::provider::auth::provider_auth_headers(provider)
-        && let Some(account_id) = auth
-            .chatgpt_account_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|id| !id.is_empty())
-    {
-        headers
-            .entry("ChatGPT-Account-ID".to_string())
-            .or_insert_with(|| account_id.to_string());
     }
     headers
 }
@@ -1144,18 +1132,10 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_provider_auth_adds_account_header() {
-        crate::provider::auth::install_provider_auth_headers(
-            "openai-chatgpt-test",
-            crate::provider::auth::ProviderAuthHeaders {
-                bearer_token: "token".to_string(),
-                chatgpt_account_id: Some("acct-test".to_string()),
-            },
-        );
+    fn chatgpt_provider_auth_does_not_add_account_header_to_body() {
         let opts = StreamOptions::from_signal(AbortSignal::new());
 
-        let v = build_provider_additional_params(Some("openai-chatgpt-test"), &opts).unwrap();
-        assert_eq!(v["headers"]["ChatGPT-Account-ID"], "acct-test");
+        assert!(build_provider_additional_params(Some("openai-chatgpt-test"), &opts).is_none());
     }
 
     /// No reasoning, no headers, no metadata → None (caller

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -570,8 +570,9 @@ pub fn build_provider_additional_params(
     }
 
     // ----- headers (provider-agnostic) -----
-    if !opts.headers.is_empty()
-        && let Ok(v) = serde_json::to_value(&opts.headers)
+    let headers = merged_request_headers(provider_name, opts);
+    if !headers.is_empty()
+        && let Ok(v) = serde_json::to_value(&headers)
     {
         additional.insert("headers".to_string(), v);
     }
@@ -594,6 +595,36 @@ pub fn build_provider_additional_params(
     } else {
         Some(serde_json::Value::Object(additional))
     }
+}
+
+fn merged_request_headers(
+    provider_name: Option<&str>,
+    opts: &super::stream::StreamOptions,
+) -> std::collections::HashMap<String, String> {
+    let mut headers = opts.headers.clone();
+    if let Some(key) = opts
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+    {
+        headers
+            .entry("Authorization".to_string())
+            .or_insert_with(|| format!("Bearer {key}"));
+    }
+    if let Some(provider) = provider_name
+        && let Some(auth) = crate::provider::auth::provider_auth_headers(provider)
+        && let Some(account_id) = auth
+            .chatgpt_account_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+    {
+        headers
+            .entry("ChatGPT-Account-ID".to_string())
+            .or_insert_with(|| account_id.to_string());
+    }
+    headers
 }
 
 /// Map our `ThinkingLevel` enum to OpenAI Responses `reasoning.
@@ -1088,6 +1119,43 @@ mod tests {
             assert_eq!(v["headers"]["X-Tenant"], "acme", "provider {provider}");
             assert_eq!(v["metadata"]["user_id"], "u-42", "provider {provider}");
         }
+    }
+
+    #[test]
+    fn stream_options_api_key_adds_authorization_header() {
+        let mut opts = StreamOptions::from_signal(AbortSignal::new());
+        opts.api_key = Some("dynamic-token".to_string());
+
+        let v = build_provider_additional_params(Some("openai"), &opts).unwrap();
+        assert_eq!(v["headers"]["Authorization"], "Bearer dynamic-token");
+    }
+
+    #[test]
+    fn explicit_authorization_header_wins_over_stream_api_key() {
+        let mut opts = StreamOptions::from_signal(AbortSignal::new());
+        opts.api_key = Some("dynamic-token".to_string());
+        opts.headers.insert(
+            "Authorization".to_string(),
+            "Bearer explicit-token".to_string(),
+        );
+
+        let v = build_provider_additional_params(Some("openai"), &opts).unwrap();
+        assert_eq!(v["headers"]["Authorization"], "Bearer explicit-token");
+    }
+
+    #[test]
+    fn chatgpt_provider_auth_adds_account_header() {
+        crate::provider::auth::install_provider_auth_headers(
+            "openai-chatgpt-test",
+            crate::provider::auth::ProviderAuthHeaders {
+                bearer_token: "token".to_string(),
+                chatgpt_account_id: Some("acct-test".to_string()),
+            },
+        );
+        let opts = StreamOptions::from_signal(AbortSignal::new());
+
+        let v = build_provider_additional_params(Some("openai-chatgpt-test"), &opts).unwrap();
+        assert_eq!(v["headers"]["ChatGPT-Account-ID"], "acct-test");
     }
 
     /// No reasoning, no headers, no metadata → None (caller

--- a/src/agent/builder/reminder_tests.rs
+++ b/src/agent/builder/reminder_tests.rs
@@ -491,9 +491,7 @@ async fn build_agent_inner_emits_assembled_preamble() {
     // Real openai client/model — never called (no network until
     // first request). The builder only inspects type bounds and
     // builds the rig Agent wrapper around it.
-    let client = openai::Client::new("test-key")
-        .expect("openai client builds")
-        .completions_api();
+    let client = openai::Client::new("test-key").expect("openai client builds");
     let model = client.completion_model("gpt-4o");
 
     let (agent, _cache, _provider) =
@@ -608,9 +606,7 @@ async fn steering_fragment_tracks_active_model_not_cli() {
         agent_layer: None,
         model_before_agent: None,
     };
-    let client = openai::Client::new("test-key")
-        .expect("openai client builds")
-        .completions_api();
+    let client = openai::Client::new("test-key").expect("openai client builds");
 
     // Active model = a DeepSeek chat model → fragment present, even
     // though the openai client/model and the CLI default are not DeepSeek.

--- a/src/agent/review.rs
+++ b/src/agent/review.rs
@@ -743,9 +743,11 @@ mod tests {
     fn agent_with_recording_provider() -> (AnyAgent, Arc<RecordingEndProvider>) {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::new("test-key")
-            .expect("openai client")
-            .completions_api();
+        let client = openai::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::codex_http::CodexHttpClient::default())
+            .build()
+            .expect("openai client");
         let model = client.completion_model("gpt-4o");
         let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingEndProvider::default());
@@ -849,7 +851,11 @@ mod tests {
 
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::new("test-key").unwrap().completions_api();
+        let client = openai::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::codex_http::CodexHttpClient::default())
+            .build()
+            .unwrap();
         let model = client.completion_model("gpt-4o");
         let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingSwitchProvider::default());
@@ -879,7 +885,11 @@ mod tests {
     fn maybe_fire_session_switch_noop_without_provider() {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::new("test-key").unwrap().completions_api();
+        let client = openai::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::codex_http::CodexHttpClient::default())
+            .build()
+            .unwrap();
         let model = client.completion_model("gpt-4o");
         let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let agent = AnyAgent::new(
@@ -899,7 +909,11 @@ mod tests {
         // Build an agent WITHOUT calling with_memory_provider.
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::new("test-key").unwrap().completions_api();
+        let client = openai::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::codex_http::CodexHttpClient::default())
+            .build()
+            .unwrap();
         let model = client.completion_model("gpt-4o");
         let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let agent = AnyAgent::new(

--- a/src/agent/review.rs
+++ b/src/agent/review.rs
@@ -743,9 +743,8 @@ mod tests {
     fn agent_with_recording_provider() -> (AnyAgent, Arc<RecordingEndProvider>) {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::builder()
+        let client = openai::CompletionsClient::builder()
             .api_key("test-key")
-            .http_client(crate::provider::codex_http::CodexHttpClient::default())
             .build()
             .expect("openai client");
         let model = client.completion_model("gpt-4o");
@@ -851,9 +850,8 @@ mod tests {
 
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::builder()
+        let client = openai::CompletionsClient::builder()
             .api_key("test-key")
-            .http_client(crate::provider::codex_http::CodexHttpClient::default())
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");
@@ -885,9 +883,8 @@ mod tests {
     fn maybe_fire_session_switch_noop_without_provider() {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::builder()
+        let client = openai::CompletionsClient::builder()
             .api_key("test-key")
-            .http_client(crate::provider::codex_http::CodexHttpClient::default())
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");
@@ -909,9 +906,8 @@ mod tests {
         // Build an agent WITHOUT calling with_memory_provider.
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::builder()
+        let client = openai::CompletionsClient::builder()
             .api_key("test-key")
-            .http_client(crate::provider::codex_http::CodexHttpClient::default())
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,12 +21,30 @@ use crate::extras::acp::config::AcpServerConfig;
 /// a built-in backend under a different name — e.g.
 /// `"ollama": { "provider_type": "openai", "base_url": "..." }`
 /// aliases the OpenAI-compatible backend under the alias `ollama`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderAuth {
+    #[serde(alias = "api-key")]
+    ApiKey,
+    #[serde(
+        alias = "chatgpt",
+        alias = "chat-gpt",
+        alias = "chatgpt_auth_tokens",
+        alias = "codex"
+    )]
+    ChatGpt,
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct ProviderEntry {
     pub provider_type: Option<String>,
     pub base_url: Option<String>,
     pub model: Option<String>,
+    /// Authentication source for this provider. Default is API-key
+    /// auth. Set to `chatgpt` to reuse Codex ChatGPT-login tokens
+    /// (`CODEX_ACCESS_TOKEN` or `CODEX_HOME/auth.json`).
+    pub auth: Option<ProviderAuth>,
     /// Name of the env var holding the API key. Kept for backward
     /// compatibility — prefer `api_key` with `${VAR}` interpolation
     /// for clarity.
@@ -407,6 +425,9 @@ impl<'de> Deserialize<'de> for SandboxConfig {
 #[serde(default)]
 pub struct Config {
     pub provider: Option<String>,
+    /// Default authentication source for providers that do not set
+    /// `providers.<name>.auth`. `ApiKey` remains the implicit default.
+    pub auth: Option<ProviderAuth>,
     pub max_tokens: Option<u64>,
     pub temperature: Option<f64>,
     pub no_tools: Option<bool>,
@@ -1166,6 +1187,33 @@ mod tests {
         let empty: Config = serde_json::from_str("{}").unwrap();
         assert!(empty.plugin_enabled("anything"));
         assert!(!empty.plugin_auto_start("anything"));
+    }
+
+    #[test]
+    fn provider_auth_mode_parses_chatgpt_aliases() {
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "auth": "chatgpt",
+                "providers": {
+                    "openai": { "auth": "chatgpt" },
+                    "codex": { "auth": "chatgpt_auth_tokens" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.auth, Some(ProviderAuth::ChatGpt));
+        let providers = cfg.providers.unwrap();
+        assert_eq!(providers["openai"].auth, Some(ProviderAuth::ChatGpt));
+        assert_eq!(providers["codex"].auth, Some(ProviderAuth::ChatGpt));
+
+        let cfg: Config =
+            serde_json::from_str(r#"{ "providers": { "openai": { "auth": "api-key" } } }"#)
+                .unwrap();
+        assert_eq!(
+            cfg.providers.unwrap()["openai"].auth,
+            Some(ProviderAuth::ApiKey)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -948,6 +948,7 @@ async fn main() -> anyhow::Result<()> {
                             provider_type: Some(ptype),
                             base_url: Some(base_url),
                             model: None,
+                            auth: None,
                             api_key_env,
                             // Plugin-registered providers don't expose
                             // a chunk-timeout knob via the
@@ -1014,7 +1015,12 @@ async fn main() -> anyhow::Result<()> {
         cli.api_key.clone()
     };
 
-    let client = provider::create_client(&provider, resolved_key.as_deref(), &cfg.providers_map())?;
+    let client = provider::create_client_with_auth(
+        &provider,
+        resolved_key.as_deref(),
+        &cfg.providers_map(),
+        cfg.auth,
+    )?;
 
     // dirge-ykeu Phase 4: pre-resolve user agent profiles into subagent
     // routes (model + system prompt) and install them process-globally so the

--- a/src/provider/auth.rs
+++ b/src/provider/auth.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 
 use crate::config::ProviderAuth;
 
@@ -16,47 +15,38 @@ pub fn resolve_auth_headers(auth: ProviderAuth) -> anyhow::Result<Option<Provide
     }
 }
 
-static PROVIDER_AUTH_HEADERS: OnceLock<
-    Mutex<std::collections::HashMap<String, ProviderAuthHeaders>>,
-> = OnceLock::new();
-
-pub fn install_provider_auth_headers(provider: &str, headers: ProviderAuthHeaders) {
-    let map = PROVIDER_AUTH_HEADERS.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
-    if let Ok(mut map) = map.lock() {
-        map.insert(provider.to_ascii_lowercase(), headers);
-    }
-}
-
-pub fn provider_auth_headers(provider: &str) -> Option<ProviderAuthHeaders> {
-    let map = PROVIDER_AUTH_HEADERS.get()?;
-    map.lock()
-        .ok()
-        .and_then(|map| map.get(&provider.to_ascii_lowercase()).cloned())
-}
-
 fn resolve_chatgpt_auth() -> anyhow::Result<ProviderAuthHeaders> {
-    if let Ok(token) = std::env::var("CODEX_ACCESS_TOKEN")
+    resolve_chatgpt_auth_from(
+        std::env::var("CODEX_ACCESS_TOKEN").ok(),
+        std::env::var("CHATGPT_ACCOUNT_ID").ok(),
+        codex_auth_file_path(),
+    )
+}
+
+fn resolve_chatgpt_auth_from(
+    codex_access_token: Option<String>,
+    chatgpt_account_id: Option<String>,
+    auth_file_path: PathBuf,
+) -> anyhow::Result<ProviderAuthHeaders> {
+    if let Some(token) = codex_access_token
         && !token.trim().is_empty()
     {
         return Ok(ProviderAuthHeaders {
             bearer_token: token.trim().to_string(),
-            chatgpt_account_id: std::env::var("CHATGPT_ACCOUNT_ID")
-                .ok()
-                .filter(|v| !v.trim().is_empty()),
+            chatgpt_account_id: chatgpt_account_id.filter(|v| !v.trim().is_empty()),
         });
     }
 
-    let path = codex_auth_file_path();
-    let raw = std::fs::read_to_string(&path).map_err(|e| {
+    let raw = std::fs::read_to_string(&auth_file_path).map_err(|e| {
         anyhow::anyhow!(
             "ChatGPT auth requested, but CODEX_ACCESS_TOKEN is unset and Codex auth storage could not be read at {}: {e}. Run `codex login` or set CODEX_ACCESS_TOKEN.",
-            path.display()
+            auth_file_path.display()
         )
     })?;
     let json: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
         anyhow::anyhow!(
             "ChatGPT auth requested, but Codex auth storage at {} is not valid JSON: {e}",
-            path.display()
+            auth_file_path.display()
         )
     })?;
 
@@ -64,7 +54,7 @@ fn resolve_chatgpt_auth() -> anyhow::Result<ProviderAuthHeaders> {
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "ChatGPT auth requested, but no access token was found in {}. Run `codex login` again or set CODEX_ACCESS_TOKEN.",
-                path.display()
+                auth_file_path.display()
             )
         })?;
     let chatgpt_account_id = extract_string_by_keys(
@@ -149,32 +139,14 @@ mod tests {
 
     #[test]
     fn codex_access_token_env_wins() {
-        unsafe {
-            std::env::set_var("CODEX_ACCESS_TOKEN", " env-token ");
-            std::env::set_var("CHATGPT_ACCOUNT_ID", "acct-env");
-        }
-        let headers = resolve_chatgpt_auth().unwrap();
-        unsafe {
-            std::env::remove_var("CODEX_ACCESS_TOKEN");
-            std::env::remove_var("CHATGPT_ACCOUNT_ID");
-        }
+        let headers = resolve_chatgpt_auth_from(
+            Some(" env-token ".to_string()),
+            Some("acct-env".to_string()),
+            PathBuf::from("/should/not/be/read"),
+        )
+        .unwrap();
 
         assert_eq!(headers.bearer_token, "env-token");
         assert_eq!(headers.chatgpt_account_id.as_deref(), Some("acct-env"));
-    }
-
-    #[test]
-    fn provider_auth_headers_are_keyed_case_insensitively() {
-        install_provider_auth_headers(
-            "OpenAI-ChatGPT",
-            ProviderAuthHeaders {
-                bearer_token: "token".to_string(),
-                chatgpt_account_id: Some("acct".to_string()),
-            },
-        );
-
-        let headers = provider_auth_headers("openai-chatgpt").unwrap();
-        assert_eq!(headers.bearer_token, "token");
-        assert_eq!(headers.chatgpt_account_id.as_deref(), Some("acct"));
     }
 }

--- a/src/provider/auth.rs
+++ b/src/provider/auth.rs
@@ -1,0 +1,180 @@
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use crate::config::ProviderAuth;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderAuthHeaders {
+    pub bearer_token: String,
+    pub chatgpt_account_id: Option<String>,
+}
+
+pub fn resolve_auth_headers(auth: ProviderAuth) -> anyhow::Result<Option<ProviderAuthHeaders>> {
+    match auth {
+        ProviderAuth::ApiKey => Ok(None),
+        ProviderAuth::ChatGpt => Ok(Some(resolve_chatgpt_auth()?)),
+    }
+}
+
+static PROVIDER_AUTH_HEADERS: OnceLock<
+    Mutex<std::collections::HashMap<String, ProviderAuthHeaders>>,
+> = OnceLock::new();
+
+pub fn install_provider_auth_headers(provider: &str, headers: ProviderAuthHeaders) {
+    let map = PROVIDER_AUTH_HEADERS.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Ok(mut map) = map.lock() {
+        map.insert(provider.to_ascii_lowercase(), headers);
+    }
+}
+
+pub fn provider_auth_headers(provider: &str) -> Option<ProviderAuthHeaders> {
+    let map = PROVIDER_AUTH_HEADERS.get()?;
+    map.lock()
+        .ok()
+        .and_then(|map| map.get(&provider.to_ascii_lowercase()).cloned())
+}
+
+fn resolve_chatgpt_auth() -> anyhow::Result<ProviderAuthHeaders> {
+    if let Ok(token) = std::env::var("CODEX_ACCESS_TOKEN")
+        && !token.trim().is_empty()
+    {
+        return Ok(ProviderAuthHeaders {
+            bearer_token: token.trim().to_string(),
+            chatgpt_account_id: std::env::var("CHATGPT_ACCOUNT_ID")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+        });
+    }
+
+    let path = codex_auth_file_path();
+    let raw = std::fs::read_to_string(&path).map_err(|e| {
+        anyhow::anyhow!(
+            "ChatGPT auth requested, but CODEX_ACCESS_TOKEN is unset and Codex auth storage could not be read at {}: {e}. Run `codex login` or set CODEX_ACCESS_TOKEN.",
+            path.display()
+        )
+    })?;
+    let json: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        anyhow::anyhow!(
+            "ChatGPT auth requested, but Codex auth storage at {} is not valid JSON: {e}",
+            path.display()
+        )
+    })?;
+
+    let bearer_token = extract_string_by_keys(&json, &["access_token", "accessToken"])
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "ChatGPT auth requested, but no access token was found in {}. Run `codex login` again or set CODEX_ACCESS_TOKEN.",
+                path.display()
+            )
+        })?;
+    let chatgpt_account_id = extract_string_by_keys(
+        &json,
+        &[
+            "chatgpt_account_id",
+            "chatgptAccountId",
+            "chatgpt_account",
+            "account_id",
+            "accountId",
+        ],
+    );
+
+    Ok(ProviderAuthHeaders {
+        bearer_token,
+        chatgpt_account_id,
+    })
+}
+
+fn codex_auth_file_path() -> PathBuf {
+    if let Ok(home) = std::env::var("CODEX_HOME")
+        && !home.trim().is_empty()
+    {
+        return PathBuf::from(home).join("auth.json");
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codex")
+        .join("auth.json")
+}
+
+fn extract_string_by_keys(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    if let serde_json::Value::Object(map) = value {
+        for key in keys {
+            if let Some(s) = map
+                .get(*key)
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                return Some(s.to_string());
+            }
+        }
+        for child in map.values() {
+            if let Some(s) = extract_string_by_keys(child, keys) {
+                return Some(s);
+            }
+        }
+    } else if let serde_json::Value::Array(items) = value {
+        for child in items {
+            if let Some(s) = extract_string_by_keys(child, keys) {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_nested_codex_access_token_and_account_id() {
+        let value = serde_json::json!({
+            "chatgpt_auth_tokens": {
+                "access_token": "token-123",
+                "refresh_token": "must-not-win"
+            },
+            "chatgpt_account_id": "acct-456"
+        });
+
+        assert_eq!(
+            extract_string_by_keys(&value, &["access_token", "accessToken"]).as_deref(),
+            Some("token-123")
+        );
+        assert_eq!(
+            extract_string_by_keys(&value, &["chatgpt_account_id"]).as_deref(),
+            Some("acct-456")
+        );
+    }
+
+    #[test]
+    fn codex_access_token_env_wins() {
+        unsafe {
+            std::env::set_var("CODEX_ACCESS_TOKEN", " env-token ");
+            std::env::set_var("CHATGPT_ACCOUNT_ID", "acct-env");
+        }
+        let headers = resolve_chatgpt_auth().unwrap();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+            std::env::remove_var("CHATGPT_ACCOUNT_ID");
+        }
+
+        assert_eq!(headers.bearer_token, "env-token");
+        assert_eq!(headers.chatgpt_account_id.as_deref(), Some("acct-env"));
+    }
+
+    #[test]
+    fn provider_auth_headers_are_keyed_case_insensitively() {
+        install_provider_auth_headers(
+            "OpenAI-ChatGPT",
+            ProviderAuthHeaders {
+                bearer_token: "token".to_string(),
+                chatgpt_account_id: Some("acct".to_string()),
+            },
+        );
+
+        let headers = provider_auth_headers("openai-chatgpt").unwrap();
+        assert_eq!(headers.bearer_token, "token");
+        assert_eq!(headers.chatgpt_account_id.as_deref(), Some("acct"));
+    }
+}

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -36,6 +36,15 @@ pub fn create_client(
     client::create_client(provider_name, api_key, providers)
 }
 
+pub fn create_client_with_auth(
+    provider_name: &str,
+    api_key: Option<&str>,
+    providers: &HashMap<String, ProviderEntry>,
+    default_auth: Option<crate::config::ProviderAuth>,
+) -> anyhow::Result<AnyClient> {
+    client::create_client_with_auth(provider_name, api_key, providers, default_auth)
+}
+
 // Arity matches `build_agent_inner` — explicit DI signature kept
 // grep-able, refactoring into a struct is tracked separately.
 #[allow(clippy::too_many_arguments)]

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -183,6 +183,7 @@ pub async fn build_agent(
     let mut agent = match model {
         AnyModel::OpenRouter(m) => build_inner!(m, OpenRouter),
         AnyModel::OpenAI(m) => build_inner!(m, OpenAI),
+        AnyModel::ChatGptOpenAI(m) => build_inner!(m, ChatGptOpenAI),
         AnyModel::Anthropic(m) => build_inner!(m, Anthropic),
         AnyModel::Gemini(m) => build_inner!(m, Gemini),
         AnyModel::DeepSeek(m) => build_inner!(m, DeepSeek),

--- a/src/provider/client.rs
+++ b/src/provider/client.rs
@@ -8,16 +8,30 @@
 
 use std::collections::HashMap;
 
+use rig::http_client::HeaderMap;
 use rig::providers::{anthropic, gemini, ollama, openai, openrouter};
 
-use crate::config::ProviderEntry;
+use crate::config::{ProviderAuth, ProviderEntry};
 
+use super::auth::{install_provider_auth_headers, resolve_auth_headers};
+use super::codex_http::CodexHttpClient;
 use super::{AnyClient, ProviderKind, resolve_api_key, resolve_provider_info};
+
+const CHATGPT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 
 pub(crate) fn create_client(
     provider_name: &str,
     api_key: Option<&str>,
     providers: &HashMap<String, ProviderEntry>,
+) -> anyhow::Result<AnyClient> {
+    create_client_with_auth(provider_name, api_key, providers, None)
+}
+
+pub(crate) fn create_client_with_auth(
+    provider_name: &str,
+    api_key: Option<&str>,
+    providers: &HashMap<String, ProviderEntry>,
+    default_auth: Option<ProviderAuth>,
 ) -> anyhow::Result<AnyClient> {
     let info = resolve_provider_info(provider_name, providers).ok_or_else(|| {
         anyhow::anyhow!(
@@ -26,15 +40,25 @@ pub(crate) fn create_client(
         )
     })?;
 
-    // Precedence: CLI `--api-key` > `entry.api_key` (literal or
-    // `${VAR}`-expanded) > `entry.api_key_env` > default env var
-    // for the kind > kind-specific fallback env vars.
-    let key = match (api_key, info.api_key_literal.as_deref()) {
-        (Some(k), _) if !k.is_empty() => k.to_string(),
-        (_, Some(k)) if !k.is_empty() => k.to_string(),
-        _ => resolve_api_key(info.kind, info.api_key_env.as_deref(), api_key)?,
+    let auth = info.auth.or(default_auth).unwrap_or(ProviderAuth::ApiKey);
+    let auth_headers = resolve_auth_headers(auth)?;
+    // Precedence for API-key auth: CLI `--api-key` > `entry.api_key`
+    // (literal or `${VAR}`-expanded) > `entry.api_key_env` > default
+    // env var for the kind > kind-specific fallback env vars.
+    // ChatGPT auth intentionally ignores API-key sources and uses the
+    // Codex bearer token as the OpenAI client credential.
+    let key = if let Some(headers) = auth_headers.as_ref() {
+        install_provider_auth_headers(provider_name, headers.clone());
+        headers.bearer_token.clone()
+    } else {
+        match (api_key, info.api_key_literal.as_deref()) {
+            (Some(k), _) if !k.is_empty() => k.to_string(),
+            (_, Some(k)) if !k.is_empty() => k.to_string(),
+            _ => resolve_api_key(info.kind, info.api_key_env.as_deref(), api_key)?,
+        }
     };
 
+    let is_chatgpt_auth = auth == ProviderAuth::ChatGpt;
     let base_url = match info.kind {
         ProviderKind::DeepSeek => Some(
             std::env::var("DEEPSEEK_BASE_URL")
@@ -47,14 +71,22 @@ pub(crate) fn create_client(
         ProviderKind::Custom => info
             .base_url
             .or_else(|| std::env::var("CUSTOM_BASE_URL").ok()),
+        ProviderKind::OpenAI if is_chatgpt_auth => info
+            .base_url
+            .or_else(|| Some(CHATGPT_CODEX_BASE_URL.to_string())),
         _ => info.base_url,
     };
 
     match info.kind {
         ProviderKind::OpenAI => {
-            let mut b = openai::CompletionsClient::builder().api_key(&key);
+            let mut b = openai::Client::builder()
+                .api_key(&key)
+                .http_client(CodexHttpClient::default());
             if let Some(base_url) = &base_url {
                 b = b.base_url(base_url);
+            }
+            if let Some(headers) = chatgpt_http_headers(auth_headers.as_ref()) {
+                b = b.http_headers(headers);
             }
             Ok(AnyClient::OpenAI(b.build()?))
         }
@@ -112,5 +144,109 @@ pub(crate) fn create_client(
                 .base_url(&base_url);
             Ok(AnyClient::Custom(b.build()?))
         }
+    }
+}
+
+fn chatgpt_http_headers(
+    auth_headers: Option<&super::auth::ProviderAuthHeaders>,
+) -> Option<HeaderMap> {
+    let account_id = auth_headers?
+        .chatgpt_account_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())?;
+    let mut headers = HeaderMap::new();
+    let name = http::HeaderName::from_static("chatgpt-account-id");
+    let value = http::HeaderValue::from_str(account_id).ok()?;
+    headers.insert(name, value);
+    Some(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::config::{ProviderAuth, ProviderEntry};
+
+    use super::{CHATGPT_CODEX_BASE_URL, create_client_with_auth, resolve_provider_info};
+
+    #[test]
+    fn top_level_auth_can_default_provider_entry_auth() {
+        let providers = HashMap::from([(
+            "openai".to_string(),
+            ProviderEntry {
+                model: Some("gpt-5.5".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let info = resolve_provider_info("openai", &providers).unwrap();
+
+        assert_eq!(
+            info.auth.or(Some(ProviderAuth::ChatGpt)),
+            Some(ProviderAuth::ChatGpt)
+        );
+    }
+
+    #[test]
+    fn provider_auth_overrides_top_level_default() {
+        let providers = HashMap::from([(
+            "openai".to_string(),
+            ProviderEntry {
+                auth: Some(ProviderAuth::ApiKey),
+                ..Default::default()
+            },
+        )]);
+        let info = resolve_provider_info("openai", &providers).unwrap();
+
+        assert_eq!(
+            info.auth.or(Some(ProviderAuth::ChatGpt)),
+            Some(ProviderAuth::ApiKey)
+        );
+    }
+
+    #[test]
+    fn chatgpt_auth_openai_uses_codex_backend_by_default() {
+        let providers = HashMap::new();
+
+        unsafe {
+            std::env::set_var("CODEX_ACCESS_TOKEN", "test-token");
+        }
+        let client =
+            create_client_with_auth("openai", None, &providers, Some(ProviderAuth::ChatGpt))
+                .unwrap();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+        }
+
+        let crate::provider::AnyClient::OpenAI(client) = client else {
+            panic!("expected OpenAI client");
+        };
+        assert_eq!(client.base_url(), CHATGPT_CODEX_BASE_URL);
+    }
+
+    #[test]
+    fn chatgpt_auth_openai_preserves_explicit_base_url() {
+        let providers = HashMap::from([(
+            "openai".to_string(),
+            ProviderEntry {
+                base_url: Some("https://proxy.example.com/openai".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        unsafe {
+            std::env::set_var("CODEX_ACCESS_TOKEN", "test-token");
+        }
+        let client =
+            create_client_with_auth("openai", None, &providers, Some(ProviderAuth::ChatGpt))
+                .unwrap();
+        unsafe {
+            std::env::remove_var("CODEX_ACCESS_TOKEN");
+        }
+
+        let crate::provider::AnyClient::OpenAI(client) = client else {
+            panic!("expected OpenAI client");
+        };
+        assert_eq!(client.base_url(), "https://proxy.example.com/openai");
     }
 }

--- a/src/provider/client.rs
+++ b/src/provider/client.rs
@@ -13,7 +13,7 @@ use rig::providers::{anthropic, gemini, ollama, openai, openrouter};
 
 use crate::config::{ProviderAuth, ProviderEntry};
 
-use super::auth::{install_provider_auth_headers, resolve_auth_headers};
+use super::auth::{ProviderAuthHeaders, resolve_auth_headers};
 use super::codex_http::CodexHttpClient;
 use super::{AnyClient, ProviderKind, resolve_api_key, resolve_provider_info};
 
@@ -33,6 +33,16 @@ pub(crate) fn create_client_with_auth(
     providers: &HashMap<String, ProviderEntry>,
     default_auth: Option<ProviderAuth>,
 ) -> anyhow::Result<AnyClient> {
+    create_client_with_resolved_auth(provider_name, api_key, providers, default_auth, None)
+}
+
+fn create_client_with_resolved_auth(
+    provider_name: &str,
+    api_key: Option<&str>,
+    providers: &HashMap<String, ProviderEntry>,
+    default_auth: Option<ProviderAuth>,
+    resolved_auth_headers: Option<ProviderAuthHeaders>,
+) -> anyhow::Result<AnyClient> {
     let info = resolve_provider_info(provider_name, providers).ok_or_else(|| {
         anyhow::anyhow!(
             "Unknown provider: {}. Supported providers: openrouter, openai, anthropic, gemini, deepseek, glm, ollama, custom",
@@ -41,14 +51,16 @@ pub(crate) fn create_client_with_auth(
     })?;
 
     let auth = info.auth.or(default_auth).unwrap_or(ProviderAuth::ApiKey);
-    let auth_headers = resolve_auth_headers(auth)?;
+    let auth_headers = match (auth, resolved_auth_headers) {
+        (ProviderAuth::ChatGpt, Some(headers)) => Some(headers),
+        _ => resolve_auth_headers(auth)?,
+    };
     // Precedence for API-key auth: CLI `--api-key` > `entry.api_key`
     // (literal or `${VAR}`-expanded) > `entry.api_key_env` > default
     // env var for the kind > kind-specific fallback env vars.
     // ChatGPT auth intentionally ignores API-key sources and uses the
     // Codex bearer token as the OpenAI client credential.
     let key = if let Some(headers) = auth_headers.as_ref() {
-        install_provider_auth_headers(provider_name, headers.clone());
         headers.bearer_token.clone()
     } else {
         match (api_key, info.api_key_literal.as_deref()) {
@@ -59,6 +71,18 @@ pub(crate) fn create_client_with_auth(
     };
 
     let is_chatgpt_auth = auth == ProviderAuth::ChatGpt;
+    if is_chatgpt_auth {
+        let has_account_id = auth_headers
+            .as_ref()
+            .and_then(|headers| headers.chatgpt_account_id.as_deref())
+            .map(str::trim)
+            .is_some_and(|account_id| !account_id.is_empty());
+        if !has_account_id {
+            anyhow::bail!(
+                "ChatGPT auth requested, but no ChatGPT account id was found. Set CHATGPT_ACCOUNT_ID or run `codex login` so auth.json contains a chatgpt_account_id/account_id."
+            );
+        }
+    }
     let base_url = match info.kind {
         ProviderKind::DeepSeek => Some(
             std::env::var("DEEPSEEK_BASE_URL")
@@ -79,16 +103,24 @@ pub(crate) fn create_client_with_auth(
 
     match info.kind {
         ProviderKind::OpenAI => {
-            let mut b = openai::Client::builder()
-                .api_key(&key)
-                .http_client(CodexHttpClient::default());
-            if let Some(base_url) = &base_url {
-                b = b.base_url(base_url);
+            if is_chatgpt_auth {
+                let mut b = openai::Client::builder()
+                    .api_key(&key)
+                    .http_client(CodexHttpClient::default());
+                if let Some(base_url) = &base_url {
+                    b = b.base_url(base_url);
+                }
+                if let Some(headers) = chatgpt_http_headers(auth_headers.as_ref()) {
+                    b = b.http_headers(headers);
+                }
+                Ok(AnyClient::ChatGptOpenAI(b.build()?))
+            } else {
+                let mut b = openai::CompletionsClient::builder().api_key(&key);
+                if let Some(base_url) = &base_url {
+                    b = b.base_url(base_url);
+                }
+                Ok(AnyClient::OpenAI(b.build()?))
             }
-            if let Some(headers) = chatgpt_http_headers(auth_headers.as_ref()) {
-                b = b.http_headers(headers);
-            }
-            Ok(AnyClient::OpenAI(b.build()?))
         }
         ProviderKind::Anthropic => {
             let mut b = anthropic::Client::builder().api_key(&key);
@@ -147,6 +179,21 @@ pub(crate) fn create_client_with_auth(
     }
 }
 
+#[cfg(test)]
+fn create_client_with_chatgpt_auth_headers(
+    provider_name: &str,
+    providers: &HashMap<String, ProviderEntry>,
+    headers: ProviderAuthHeaders,
+) -> anyhow::Result<AnyClient> {
+    create_client_with_resolved_auth(
+        provider_name,
+        None,
+        providers,
+        Some(ProviderAuth::ChatGpt),
+        Some(headers),
+    )
+}
+
 fn chatgpt_http_headers(
     auth_headers: Option<&super::auth::ProviderAuthHeaders>,
 ) -> Option<HeaderMap> {
@@ -168,7 +215,17 @@ mod tests {
 
     use crate::config::{ProviderAuth, ProviderEntry};
 
-    use super::{CHATGPT_CODEX_BASE_URL, create_client_with_auth, resolve_provider_info};
+    use super::{
+        CHATGPT_CODEX_BASE_URL, create_client_with_auth, create_client_with_chatgpt_auth_headers,
+        resolve_provider_info,
+    };
+
+    fn test_chatgpt_headers() -> crate::provider::auth::ProviderAuthHeaders {
+        crate::provider::auth::ProviderAuthHeaders {
+            bearer_token: "test-token".to_string(),
+            chatgpt_account_id: Some("acct-test".to_string()),
+        }
+    }
 
     #[test]
     fn top_level_auth_can_default_provider_entry_auth() {
@@ -205,21 +262,27 @@ mod tests {
     }
 
     #[test]
+    fn api_key_openai_uses_chat_completions_client() {
+        let providers = HashMap::new();
+
+        let client =
+            create_client_with_auth("openai", Some("test-api-key"), &providers, None).unwrap();
+
+        let crate::provider::AnyClient::OpenAI(_) = client else {
+            panic!("expected API-key OpenAI to use Chat Completions client");
+        };
+    }
+
+    #[test]
     fn chatgpt_auth_openai_uses_codex_backend_by_default() {
         let providers = HashMap::new();
 
-        unsafe {
-            std::env::set_var("CODEX_ACCESS_TOKEN", "test-token");
-        }
         let client =
-            create_client_with_auth("openai", None, &providers, Some(ProviderAuth::ChatGpt))
+            create_client_with_chatgpt_auth_headers("openai", &providers, test_chatgpt_headers())
                 .unwrap();
-        unsafe {
-            std::env::remove_var("CODEX_ACCESS_TOKEN");
-        }
 
-        let crate::provider::AnyClient::OpenAI(client) = client else {
-            panic!("expected OpenAI client");
+        let crate::provider::AnyClient::ChatGptOpenAI(client) = client else {
+            panic!("expected ChatGPT OpenAI client");
         };
         assert_eq!(client.base_url(), CHATGPT_CODEX_BASE_URL);
     }
@@ -234,19 +297,33 @@ mod tests {
             },
         )]);
 
-        unsafe {
-            std::env::set_var("CODEX_ACCESS_TOKEN", "test-token");
-        }
         let client =
-            create_client_with_auth("openai", None, &providers, Some(ProviderAuth::ChatGpt))
+            create_client_with_chatgpt_auth_headers("openai", &providers, test_chatgpt_headers())
                 .unwrap();
-        unsafe {
-            std::env::remove_var("CODEX_ACCESS_TOKEN");
-        }
 
-        let crate::provider::AnyClient::OpenAI(client) = client else {
-            panic!("expected OpenAI client");
+        let crate::provider::AnyClient::ChatGptOpenAI(client) = client else {
+            panic!("expected ChatGPT OpenAI client");
         };
         assert_eq!(client.base_url(), "https://proxy.example.com/openai");
+    }
+
+    #[test]
+    fn chatgpt_auth_requires_account_id() {
+        let providers = HashMap::new();
+
+        let result = create_client_with_chatgpt_auth_headers(
+            "openai",
+            &providers,
+            crate::provider::auth::ProviderAuthHeaders {
+                bearer_token: "test-token".to_string(),
+                chatgpt_account_id: None,
+            },
+        );
+        let err = match result {
+            Ok(_) => panic!("expected ChatGPT auth without account id to fail"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("no ChatGPT account id was found"));
     }
 }

--- a/src/provider/codex_http.rs
+++ b/src/provider/codex_http.rs
@@ -1,0 +1,249 @@
+use bytes::Bytes;
+use rig::http_client::{
+    self, HttpClientExt, LazyBody, MultipartForm, Request, Response, StreamingResponse,
+};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CodexHttpClient {
+    inner: reqwest::Client,
+}
+
+impl CodexHttpClient {
+    // Rig 0.37's OpenAI Responses adapter moves `preamble` into the
+    // first `input` system message, then serializes `instructions: null`.
+    // The ChatGPT Codex backend wants the opposite shape: a non-empty
+    // Responses-native `instructions` field, no `system` role in
+    // `input`, and `store: false`. Keep the fix inside Dirge by
+    // normalizing the outgoing `/responses` JSON body at the
+    // transport boundary instead of vendoring or forking rig-core.
+    fn normalized_request<T>(req: Request<T>) -> http_client::Result<Request<Bytes>>
+    where
+        T: Into<Bytes>,
+    {
+        let (parts, body) = req.into_parts();
+        let body = body.into();
+        let body = if is_responses_path(parts.uri.path()) {
+            normalize_codex_responses_body(body)
+        } else {
+            body
+        };
+
+        let mut builder = Request::builder()
+            .method(parts.method)
+            .uri(parts.uri)
+            .version(parts.version);
+        if let Some(headers) = builder.headers_mut() {
+            *headers = parts.headers;
+        }
+        builder.body(body).map_err(http_client::Error::Protocol)
+    }
+}
+
+impl HttpClientExt for CodexHttpClient {
+    fn send<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        T: Into<Bytes>,
+        T: Send,
+        U: From<Bytes>,
+        U: Send + 'static,
+    {
+        let inner = self.inner.clone();
+        let req = Self::normalized_request(req);
+        async move {
+            let req = req?;
+            inner.send(req).await
+        }
+    }
+
+    fn send_multipart<U>(
+        &self,
+        req: Request<MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + Send + 'static
+    where
+        U: From<Bytes> + Send + 'static,
+    {
+        self.inner.send_multipart(req)
+    }
+
+    fn send_streaming<T>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + Send
+    where
+        T: Into<Bytes> + Send,
+    {
+        let inner = self.inner.clone();
+        let is_responses_stream = is_responses_path(req.uri().path());
+        let req = Self::normalized_request(req);
+        async move {
+            let req = req?;
+            let mut response = inner.send_streaming(req).await?;
+            if is_responses_stream
+                && !response
+                    .headers()
+                    .contains_key(reqwest::header::CONTENT_TYPE)
+            {
+                response.headers_mut().insert(
+                    reqwest::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("text/event-stream"),
+                );
+            }
+            Ok(response)
+        }
+    }
+}
+
+fn is_responses_path(path: &str) -> bool {
+    path.ends_with("/responses")
+}
+
+fn normalize_codex_responses_body(body: Bytes) -> Bytes {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+
+    let instructions = if value
+        .as_object()
+        .and_then(|obj| obj.get("instructions"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .is_some_and(|instructions| !instructions.is_empty())
+    {
+        None
+    } else {
+        // Rig has already preserved Dirge's actual system prompt in
+        // `input`; we mirror that into the Responses-native field Codex
+        // requires. The fallback is intentionally minimal and should only
+        // matter for malformed/test requests with no system input.
+        Some(extract_system_instructions(&value).unwrap_or_else(|| ".".to_string()))
+    };
+
+    let Some(obj) = value.as_object_mut() else {
+        return body;
+    };
+    if let Some(instructions) = instructions {
+        obj.insert(
+            "instructions".to_string(),
+            serde_json::Value::String(instructions),
+        );
+    }
+    obj.insert("store".to_string(), serde_json::Value::Bool(false));
+    strip_system_input_items(obj);
+
+    serde_json::to_vec(&value).map(Bytes::from).unwrap_or(body)
+}
+
+fn strip_system_input_items(obj: &mut serde_json::Map<String, serde_json::Value>) {
+    let Some(input) = obj
+        .get_mut("input")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    input.retain(|item| item.get("role").and_then(serde_json::Value::as_str) != Some("system"));
+}
+
+fn extract_system_instructions(value: &serde_json::Value) -> Option<String> {
+    let input = value.get("input")?.as_array()?;
+    input
+        .iter()
+        .find(|item| item.get("role").and_then(serde_json::Value::as_str) == Some("system"))
+        .and_then(extract_message_text)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn extract_message_text(item: &serde_json::Value) -> Option<String> {
+    match item.get("content")? {
+        serde_json::Value::String(text) => Some(text.clone()),
+        serde_json::Value::Array(parts) => {
+            let text = parts
+                .iter()
+                .filter_map(|part| {
+                    part.get("text")
+                        .or_else(|| part.get("content"))
+                        .and_then(serde_json::Value::as_str)
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Some(text)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_responses_instructions_from_system_input() {
+        let body = Bytes::from(
+            serde_json::json!({
+                "model": "gpt-5",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "system",
+                        "content": [{ "type": "input_text", "text": "Follow Dirge instructions." }]
+                    },
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{ "type": "input_text", "text": "Hi" }]
+                    }
+                ]
+            })
+            .to_string(),
+        );
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&normalize_codex_responses_body(body)).unwrap();
+
+        assert_eq!(value["instructions"], "Follow Dirge instructions.");
+        assert_eq!(value["store"], false);
+        assert_eq!(value["input"].as_array().unwrap().len(), 1);
+        assert_eq!(value["input"][0]["role"], "user");
+    }
+
+    #[test]
+    fn preserves_existing_instructions_but_still_strips_system_input() {
+        let body = Bytes::from(
+            serde_json::json!({
+                "instructions": "Existing",
+                "input": [
+                    { "role": "system", "content": "Replacement" }
+                ]
+            })
+            .to_string(),
+        );
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&normalize_codex_responses_body(body)).unwrap();
+
+        assert_eq!(value["instructions"], "Existing");
+        assert_eq!(value["store"], false);
+        assert!(value["input"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn overrides_true_store_for_codex_backend() {
+        let body = Bytes::from(
+            serde_json::json!({
+                "store": true,
+                "input": [
+                    { "role": "user", "content": "Hi" }
+                ]
+            })
+            .to_string(),
+        );
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&normalize_codex_responses_body(body)).unwrap();
+
+        assert_eq!(value["store"], false);
+    }
+}

--- a/src/provider/dispatch.rs
+++ b/src/provider/dispatch.rs
@@ -15,11 +15,12 @@ use rig::providers::{anthropic, gemini, ollama, openai, openrouter};
 use crate::agent::prompt;
 use crate::session::SessionMessage;
 
+use super::codex_http::CodexHttpClient;
 use super::summarize;
 
 pub enum AnyClient {
     OpenRouter(openrouter::Client),
-    OpenAI(openai::CompletionsClient),
+    OpenAI(openai::Client<CodexHttpClient>),
     Anthropic(anthropic::Client),
     Gemini(gemini::Client),
     DeepSeek(openai::CompletionsClient),
@@ -127,7 +128,7 @@ impl AnyClient {
 #[derive(Clone)]
 pub enum AnyModel {
     OpenRouter(openrouter::completion::CompletionModel),
-    OpenAI(openai::completion::CompletionModel),
+    OpenAI(openai::responses_api::ResponsesCompletionModel<CodexHttpClient>),
     Anthropic(anthropic::completion::CompletionModel),
     Gemini(gemini::completion::CompletionModel),
     DeepSeek(openai::completion::CompletionModel),

--- a/src/provider/dispatch.rs
+++ b/src/provider/dispatch.rs
@@ -20,7 +20,8 @@ use super::summarize;
 
 pub enum AnyClient {
     OpenRouter(openrouter::Client),
-    OpenAI(openai::Client<CodexHttpClient>),
+    OpenAI(openai::CompletionsClient),
+    ChatGptOpenAI(openai::Client<CodexHttpClient>),
     Anthropic(anthropic::Client),
     Gemini(gemini::Client),
     DeepSeek(openai::CompletionsClient),
@@ -35,6 +36,7 @@ impl AnyClient {
         match self {
             AnyClient::OpenRouter(c) => AnyModel::OpenRouter(c.completion_model(name)),
             AnyClient::OpenAI(c) => AnyModel::OpenAI(c.completion_model(name)),
+            AnyClient::ChatGptOpenAI(c) => AnyModel::ChatGptOpenAI(c.completion_model(name)),
             AnyClient::Anthropic(c) => AnyModel::Anthropic(c.completion_model(name)),
             AnyClient::Gemini(c) => AnyModel::Gemini(c.completion_model(name)),
             AnyClient::DeepSeek(c) => AnyModel::DeepSeek(c.completion_model(name)),
@@ -128,7 +130,8 @@ impl AnyClient {
 #[derive(Clone)]
 pub enum AnyModel {
     OpenRouter(openrouter::completion::CompletionModel),
-    OpenAI(openai::responses_api::ResponsesCompletionModel<CodexHttpClient>),
+    OpenAI(openai::completion::CompletionModel),
+    ChatGptOpenAI(openai::responses_api::ResponsesCompletionModel<CodexHttpClient>),
     Anthropic(anthropic::completion::CompletionModel),
     Gemini(gemini::completion::CompletionModel),
     DeepSeek(openai::completion::CompletionModel),
@@ -181,6 +184,7 @@ impl AnyModel {
         match self {
             AnyModel::OpenRouter(m) => one_shot!(m),
             AnyModel::OpenAI(m) => one_shot!(m),
+            AnyModel::ChatGptOpenAI(m) => one_shot!(m),
             AnyModel::Anthropic(m) => one_shot!(m),
             AnyModel::Gemini(m) => one_shot!(m),
             AnyModel::DeepSeek(m) => one_shot!(m),
@@ -228,6 +232,7 @@ impl AnyModel {
         match self {
             AnyModel::OpenRouter(m) => m.model.clone(),
             AnyModel::OpenAI(m) => m.model.clone(),
+            AnyModel::ChatGptOpenAI(m) => m.model.clone(),
             AnyModel::Anthropic(m) => m.model.clone(),
             AnyModel::Gemini(m) => m.model.clone(),
             AnyModel::DeepSeek(m) => m.model.clone(),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,5 +1,7 @@
+pub(crate) mod auth;
 mod build;
 pub mod client;
+pub(crate) mod codex_http;
 mod dispatch;
 mod resolve;
 mod run;
@@ -135,7 +137,7 @@ pub struct AnyAgent {
 #[derive(Clone)]
 pub(crate) enum AnyAgentInner {
     OpenRouter(Agent<openrouter::completion::CompletionModel>),
-    OpenAI(Agent<openai::completion::CompletionModel>),
+    OpenAI(Agent<openai::responses_api::ResponsesCompletionModel<codex_http::CodexHttpClient>>),
     Anthropic(Agent<anthropic::completion::CompletionModel>),
     Gemini(Agent<gemini::completion::CompletionModel>),
     DeepSeek(Agent<openai::completion::CompletionModel>),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -137,7 +137,10 @@ pub struct AnyAgent {
 #[derive(Clone)]
 pub(crate) enum AnyAgentInner {
     OpenRouter(Agent<openrouter::completion::CompletionModel>),
-    OpenAI(Agent<openai::responses_api::ResponsesCompletionModel<codex_http::CodexHttpClient>>),
+    OpenAI(Agent<openai::completion::CompletionModel>),
+    ChatGptOpenAI(
+        Agent<openai::responses_api::ResponsesCompletionModel<codex_http::CodexHttpClient>>,
+    ),
     Anthropic(Agent<anthropic::completion::CompletionModel>),
     Gemini(Agent<gemini::completion::CompletionModel>),
     DeepSeek(Agent<openai::completion::CompletionModel>),
@@ -363,6 +366,7 @@ impl AnyAgent {
         match &self.inner {
             AnyAgentInner::OpenRouter(_) => "openrouter",
             AnyAgentInner::OpenAI(_) => "openai",
+            AnyAgentInner::ChatGptOpenAI(_) => "openai",
             AnyAgentInner::Anthropic(_) => "anthropic",
             AnyAgentInner::Gemini(_) => "gemini",
             AnyAgentInner::DeepSeek(_) => "deepseek",

--- a/src/provider/mod_tests.rs
+++ b/src/provider/mod_tests.rs
@@ -122,15 +122,15 @@ fn fallback_list_covers_canonical_alternatives() {
 /// model. The Client::new doesn't connect (no network until
 /// the first request), so this works in unit tests.
 ///
-/// Use `completions_api()` to get the chat-completion model
-/// (the variant `AnyAgentInner::OpenAI` holds); the default
-/// `completion_model` on a fresh `Client` returns the
-/// responses-api model, which is a different type.
+/// The OpenAI variant uses Rig's Responses API model; it is never
+/// called during these tests, so construction stays offline.
 fn build_openai_any_agent() -> AnyAgent {
     use rig::providers::openai;
-    let client = openai::Client::new("test-key")
-        .expect("openai Client::new should work")
-        .completions_api();
+    let client = openai::Client::builder()
+        .api_key("test-key")
+        .http_client(crate::provider::codex_http::CodexHttpClient::default())
+        .build()
+        .expect("openai Client::new should work");
     let model = client.completion_model("gpt-4o");
     let agent = rig::agent::AgentBuilder::new(model).build();
     AnyAgent::new(

--- a/src/provider/mod_tests.rs
+++ b/src/provider/mod_tests.rs
@@ -122,15 +122,14 @@ fn fallback_list_covers_canonical_alternatives() {
 /// model. The Client::new doesn't connect (no network until
 /// the first request), so this works in unit tests.
 ///
-/// The OpenAI variant uses Rig's Responses API model; it is never
+/// The OpenAI variant uses Rig's Chat Completions model; it is never
 /// called during these tests, so construction stays offline.
 fn build_openai_any_agent() -> AnyAgent {
     use rig::providers::openai;
-    let client = openai::Client::builder()
+    let client = openai::CompletionsClient::builder()
         .api_key("test-key")
-        .http_client(crate::provider::codex_http::CodexHttpClient::default())
         .build()
-        .expect("openai Client::new should work");
+        .expect("openai CompletionsClient::new should work");
     let model = client.completion_model("gpt-4o");
     let agent = rig::agent::AgentBuilder::new(model).build();
     AnyAgent::new(

--- a/src/provider/resolve.rs
+++ b/src/provider/resolve.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use crate::config::{Config, ProviderEntry};
+use crate::config::{Config, ProviderAuth, ProviderEntry};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ProviderKind {
@@ -88,6 +88,7 @@ pub struct ProviderInfo {
     pub kind: ProviderKind,
     pub base_url: Option<String>,
     pub api_key_env: Option<String>,
+    pub auth: Option<ProviderAuth>,
     /// Literal API key resolved from `entry.api_key` (with `${VAR}`
     /// already expanded). When present, takes precedence over both
     /// `api_key_env` and the standard env-var fallback chain.
@@ -152,6 +153,7 @@ pub fn resolve_provider_info(
             kind,
             base_url: entry.base_url.clone(),
             api_key_env: entry.api_key_env.clone(),
+            auth: entry.auth,
             api_key_literal,
         });
     }
@@ -197,6 +199,7 @@ pub fn resolve_provider_info(
             kind,
             base_url: entry.base_url,
             api_key_env: entry.api_key_env,
+            auth: entry.auth,
             api_key_literal,
         });
     }
@@ -205,6 +208,7 @@ pub fn resolve_provider_info(
         kind,
         base_url: None,
         api_key_env: None,
+        auth: None,
         api_key_literal: None,
     })
 }

--- a/src/provider/stream_dispatch.rs
+++ b/src/provider/stream_dispatch.rs
@@ -30,6 +30,9 @@ macro_rules! dispatch_stream_fn {
         match $value {
             $enum::OpenRouter($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::OpenAI($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
+            $enum::ChatGptOpenAI($bind) => {
+                __stream_fn($model, $tools, $timeout, $provider, $filter)
+            }
             $enum::Anthropic($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::Gemini($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::DeepSeek($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -99,6 +99,7 @@ pub(crate) async fn oneshot_with_model(
     match model {
         super::AnyModel::OpenRouter(m) => run_oneshot(m, label, preamble, prompt).await,
         super::AnyModel::OpenAI(m) => run_oneshot(m, label, preamble, prompt).await,
+        super::AnyModel::ChatGptOpenAI(m) => run_oneshot(m, label, preamble, prompt).await,
         super::AnyModel::Anthropic(m) => run_oneshot(m, label, preamble, prompt).await,
         super::AnyModel::Gemini(m) => run_oneshot(m, label, preamble, prompt).await,
         super::AnyModel::DeepSeek(m) => run_oneshot(m, label, preamble, prompt).await,

--- a/src/ui/plugin_tree.rs
+++ b/src/ui/plugin_tree.rs
@@ -484,9 +484,11 @@ mod tests {
     fn agent_with_provider() -> (AnyAgent, Arc<RecordingProvider>) {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::new("test-key")
-            .expect("openai client")
-            .completions_api();
+        let client = openai::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::codex_http::CodexHttpClient::default())
+            .build()
+            .expect("openai client");
         let model = client.completion_model("gpt-4o");
         let inner = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingProvider::default());

--- a/src/ui/plugin_tree.rs
+++ b/src/ui/plugin_tree.rs
@@ -484,9 +484,8 @@ mod tests {
     fn agent_with_provider() -> (AnyAgent, Arc<RecordingProvider>) {
         use rig::client::CompletionClient;
         use rig::providers::openai;
-        let client = openai::Client::builder()
+        let client = openai::CompletionsClient::builder()
             .api_key("test-key")
-            .http_client(crate::provider::codex_http::CodexHttpClient::default())
             .build()
             .expect("openai client");
         let model = client.completion_model("gpt-4o");


### PR DESCRIPTION
chatgpt-5.5 assisted PR that allows codex users to authenticate and use dirge.

```
codex login
dirge
```
Dirge reads your auth token that is saved locally with codex login. I had to also create a custom http shim because codex's api is different than their normal "API" usage and has weird expectations. 