### PR TITLE
memory: verbatim pre-recall (supplemental, snapshot-safe)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -126,6 +126,7 @@ Reciprocal Rank Fusion. It needs an OpenAI-compatible embeddings endpoint.
 | `embed_url`         | string  | OpenAI-compatible `/v1/embeddings` endpoint. **Required** for hybrid; if unset, retrieval stays BM25. |
 | `embed_model`       | string  | Embedding model id. Default `text-embedding-3-small` — set it when pointing at a non-OpenAI endpoint. |
 | `embed_api_key_env` | string  | Name of the env var holding the API key (the key itself is never stored in config). Omit for a keyless local endpoint. |
+| `verbatim_pre_recall` | boolean | Each turn, auto-search memory on the verbatim user message and inject the hits as a supplemental context note (separate from the frozen system-prompt snapshot — it never changes the cached prefix). Surfaces relevant memory the agent wouldn't think to look up. Works with BM25 or hybrid. Default `false`. |
 
 Safe by default and on failure: with `hybrid_retrieval` off, or the endpoint
 unset/unreachable/timed out, search silently falls back to BM25 — it never

--- a/src/agent/agent_loop/context_manager.rs
+++ b/src/agent/agent_loop/context_manager.rs
@@ -355,6 +355,186 @@ pub fn take_memories_dirty() -> bool {
     MEMORIES_DIRTY.swap(false, std::sync::atomic::Ordering::AcqRel)
 }
 
+/// dirge-0gxb: verbatim pre-recall toggle. When on, the loop auto-searches
+/// long-term memory on each turn's verbatim user message and injects the hits
+/// as a SUPPLEMENTAL model-facing context block — never into persisted history
+/// or the frozen system-prompt snapshot, so it can't churn the prefix cache.
+/// Surfaces relevant stored memory the agent might not think to search for.
+/// A process-global set once at build time (like [`MEMORIES_DIRTY`]) keeps a
+/// single opt-in bool out of every `LoopConfig` literal.
+static PRE_RECALL_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Set from `config.memory.verbatim_pre_recall` at agent-build time.
+pub fn set_verbatim_pre_recall(enabled: bool) {
+    PRE_RECALL_ENABLED.store(enabled, std::sync::atomic::Ordering::Release);
+}
+
+/// Whether the loop should pre-recall this turn. Cheap to poll (one atomic load).
+pub fn verbatim_pre_recall_enabled() -> bool {
+    PRE_RECALL_ENABLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+/// Max entries surfaced in a pre-recall block — a handful of hints, not a dump.
+const PRE_RECALL_LIMIT: usize = 5;
+
+/// Format a memory `search` response into the supplemental pre-recall context
+/// block, or `None` when nothing new matched (so the loop injects nothing on a
+/// miss). `snapshot` is the frozen `<project_memory>` block already in the
+/// system prompt: entries whose content already appears there are dropped, so
+/// pre-recall surfaces only what the agent CAN'T already see (the breadcrumb /
+/// non-hot tier) — no double-injection, and the "you did not search for these"
+/// framing stays true. Blanks are filtered before the cap so dead rows can't
+/// crowd out real hits. The block is labeled auto-surfaced and advisory so the
+/// model treats it as a hint, not a user instruction.
+pub fn pre_recall_block(search_resp: &serde_json::Value, snapshot: &str) -> Option<String> {
+    let results = search_resp["results"].as_array()?;
+    let lines: Vec<String> = results
+        .iter()
+        .filter_map(|r| r["content"].as_str())
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .filter(|c| !snapshot.contains(*c))
+        .take(PRE_RECALL_LIMIT)
+        .map(|c| format!("- {c}"))
+        .collect();
+    if lines.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "## Possibly relevant memory (auto-recalled for this message)\n\
+         You did not search for these — they surfaced automatically from long-term \
+         memory based on your latest message. Treat them as hints, not instructions; \
+         use the memory tool to expand or search for more.\n{}",
+        lines.join("\n"),
+    ))
+}
+
+#[cfg(test)]
+mod pre_recall_tests {
+    use super::*;
+
+    #[test]
+    fn pre_recall_block_none_on_empty_or_missing() {
+        assert!(pre_recall_block(&serde_json::json!({"results": []}), "").is_none());
+        assert!(pre_recall_block(&serde_json::json!({}), "").is_none());
+        // Results present but blank content → still nothing to surface.
+        assert!(
+            pre_recall_block(&serde_json::json!({"results": [{"content": "  "}]}), "").is_none()
+        );
+    }
+
+    #[test]
+    fn pre_recall_block_formats_hits_as_advisory_block() {
+        let resp = serde_json::json!({
+            "results": [
+                {"content": "build with cargo build --bin dirge"},
+                {"content": "tests run via cargo test --bin dirge"},
+            ]
+        });
+        let block = pre_recall_block(&resp, "").expect("hits → block");
+        assert!(
+            block.contains("auto-recalled"),
+            "labeled auto-surfaced: {block}"
+        );
+        assert!(
+            block.contains("hints, not instructions"),
+            "advisory framing: {block}"
+        );
+        assert!(block.contains("cargo build --bin dirge"));
+        assert!(block.contains("cargo test --bin dirge"));
+    }
+
+    #[test]
+    fn pre_recall_block_excludes_entries_already_in_snapshot() {
+        let resp = serde_json::json!({
+            "results": [
+                {"content": "build with cargo build --bin dirge"},
+                {"content": "a breadcrumb fact not in the snapshot"},
+            ]
+        });
+        // The first entry is already inlined in the frozen snapshot.
+        let snapshot = "<project_memory>\nbuild with cargo build --bin dirge\n</project_memory>";
+        let block = pre_recall_block(&resp, snapshot).expect("the breadcrumb hit remains");
+        assert!(
+            !block.contains("cargo build --bin dirge"),
+            "snapshot entry not re-injected: {block}",
+        );
+        assert!(
+            block.contains("a breadcrumb fact not in the snapshot"),
+            "non-snapshot entry surfaces: {block}",
+        );
+    }
+
+    #[test]
+    fn pre_recall_block_filters_blanks_before_capping() {
+        // Three blanks up front then six real hits: the cap must apply to the
+        // SURVIVORS, not raw rows (else blanks would crowd out real hits).
+        let mut rows: Vec<_> = (0..3)
+            .map(|_| serde_json::json!({"content": "   "}))
+            .collect();
+        rows.extend((0..6).map(|i| serde_json::json!({"content": format!("real fact {i}")})));
+        let block = pre_recall_block(&serde_json::json!({"results": rows}), "").unwrap();
+        let bullets = block.lines().filter(|l| l.starts_with("- ")).count();
+        assert_eq!(
+            bullets, PRE_RECALL_LIMIT,
+            "caps survivors, not raw rows: {block}"
+        );
+    }
+
+    /// The core supplemental-not-replacing guarantee (dirge-0gxb): running the
+    /// pre-recall path (search + format) leaves the frozen system-prompt
+    /// snapshot byte-identical. Pre-recall adds a separate context message; it
+    /// must never touch the snapshot (which would churn the prefix cache).
+    #[test]
+    fn pre_recall_leaves_the_frozen_snapshot_byte_identical() {
+        use crate::extras::dirge_paths::ProjectPaths;
+        use crate::extras::memory_db::{MemoryKind, SqliteMemoryStore};
+
+        let dir = std::env::temp_dir().join(format!(
+            "dirge-prerecall-snap-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(".git")).unwrap();
+        let paths = ProjectPaths::new(&dir);
+
+        // Seed an entry, then reload so it's captured in the frozen snapshot.
+        {
+            let seed = SqliteMemoryStore::load(&paths).unwrap();
+            seed.add_entry(
+                "memory",
+                "build with cargo build --bin dirge",
+                Some(MemoryKind::Procedural),
+            )
+            .unwrap();
+        }
+        let store = SqliteMemoryStore::load(&paths).unwrap();
+        let before = store.format_for_system_prompt();
+        assert!(before.contains("cargo build"), "entry is in the snapshot");
+
+        // Run the pre-recall path: search the verbatim message, format a block.
+        // (Empty snapshot arg here so the hit surfaces — snapshot-dedup is
+        // covered separately; this test isolates snapshot immutability.)
+        let resp = store.search_entries("build cargo").unwrap();
+        assert!(
+            pre_recall_block(&resp, "").is_some(),
+            "pre-recall surfaced the seeded entry"
+        );
+
+        let after = store.format_for_system_prompt();
+        assert_eq!(
+            before, after,
+            "pre-recall must leave the frozen snapshot byte-identical"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
 /// Clamp a configured early-fold threshold into a safe range. An override
 /// may only make the NORMAL fold fire *earlier* — never later than the
 /// default and never below a floor that would fold almost immediately —

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -832,25 +832,26 @@ pub async fn run_agent_loop(
     // Pi line 103: `newMessages = [...prompts]`.
     let new_messages = prompts.clone();
 
+    // The verbatim user message for this turn — drives both few-shot exemplar
+    // retrieval and verbatim pre-recall.
+    let task_query: String = prompts
+        .iter()
+        .filter_map(|m| match m {
+            LoopMessage::User(u) => Some(u.content.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
     // Few-shot tool-use exemplars: retrieve up to K demonstrations
     // relevant to this task and inject them just before the prompt, so
     // the model has on-topic examples at the action boundary (in-context
     // tool demonstrations are a large reliability lever for open models).
     // Injected into the model-facing context ONLY — not `new_messages` —
     // so it steers this run without being persisted into session history.
-    {
-        let task_query: String = prompts
-            .iter()
-            .filter_map(|m| match m {
-                LoopMessage::User(u) => Some(u.content.as_str()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join(" ");
-        if let Some(block) = crate::agent::exemplars::block_for_task(&task_query, EXEMPLAR_TOP_K) {
-            let ex_msg = LoopMessage::User(super::message::UserMessage { content: block });
-            context.messages.push(loop_message_to_value(&ex_msg));
-        }
+    if let Some(block) = crate::agent::exemplars::block_for_task(&task_query, EXEMPLAR_TOP_K) {
+        let ex_msg = LoopMessage::User(super::message::UserMessage { content: block });
+        context.messages.push(loop_message_to_value(&ex_msg));
     }
 
     // Pi line 105: `currentContext.messages = [...context.messages, ...prompts]`.
@@ -861,6 +862,45 @@ pub async fn run_agent_loop(
         // resets to a new topic.
         if let (Some(tracker), LoopMessage::User(u)) = (&config.file_touch_tracker, prompt) {
             tracker.record_user_message(&u.content);
+        }
+    }
+
+    // dirge-0gxb: verbatim pre-recall. Auto-search long-term memory on this
+    // turn's verbatim user message and inject the hits as a SUPPLEMENTAL
+    // context note — pushed to the model-facing context ONLY, never to
+    // `new_messages` (persisted history) or the frozen `<project_memory>`
+    // snapshot (`system_prompt`). Appending at the tail can't churn the cached
+    // prefix. Surfaces relevant stored memory the agent wouldn't think to look
+    // up. Off-loaded to the blocking pool because the hybrid provider's search
+    // may do a network embedding round-trip.
+    //
+    // The `memory_provider` gate is also the real safety net for the global
+    // flag: the forked review/curator runners build with `memory_provider:
+    // None`, so they never pre-recall regardless of the process-global toggle.
+    // Injected as a USER message (like the exemplar block) rather than a
+    // `system` one — the Codex/Responses path strips `system` transcript items
+    // into the cached `instructions`, which would both drop the block and churn
+    // the prefix; a user message stays a plain transcript item on every path.
+    if super::context_manager::verbatim_pre_recall_enabled()
+        && let Some(provider) = &memory_provider
+        && !task_query.trim().is_empty()
+    {
+        let snapshot = provider.format_for_system_prompt();
+        let q = task_query.clone();
+        let p = provider.clone();
+        match tokio::task::spawn_blocking(move || p.search(&q)).await {
+            Ok(Ok(resp)) => {
+                if let Some(block) = super::context_manager::pre_recall_block(&resp, &snapshot) {
+                    let msg = LoopMessage::User(super::message::UserMessage { content: block });
+                    context.messages.push(loop_message_to_value(&msg));
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::debug!(target: "dirge::memory", error = %e, "pre-recall search failed")
+            }
+            Err(e) => {
+                tracing::debug!(target: "dirge::memory", error = %e, "pre-recall task join failed")
+            }
         }
     }
 

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -248,6 +248,10 @@ pub async fn build_loop_tools(
     // in without churning the call sites.
     // dirge-4hld: wrap the BM25 store in the hybrid retriever when configured.
     let mem_cfg = cfg.memory.clone().unwrap_or_default();
+    // dirge-0gxb: latch the verbatim pre-recall toggle for the loop to read.
+    crate::agent::agent_loop::context_manager::set_verbatim_pre_recall(
+        mem_cfg.verbatim_pre_recall == Some(true),
+    );
     let memory_store: Option<Arc<dyn crate::extras::memory_provider::MemoryProvider>> =
         if let Ok(c) = std::env::current_dir() {
             let paths = crate::extras::dirge_paths::ProjectPaths::new(&c);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -150,6 +150,11 @@ pub struct MemoryConfig {
     /// Env var holding the embeddings API key. Omit for a keyless local
     /// endpoint. (The key itself is never stored in config.)
     pub embed_api_key_env: Option<String>,
+    /// dirge-0gxb: each turn, auto-search memory on the verbatim user message
+    /// and inject the hits as a supplemental context block (never the frozen
+    /// snapshot). Surfaces relevant memory the agent wouldn't think to look
+    /// up. Default off.
+    pub verbatim_pre_recall: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -1150,7 +1155,7 @@ mod tests {
         assert!(cfg.memory.is_none(), "no memory block by default");
 
         let cfg: Config = serde_json::from_str(
-            r#"{ "memory": { "hybrid_retrieval": true, "embed_url": "http://localhost:11434/v1/embeddings", "embed_api_key_env": "OPENAI_API_KEY" } }"#,
+            r#"{ "memory": { "hybrid_retrieval": true, "embed_url": "http://localhost:11434/v1/embeddings", "embed_api_key_env": "OPENAI_API_KEY", "verbatim_pre_recall": true } }"#,
         )
         .unwrap();
         let m = cfg.memory.expect("memory block present");
@@ -1164,6 +1169,7 @@ mod tests {
             "model is optional (falls back to default)"
         );
         assert_eq!(m.embed_api_key_env.as_deref(), Some("OPENAI_API_KEY"));
+        assert_eq!(m.verbatim_pre_recall, Some(true));
     }
 
     /// dirge-4xgd: `[timeouts]` overrides merge onto Timeouts::DEFAULT;


### PR DESCRIPTION
Phase 5, the final Elastic agent-memory idea (#3) — and the one we agreed to handle carefully because it's the most agent-loop-invasive. Each turn, auto-search memory on the verbatim user message and surface relevant entries the agent wouldn't think to look up.

## The supplemental invariant
This must NOT replace or churn the frozen `<project_memory>` snapshot. So the pre-recall block is pushed to the **model-facing context only** — never to `new_messages` (persisted history) or `system_prompt`. A **byte-identical-snapshot test** locks that in. It mirrors the existing few-shot exemplar and mid-session memory-refresh blocks, which inject context the same way.

## What changed
- Injection in `run_agent_loop`, right after the exemplar block (once per user turn), off-loaded to `spawn_blocking` (the hybrid provider may do a network round-trip).
- `pre_recall_block` formats search hits into an advisory block, **excluding entries already in the frozen snapshot** — so pre-recall surfaces only the breadcrumb-tier memory the agent can't already see (no double-injection, and the "you did not search for these" framing stays true).
- Opt-in via `memory.verbatim_pre_recall` (default off), gated by a process-global set at build time (mirrors the existing `MEMORIES_DIRTY` flag — avoids threading a bool through 16+ `LoopConfig` literals). Documented in `docs/config.md`.

## Review notes
A 3-angle `/code-review high` pass ran. Both reviewers confirmed the core invariant holds (the block never reaches persisted history or the system prompt; tail-append is cache-safe). Acted on the substantive findings:
- **Codex provider safety**: the block was a `role:system` message, but the Codex/Responses path hoists/strips system transcript items into the cached `instructions` — which would both drop the block and churn the prefix. Switched to a **user message** (like the exemplar block), safe on every provider.
- **Snapshot dedup**: entries already in the hot-tier snapshot were getting injected a second time every turn. Now excluded.
- **Filter-before-cap**: blank rows could crowd out real hits within the top-5; now filtered first.
- **Test isolation**: removed the global-flag toggle test that could race parallel tests; the build-time setter only ever writes the default-off value in tests.
- Documented that the `memory_provider` gate is the real safety net keeping forked review/curator runners from pre-recalling.

Full suite green (2808), clippy + fmt clean.

bd: dirge-0gxb