### PR TITLE
ui: stream live thinking into the Ctrl+O panel

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1558,6 +1558,7 @@ pub async fn run_interactive(
                                         renderer.replace_from(start, Vec::new());
                                     }
                                     ui.expansion_anchor = None;
+                                    ui.live_thinking_expanded = false;
                                 }
                                 ExpandToggle::Expand => {
                                     let start = renderer.buffer_len();
@@ -1571,8 +1572,13 @@ pub async fn run_interactive(
                                         ExpandSource::LiveThinking => {
                                             let text = ui.reasoning_buf.clone();
                                             render_thinking_block(&mut renderer, &text)?;
+                                            // dirge #444: track that this block is
+                                            // LIVE so new reasoning deltas stream
+                                            // into it instead of freezing here.
+                                            ui.live_thinking_expanded = true;
                                         }
                                         ExpandSource::Thinking => {
+                                            ui.live_thinking_expanded = false;
                                             if let Some(text) = ui.last_thinking.clone() {
                                                 render_thinking_block(&mut renderer, &text)?;
                                             }
@@ -1847,6 +1853,7 @@ pub async fn run_interactive(
                             ui.last_thinking = None;
                             ui.expand_target = crate::ui::state::ExpandTarget::None;
                             ui.expansion_anchor = None;
+                            ui.live_thinking_expanded = false;
                             #[cfg(feature = "loop")]
                             if loop_state.as_ref().is_some_and(|ls| ls.active) && !text.starts_with('/') {
                                 // Queue the message instead of dropping it.
@@ -2380,9 +2387,37 @@ pub async fn run_interactive(
                                 ui.was_reasoning = true;
                             }
                             ui.reasoning_buf.push_str(&sanitize_output(&text));
+
+                            // dirge #444: if the user expanded this live thinking
+                            // with Ctrl+O, stream new deltas into the expanded
+                            // block IN PLACE instead of leaving a frozen snapshot.
+                            if ui.live_thinking_expanded
+                                && let Some(anchor) = ui.expansion_anchor
+                            {
+                                match restream_expanded_thinking(
+                                    &mut renderer,
+                                    anchor,
+                                    &ui.reasoning_buf,
+                                )? {
+                                    Some(updated) => ui.expansion_anchor = Some(updated),
+                                    None => {
+                                        ui.expansion_anchor = None;
+                                        ui.live_thinking_expanded = false;
+                                    }
+                                }
+                                renderer.request_repaint();
+                            }
                         }
                     }
                     AgentEvent::Token(text) => {
+                        // dirge #444: the thinking burst is over once response
+                        // tokens start. Stop live-updating any expanded thinking
+                        // panel so an interleaved later reasoning delta can't
+                        // re-render at the (now-buried) anchor and clobber the
+                        // response. The block stays as collapsible history.
+                        if ui.was_reasoning {
+                            ui.live_thinking_expanded = false;
+                        }
                         // Caught-up check for the render coalescer, computed
                         // before ctx borrows the render state (dirge-ufe0).
                         let pending = ui.agent_rx.as_ref().map_or(0, |rx| rx.len());
@@ -3615,6 +3650,34 @@ fn render_thinking_block(renderer: &mut Renderer, text: &str) -> std::io::Result
     renderer.write_line("  ╰─", crate::ui::theme::thinking())?;
     renderer.write_line("", Color::White)?;
     Ok(())
+}
+
+/// dirge #444: re-render the expanded LIVE-thinking block in place with the
+/// latest `reasoning_buf`, so new reasoning deltas stream into the panel
+/// instead of leaving a frozen snapshot. `anchor` is `(start, _end,
+/// eviction_gen)` from `expansion_anchor`. Returns the UPDATED anchor, or
+/// `None` when the block can't be re-rendered in place — front-eviction shifted
+/// indices (gen mismatch), or the start is past the buffer end — in which case
+/// the caller stops tracking and leaves the block as history (Ctrl+O re-expands
+/// a fresh snapshot). Assumes the block sits at the buffer tail, which holds
+/// during a pure thinking burst where nothing else appends.
+fn restream_expanded_thinking(
+    renderer: &mut Renderer,
+    anchor: (usize, usize, u64),
+    reasoning_buf: &str,
+) -> std::io::Result<Option<(usize, usize, u64)>> {
+    let (start, _end, anchor_gen) = anchor;
+    if renderer.eviction_generation() != anchor_gen || start > renderer.buffer_len() {
+        return Ok(None);
+    }
+    let gen_before = renderer.eviction_generation();
+    renderer.replace_from(start, Vec::new());
+    render_thinking_block(renderer, reasoning_buf)?;
+    Ok(if renderer.eviction_generation() == gen_before {
+        Some((start, renderer.buffer_len(), gen_before))
+    } else {
+        None
+    })
 }
 
 fn render_custom_entry(renderer: &mut Renderer, buf: &str, input_anchor: usize) {

--- a/src/ui/mod_tests.rs
+++ b/src/ui/mod_tests.rs
@@ -707,3 +707,72 @@ fn scroll_snap_typing_and_down_snap_but_command_combos_dont() {
     assert_eq!(scroll_snap_for(&KeyEvent::new(KeyCode::Up, none)), None);
     assert_eq!(scroll_snap_for(&KeyEvent::new(KeyCode::Enter, none)), None);
 }
+
+// ============================================================
+// dirge #444 — live thinking streams into the Ctrl+O panel
+// ============================================================
+
+/// After Ctrl+O expands a live thinking burst, new reasoning deltas re-render
+/// the expanded block IN PLACE (anchored at the same start) rather than leaving
+/// the frozen snapshot the user first saw.
+#[test]
+fn live_thinking_expansion_streams_in_place() {
+    let mut r = Renderer::new().expect("renderer");
+    r.write_line("<you> hi", Color::White).unwrap();
+    r.write_line(
+        "  ◇ thinking… (Ctrl+O to view)",
+        crate::ui::theme::thinking(),
+    )
+    .unwrap();
+
+    // Ctrl+O expands the current snapshot of the thinking-so-far.
+    let start = r.buffer_len();
+    render_thinking_block(&mut r, "first thought").unwrap();
+    let anchor = (start, r.buffer_len(), r.eviction_generation());
+    let snap: Vec<String> = r.buffer_lines().iter().map(|s| s.to_string()).collect();
+    assert!(snap.iter().any(|l| l.contains("first thought")));
+    assert!(
+        !snap.iter().any(|l| l.contains("second thought")),
+        "snapshot must not contain text that hasn't streamed yet",
+    );
+
+    // More reasoning arrives — re-render in place with the fuller buffer.
+    let updated = restream_expanded_thinking(&mut r, anchor, "first thought\nsecond thought")
+        .unwrap()
+        .expect("re-rendered in place");
+
+    let now: Vec<String> = r.buffer_lines().iter().map(|s| s.to_string()).collect();
+    assert!(now.iter().any(|l| l.contains("first thought")));
+    assert!(
+        now.iter().any(|l| l.contains("second thought")),
+        "new thinking streamed into the expanded block: {now:?}",
+    );
+    // Exactly one of each — the old block was replaced, not duplicated.
+    assert_eq!(
+        now.iter().filter(|l| l.contains("first thought")).count(),
+        1
+    );
+    assert_eq!(updated.0, start, "block stays anchored at the same start");
+    // The placeholder above the block is untouched.
+    assert!(now.iter().any(|l| l.contains("thinking… (Ctrl+O to view)")));
+}
+
+/// When front-eviction has shifted indices since the block was anchored
+/// (gen mismatch), the in-place re-render bails (returns None) so the caller
+/// stops tracking instead of truncating live content at a stale index.
+#[test]
+fn restream_bails_on_eviction_generation_mismatch() {
+    let mut r = Renderer::new().expect("renderer");
+    render_thinking_block(&mut r, "thought").unwrap();
+    // Anchor with a deliberately wrong eviction generation.
+    let stale = (
+        0usize,
+        r.buffer_len(),
+        r.eviction_generation().wrapping_add(1),
+    );
+    let out = restream_expanded_thinking(&mut r, stale, "thought more").unwrap();
+    assert!(
+        out.is_none(),
+        "stale-generation anchor must not re-render in place"
+    );
+}

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -178,6 +178,11 @@ pub(crate) struct UiState {
     /// eviction counter is unchanged — so streamed output or buffer-cap
     /// eviction after expanding can't make collapse delete real content.
     pub(crate) expansion_anchor: Option<(usize, usize, u64)>,
+    /// dirge #444: `true` when the current `expansion_anchor` block is showing
+    /// LIVE (still-streaming) thinking, so new reasoning deltas re-render it in
+    /// place instead of leaving a frozen snapshot. Cleared on collapse, on a
+    /// new turn, or when the expansion targets a completed burst / tool output.
+    pub(crate) live_thinking_expanded: bool,
 
     // ── User toggles ─────────────────────────────────────────────────
     pub(crate) show_reasoning: bool,
@@ -363,6 +368,7 @@ impl UiState {
             last_thinking: None,
             expand_target: ExpandTarget::None,
             expansion_anchor: None,
+            live_thinking_expanded: false,
 
             show_reasoning: false,
             todo_tools_enabled: false,


### PR DESCRIPTION
Fixes #444.

## Problem
Pressing Ctrl+O during a thinking burst expanded a one-time **snapshot** of the reasoning-so-far. New thinking kept accumulating into the buffer but never re-rendered the expanded block, so the panel froze — to see more you had to toggle Ctrl+O twice for a fresh snapshot.

## Fix
Track when the expanded block is showing **live** thinking (`live_thinking_expanded`, set only for `ExpandSource::LiveThinking`) and re-render it **in place** as new reasoning deltas arrive, anchored at the same buffer position — so the panel streams continuously, matching the visible-reasoning mode.

The in-place re-render (`restream_expanded_thinking`) truncates back to the block's start and re-renders with the fuller buffer. Safety:
- **Front-eviction**: guarded by the eviction generation. If indices shifted, it stops tracking and leaves the block as history (Ctrl+O re-expands a fresh snapshot) rather than truncating at a stale index.
- **Interleaved thinking/response**: the flag clears at the thinking→token transition, so a later reasoning delta (some models interleave) can't re-render at the now-buried anchor and clobber the response.
- Also clears on collapse, on a new turn, and when the expansion targets a completed burst / tool output.

## Tests
- `live_thinking_expansion_streams_in_place` — after expanding a snapshot, a later delta re-renders the block in place (both thoughts visible, no duplication, same anchor, placeholder untouched).
- `restream_bails_on_eviction_generation_mismatch` — a stale-generation anchor returns `None` (no in-place truncation).

Full suite green (2825), clippy + fmt clean.