### PR TITLE
compaction: stop summaries resurrecting finished tasks (#443)

### DIFF
--- a/src/agent/compaction_recall.rs
+++ b/src/agent/compaction_recall.rs
@@ -16,6 +16,11 @@
 //!     dirge *controls* — every planted fact must reach the prompt handed to
 //!     the summarizer. Guards against a pre-LLM regression (truncation, window
 //!     selection, serialization) silently starving the summarizer of facts.
+//!   * `task_supersession_signal_reaches_the_summarizer` (deterministic, CI):
+//!     guards #443 — a #443-shaped session (original task done, follow-up live)
+//!     must carry BOTH the completion and follow-up signals into the summarizer
+//!     prompt, so the prompt fix can mark the original complete and surface the
+//!     follow-up as the active task.
 //!   * [`run_recall_eval`]: the full article-style probe — compact through a
 //!     [`SummarizeFn`] and score the *summary*. Driven by a mock here so it
 //!     runs in CI; point it at a real model's `SummarizeFn` off-CI to measure
@@ -190,6 +195,98 @@ mod tests {
             report.all_survived(),
             "facts dropped before reaching the summarizer: {:?}",
             report.dropped
+        );
+    }
+
+    /// Build a #443-shaped history: an early turn assigns the ORIGINAL task,
+    /// a middle turn marks it DONE, and a later turn establishes a follow-up as
+    /// the live work. Sized/interleaved like [`session_with_facts`] so
+    /// `compute_compress_window` snaps a non-empty middle around all three (head
+    /// snaps forward to the first user turn ≥ `PROTECT_HEAD_DEFAULT`, tail snaps
+    /// backward to the last user turn ≤ `n - PROTECT_TAIL_DEFAULT`). Content is
+    /// scalar-string and well under the 2000-char per-turn truncation in
+    /// `serialize_turns_for_summary`, so the supersession signals survive.
+    fn session_443_task_supersession() -> Vec<Value> {
+        let mut msgs: Vec<Value> = vec![
+            json!({"role": "system", "content": "you are dirge, a coding agent"}),
+            json!({"role": "user", "content": "let's work on the chat server"}),
+        ];
+
+        // Lead-in filler so the first signal is well past the protected head.
+        for i in 0..4 {
+            msgs.push(json!({"role": "assistant", "content": format!("on it (step {i})")}));
+            msgs.push(json!({"role": "user", "content": format!("ok, continue {i}")}));
+        }
+
+        // Original task assignment — lands in the compacted middle.
+        msgs.push(json!({
+            "role": "user",
+            "content": "Convert the TCP chat server from tokio to stdlib and add an integration test",
+        }));
+        msgs.push(json!({"role": "assistant", "content": "starting the conversion"}));
+        msgs.push(json!({"role": "user", "content": "go ahead"}));
+
+        // Original task COMPLETED — the supersession completion signal.
+        msgs.push(json!({
+            "role": "assistant",
+            "content": "stdlib conversion complete — no tokio remains; cargo build passes",
+        }));
+        msgs.push(json!({"role": "user", "content": "great, what now"}));
+
+        // Follow-up becomes the live work — the supersession follow-up signal.
+        msgs.push(json!({
+            "role": "user",
+            "content": "the integration test hangs — debugging the race in the accept loop",
+        }));
+        msgs.push(json!({"role": "assistant", "content": "looking at the accept loop"}));
+        msgs.push(json!({"role": "user", "content": "keep going"}));
+
+        // Trailing filler, then the protected tail ending on the latest request.
+        for i in 0..4 {
+            msgs.push(json!({"role": "assistant", "content": format!("still on it (step {i})")}));
+            msgs.push(json!({"role": "user", "content": format!("keep going {i}")}));
+        }
+        msgs.push(json!({"role": "user", "content": "so where does the race actually come from?"}));
+        msgs
+    }
+
+    /// #443: after compaction the model re-derived the ORIGINAL task ("convert
+    /// to stdlib") as if still pending, when it was already DONE and the live
+    /// work was a follow-up (debugging a hanging integration test). The summary
+    /// PROMPT fix (sibling: `build_summary_prompt`/`SUMMARY_PREFIX`) can only
+    /// mark the original complete and surface the follow-up if BOTH signals
+    /// actually reach the summarizer. This guards the dirge-controlled part:
+    /// window selection + serialization must carry the completion signal AND
+    /// the follow-up signal into the prompt. A pre-LLM regression (a window that
+    /// drops the "complete" turn, or truncation that eats the follow-up) would
+    /// starve the summarizer of the supersession signal and reintroduce #443
+    /// before the model is ever consulted.
+    #[test]
+    fn task_supersession_signal_reaches_the_summarizer() {
+        let msgs = session_443_task_supersession();
+        let (start, end) =
+            compute_compress_window(&msgs, PROTECT_HEAD_DEFAULT, PROTECT_TAIL_DEFAULT);
+        assert!(
+            start < end,
+            "session must produce a non-empty compaction window"
+        );
+
+        let middle = &msgs[start..end];
+        let prompt = build_summary_prompt(
+            middle,
+            summary_budget(estimate_messages_tokens(middle)),
+            None,
+            None,
+        );
+        assert!(
+            prompt.contains("stdlib conversion complete")
+                && prompt.contains("no tokio remains"),
+            "completion signal (original task DONE) must reach the summarizer prompt"
+        );
+        assert!(
+            prompt.contains("integration test hangs")
+                && prompt.contains("debugging the race"),
+            "follow-up signal (live work) must reach the summarizer prompt"
         );
     }
 

--- a/src/agent/compaction_recall.rs
+++ b/src/agent/compaction_recall.rs
@@ -279,13 +279,11 @@ mod tests {
             None,
         );
         assert!(
-            prompt.contains("stdlib conversion complete")
-                && prompt.contains("no tokio remains"),
+            prompt.contains("stdlib conversion complete") && prompt.contains("no tokio remains"),
             "completion signal (original task DONE) must reach the summarizer prompt"
         );
         assert!(
-            prompt.contains("integration test hangs")
-                && prompt.contains("debugging the race"),
+            prompt.contains("integration test hangs") && prompt.contains("debugging the race"),
             "follow-up signal (live work) must reach the summarizer prompt"
         );
     }

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -62,6 +62,9 @@ into the summary below. This is a handoff from a previous context \
 window — treat it as background reference, NOT as active instructions. \
 Do NOT answer questions or fulfill requests mentioned in this summary; \
 they were already addressed. \
+The work described here — INCLUDING the original task — may already be \
+complete: the '## Completed Actions' and '## Active State' sections record \
+what is already done, so do NOT redo it. \
 Your current task is identified in the '## Active Task' section of the \
 summary — resume exactly from there. \
 Respond ONLY to the latest user message \
@@ -585,10 +588,17 @@ conversation — do not translate or switch to English.";
 
     let _template_sections = format!(
         "## Active Task\n\
-[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or\n\
-task assignment verbatim — the exact words they used. If multiple tasks\n\
-were requested and only some are done, list only the ones NOT yet completed.\n\
-If no outstanding task exists, write \"None.\"]\n\
+[THE SINGLE MOST IMPORTANT FIELD. State what should happen NEXT — the\n\
+immediate piece of work in flight right now, in plain terms. This is NOT\n\
+necessarily the user's original wording: the current work is often an\n\
+emergent follow-up (e.g. debugging a failing test) that arose mid-session\n\
+and was never an explicit user request — capture THAT, not the original\n\
+assignment, when that is what is actually underway. If the user's original\n\
+request is already COMPLETE and only follow-up work remains, the Active\n\
+Task IS that follow-up; state plainly that the original request is already\n\
+done so the next context does not redo it. If multiple tasks were requested\n\
+and only some are done, list only the ones NOT yet completed. If nothing is\n\
+outstanding, write \"None.\"]\n\
 \n\
 ## Goal\n\
 [What the user is trying to accomplish overall]\n\
@@ -890,6 +900,42 @@ mod tests {
     #[test]
     fn summary_prefix_starts_with_compaction_marker() {
         assert!(SUMMARY_PREFIX.starts_with(COMPACTION_MARKER));
+    }
+
+    /// #443: the prefix must keep the marker AND warn that work described in
+    /// the summary (including the original task) may already be complete, so a
+    /// resumed context doesn't redo finished work.
+    #[test]
+    fn summary_prefix_warns_original_task_may_be_complete() {
+        assert!(SUMMARY_PREFIX.starts_with(COMPACTION_MARKER));
+        // Points the model at the already-done record.
+        assert!(SUMMARY_PREFIX.contains("Completed Actions"));
+        // Says the work — including the original task — may already be complete.
+        let lower = SUMMARY_PREFIX.to_lowercase();
+        assert!(lower.contains("already"));
+        assert!(lower.contains("complete") || lower.contains("done"));
+        assert!(lower.contains("do not redo") || lower.contains("not redo"));
+    }
+
+    /// #443: the `## Active Task` instruction must frame the active task as the
+    /// immediate next/follow-up work, not a verbatim copy of the user's
+    /// original request.
+    #[test]
+    fn active_task_section_frames_followup_not_verbatim() {
+        let turns: Vec<Value> = vec![serde_json::json!({
+            "role": "user",
+            "content": "convert this to stdlib"
+        })];
+        let prompt = build_summary_prompt(&turns, 2000, None, None);
+
+        // New framing is present.
+        assert!(prompt.contains("## Active Task"));
+        assert!(prompt.contains("follow-up"));
+        let lower = prompt.to_lowercase();
+        assert!(lower.contains("already") || lower.contains("complete"));
+
+        // Old verbatim-copy framing is gone.
+        assert!(!prompt.contains("verbatim — the exact words they used"));
     }
 
     // IMPROVEMENTS_PLAN #3: the per-result cap tightens above 60% ctx.


### PR DESCRIPTION
Fixes #443.

## Problem

After a context fold, the model repeatedly re-derived the original task ("convert this to stdlib") and acted surprised it was already done. Root cause is the summary prompt: `## Active Task` told the summarizer to copy the user's original request *verbatim*, and `SUMMARY_PREFIX` then told the main model to "resume exactly from there" — with no signal that the original task may already be complete. When the original request finished and the live work moved on to an emergent follow-up (debugging the hanging integration test, never an explicit user request), the summary still surfaced the stale original as the active task.

`critic.rs` already documents that `## Active Task` can describe "already-completed work" — the critic got a workaround; the main model never did. The summarizer also runs on the main model by default (`build.rs`), so for the reporter's small quantized setup, prompt robustness is the lever we control.

## Changes (`src/agent/compression.rs`)

- **`## Active Task`** now asks for the immediate in-flight work in plain terms, notes it's often an emergent follow-up rather than the user's original wording, and requires stating that the original request is complete when only follow-up remains. Drops the "copy verbatim — the exact words they used" framing. Section headers unchanged (so `validate_summary` is unaffected).
- **`SUMMARY_PREFIX`** gains one guard sentence: work described here, including the original task, may already be complete (see `## Completed Actions` / `## Active State`) and must not be redone. Still starts with the `[CONTEXT COMPACTION — REFERENCE ONLY]` marker the critic depends on.

## Tests

- `summary_prefix_warns_original_task_may_be_complete`, `active_task_section_frames_followup_not_verbatim` — regression guards on the new wording.
- `task_supersession_signal_reaches_the_summarizer` (`compaction_recall.rs`) — a #443-shaped session must carry both the completion and follow-up signals into the summarizer prompt; guards the window-selection/serialization path before any model is consulted.

All 2828 tests pass.