### PR TITLE
fix: restore Cargo version to 0.7.8 to match the released tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "dirge-agent"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # taken on crates.io. The installed BINARY is still `dirge` (see [[bin]]),
 # so users run: `cargo install dirge-agent` then the `dirge` command.
 name = "dirge-agent"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 # edition 2024 was stabilized in Rust 1.85; pin the MSRV so older
 # toolchains get a clear error instead of a cryptic edition failure.


### PR DESCRIPTION
#454 branched from a pre-0.7.8 base and, when merged, regressed the manifest `version` from `0.7.8` back to `0.7.7` in both `Cargo.toml` and `Cargo.lock`. The `v0.7.8` git tag and the published release shipped `0.7.8`, so main's manifest disagreed with the tag.

Verified that **only the version string regressed** — none of the 0.7.8 functionality was reverted:
- `## [0.7.8]` CHANGELOG section, `freeze_live_thinking` (#450), the compaction Active-Task reframe (#451), the code-block wrap (#453), and the restream tail-guard (#449) are all present on main.
- #454 touched no 0.7.8 feature files; the only manifest overlap was the version line plus its own OAuth deps (`sha2`/`base64` made non-optional because the OAuth code uses them unconditionally, and `+url`), which are legitimate, not reversions.

Bumps both manifests back to `0.7.8`.