### PR TITLE
Add a  Nix flake, including devshell, package overlay and direnv integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,37 @@
+name: Nix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - Cargo.toml
+      - Cargo.lock
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - Cargo.toml
+      - Cargo.lock
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Cache Nix builds
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Check flake
+        run: nix flake check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,73 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
+  nix-binary-package:
+    name: Bump Nix binary package
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Prefetch release assets and update nix/bin.nix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          version="${tag#v}"
+          assets="$(gh release view "$tag" -R "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+
+          python3 - <<'PY' > /tmp/dirge-nix-assets.tsv
+          import re
+          from pathlib import Path
+
+          text = Path("nix/bin.nix").read_text()
+          for match in re.finditer(r'"(?P<system>[^"]+)" = \{\s*triple = "(?P<triple>[^"]+)";', text):
+              print(f"{match.group('system')}\t{match.group('triple')}")
+          PY
+
+          hashes_json="{}"
+          while IFS=$'\t' read -r system triple; do
+            asset="dirge-${triple}.tar.gz"
+            if ! grep -Fxq "$asset" <<< "$assets"; then
+              echo "Missing release asset: $asset" >&2
+              exit 1
+            fi
+            url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/${asset}"
+            hash="$(nix store prefetch-file --hash-type sha256 --json "$url" | jq -r .hash)"
+            hashes_json="$(jq --arg system "$system" --arg hash "$hash" '. + {($system): $hash}' <<< "$hashes_json")"
+          done < /tmp/dirge-nix-assets.tsv
+
+          HASHES_JSON="$hashes_json" VERSION="$version" python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("nix/bin.nix")
+          text = path.read_text()
+          text = re.sub(r'version = "[^"]+";', f'version = "{os.environ["VERSION"]}";', text, count=1)
+          hashes = json.loads(os.environ["HASHES_JSON"])
+          for system, hash_ in hashes.items():
+              pattern = rf'("{re.escape(system)}" = \{{\n\s+triple = "[^"]+";\n\s+hash = ")[^"]+(";)'
+              text = re.sub(pattern, rf'\g<1>{hash_}\2', text, count=1)
+          path.write_text(text)
+          PY
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Bump Nix dirge-bin to ${{ github.ref_name }}
+          title: Bump Nix dirge-bin to ${{ github.ref_name }}
+          body: Update nix/bin.nix for the ${{ github.ref_name }} release assets.
+          branch: automation/nix-dirge-bin-${{ github.ref_name }}
+          delete-branch: true
+
   # Bump the Homebrew tap (dirge-code/homebrew-dirge) to the just-released
   # version + checksums. Runs after every target has uploaded its assets, so
   # the .sha256 files exist to read back. Needs a HOMEBREW_TAP_TOKEN secret —

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ publishing.md
 /tmux
 LOOP_PLAN.md
 __pycache__/
+.direnv

--- a/README.md
+++ b/README.md
@@ -80,6 +80,75 @@ cargo install dirge-agent --no-default-features \
 Prebuilt binaries for Linux (glibc + static musl), macOS (Intel + Apple
 Silicon), and Windows are attached to each [GitHub Release](https://github.com/dirge-code/dirge/releases).
 
+### Build with Nix
+
+The flake ships the crate default features (the release feature set):
+
+```bash
+nix build                 # builds packages.default / packages.dirge from this pinned ref
+nix run . -- --version    # runs the source-built binary
+nix develop               # opens a Rust dev shell with clang, cmake, and bindgen support
+nix build .#dirge-bin     # installs the recorded upstream release binary
+```
+
+`packages.default` / `packages.dirge` build from the flake input's pinned
+source (`self`). `packages.dirge-bin` downloads the latest release recorded in
+`nix/bin.nix`, so it can differ when you pin `main` or a feature branch.
+
+
+#### Automatic devshell activation with direnv
+This repository includes a `.envrc`. If you have `direnv` installed, this will activate the nix devshell automatically.
+N.B. .envrc is untrusted by default -- opt in by entering the command `direnv allow` at the repository root.
+
+
+#### Install via your own flake (home-manager)
+
+A minimal `flake.nix` that installs dirge through home-manager:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    dirge.url = "github:dirge-code/dirge";
+  };
+
+  outputs = { nixpkgs, home-manager, dirge, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ dirge.overlays.default ];
+      };
+    in {
+      homeConfigurations.me = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [{
+          home.username = "me";
+          home.homeDirectory = "/home/me";
+          home.stateVersion = "24.11";
+          home.packages = [ pkgs.dirge ]; # or pkgs.dirge-bin for the prebuilt binary
+        }];
+      };
+    };
+}
+```
+
+Then `home-manager switch --flake .#me`.
+
+#### Maintaining the flake
+
+- `nix/bin.nix` (the prebuilt `dirge-bin`) is bumped automatically: on a release
+  tag the release workflow refreshes its version and hashes from the new assets
+  and opens a PR.
+- `nix flake check` runs in CI whenever the flake, `nix/`, or the Cargo
+  manifests change.
+- Run `nix flake update` to refresh the pinned `nixpkgs` in the committed
+  `flake.lock`.
+
+Consumers can also import `inputs.dirge.overlays.default` into an existing
+`nixpkgs` overlay list to expose `pkgs.dirge` and `pkgs.dirge-bin`.
+
 ### Optional: sandbox mode
 
 Install [bubblewrap](https://github.com/containers/bubblewrap) for `--sandbox`, which runs every bash command inside an isolated environment:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Minimal, fast pure-Rust coding agent with persistent memory";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            inherit system;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+        );
+    in
+    {
+      packages = forAllSystems (
+        { pkgs, ... }:
+        rec {
+          dirge = pkgs.callPackage ./nix/package.nix { src = self; };
+          dirge-bin = pkgs.callPackage ./nix/bin.nix { };
+          default = dirge;
+        }
+      );
+
+      apps = forAllSystems (
+        { system, ... }:
+        {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/dirge";
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        {
+          default = pkgs.callPackage ./nix/devshell.nix { };
+        }
+      );
+
+      checks = forAllSystems (
+        { system, ... }:
+        {
+          build = self.packages.${system}.default;
+        }
+      );
+
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
+
+      overlays.default = final: prev: {
+        dirge = final.callPackage ./nix/package.nix { src = self; };
+        dirge-bin = final.callPackage ./nix/bin.nix { };
+      };
+    };
+}

--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+let
+  version = "0.8.1";
+  sel =
+    {
+      "x86_64-linux" = {
+        triple = "x86_64-unknown-linux-gnu";
+        hash = "sha256-T9pC3gvnI3ZVXqsiLXLy/Mt0Ad8/yMeqMxFtiCjL4/E=";
+      };
+      "aarch64-darwin" = {
+        triple = "aarch64-apple-darwin";
+        hash = "sha256-ZT3jXl1OcnK492logt4cs/Z4AWs/jyBiDQ1yodnTmF4=";
+      };
+    }
+    .${stdenv.hostPlatform.system};
+in
+stdenv.mkDerivation {
+  pname = "dirge-bin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/dirge-code/dirge/releases/download/v${version}/dirge-${sel.triple}.tar.gz";
+    inherit (sel) hash;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  dontBuild = true;
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dirge "$out/bin/dirge"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minimal, fast pure-Rust coding agent with persistent memory";
+    homepage = "https://github.com/dirge-code/dirge";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "dirge";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  mkShell,
+  rustc,
+  cargo,
+  rustfmt,
+  clippy,
+  rust-analyzer,
+  cmake,
+  mold,
+  clang,
+  libclang,
+  pkg-config,
+}:
+
+mkShell {
+  packages = [
+    rustc
+    cargo
+    rustfmt
+    clippy
+    rust-analyzer
+    cmake
+    clang
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.isLinux [ mold ];
+
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  cmake,
+  mold,
+  src,
+}:
+
+let
+  # The flake passes `src = self`; use path literals for lib.fileset because
+  # flake `self.outPath` is string-like and filesets require paths.
+  cargoToml = lib.importTOML ../Cargo.toml;
+  source = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../build.rs
+      ../src
+      ../prompts
+      ../plugins
+    ];
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "dirge";
+  version = cargoToml.package.version;
+
+  src = source;
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    cmake
+    # evil-janet generates bindings during the build; bindgenHook also
+    # provides clang on PATH for .cargo/config.toml's linker setting.
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.isLinux [ mold ];
+
+  # Tests reach network/LLM providers and can exceed build timeouts.
+  doCheck = false;
+
+  meta = {
+    description = "Minimal, fast pure-Rust coding agent with persistent memory";
+    homepage = "https://github.com/dirge-code/dirge";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "dirge";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
Adds a flake.nix so the repo can be built, run, and developed with Nix directly.
Includes a package overlay for dirge installation from flake-based nix/home-manager configurations.

### Instructions

```bash
nix build                    # build dirge from source (this checkout)
nix run .                    # run it
nix build .#dirge-bin # install the prebuilt release binary instead
nix develop              # dev shell: rustc/cargo, clang, mold, cmake, libclang
```
With direnv installed, the bundled .envrc (use flake) activates the dev shell
automatically (direnv allow to opt in).

See README.md for more information.

### Packages

- dirge (default) - Builds this checkout from source
- dirge-bin - Builds the latest tagged release, wrapping the static binaries from github

### Commit increments

- Add Nix flake including devshell and package overlay
- Add Nix release automation — nix.yml runs nix flake check when the flake/nix//Cargo manifests change; on a
  release tag, release.yml refreshes the prebuilt dirge-bin version + hashes from the new assets and opens a
  PR.
- Add .envrc for direnv — automatic dev-shell activation.