### PR TITLE
List preamble skills from discover_skills so global tiers show

### DIFF
--- a/src/agent/builder/agent_inner.rs
+++ b/src/agent/builder/agent_inner.rs
@@ -197,45 +197,37 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     {
         preamble.push_str(&block);
     }
-    let skill_manager = crate::extras::skills::manager::SkillManager::new(&paths);
     let mut usage_store = crate::extras::skills::usage::UsageStore::load(&paths).ok();
 
-    // Inject available project skills into the preamble so the
-    // model knows what procedural knowledge exists for this project.
-    // Skills are listed with name + description; the model loads
-    // full content on demand via the `skill` tool.
+    // Inject available skills into the preamble so the model knows
+    // what procedural knowledge exists. dirge-rq65 follow-up: list
+    // from the SAME source as the loadable tool set
+    // (`skill::discover_skills`, which spans the global tiers
+    // ~/.claude|.opencode|.agents|.dirge/skills plus every project
+    // ancestor) rather than `SkillManager::list()`, which only reads
+    // the single project `.dirge/skills/`. Otherwise a global skill
+    // is loadable via the `skill` tool but never advertised in the
+    // preamble, so the model never knows to load it.
+    // Skills carry name + description; full content loads on demand.
     // Bumps view counters for each listed skill (best-effort).
-    match skill_manager.list() {
-        Ok(names) if !names.is_empty() => {
-            let mut skill_lines = Vec::new();
-            for name in &names {
-                if let Ok(content) = skill_manager.read_content(name)
-                    && let Some(spec) =
-                        crate::extras::skills::format::parse_skill_spec(&content, name)
-                {
-                    let desc = if spec.description.is_empty() {
-                        "(no description)".to_string()
-                    } else {
-                        spec.description.clone()
-                    };
-                    skill_lines.push(format!("  - **{name}**: {desc}"));
-                }
-            }
-            if !skill_lines.is_empty() {
-                preamble.push_str(PROJECT_SKILLS_PREAMBLE);
-                for line in &skill_lines {
-                    preamble.push_str(line);
-                    preamble.push('\n');
-                }
-                // Bump view counters for each skill listed in preamble (best-effort).
-                if let Some(ref mut u) = usage_store {
-                    for name in &names {
-                        u.record_view(name);
-                    }
-                }
+    let skills = crate::skill::discover_skills(
+        &std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+    );
+    if !skills.is_empty() {
+        preamble.push_str(PROJECT_SKILLS_PREAMBLE);
+        for skill in &skills {
+            let desc = if skill.description.is_empty() {
+                "(no description)"
+            } else {
+                skill.description.as_str()
+            };
+            preamble.push_str(&format!("  - **{}**: {}\n", skill.name, desc));
+        }
+        if let Some(ref mut u) = usage_store {
+            for skill in &skills {
+                u.record_view(&skill.name);
             }
         }
-        _ => {}
     }
 
     // Inject mode-specific reminders

--- a/src/agent/builder/reminder_tests.rs
+++ b/src/agent/builder/reminder_tests.rs
@@ -579,6 +579,75 @@ async fn build_agent_inner_emits_assembled_preamble() {
     }
 }
 
+/// dirge-rq65 follow-up — the system-prompt skill catalog must list
+/// skills from the SAME source as the loadable `skill` tool
+/// (`skill::discover_skills`, which spans the global tiers under
+/// `$HOME`), not from the project-only `SkillManager::list()`.
+/// Regression: a skill installed in `~/.dirge/skills/` is loadable
+/// but, pre-fix, was never advertised in the preamble because the
+/// listing read only the single project `.dirge/skills/`. Here we
+/// point `$HOME` at a temp dir holding a global skill and assert it
+/// shows up in the assembled preamble. `dirs::home_dir()` reads
+/// `$HOME` live on Unix; serialize the override so parallel tests
+/// don't observe the temporary HOME.
+#[tokio::test]
+async fn preamble_lists_global_tier_skills() {
+    use crate::context::ContextFiles;
+    use rig::client::CompletionClient;
+    use rig::providers::openai;
+    use std::sync::Mutex;
+
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let home = std::env::temp_dir().join(format!("dirge-preamble-home-{}", std::process::id()));
+    let skill_dir = home
+        .join(".dirge")
+        .join("skills")
+        .join("global-preamble-skill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: global-preamble-skill\ndescription: advertised from the global tier\n---\nBody.\n",
+    )
+    .unwrap();
+
+    let cli = Cli::parse_from::<_, &str>(["dirge"]);
+    let cfg = Config::default();
+    let context = ContextFiles {
+        agents: None,
+        prompts: std::collections::HashMap::new(),
+        agent_defs: Default::default(),
+        current_agent: None,
+        current_prompt: None,
+        current_prompt_name: None,
+        current_prompt_deny_tools: Vec::new(),
+        prompt_layer: None,
+        agent_layer: None,
+        model_before_agent: None,
+    };
+    let client = openai::Client::new("test-key").expect("openai client builds");
+    let model = client.completion_model("gpt-4o");
+
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by HOME_LOCK; restored before the lock drops.
+    unsafe { std::env::set_var("HOME", &home) };
+    let (agent, _cache, _provider) =
+        build_agent_inner(model, &cli, &cfg, &context, "openai", "gpt-4o").await;
+    match prev_home {
+        Some(h) => unsafe { std::env::set_var("HOME", h) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+
+    let preamble = agent.preamble.unwrap_or_default();
+    assert!(
+        preamble.contains("global-preamble-skill"),
+        "preamble must advertise a skill from the global ~/.dirge/skills tier; got:\n{preamble}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
 /// dirge-5db6 — model-family steering keys off the ACTIVE model passed
 /// to `build_agent_inner`, not the launch-time CLI model. The CLI here
 /// carries no `--model`, so `cli.resolve_model` would resolve to a

--- a/src/extras/skills/manager.rs
+++ b/src/extras/skills/manager.rs
@@ -204,6 +204,7 @@ impl SkillManager {
     }
 
     /// Read a skill's full SKILL.md content.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn read_content(&self, name: &str) -> Result<String, String> {
         let path = self.skills_dir.join(name).join("SKILL.md");
         std::fs::read_to_string(&path).map_err(|e| format!("Failed to read skill '{}': {e}", name))


### PR DESCRIPTION
The system-prompt skill catalog listed only project-local skills via SkillManager::list (single .dirge/skills/), while the loadable `skill` tool used skill::discover_skills, which also spans the global tiers (~/.claude|.opencode|.agents|.dirge/skills) and every project ancestor. A skill installed in a global tier was therefore loadable but never advertised, so the model never knew to load it.

Build the preamble listing from skill::discover_skills, the same source that feeds the tool. Reuse each Skill's name/description instead of the per-skill read_content + parse_skill_spec round-trip; view counters are preserved. SkillManager::read_content is now test-only.

Add preamble_lists_global_tier_skills, which runs build_agent_inner with $HOME pointed at a temp global skill and asserts it appears in the preamble.