### PR TITLE
nix: enable aarch64-linux support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     let
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
       forAllSystems =

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,6 +49,7 @@ rustPlatform.buildRustPackage {
     mainProgram = "dirge";
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
       "aarch64-darwin"
     ];
   };


### PR DESCRIPTION
Adds support for aarch64-linux for devshell/source package, useful for e.g. Asahi Linux devices.