### PR TITLE
theme: Color bottom input text with aper-theme user_input option

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -82,7 +82,8 @@ Each color field accepts three forms:
 | Field | What it colors |
 |---|---|
 | `agent` | Assistant chat text |
-| `user` | User message prefix (`<you>`) and the bottom input-bar text you type |
+| `user` | User message prefix (`<you>`) |
+| `user_input` | The bottom input-bar text you type (defaults to white) |
 | `system` | System messages — context loaded, compactions |
 | `tool` | Tool chamber headers (`╭─ BASH ─ …`) |
 | `perm` | Permission prompts (loud — yellow/red recommended) |

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -82,7 +82,7 @@ Each color field accepts three forms:
 | Field | What it colors |
 |---|---|
 | `agent` | Assistant chat text |
-| `user` | User message prefix (`<you>`) |
+| `user` | User message prefix (`<you>`) and the bottom input-bar text you type |
 | `system` | System messages — context loaded, compactions |
 | `tool` | Tool chamber headers (`╭─ BASH ─ …`) |
 | `perm` | Permission prompts (loud — yellow/red recommended) |

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -45,7 +45,8 @@ use serde::Deserialize;
 pub struct Theme {
     /// Assistant chat text.
     pub agent: Color,
-    /// User-message prefix (and prompt indicator).
+    /// User-message prefix (and prompt indicator), plus the text the
+    /// user types in the bottom input bar.
     pub user: Color,
     /// System/info messages — context loaded, compactions, etc.
     pub system: Color,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -45,9 +45,10 @@ use serde::Deserialize;
 pub struct Theme {
     /// Assistant chat text.
     pub agent: Color,
-    /// User-message prefix (and prompt indicator), plus the text the
-    /// user types in the bottom input bar.
+    /// User-message prefix (and prompt indicator).
     pub user: Color,
+    /// The text the user types in the bottom input bar.
+    pub user_input: Color,
     /// System/info messages — context loaded, compactions, etc.
     pub system: Color,
     /// Tool execution headers (`bash:`, `read:`, …).
@@ -122,6 +123,9 @@ impl Theme {
                 g: 205,
                 b: 210,
             },
+            // White — the text you type in the bottom input bar. Matches
+            // the pre-theme behavior where the composer was pinned white.
+            user_input: Color::White,
             // Muted green-grey — system / info notes ("context loaded",
             // compactions). Supporting; recedes below the conversation.
             system: Color::Rgb {
@@ -231,6 +235,7 @@ impl Theme {
         Theme {
             agent: Color::White,
             user: Color::Green,
+            user_input: Color::White,
             system: Color::DarkGrey,
             tool: Color::Yellow,
             perm: Color::Magenta,
@@ -267,6 +272,7 @@ impl Theme {
 struct ThemeJson {
     agent: Option<ColorValue>,
     user: Option<ColorValue>,
+    user_input: Option<ColorValue>,
     system: Option<ColorValue>,
     tool: Option<ColorValue>,
     perm: Option<ColorValue>,
@@ -375,6 +381,7 @@ impl ThemeJson {
         Ok(Theme {
             agent: pick(self.agent, base.agent),
             user: pick(self.user, base.user),
+            user_input: pick(self.user_input, base.user_input),
             system: pick(self.system, base.system),
             tool: pick(self.tool, base.tool),
             perm: pick(self.perm, base.perm),
@@ -501,6 +508,9 @@ pub fn agent() -> Color {
 }
 pub fn user() -> Color {
     themed(current().user)
+}
+pub fn user_input() -> Color {
+    themed(current().user_input)
 }
 pub fn system() -> Color {
     themed(current().system)

--- a/src/ui/tui/bottom.rs
+++ b/src/ui/tui/bottom.rs
@@ -302,7 +302,8 @@ fn paint_editor_box(
     let prompt_cont = if is_running { "▏  " } else { "▏ " };
     let prompt_w = input_prompt_width(is_running) as usize;
     let accent = Style::default().fg(RColor::Yellow);
-    let user = Style::default().fg(RColor::White);
+    let user =
+        Style::default().fg(super::chat::crossterm_to_ratatui(crate::ui::theme::user()));
     let dim = Style::default().fg(RColor::DarkGray);
     let text_avail = inner_w.saturating_sub(prompt_w);
     let visible_rows = (area.height as usize).saturating_sub(2);

--- a/src/ui/tui/bottom.rs
+++ b/src/ui/tui/bottom.rs
@@ -303,7 +303,7 @@ fn paint_editor_box(
     let prompt_w = input_prompt_width(is_running) as usize;
     let accent = Style::default().fg(RColor::Yellow);
     let user =
-        Style::default().fg(super::chat::crossterm_to_ratatui(crate::ui::theme::user()));
+        Style::default().fg(super::chat::crossterm_to_ratatui(crate::ui::theme::user_input()));
     let dim = Style::default().fg(RColor::DarkGray);
     let text_avail = inner_w.saturating_sub(prompt_w);
     let visible_rows = (area.height as usize).saturating_sub(2);


### PR DESCRIPTION
By default the user input is locked to `RColor::White`. This PR swaps that to use the a new user_input theme option. The previous white input color is maintained as a default.