### PR TITLE
Fix rustfmt regression in bottom.rs from #469

### DIFF
--- a/src/ui/tui/bottom.rs
+++ b/src/ui/tui/bottom.rs
@@ -302,8 +302,9 @@ fn paint_editor_box(
     let prompt_cont = if is_running { "▏  " } else { "▏ " };
     let prompt_w = input_prompt_width(is_running) as usize;
     let accent = Style::default().fg(RColor::Yellow);
-    let user =
-        Style::default().fg(super::chat::crossterm_to_ratatui(crate::ui::theme::user_input()));
+    let user = Style::default().fg(super::chat::crossterm_to_ratatui(
+        crate::ui::theme::user_input(),
+    ));
     let dim = Style::default().fg(RColor::DarkGray);
     let text_avail = inner_w.saturating_sub(prompt_w);
     let visible_rows = (area.height as usize).saturating_sub(2);


### PR DESCRIPTION
#469 merged with an unformatted line in `src/ui/tui/bottom.rs`, turning main's CI red (run 27858556209) and blocking every open PR — they're tested merged with main, so they all fail rustfmt on a file they don't touch.

Wrap the `user` style binding the way stable rustfmt wants. No behavior change.