### PR TITLE
Bump Nix dirge-bin to v0.9.1

### DIFF
--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -6,16 +6,16 @@
 }:
 
 let
-  version = "0.9.0";
+  version = "0.9.1";
   sel =
     {
       "x86_64-linux" = {
         triple = "x86_64-unknown-linux-gnu";
-        hash = "sha256-eZG/uSC68JR9hh6E18/drsA1Y5Qcq/AIlF1JZOv8kgQ=";
+        hash = "sha256-ec6B7v69+Cr9B30Z9t78HPdPflrirWcX964+OapUmvI=";
       };
       "aarch64-darwin" = {
         triple = "aarch64-apple-darwin";
-        hash = "sha256-2UmMUl9IhF6dj86VwT/L1Xjl2IhchNqUZHeT4QeCVtI=";
+        hash = "sha256-qqVW0sQ6OYDHfQtcArbJDv8lN57CA4XlNU3Ud94m3H4=";
       };
     }
     .${stdenv.hostPlatform.system};


### PR DESCRIPTION
The `release.yml` Nix step builds the updated `nix/bin.nix` but its 'Open pull request' step fails with "GitHub Actions is not permitted to create or approve pull requests" (same as v0.9.0, which was bumped manually in #467). Doing it by hand here.

- `version` → 0.9.1
- refreshed `x86_64-linux` and `aarch64-darwin` hashes from the v0.9.1 release tarballs (verified: hex→SRI conversion checked against the known-good v0.9.0 hash).