### PR TITLE
release: v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-20
+
+### Added
+- **Configurable key bindings everywhere.** One `keybindings` array now rebinds
+  both the global command keys (scroll, chat nav, …) and the input-editor keys
+  (cursor/word motion, kill-ring, history, …) — the text-box keys used to be
+  hardcoded. Built-in defaults are declarative tables your config merges over;
+  see [docs/config.md](docs/config.md#key-bindings) for the full command list.
+  (#477)
+- **Emacs-style chord sequences.** A binding key may be a sequence like
+  `ctrl-x ctrl-s`; the footer shows the pending prefix and **Esc**/**Ctrl+G**
+  cancels it. Optional `chord_timeout_ms` auto-cancels a pending prefix after a
+  set idle time (default: wait indefinitely). (#477, #478, issue #234)
+- **Plugins can remap built-in bindings.** `(harness/bind-key keys command)`
+  binds a chord (or sequence) to a built-in command, or `"none"` to unbind one,
+  merged under your config (defaults < plugin < user). `register-shortcut`
+  (bind a key to plugin code) is unchanged. (#477, issue #476)
+- **Visual-line cursor motion.** `Ctrl+A`/`Ctrl+E`, `Home`/`End`, and the
+  `Ctrl+U` kill now act on the current soft-wrapped line rather than the whole
+  buffer. (#474)
+
+### Changed
+- **`approval_provider` denials are advisory.** When an LLM approval evaluator
+  denies a tool call, it now escalates to the normal permission prompt (showing
+  *why* it was flagged) instead of hard-failing — so you can still allow it.
+  It's terminal only in non-interactive mode. (#475)
+- **Permission denials aren't treated as fixable failures.** The recovery
+  checkpoint no longer tells the model to "try a different approach" after a
+  permission block (which pushed it to route around the guardrail), and the
+  critic treats a permission-denied capability as out of scope rather than
+  unfinished work. (#475)
+
+### Fixed
+- **`/sessions delete` works when ids collide.** Compacted sessions are named
+  `compacted-<uuid>`, so every one rendered as the identical 8-char stub
+  "compacte" and "be more specific" was impossible. The list/switch/delete
+  views now show ids at the shortest length that keeps them distinct, and never
+  cut the leading marker mid-word. (#478)
+
 ## [0.9.1] - 2026-06-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "dirge-agent"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # taken on crates.io. The installed BINARY is still `dirge` (see [[bin]]),
 # so users run: `cargo install dirge-agent` then the `dirge` command.
 name = "dirge-agent"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 # edition 2024 was stabilized in Rust 1.85; pin the MSRV so older
 # toolchains get a clear error instead of a cryptic edition failure.

--- a/src/ui/slash/cmd/sessions/mod.rs
+++ b/src/ui/slash/cmd/sessions/mod.rs
@@ -45,15 +45,24 @@ pub(crate) fn parse_sessions_command<'a>(parts: &[&'a str]) -> SessionAction<'a>
 /// old fixed 8-char head ("compacte") was identical for every one and
 /// "be more specific" was impossible (dirge).
 pub(crate) fn distinct_id_len(ids: &[&str]) -> usize {
-    const FLOOR: usize = 8;
-    let max = ids.iter().map(|s| s.len()).max().unwrap_or(FLOOR);
-    for n in FLOOR..=max {
+    // Floor: at least 8, but never cut inside an id's leading marker — the
+    // run before its first `-`. A `compacted-<uuid>` session must read as
+    // "compacted…", not the confusing mid-word "compacte" (dirge). Plain
+    // UUID ids have their first `-` at index 8, so they stay at 8.
+    let floor = ids
+        .iter()
+        .map(|s| s.find('-').unwrap_or_else(|| s.len()).min(s.len()))
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let max = ids.iter().map(|s| s.len()).max().unwrap_or(floor);
+    for n in floor..=max {
         let mut seen = std::collections::HashSet::new();
         if ids.iter().all(|s| seen.insert(crate::text::head(s, n))) {
             return n;
         }
     }
-    max.max(FLOOR)
+    max.max(floor)
 }
 
 #[cfg(test)]
@@ -80,8 +89,19 @@ mod distinct_id_len_tests {
     }
 
     #[test]
-    fn single_id_uses_floor() {
-        assert_eq!(distinct_id_len(&["compacted-whatever"]), 8);
+    fn single_compacted_id_reads_as_compacted_not_compacte() {
+        // The floor never cuts the leading marker, so a lone compacted
+        // session shows "compacted", not the mid-word "compacte" (dirge).
+        let n = distinct_id_len(&["compacted-whatever"]);
+        assert_eq!(n, 9);
+        assert_eq!(crate::text::head("compacted-whatever", n), "compacted");
+    }
+
+    #[test]
+    fn plain_uuid_ids_stay_at_floor_8() {
+        // A first `-` at index 8 (UUID heads) keeps the compact 8-char view.
+        let ids = ["550e8400-aaa", "a1b2c3d4-bbb"];
+        assert_eq!(distinct_id_len(&ids), 8);
     }
 }
 


### PR DESCRIPTION
Cuts v0.10.0. Includes a final `/sessions` display refinement (compacted ids read as "compacted", never the mid-word "compacte") plus the version bump and CHANGELOG.

Highlights this release (all already merged to main):
- Configurable key bindings for input + global keys, one `keybindings` array (#477)
- Emacs-style chord sequences + optional `chord_timeout_ms` (#477/#478, issue #234)
- Plugin keybinding remapping via `harness/bind-key` (#477, issue #476)
- Visual-line cursor motion (#474)
- approval_provider denials are advisory and show their reason (#475)
- /sessions delete works when ids collide (#478)

Nix `dirge-bin` bump is a follow-up once the release artifacts exist (as with v0.9.1's #473).