### PR TITLE
Bump Nix dirge-bin to v0.10.0

### DIFF
--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -6,16 +6,16 @@
 }:
 
 let
-  version = "0.9.1";
+  version = "0.10.0";
   sel =
     {
       "x86_64-linux" = {
         triple = "x86_64-unknown-linux-gnu";
-        hash = "sha256-ec6B7v69+Cr9B30Z9t78HPdPflrirWcX964+OapUmvI=";
+        hash = "sha256-/wrIGmvcOc1AB8JoOvTbZgD3uFg5oF6qX8WzOYvJJOo=";
       };
       "aarch64-darwin" = {
         triple = "aarch64-apple-darwin";
-        hash = "sha256-qqVW0sQ6OYDHfQtcArbJDv8lN57CA4XlNU3Ud94m3H4=";
+        hash = "sha256-rF8eU0xIbqv0zPeYz3OMDqZpWGTTfACTULMHzEM9iuk=";
       };
     }
     .${stdenv.hostPlatform.system};


### PR DESCRIPTION
Points `nix/bin.nix` at the v0.10.0 release artifacts (version + SRI hashes for x86_64-linux-gnu and aarch64-darwin). The in-release-workflow auto-bump step failed again (pre-existing), so done manually as with #473.