### PR TITLE
Prompts: Add keybinding for cycling prompts, default to shift-tab

### DIFF
--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -273,7 +273,7 @@ fn copy_embedded(dest: &Path) -> anyhow::Result<()> {
 /// available prompt names; `current` is the active prompt name, or `None` for
 /// the base layer. Wraps past the end; an unknown or missing `current` starts
 /// from the head. Returns `None` only when there are no prompts to cycle.
-pub fn next_prompt<'a>(current: Option<&str>, sorted: &'a [String]) -> Option<&'a str> {
+pub fn next_prompt<'a>(current: Option<&str>, sorted: &'a [&'a String]) -> Option<&'a str> {
     if sorted.is_empty() {
         return None;
     }

--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -417,12 +417,14 @@ body
     #[test]
     fn next_prompt_starts_at_head_from_base() {
         let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(None, &names), Some("a"));
     }
 
     #[test]
     fn next_prompt_advances_then_wraps() {
         let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(Some("a"), &names), Some("b"));
         assert_eq!(next_prompt(Some("b"), &names), Some("c"));
         assert_eq!(next_prompt(Some("c"), &names), Some("a"));
@@ -431,6 +433,7 @@ body
     #[test]
     fn next_prompt_unknown_current_starts_at_head() {
         let names = vec!["a".to_string(), "b".to_string()];
+        let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(Some("zzz"), &names), Some("a"));
     }
 

--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -269,6 +269,22 @@ fn copy_embedded(dest: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Pick the next prompt name in a cycle. `sorted` is the caller-sorted list of
+/// available prompt names; `current` is the active prompt name, or `None` for
+/// the base layer. Wraps past the end; an unknown or missing `current` starts
+/// from the head. Returns `None` only when there are no prompts to cycle.
+pub fn next_prompt<'a>(current: Option<&str>, sorted: &'a [String]) -> Option<&'a str> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let len = sorted.len();
+    let i = current
+        .and_then(|c| sorted.iter().position(|n| n.as_str() == c))
+        .map(|found| (found + 1) % len)
+        .unwrap_or(0);
+    Some(sorted[i].as_str())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,5 +412,30 @@ body
 ";
         let p = parse_frontmatter(raw);
         assert_eq!(p.deny_tools, vec!["edit", "write", "bash"]);
+    }
+
+    #[test]
+    fn next_prompt_starts_at_head_from_base() {
+        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(next_prompt(None, &names), Some("a"));
+    }
+
+    #[test]
+    fn next_prompt_advances_then_wraps() {
+        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(next_prompt(Some("a"), &names), Some("b"));
+        assert_eq!(next_prompt(Some("b"), &names), Some("c"));
+        assert_eq!(next_prompt(Some("c"), &names), Some("a"));
+    }
+
+    #[test]
+    fn next_prompt_unknown_current_starts_at_head() {
+        let names = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(next_prompt(Some("zzz"), &names), Some("a"));
+    }
+
+    #[test]
+    fn next_prompt_empty_is_none() {
+        assert_eq!(next_prompt(None, &[]), None);
     }
 }

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -78,6 +78,9 @@ pub enum KeyAction {
     /// running agent (dirge-e59d). Distinct from Ctrl+C, which cancels the
     /// run AND clears the queue.
     DropQueue,
+    /// Cycle the active prompt layer to the next available prompt. Silent —
+    /// updates the status-bar badge without writing to the chat log.
+    CyclePrompt,
 }
 
 impl Command for KeyAction {
@@ -142,6 +145,14 @@ impl Command for KeyAction {
             "drop_queue",
             &[(KeyCode::Char('x'), KeyModifiers::ALT)],
         ),
+        (
+            // Shift+Tab arrives from the terminal as the BackTab sequence;
+            // see `normalize_chord`. Tab itself stays intrinsic to the
+            // input editor (completion), so this is a distinct key.
+            KeyAction::CyclePrompt,
+            "cycle_prompt",
+            &[(KeyCode::Tab, KeyModifiers::SHIFT)],
+        ),
     ];
 }
 
@@ -164,6 +175,19 @@ impl<A: Command> Default for Bindings<A> {
     }
 }
 
+/// Canonicalize a raw key chord for lookup. Shift+Tab is delivered by the
+/// terminal as the BackTab sequence (crossterm `KeyCode::BackTab`), with or
+/// without SHIFT depending on the terminal, while config bindings spell it
+/// `"shift-tab"` / `"backtab"` → `(Tab, SHIFT)`. Fold the keystroke onto that
+/// chord so a binding matches regardless of how it is reported.
+fn normalize_chord(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
+    if code == KeyCode::BackTab {
+        (KeyCode::Tab, KeyModifiers::SHIFT)
+    } else {
+        (code, modifiers)
+    }
+}
+
 impl<A: Command> Bindings<A> {
     /// The built-in keymap (no config applied).
     pub fn defaults() -> Self {
@@ -179,7 +203,8 @@ impl<A: Command> Bindings<A> {
     /// The action bound to `key` (as a single-key chord), matching modifiers
     /// exactly. Used by the global keymap.
     pub fn resolve(&self, key: &KeyEvent) -> Option<A> {
-        self.map.get(&[(key.code, key.modifiers)][..]).copied()
+        let chord = normalize_chord(key.code, key.modifiers);
+        self.map.get(&[chord][..]).copied()
     }
 
     /// Like [`resolve`], but on a miss retries with Shift dropped. The input
@@ -590,6 +615,12 @@ pub fn parse_chord(spec: &str) -> Option<(KeyCode, KeyModifiers)> {
         "enter" | "return" => KeyCode::Enter,
         "esc" | "escape" => KeyCode::Esc,
         "tab" => KeyCode::Tab,
+        // "backtab" is how terminals deliver Shift+Tab; canonicalize it to
+        // the same chord as "shift-tab" (Tab + SHIFT).
+        "backtab" => {
+            modifiers |= KeyModifiers::SHIFT;
+            KeyCode::Tab
+        }
         "backspace" | "bs" => KeyCode::Backspace,
         "delete" | "del" => KeyCode::Delete,
         "insert" | "ins" => KeyCode::Insert,
@@ -747,6 +778,62 @@ mod tests {
         assert_eq!(
             parse_chord("option-f"),
             Some((KeyCode::Char('f'), KeyModifiers::ALT))
+        );
+    }
+
+    #[test]
+    fn shift_tab_and_backtab_parse_to_tab_shift() {
+        // Terminals deliver Shift+Tab as the BackTab sequence; both spellings
+        // canonicalize to the same chord so a config binding matches either.
+        assert_eq!(
+            parse_chord("shift-tab"),
+            Some((KeyCode::Tab, KeyModifiers::SHIFT))
+        );
+        assert_eq!(
+            parse_chord("backtab"),
+            Some((KeyCode::Tab, KeyModifiers::SHIFT))
+        );
+    }
+
+    #[test]
+    fn backtab_keyevent_resolves_a_shift_tab_binding() {
+        // A real Shift+Tab keystroke arrives as KeyCode::BackTab (with or
+        // without SHIFT, depending on the terminal); a "shift-tab" config
+        // binding must match it.
+        let (km, warns) = global_from(&[cfg("shift-tab", "toggle_reasoning")]);
+        assert!(warns.is_empty(), "{warns:?}");
+        assert_eq!(
+            km.resolve(&ev(KeyCode::BackTab, KeyModifiers::NONE)),
+            Some(KeyAction::ToggleReasoning)
+        );
+        assert_eq!(
+            km.resolve(&ev(KeyCode::BackTab, KeyModifiers::SHIFT)),
+            Some(KeyAction::ToggleReasoning)
+        );
+    }
+
+    #[test]
+    fn cycle_prompt_command_resolves() {
+        assert_eq!(
+            KeyAction::from_command("cycle_prompt"),
+            Some(KeyAction::CyclePrompt)
+        );
+        assert_eq!(
+            KeyAction::from_command("cycle-prompt"),
+            Some(KeyAction::CyclePrompt)
+        );
+    }
+
+    #[test]
+    fn cycle_prompt_is_the_default_shift_tab_binding() {
+        let km = Keymap::defaults();
+        assert_eq!(
+            km.resolve(&ev(KeyCode::BackTab, KeyModifiers::NONE)),
+            Some(KeyAction::CyclePrompt)
+        );
+        assert_eq!(
+            km.resolve(&ev(KeyCode::Tab, KeyModifiers::SHIFT)),
+            Some(KeyAction::CyclePrompt)
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1778,8 +1778,8 @@ pub async fn run_interactive(
                         // turn.
                         if action == Some(KeyAction::CyclePrompt) {
                             let names = {
-                                let mut v: Vec<String> =
-                                    context.prompts.keys().cloned().collect();
+                                let mut v: Vec<_> =
+                                    context.prompts.keys().collect();
                                 v.sort();
                                 v
                             };
@@ -1801,12 +1801,13 @@ pub async fn run_interactive(
                                 .expect("name drawn from prompts.keys()");
                             let body = p.body.clone();
                             let deny = p.deny_tools.clone();
-                            context.set_prompt_layer(Some(name.to_string()), Some(body), deny);
+                            let name = name.to_string();
+                            context.set_prompt_layer(Some(name.clone()), Some(body), deny);
                             crate::permission::apply_prompt_deny(
                                 &permission,
                                 &context.current_prompt_deny_tools,
                             );
-                            session.current_prompt_name = Some(name.to_string());
+                            session.current_prompt_name = Some(name);
                             let model = client.completion_model(session.model.to_string());
                             agent = crate::provider::build_agent(
                                 model,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1769,6 +1769,69 @@ pub async fn run_interactive(
                             continue;
                         }
 
+                        // Shift+Tab cycles the active prompt layer to the next
+                        // available prompt. Silent: updates the status-bar
+                        // badge without writing to the chat log (unlike the
+                        // `/prompt <name>` slash command, which announces the
+                        // switch). Mirrors that command's layer swap + agent
+                        // rebuild so the new prompt takes effect on the next
+                        // turn.
+                        if action == Some(KeyAction::CyclePrompt) {
+                            let names = {
+                                let mut v: Vec<String> =
+                                    context.prompts.keys().cloned().collect();
+                                v.sort();
+                                v
+                            };
+                            let Some(name) = crate::context::prompts::next_prompt(
+                                context.current_prompt_name.as_deref(),
+                                &names,
+                            ) else {
+                                continue;
+                            };
+                            // No-op when cycling lands on the active prompt
+                            // (e.g. only one prompt configured): skip the wasted
+                            // agent rebuild.
+                            if context.current_prompt_name.as_deref() == Some(name) {
+                                continue;
+                            }
+                            let p = context
+                                .prompts
+                                .get(name)
+                                .expect("name drawn from prompts.keys()");
+                            let body = p.body.clone();
+                            let deny = p.deny_tools.clone();
+                            context.set_prompt_layer(Some(name.to_string()), Some(body), deny);
+                            crate::permission::apply_prompt_deny(
+                                &permission,
+                                &context.current_prompt_deny_tools,
+                            );
+                            session.current_prompt_name = Some(name.to_string());
+                            let model = client.completion_model(session.model.to_string());
+                            agent = crate::provider::build_agent(
+                                model,
+                                cli,
+                                cfg,
+                                context,
+                                permission.clone(),
+                                ask_tx.clone(),
+                                question_tx.clone(),
+                                plan_tx.clone(),
+                                bg_store.clone(),
+                                #[cfg(feature = "lsp")]
+                                lsp_manager.clone(),
+                                sandbox.clone(),
+                                #[cfg(feature = "mcp")]
+                                mcp_manager.as_ref(),
+                                #[cfg(feature = "semantic")]
+                                semantic_manager,
+                                Some(session.id.to_string()),
+                            )
+                            .await;
+                            renderer.request_repaint();
+                            continue;
+                        }
+
                         let ctrl_p = action == Some(KeyAction::PrevChat);
                         let ctrl_x = action == Some(KeyAction::CloseChat);
                         if matches!(


### PR DESCRIPTION
Add the ability to cycle through prompts using a hot key. Works kinda like the claude-code mode switcher