### PR TITLE
docs: document cycle_prompt / Shift+Tab

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -640,6 +640,7 @@ routes to the right one by its command name.
 | `close_chat` | `ctrl-x` | Close the active chat window |
 | `kill_subagent` | `ctrl-k` | Kill the focused subagent |
 | `drop_queue` | `alt-x` | Drop queued interjections (without cancelling the run) |
+| `cycle_prompt` | `shift-tab` | Cycle the active prompt layer to the next available prompt |
 
 ### Input-editor commands
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -48,6 +48,7 @@ kill-subagent) are **rebindable** via the `keybindings` config — see
 | Esc-Esc (idle) | Open rewind picker (truncate history) |
 | Ctrl+O | Expand collapsed tool result |
 | Ctrl+R | Toggle reasoning visibility |
+| Shift+Tab | Cycle the active prompt layer to the next prompt (silent; status badge updates) |
 | PgUp/PgDn | Scroll chat history |
 | Ctrl+Home/End | Jump chat to top/bottom |
 | `! cmd` | Run shell command (visible, injected into chat) |


### PR DESCRIPTION
Follow-up to #485. The prompt-cycling keybinding shipped without docs; add `cycle_prompt` to the global command table in docs/config.md and a Shift+Tab row to docs/tui.md.