### PR TITLE
release: v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-06-20
+
+### Added
+- **Cycle prompts with Shift+Tab.** A hotkey (rebindable as `cycle_prompt`)
+  steps through the configured prompt layers like a mode switcher, and now
+  cycles back to the no-prompt base layer past the last one. (#485, #489)
+
+### Fixed
+- **Critic / verifier / todo nudge no longer vanishes from the log.** These
+  finalization nudges re-enter as user-role messages without a Done/ToolCall to
+  reset the stream anchor, so the next turn's render overwrote them — they
+  disappeared on screen a moment later even though the model still had them in
+  context. The in-flight response is now finalized before the nudge renders, so
+  the next turn streams below it. (#488)
+
 ## [0.10.1] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "dirge-agent"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # taken on crates.io. The installed BINARY is still `dirge` (see [[bin]]),
 # so users run: `cargo install dirge-agent` then the `dirge` command.
 name = "dirge-agent"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 # edition 2024 was stabilized in Rust 1.85; pin the MSRV so older
 # toolchains get a clear error instead of a cryptic edition failure.


### PR DESCRIPTION
Patch release bundling the four changes since v0.10.1.

### Added
- Shift+Tab cycles the active prompt layer, including back to the no-prompt base layer. (#485, #489)

### Fixed
- Critic/verifier/todo nudge no longer disappears from the chat log after the next turn streams. (#488)

(Docs for the keybinding: #487.)

Tag `v0.10.2` will be pushed after merge to trigger the release-artifact build.