### PR TITLE
Fix recurring Nix-bump failure on release; catch nix/bin.nix up to 0.10.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          # Full history so the post-build commit can rebase+push to main.
+          fetch-depth: 0
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
@@ -141,14 +143,28 @@ jobs:
           path.write_text(text)
           PY
 
-      - name: Open pull request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: Bump Nix dirge-bin to ${{ github.ref_name }}
-          title: Bump Nix dirge-bin to ${{ github.ref_name }}
-          body: Update nix/bin.nix for the ${{ github.ref_name }} release assets.
-          branch: automation/nix-dirge-bin-${{ github.ref_name }}
-          delete-branch: true
+      # Commit the bump straight to `main` instead of opening a PR. The
+      # PR route (peter-evans/create-pull-request) failed on every release
+      # with "GitHub Actions is not permitted to create or approve pull
+      # requests" — a repo Actions toggle that's off. `main` is unprotected
+      # and this job has `contents: write` (permissions: write-all), so a
+      # direct push works and needs no extra setting or PAT. A GITHUB_TOKEN
+      # push doesn't re-trigger workflows, so this can't loop.
+      - name: Commit nix/bin.nix bump
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- nix/bin.nix; then
+            echo "nix/bin.nix already current for ${GITHUB_REF_NAME} — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add nix/bin.nix
+          git commit -m "Bump Nix dirge-bin to ${GITHUB_REF_NAME}"
+          # The release job can run minutes after the tag; rebase on any
+          # main movement so the push fast-forwards.
+          git pull --rebase origin main
+          git push origin HEAD:main
 
   # Bump the Homebrew tap (dirge-code/homebrew-dirge) to the just-released
   # version + checksums. Runs after every target has uploaded its assets, so

--- a/nix/bin.nix
+++ b/nix/bin.nix
@@ -6,16 +6,16 @@
 }:
 
 let
-  version = "0.10.0";
+  version = "0.10.2";
   sel =
     {
       "x86_64-linux" = {
         triple = "x86_64-unknown-linux-gnu";
-        hash = "sha256-/wrIGmvcOc1AB8JoOvTbZgD3uFg5oF6qX8WzOYvJJOo=";
+        hash = "sha256-NyT8negcPKWMtUAPnTtuqvzyye6IqV5/suGF9aBN1FU=";
       };
       "aarch64-darwin" = {
         triple = "aarch64-apple-darwin";
-        hash = "sha256-rF8eU0xIbqv0zPeYz3OMDqZpWGTTfACTULMHzEM9iuk=";
+        hash = "sha256-Yn4UrtQS8px5Ck0sIgxBVan6GZiRW+SWQsBeSKMNthM=";
       };
     }
     .${stdenv.hostPlatform.system};


### PR DESCRIPTION
## Problem
Every release the "Bump Nix binary package" job fails — but **not** at the Nix step. The prefetch + `nix/bin.nix` rewrite succeed; it dies at **`Open pull request`** with *"GitHub Actions is not permitted to create or approve pull requests"* (a repo Actions toggle that's off, `can_approve_pull_request_reviews:false`). So the bump never lands — `nix/bin.nix` was stuck at **0.10.0** through both the 0.10.1 and 0.10.2 releases.

## Fix
Commit the bump **straight to `main`** instead of opening a PR. `main` is unprotected and the job already has `contents: write` (`permissions: write-all`), so a `GITHUB_TOKEN` push works with no extra setting or PAT — and a token push doesn't re-trigger workflows, so it can't loop. Checkout gets `fetch-depth: 0` so the post-build commit rebases+pushes cleanly.

## Also
Manually bump `nix/bin.nix` to **0.10.2** to catch up the two missed releases. Hashes are SRI-base64 of the published v0.10.2 release tarballs:
- x86_64-linux: `sha256-NyT8negcPKWMtUAPnTtuqvzyye6IqV5/suGF9aBN1FU=`
- aarch64-darwin: `sha256-Yn4UrtQS8px5Ck0sIgxBVan6GZiRW+SWQsBeSKMNthM=`

Alternative considered: flip *Settings → Actions → Allow GitHub Actions to create and approve pull requests* and keep the PR flow — but that also lets workflows self-approve PRs; the direct push is more contained.