### PR TITLE
feat: map Ctrl+D to DeleteCharForward in input editor

### DIFF
--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -998,6 +998,13 @@ impl InputEditor {
                 self.reset_kill_accumulation();
                 None
             }
+            InputAction::DeleteCharForward => {
+                if let Some((start, end)) = delete_range(&self.buffer, self.cursor) {
+                    self.remove_range(start, end);
+                }
+                self.reset_kill_accumulation();
+                None
+            }
             InputAction::KillToLineEnd => {
                 if self.cursor < self.buffer.len() {
                     let killed: CompactString = self.buffer[self.cursor..].into();

--- a/src/ui/keymap.rs
+++ b/src/ui/keymap.rs
@@ -432,6 +432,8 @@ pub enum InputAction {
     /// Delete the character before the cursor (Ctrl+H synonym for
     /// Backspace; the Backspace key itself stays intrinsic).
     DeleteCharBack,
+    /// Delete the character at the cursor (forward delete, Ctrl+D).
+    DeleteCharForward,
     /// Kill (cut to the kill-ring) from the cursor to end of line.
     KillToLineEnd,
     /// Kill from the start of the line to the cursor.
@@ -512,6 +514,11 @@ impl Command for InputAction {
             InputAction::DeleteCharBack,
             "delete_char_back",
             &[(KeyCode::Char('h'), KeyModifiers::CONTROL)],
+        ),
+        (
+            InputAction::DeleteCharForward,
+            "delete_char_forward",
+            &[(KeyCode::Char('d'), KeyModifiers::CONTROL)],
         ),
         (
             InputAction::KillToLineEnd,
@@ -938,6 +945,10 @@ mod tests {
                 InputAction::WordRight,
             ),
             ((KeyCode::Right, KeyModifiers::ALT), InputAction::WordRight),
+            (
+                (KeyCode::Char('d'), KeyModifiers::CONTROL),
+                InputAction::DeleteCharForward,
+            ),
             (
                 (KeyCode::Char('k'), KeyModifiers::CONTROL),
                 InputAction::KillToLineEnd,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1438,7 +1438,7 @@ pub async fn run_interactive(
                         // Resolve the key to a rebindable global command
                         // (config-overridable), or use the action a completed
                         // chord sequence produced. `None` for everything else
-                        // (typing, input-editor keys, the Ctrl+C/D/Esc cancel
+                        // (typing, input-editor keys, Ctrl+C cancel
                         // gesture), which flows through unchanged.
                         let action = seq_action.or_else(|| keymap.resolve(&key));
                         // A completed chord sequence consumes its terminal key:
@@ -1450,10 +1450,7 @@ pub async fn run_interactive(
                         let is_ctrl_c = !from_sequence
                             && key.code == KeyCode::Char('c')
                             && key.modifiers.contains(KeyModifiers::CONTROL);
-                        let is_ctrl_d = !from_sequence
-                            && key.code == KeyCode::Char('d')
-                            && key.modifiers.contains(KeyModifiers::CONTROL);
-                        if is_ctrl_c || is_ctrl_d {
+                        if is_ctrl_c {
                             if ui.rewind_picker.active {
                                 ui.rewind_picker.deactivate();
                                 renderer.set_rewind_overlay(None);
@@ -1543,7 +1540,7 @@ pub async fn run_interactive(
                                 )?;
                                 renderer.request_repaint();
                             } else if !input.expanded().is_empty() {
-                                // Idle Ctrl+C/D with a typed draft: clear the
+                                // Idle Ctrl+C with a typed draft: clear the
                                 // line instead of quitting, so an accidental
                                 // Ctrl+C doesn't end the session and discard the
                                 // draft (readline/bash behavior). Only an EMPTY
@@ -1551,7 +1548,7 @@ pub async fn run_interactive(
                                 input.set_text("");
                                 renderer.request_repaint();
                             } else {
-                                // dirge-bx4g: clean exit via Ctrl+C / Ctrl+D
+                                // dirge-bx4g: clean exit via Ctrl+C
                                 // while idle — fire on_session_end so plugin
                                 // providers see the session boundary.
                                 crate::agent::review::maybe_fire_session_end(


### PR DESCRIPTION
Remove Ctrl+D as a global TUI exit gesture so it flows through to the input editor, where it deletes the character at the cursor (forward delete). Ctrl+D on an empty buffer is a no-op. Ctrl+C remains the only key-based quit gesture.