### PR TITLE
docs: Ctrl+D is forward-delete now, not a quit gesture

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -653,6 +653,7 @@ routes to the right one by its command name.
 | `word_left` | `alt-b`, `alt-left` | Cursor one word left |
 | `word_right` | `alt-f`, `alt-right` | Cursor one word right |
 | `delete_char_back` | `ctrl-h` | Delete character before cursor |
+| `delete_char_forward` | `ctrl-d` | Delete character at cursor (forward) |
 | `kill_to_line_end` | `ctrl-k` | Kill to end of line |
 | `kill_to_line_start` | `ctrl-u` | Kill to start of line |
 | `kill_word_back` | `ctrl-w` | Kill word before cursor |
@@ -688,7 +689,7 @@ you'll see a warning.
 
 Notes:
 - **Always fixed** (never rebindable): the cancel/interrupt gesture
-  **Ctrl+C / Ctrl+D / Esc** (the panic button) and intrinsic editing —
+  **Ctrl+C / Esc** (the panic button) and intrinsic editing —
   typing a character, **Backspace**, **Delete**, **Enter** to submit,
   **Ctrl+J** (insert newline), and **Tab** completion. Binding a global
   command to one of these chords shadows the intrinsic behavior while

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -225,7 +225,7 @@ or more chords separated by whitespace for a sequence. Modifiers: `ctrl`,
 user can still override. `register-shortcut` handlers dispatch after the
 built-in global commands but before the text input.
 
-Reserved keys neither form can override: Ctrl+C, Ctrl+D, Esc (the panic
+Reserved keys neither form can override: Ctrl+C, Esc (the panic
 gesture), and the search / rewind picker keys. Modifier matching is exact —
 `ctrl-x` and `ctrl-shift-x` are distinct bindings. Bad specs are dropped
 with a `tracing::warn`.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -22,6 +22,7 @@ kill-subagent) are **rebindable** via the `keybindings` config — see
 | Ctrl+K | Kill to end of line |
 | Ctrl+U | Kill to start of line |
 | Ctrl+W | Kill word before cursor |
+| Ctrl+D | Delete the character at the cursor (forward; no-op at end of line) |
 | Meta+Backspace | Delete word before cursor |
 | Meta+D | Delete word after cursor |
 | Ctrl+Y | Yank (paste) last kill |
@@ -39,7 +40,7 @@ kill-subagent) are **rebindable** via the `keybindings` config — see
 
 | Key | Action |
 |-----|--------|
-| Ctrl+C / Ctrl+D / Esc | Interrupt running agent (also clears queued interjections) |
+| Ctrl+C / Esc | Interrupt running agent (also clears queued interjections) |
 | Type while running | Queues your message; runs after the current turn finishes. The runner also stops at the next tool-result boundary so the message is picked up quickly instead of waiting for the whole multi-turn run. Status line shows `q:N` for pending count. |
 | Alt+X | Drop all queued interjections (without cancelling the running agent) |
 | Ctrl+K | Kill subagent on focused chat tab |


### PR DESCRIPTION
Follow-up to #493, which remapped Ctrl+D to forward-delete in the input editor (rebindable as `delete_char_forward`) and dropped it as a global quit/interrupt gesture.

Docs still called Ctrl+D a panic/exit key:
- **tui.md** — interrupt row is now `Ctrl+C / Esc`; added a Ctrl+D forward-delete row to the input-editor keys.
- **config.md** — removed Ctrl+D from the always-fixed panic button (it's rebindable now); added `delete_char_forward` to the input-editor command table.
- **plugins.md** — removed Ctrl+D from the reserved keys.

Left `docs/microvm/SLASH_COMMANDS.md` untouched — that Ctrl-D is the microVM shell's own EOF, not dirge's keymap.