### PR TITLE
status: context gauge reads 0–100% against the full window

### DIFF
--- a/src/agent/agent_loop/context_manager.rs
+++ b/src/agent/agent_loop/context_manager.rs
@@ -298,21 +298,6 @@ pub fn effective_ctx_max(model_window: u64) -> u64 {
     model_window.min(context_target())
 }
 
-/// The token budget the agent actually has to work within before
-/// auto-compaction kicks in: the effective window
-/// ([`effective_ctx_max`], i.e. `min(model_window, context_target)`) times
-/// the active early-fold threshold ([`effective_fold_threshold`], default
-/// [`HISTORY_FOLD_THRESHOLD`], lowered by `compaction_fold_threshold`). The
-/// post-response fold — the earliest tier that fires in normal operation —
-/// triggers once usage crosses this, so it is the honest denominator for
-/// the status line: at 100% a fold is imminent, rather than the misleading
-/// fraction-of-a-1M-window the raw model window would show. Uses the
-/// process-installed knobs (`None` override), so it tracks whatever the
-/// user configured at startup.
-pub fn compaction_budget(model_window: u64) -> u64 {
-    (effective_ctx_max(model_window) as f64 * effective_fold_threshold(None)) as u64
-}
-
 /// Process-wide explicit context-window override from
 /// `Config::context_window`, installed at startup. When set it replaces the
 /// built-in model-table lookup for the loop's window (before the
@@ -744,23 +729,6 @@ mod tests {
             decide_after_usage(Some(76_000), budget, false).kind,
             PostUsageDecisionKind::Fold
         );
-    }
-
-    #[test]
-    fn compaction_budget_caps_window_and_applies_fold_threshold() {
-        // The status-line budget is the fold-trigger point: the effective
-        // window (capped by the context target) times the active fold
-        // threshold — never the raw advertised window. Computed from the
-        // same primitives so it holds regardless of any process-global
-        // knobs another test may have installed.
-        let huge = 1_000_000;
-        let eff = effective_ctx_max(huge);
-        let expected = (eff as f64 * effective_fold_threshold(None)) as u64;
-        assert_eq!(compaction_budget(huge), expected);
-        // Strictly below the effective window (a fold fires before it fills)…
-        assert!(compaction_budget(huge) < eff);
-        // …and far below the raw advertised window.
-        assert!(compaction_budget(huge) < huge);
     }
 
     // ============================================================

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -102,15 +102,26 @@ impl StatusLine {
             None => dir.to_string(),
         };
 
-        // Denominator is the compaction-trigger budget, not the raw model
-        // window: the loop folds at `fold_threshold * min(window,
-        // context_target)`, so showing the advertised window (200k/1M)
-        // understated how full the working context really was. At 100% here
-        // a fold is imminent (dirge-l4rp).
+        // Denominator is the EFFECTIVE context window (`min(model window,
+        // context_target)`) — a true fullness meter that reads 0–100% and
+        // doesn't overflow. The previous denominator was the fold-trigger
+        // budget (~75% of the window), so once real usage passed 75% the gauge
+        // showed a confusing >100% (e.g. `90k/75k (120%)`). The loop still
+        // folds well before the window fills — ~75% (normal) and ~90%
+        // (turn-start) — so a compact `fold`/`fold!` marker flags when a fold
+        // is near/imminent instead of pushing the percentage past 100
+        // (dirge-l4rp, dirge-cx7t).
         let ctx =
-            crate::agent::agent_loop::context_manager::compaction_budget(session.context_window);
+            crate::agent::agent_loop::context_manager::effective_ctx_max(session.context_window);
         let used = session.total_estimated_tokens;
         let pct = (used * 100).checked_div(ctx).unwrap_or(0);
+        let pct_str = if pct >= 90 {
+            format!("{pct}% fold!")
+        } else if pct >= 75 {
+            format!("{pct}% fold")
+        } else {
+            format!("{pct}%")
+        };
 
         // TODO(cost-tracking): `session.total_cost` is always 0.0
         // because dirge doesn't yet have a per-provider pricing
@@ -166,14 +177,14 @@ impl StatusLine {
         let session_badge = format!(" session:{}", crate::text::short_id(session.id.as_str()));
 
         format!(
-            "{}{} | {}{} | {}/{} ({}%) | {}msgs | {}{}{}{}{}{}{}{}",
+            "{}{} | {}{} | {}/{} ({}) | {}msgs | {}{}{}{}{}{}{}{}",
             project_label,
             cost_str,
             session.model,
             loop_badge,
             fmt_tokens(used),
             fmt_tokens(ctx),
-            pct,
+            pct_str,
             session.messages.len(),
             state,
             compact_badge,
@@ -265,6 +276,35 @@ mod tests {
         let line = render(2, 3);
         assert!(line.contains("agents:2"), "expected agents:2 in: {line}");
         assert!(line.contains("shells:3"), "expected shells:3 in: {line}");
+    }
+
+    /// dirge-cx7t: the gauge denominator is the full effective window, so the
+    /// percentage reads 0–100% (not the old >100% past 75%), with a `fold`
+    /// marker flagging when a fold is near/imminent.
+    #[tokio::test]
+    async fn gauge_uses_full_window_and_marks_fold() {
+        let mut session = Session::new("openrouter", "test-model", 100_000);
+
+        // Comfortable: 50k of a 100k window → 50%, no marker, never >100%.
+        session.total_estimated_tokens = 50_000;
+        let line = StatusLine::render(&session, false, 0, None, None, None, None, None, None);
+        assert!(line.contains("/100k (50%)"), "full-window 50%: {line}");
+        assert!(!line.contains("fold"), "no fold marker at 50%: {line}");
+
+        // Normal-fold zone (≥75%): the `fold` hint appears, still ≤100%.
+        session.total_estimated_tokens = 80_000;
+        let line = StatusLine::render(&session, false, 0, None, None, None, None, None, None);
+        assert!(line.contains("(80% fold)"), "fold hint at 80%: {line}");
+
+        // Turn-start fold zone (≥90%): `fold!` — and crucially NOT the old
+        // confusing 120% (90k against the 75k budget).
+        session.total_estimated_tokens = 90_000;
+        let line = StatusLine::render(&session, false, 0, None, None, None, None, None, None);
+        assert!(line.contains("(90% fold!)"), "fold! at 90%: {line}");
+        assert!(
+            !line.contains("120%"),
+            "must not overflow past 100%: {line}"
+        );
     }
 
     /// The session id is shown at the end of the status line so the


### PR DESCRIPTION
Fixes the confusing `>100%` footer (e.g. `90k/75k (120%)`).

The gauge divided used tokens by the **fold-trigger budget** (~75% of the window), so once usage passed 75% the percentage went over 100 — reads as "over capacity" when you're really at 90% of a 100k window.

Now it divides by the **effective window** (`min(model window, context_target)`) → a true 0–100% fullness meter. Folds still happen before the window fills (~75% normal, ~90% turn-start), so a compact `fold` / `fold!` marker flags an approaching/imminent fold instead of an overflowing number:

```
50k/100k (50%)
80k/100k (80% fold)
90k/100k (90% fold!)
```

Test asserts 50%/80%/90% rendering and that it never shows the old 120%.

(Full color-coding the gauge segment amber/red was the other option, but it needs threading severity + the segment's column range through set_bottom → cache_bottom → scene → BottomStrip → paint_status — disproportionate plumbing in the render path. The textual marker gives the same signal with no render-layer risk; happy to do the color as a follow-up if you'd prefer it.)