### PR TITLE
[vibe coded with deepseek flash] feat(config): add tools.auto_repair toggle to disable delimiter-balance auto-repair

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,5 @@
+help:
+    @just --list
+
+format:
+    nix develop --command cargo fmt

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -286,6 +286,16 @@ pub async fn build_loop_tools(
     crate::agent::agent_loop::context_manager::set_verbatim_pre_recall(
         mem_cfg.verbatim_pre_recall == Some(true),
     );
+    // Process-wide auto-repair toggle: when `tools.auto_repair` is
+    // explicitly `false`, skip delimiter-balance auto-close and reject
+    // broken edits outright. Default (unset) preserves auto-repair.
+    if cfg
+        .tools
+        .clone()
+        .is_some_and(|t| t.auto_repair == Some(false))
+    {
+        crate::semantic::syntax_validator::set_auto_repair(false);
+    }
     let memory_store: Option<Arc<dyn crate::extras::memory_provider::MemoryProvider>> =
         if let Ok(c) = std::env::current_dir() {
             let paths = crate::extras::dirge_paths::ProjectPaths::new(&c);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,6 +186,15 @@ pub struct ToolsConfig {
     /// 3000-char hard truncation that silently dropped the tail of
     /// large subagent answers.
     pub task_output_inline_max_bytes: Option<usize>,
+    /// Auto-repair delimiter imbalances in edit/write results. When
+    /// `true` (default), a file with unclosed delimiters (e.g. `{`)
+    /// gets closers appended at EOF to make it parseable, and the
+    /// edit succeeds with a note. When `false`, such edits are
+    /// rejected outright — the model sees a syntax error and must
+    /// resubmit a correct edit. Turn off if auto-repair causes more
+    /// confusion than it saves (e.g. a bad edit whose structural
+    /// mistake gets silently papered over).
+    pub auto_repair: Option<bool>,
 }
 
 /// Override block for the named per-operation timeouts, under the

--- a/src/semantic/syntax_validator.rs
+++ b/src/semantic/syntax_validator.rs
@@ -688,6 +688,7 @@ pub fn repair_delimiters(path: &Path, content: &str) -> Option<(String, String)>
 
 /// Validate `content`; on a delimiter imbalance, try a mechanical close
 /// before giving up. The single entry point the edit tools call.
+#[derive(Clone, Debug)]
 pub enum SyntaxOutcome {
     /// Clean as written.
     Clean,
@@ -970,6 +971,25 @@ int main(void) {
             }
             _ => panic!("stray closer must be rejected, not repaired"),
         }
+    }
+
+    #[cfg(feature = "semantic-rust")]
+    #[test]
+    fn disable_auto_repair_rejects_instead_of_repairing() {
+        let path = PathBuf::from("/tmp/x.rs");
+        // Unclosed `{` — default auto-repair would close it; with the flag
+        // off it must be Rejected outright.  The expected error (from
+        // format_errors) names the missing `}` token and the location.
+        let content = "fn main() {\n  let x = 1;\n";
+        set_auto_repair(false);
+        match validate_or_repair(&path, content) {
+            SyntaxOutcome::Rejected { message } => {
+                assert!(message.contains("syntax error"), "{message}");
+            }
+            other => panic!("expected Rejected with auto-repair off, got {other:?}"),
+        }
+        // Restore default so subsequent tests aren't affected.
+        set_auto_repair(true);
     }
 
     #[cfg(feature = "semantic-rust")]

--- a/src/semantic/syntax_validator.rs
+++ b/src/semantic/syntax_validator.rs
@@ -17,6 +17,12 @@
 //! broken file doesn't dump 1000 errors into the tool result.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Process-wide flag: when `false`, `validate_or_repair` skips auto-repair
+/// and rejects unbalanced-delimiter edits outright. Default `true`
+/// (auto-repair on). Set once from config at agent startup.
+static AUTO_REPAIR_ENABLED: AtomicBool = AtomicBool::new(true);
 
 /// One syntax error discovered by tree-sitter. Carries enough
 /// detail for the model to localize the fix without re-reading
@@ -695,18 +701,33 @@ pub enum SyntaxOutcome {
 /// Validate, and auto-repair a closable delimiter imbalance if possible.
 /// Parity with the JSON truncation repair (dirge-p5fu).
 pub fn validate_or_repair(path: &Path, content: &str) -> SyntaxOutcome {
-    match check_syntax(path, content) {
-        Ok(()) => SyntaxOutcome::Clean,
-        Err(errors) => match repair_delimiters(path, content) {
-            Some((repaired, note)) => SyntaxOutcome::Repaired {
-                content: repaired,
-                note,
-            },
-            None => SyntaxOutcome::Rejected {
+    if !AUTO_REPAIR_ENABLED.load(Ordering::Relaxed) {
+        match check_syntax(path, content) {
+            Ok(()) => SyntaxOutcome::Clean,
+            Err(errors) => SyntaxOutcome::Rejected {
                 message: format_errors(path, content, &errors),
             },
-        },
+        }
+    } else {
+        match check_syntax(path, content) {
+            Ok(()) => SyntaxOutcome::Clean,
+            Err(errors) => match repair_delimiters(path, content) {
+                Some((repaired, note)) => SyntaxOutcome::Repaired {
+                    content: repaired,
+                    note,
+                },
+                None => SyntaxOutcome::Rejected {
+                    message: format_errors(path, content, &errors),
+                },
+            },
+        }
     }
+}
+
+/// Enable or disable auto-repair across the process. Called once from
+/// agent startup when `tools.auto_repair` config is `Some(false)`.
+pub fn set_auto_repair(enabled: bool) {
+    AUTO_REPAIR_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
 /// Convenience wrapper: format a `Vec<SyntaxError>` as a single


### PR DESCRIPTION
## Problem

When a model edit produces an unclosed delimiter (e.g. opens a `{` with no closing `}`), dirge's auto-repair appends closers at EOF to make the file parseable. This works for truncation but silently worsens mistaken edits: a structurally-broken file gets closers attached in the wrong places and every subsequent edit passes syntax check.

## Solution

Add `tools.auto_repair: false` in config.json to disable the auto-repair path in `validate_or_repair`. With repair off, broken edits are rejected outright with a tree-sitter syntax error pointing at the unclosed opener. Default behavior (auto-repair on) is unchanged.

## Changes

- **src/config/mod.rs**: add `auto_repair` field to `ToolsConfig`
- **src/semantic/syntax_validator.rs**: add `AUTO_REPAIR_ENABLED` static + `set_auto_repair()` setter; skip `repair_delimiters()` when disabled
- **src/agent/builder/loop_tools.rs**: wire config to static at startup
