### PR TITLE
Don't delete an existing file when an auto-repair rollback can't snapshot it

### DIFF
--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -419,6 +419,9 @@ impl Tool for EditTool {
                     self.lsp_manager.as_ref(),
                     path,
                     Some(bytes.clone()),
+                    // Edit always targets an existing file; `before` is always
+                    // Some, so this flag is moot, but keep it honest.
+                    false,
                     write_at,
                 )
                 .await

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -175,6 +175,7 @@ impl Tool for WriteTool {
                     self.lsp_manager.as_ref(),
                     path,
                     repair_before,
+                    was_creation,
                     write_at,
                 )
                 .await
@@ -244,18 +245,28 @@ fn error_diagnostics(diags: &[lsp_types::Diagnostic]) -> Vec<&lsp_types::Diagnos
         .collect()
 }
 
-/// Undo a write: restore the original bytes, or remove a file that didn't
-/// exist before (`before == None`). Best-effort — a failure here can't make
+/// Undo a write. Returns `true` if the on-disk file was actually rolled back:
+/// the original bytes were restored (`before == Some`), or a file we created
+/// this call was removed (`before == None && was_creation`). Returns `false`
+/// when the file existed before but we have no snapshot to restore it from
+/// (`before == None && !was_creation` — e.g. the pre-write read failed): we must
+/// NOT delete it, or a transient read error would destroy the user's file. In
+/// that case the repaired (likely wrong) content stays on disk and the caller
+/// tells the model it wasn't reverted. Best-effort — a failure here can't make
 /// things worse than the broken write already on disk.
 #[cfg(feature = "lsp")]
-async fn revert_write(path: &Path, before: Option<&[u8]>) {
+async fn revert_write(path: &Path, before: Option<&[u8]>, was_creation: bool) -> bool {
     match before {
         Some(orig) => {
             let _ = crate::fs_atomic::atomic_write(path, orig).await;
+            true
         }
-        None => {
+        None if was_creation => {
             let _ = tokio::fs::remove_file(path).await;
+            true
         }
+        // Existed before, but its prior content is unknown — never delete.
+        None => false,
     }
 }
 
@@ -278,6 +289,7 @@ pub(crate) async fn verify_repaired_write_or_rollback(
     manager: Option<&Arc<LspManager>>,
     path: &Path,
     before: Option<Vec<u8>>,
+    was_creation: bool,
     after: Instant,
 ) -> Result<String, String> {
     let Some(manager) = manager else {
@@ -302,16 +314,21 @@ pub(crate) async fn verify_repaired_write_or_rollback(
         ));
     }
 
-    revert_write(path, before.as_deref()).await;
-    // Re-sync the server to the restored content so its diagnostics don't
+    let reverted = revert_write(path, before.as_deref(), was_creation).await;
+    // Re-sync the server to the on-disk content so its diagnostics don't
     // linger (best-effort; the disk rollback already happened).
     manager.touch_file(path, TouchMode::Notify).await;
 
-    let mut msg = String::from(
+    let mut msg = String::from(if reverted {
         "Auto-repair reverted: the file was restored to its previous state and NOT modified. \
          Closing the unbalanced delimiters in your text produced these language-server errors — \
-         fix your original text and resend:\n",
-    );
+         fix your original text and resend:\n"
+    } else {
+        "Auto-repair failed verification, but the file's prior content was unreadable so it could \
+         NOT be rolled back — the repaired (and likely wrong) content is still on disk. Closing the \
+         unbalanced delimiters in your text produced these language-server errors — fix and rewrite \
+         the file:\n"
+    });
     for d in errors.iter().take(MAX_ROLLBACK_DIAGS) {
         msg.push_str("  ");
         msg.push_str(&diagnostic::pretty(d));
@@ -476,14 +493,26 @@ mod tests {
         let p = dir.join("existing.rs");
         std::fs::write(&p, b"original").unwrap();
         std::fs::write(&p, b"broken repair").unwrap();
-        revert_write(&p, Some(b"original")).await;
+        assert!(revert_write(&p, Some(b"original"), false).await);
         assert_eq!(std::fs::read(&p).unwrap(), b"original");
 
         // Creation case: a file that didn't exist before is removed.
         let np = dir.join("new.rs");
         std::fs::write(&np, b"broken new file").unwrap();
-        revert_write(&np, None).await;
+        assert!(revert_write(&np, None, true).await);
         assert!(!np.exists(), "a newly-created file is removed on revert");
+
+        // Unsnapshotted-overwrite case: the file existed but we have no prior
+        // bytes (read failed). It must NOT be deleted — losing the user's file
+        // is worse than leaving the broken repair for them to fix.
+        let up = dir.join("unreadable.rs");
+        std::fs::write(&up, b"repaired but wrong").unwrap();
+        assert!(
+            !revert_write(&up, None, false).await,
+            "returns false: not reverted",
+        );
+        assert!(up.exists(), "an existing file is never deleted on revert");
+        assert_eq!(std::fs::read(&up).unwrap(), b"repaired but wrong");
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
Code review of `v0.10.2..main` surfaced one real bug in the repair-path LSP rollback added in #499.

`verify_repaired_write_or_rollback` rolls a write back when the language server rejects an auto-repair. `write.rs` snapshotted the pre-write bytes with `tokio::fs::read(path).await.ok()`, which folds a *read failure* into the same `None` that means "this is a new file." `revert_write` then treats `None` as "delete it."

So: repair on an **existing** file → pre-write read fails (permissions, a TOCTOU unlink between `path.exists()` and the read, transient IO) → LSP rejects the repair → `revert_write` deletes the file instead of restoring it. Data loss.

Fix: thread `was_creation` into `revert_write` and only delete on a genuine creation. When the file existed but we have no snapshot, leave the (repaired, likely wrong) content on disk and tell the model it wasn't reverted — a wrong repair the model can fix beats a destroyed file. `edit.rs` always passes `Some(bytes)` so it's unaffected; it passes `was_creation = false` for honesty.

Added a third case to `revert_restores_overwrite_and_removes_new_file`: an existing file with `before = None` is left intact and the helper returns `false`.

Build clean under `-D warnings`; rollback + diag tests pass.