### PR TITLE
release: v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-06-21
+
+### Added
+- **Debug a Python module, not just a file.** The DAP launch path now takes an
+  optional `module`, so a debuggee can start as `python -m <module>` (e.g.
+  `pytest`) instead of by program path — exposed via the `dap/launch-module`
+  Janet binding and the debug slash command. The `debug` tool's launch args also
+  gained an `env` map for per-launch environment variables. CI runs the new
+  smoke/e2e tests under a `dap` feature-matrix entry. (#497)
+
 ## [0.10.3] - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "dirge-agent"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # taken on crates.io. The installed BINARY is still `dirge` (see [[bin]]),
 # so users run: `cargo install dirge-agent` then the `dirge` command.
 name = "dirge-agent"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 # edition 2024 was stabilized in Rust 1.85; pin the MSRV so older
 # toolchains get a clear error instead of a cryptic edition failure.


### PR DESCRIPTION
Patch release bundling the DAP launch-module feature merged since v0.10.3.

### Added
- Debug a Python module via `python -m <module>` instead of by program path, exposed through the `dap/launch-module` Janet binding and the debug slash command; the `debug` tool's launch args also gain an `env` map. CI runs the new smoke/e2e tests under a `dap` feature-matrix entry. (#497)

Tag goes on the merge commit.