### PR TITLE
AI SLOP: preserve partial answers when user escapes multi-question batch

### DIFF
--- a/src/agent/tools/question.rs
+++ b/src/agent/tools/question.rs
@@ -381,6 +381,53 @@ mod tests {
         assert!(result.contains("A2"));
     }
 
+    // Partial answers (user Esc on Q2 after answering Q1) must preserve
+    // what was answered and mark the rest [no answer], not error.
+    #[tokio::test]
+    async fn partial_answers_preserve_answered_questions() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = QuestionTool::new(tx);
+
+        let args = QuestionArgs {
+            questions: vec![
+                QuestionItem {
+                    question: "Q1".to_string(),
+                    header: None,
+                    options: vec![QuestionOption {
+                        label: "A1".to_string(),
+                        description: "".to_string(),
+                    }],
+                    multi_select: None,
+                    custom: false,
+                },
+                QuestionItem {
+                    question: "Q2".to_string(),
+                    header: None,
+                    options: vec![QuestionOption {
+                        label: "A2".to_string(),
+                        description: "".to_string(),
+                    }],
+                    multi_select: None,
+                    custom: false,
+                },
+            ],
+        };
+
+        let handle = tokio::spawn(async move { tool.call(args).await });
+
+        let req = rx.recv().await.unwrap();
+        // Only Q1 answered — Q2 escaped
+        let _ = req
+            .reply
+            .send(QuestionResponse::Answered(vec![vec!["A1".to_string()]]));
+
+        let result = handle.await.unwrap().unwrap();
+        assert!(result.contains("**Q1:** Q1"));
+        assert!(result.contains("**A:** A1"));
+        assert!(result.contains("**Q2:** Q2"));
+        assert!(result.contains("**A:** [no answer]"));
+    }
+
     // Header text must be emitted as a markdown `## …` heading so the agent
     // sees structured output rather than a flat blob.
     #[tokio::test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -874,7 +874,11 @@ pub async fn run_interactive(
                                 ) else {
                                     unreachable!()
                                 };
-                                let _ = q.req.reply.send(QuestionResponse::Rejected);
+                                if q.answers.is_empty() {
+                                    let _ = q.req.reply.send(QuestionResponse::Rejected);
+                                } else {
+                                    let _ = q.req.reply.send(QuestionResponse::Answered(q.answers));
+                                }
                                 renderer.write_line("", Color::White)?;
                             }
                         }


### PR DESCRIPTION
When an agent asks multiple questions in one `question` tool call and the user presses Esc on any question after the first, all answers from earlier questions were discarded. The tool returned a `ToolError`, so the agent saw nothing.

**Fix:** On Esc with partial answers (at least one question answered), send `Answered(q.answers)` instead of `Rejected`. The tool already handles missing answers gracefully — unanswered questions show `[no answer]`. Esc on Q1 (no answers at all) still returns `Rejected → Err`.

**Changes:**
- `src/ui/mod.rs:870-883` — send `Answered(q.answers)` when `!q.answers.is_empty()`, `Rejected` otherwise
- `src/agent/tools/question.rs:384-430` — new test `partial_answers_preserve_answered_questions`