### PR TITLE
chore: follow-up from #415 — review item fixes

### DIFF
--- a/plugins/computer_use.janet
+++ b/plugins/computer_use.janet
@@ -34,19 +34,34 @@
   "Run command with argv vector. Uses os/execute directly — no shell interpolation."
   (os/execute args))
 
+(defn- mktemp-path [template]
+  "Run mktemp with template, return created path or nil. The file is
+   created with 0600 permissions by mktemp itself."
+  (let [marker (string "/tmp/dirge-mktemp-" (os/time) "-" (math/random))]
+    (when (= 0 (os/execute ["/bin/sh" "-c" (string "mktemp " template " > " marker " 2>/dev/null")]))
+      (try
+        (let [f (file/open marker :r)
+              path (string/trim (file/read f :all))]
+          (file/close f)
+          (os/execute ["/bin/rm" "-f" marker])
+          (when (and path (not (empty? path))) path))
+        ([_] nil)))))
+
 (defn- sh-capture [cmd-str]
   "Run shell command, capture stdout as trimmed string or nil.
-   Uses /bin/sh -c for output redirection (os/execute returns exit code only).
-   Temp files use os/time — low risk on single-user desktop machines."
-  (let [tmp (string "/tmp/dirge-sh-" (os/time))]
-    (os/execute ["/bin/sh" "-c" (string cmd-str " > " tmp " 2>/dev/null")] :x)
-    (try
-      (let [f (file/open tmp :r)
-            data (file/read f :all)]
-        (file/close f)
-        (os/execute ["/bin/rm" "-f" tmp])
-        (when data (string/trim data)))
-      ([_] nil))))
+   Uses /bin/sh -c for output redirection (os/execute returns exit code
+   only). Temp file via mktemp — not guessable os/time."
+  (if-let [tmp (mktemp-path "/tmp/dirge-sh-XXXXXX")]
+    (do
+      (os/execute ["/bin/sh" "-c" (string cmd-str " > " tmp " 2>/dev/null")] :x)
+      (try
+        (let [f (file/open tmp :r)
+              data (file/read f :all)]
+          (file/close f)
+          (os/execute ["/bin/rm" "-f" tmp])
+          (when data (string/trim data)))
+        ([_] nil)))
+    nil))
 
 (defn- command-exists? [cmd]
   (= 0 (os/execute ["/bin/sh" "-c" (string "command -v " cmd " >/dev/null 2>&1")])))
@@ -63,11 +78,30 @@
     "Insert" true "Menu" true "Num_Lock" true
     "super" true "alt" true "ctrl" true "shift" true})
 
+(def valid-single-char
+  # Single-character key names for ydotool/xdotool keys that don't
+  # appear in `valid-keys`. Restrict to alphanumeric + safe punctuation.
+  # Shell metacharacters (`;`, `|`, `$`, `` ` ``, `\`, quotes etc.)
+  # are NEVER valid — rejecting them closes a shell-injection path
+  # when the chord is interpolated into `ydotool key <chord>`.
+  @{"a" true "b" true "c" true "d" true "e" true "f" true "g" true
+    "h" true "i" true "j" true "k" true "l" true "m" true "n" true
+    "o" true "p" true "q" true "r" true "s" true "t" true "u" true
+    "v" true "w" true "x" true "y" true "z" true
+    "A" true "B" true "C" true "D" true "E" true "F" true "G" true
+    "H" true "I" true "J" true "K" true "L" true "M" true "N" true
+    "O" true "P" true "Q" true "R" true "S" true "T" true "U" true
+    "V" true "W" true "X" true "Y" true "Z" true
+    "0" true "1" true "2" true "3" true "4" true "5" true "6" true
+    "7" true "8" true "9" true
+    "." true "," true "/" true "-" true "=" true "[" true "]" true})
+
 (defn- validate-key [k]
   "Return k if it's a valid key name, nil otherwise."
   (if (valid-keys k) k
     (let [len (length k)]
-      (if (= len 1) k  # single character like "a", "1", "."
+      (if (= len 1)
+        (valid-single-char k)
         (if (string/has-prefix? "KP_" k) k)))))
 
 (defn- validate-keychord [chord]
@@ -193,14 +227,20 @@
           (sh-capture "ls -t /tmp/Screenshot_*.png 2>/dev/null | head -1"))
 
         "scrot"
-        (let [path (string "/tmp/dirge-screenshot-" (os/time) ".png")]
-          (sh "scrot" path)
-          (if (= (sh "test" "-f" path) 0) path nil))
+        (if-let [path (mktemp-path "/tmp/dirge-screenshot-XXXXXX.png")]
+          (do
+            (sh "scrot" path)
+            (os/execute ["chmod" "600" path])
+            (if (= (sh "test" "-f" path) 0) path nil))
+          nil)
 
         "screencapture"
-        (let [path (string "/tmp/dirge-screenshot-" (os/time) ".png")]
-          (sh "screencapture" path)
-          (if (= (sh "test" "-f" path) 0) path nil))
+        (if-let [path (mktemp-path "/tmp/dirge-screenshot-XXXXXX.png")]
+          (do
+            (sh "screencapture" path)
+            (os/execute ["chmod" "600" path])
+            (if (= (sh "test" "-f" path) 0) path nil))
+          nil)
 
         nil)
       ([_] nil))))
@@ -424,10 +464,14 @@
                   (harness/block
                     (string "computer-use blocked — host desktop requires opt-in.\n"
                             "Set DIRGE_COMPUTER_USE_HOST=1 or create ~/.config/dirge/computer-use-host-consent"))
-                  (let [desc (describe-action parsed)]
-                    (if (harness/confirm "computer-use" desc)
-                      (set pending-result (execute-action parsed))
-                      (harness/block "computer-use denied by user"))))))))))
+                  (if (= (harness/check-computer-action (parsed :action)) "deny")
+                    (harness/block
+                      (string "computer-use blocked by PDP deny_tools: " (parsed :action)
+                              "\nAdd deny_tools: [computer] or deny_tools: [computer:" (parsed :action) "] in your agent definition."))
+                    (let [desc (describe-action parsed)]
+                      (if (harness/confirm "computer-use" desc)
+                        (set pending-result (execute-action parsed))
+                        (harness/block "computer-use denied by user")))))))))))
   nil)
 
 (defn computer_use-on-tool-end [ctx]

--- a/src/agent/tools/bash/mod.rs
+++ b/src/agent/tools/bash/mod.rs
@@ -79,9 +79,7 @@ impl Tool for BashTool {
             name: "bash".to_string(),
             description: with_contract_hint(
                 "bash",
-                &("Execute a bash command in the current working directory. Returns stdout and stderr.
-
-CONTRACT: `command` is a literal shell command, not a JSON object. Pipe heavy output through `head`/`tail`/`grep` — the harness caps stored output at 256 KiB.".to_owned()
+                &("Execute a bash command in the current working directory. Returns stdout and stderr.".to_owned()
                 + cfg!(feature = "experimental-ui-computer-use").then_some("\n\nDesktop automation: prefix commands with `computer:` to control the desktop GUI. Actions: `computer:open_url <url>` (opens in browser), `computer:screenshot` (captures screen), `computer:type <text>`, `computer:key <keys>`, `computer:click <button>`, `computer:move <x> <y>`. Each action prompts for user confirmation.").unwrap_or("")),
             ),
             parameters: serde_json::json!({

--- a/src/agent/tools/bash/tests.rs
+++ b/src/agent/tools/bash/tests.rs
@@ -1167,3 +1167,19 @@ async fn coarse_external_redirect_is_gated() {
         other => panic!("expected a Path resource, got {other:?}"),
     }
 }
+
+/// The base description must NOT include a CONTRACT hint — that is
+/// appended by `with_contract_hint`.  Duplicating would waste context
+/// budget and introduce drift between the two copies.
+#[tokio::test]
+async fn bash_description_has_exactly_one_contract_line() {
+    use crate::sandbox::{Sandbox, SandboxMode};
+    let tool = BashTool::new(None, None, Sandbox::new(SandboxMode::Off));
+    let def = tool.definition("".to_string()).await;
+    let count = def.description.matches("CONTRACT:").count();
+    assert_eq!(
+        count, 1,
+        "bash description must have exactly one CONTRACT: line, got {count}:\n{}",
+        def.description
+    );
+}

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -11,10 +11,22 @@ pub mod pattern;
 /// Best-effort: a poisoned mutex falls through to `into_inner`,
 /// matching the recovery pattern used elsewhere on the checker.
 /// `None` perm (e.g. `--no-tools` builds) is a no-op.
+///
+/// Also pushes to the computer-use plugin when the feature is active,
+/// so `harness/check-computer-action` gates desktop actions against
+/// the same PDP deny_tools.
 pub fn apply_prompt_deny(perm: &Option<checker::PermCheck>, deny: &[String]) {
     if let Some(p) = perm {
         let mut guard = p.lock_ignore_poison();
         guard.set_prompt_deny_tools(deny.to_vec());
+    }
+    #[cfg(feature = "experimental-ui-computer-use")]
+    {
+        if let Some(pm) = crate::plugin::hook::global() {
+            let mut mgr = pm.lock_ignore_poison();
+            mgr.set_deny_tools_for_computer_use(deny);
+        }
+        // Without the `plugin` feature, the global is never set — no-op.
     }
 }
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -305,6 +305,7 @@ impl PluginManager {
     }
 
     #[cfg(not(feature = "experimental-ui-computer-use"))]
+    #[allow(dead_code)]
     pub fn set_deny_tools_for_computer_use(&mut self, _deny: &[String]) {}
 
     pub fn dispatch(&mut self, hook: &str, context_janet: &str) -> Result<Vec<String>, String> {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -291,6 +291,22 @@ impl PluginManager {
         let _ = self.worker.eval("(set harness-plugin-config nil)");
     }
 
+    /// Push the active prompt's `deny_tools` list into the computer-use
+    /// Janet environment so `harness/check-computer-action` can gate
+    /// desktop actions against the permission PDP.
+    #[cfg(feature = "experimental-ui-computer-use")]
+    pub fn set_deny_tools_for_computer_use(&mut self, deny: &[String]) {
+        let items: Vec<String> = deny.iter().map(|t| format!("\"{t}\"")).collect();
+        let expr = format!(
+            "(harness/set-computer-use-deny-tools [{}])",
+            items.join(" ")
+        );
+        let _ = self.worker.eval(&expr);
+    }
+
+    #[cfg(not(feature = "experimental-ui-computer-use"))]
+    pub fn set_deny_tools_for_computer_use(&mut self, _deny: &[String]) {}
+
     pub fn dispatch(&mut self, hook: &str, context_janet: &str) -> Result<Vec<String>, String> {
         let names = match self.hooks.get(hook) {
             Some(names) => names.clone(),

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -304,10 +304,6 @@ impl PluginManager {
         let _ = self.worker.eval(&expr);
     }
 
-    #[cfg(not(feature = "experimental-ui-computer-use"))]
-    #[allow(dead_code)]
-    pub fn set_deny_tools_for_computer_use(&mut self, _deny: &[String]) {}
-
     pub fn dispatch(&mut self, hook: &str, context_janet: &str) -> Result<Vec<String>, String> {
         let names = match self.hooks.get(hook) {
             Some(names) => names.clone(),

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -667,6 +667,23 @@ const HARNESS_COMPUTER_USE_INIT: &str = r#"
     (when (not result)
       (error "harness/computer-use-exec: sandbox not available"))
     result))
+
+(var harness/computer-use-deny-tools @{})
+
+(defn harness/set-computer-use-deny-tools [tools-vec]
+  "Replace the deny-tools set with a new list (called from Rust)."
+  (let [s @{}]
+    (each t tools-vec (put s (string t) true))
+    (set harness/computer-use-deny-tools s)))
+
+(defn harness/check-computer-action [action]
+  "Query the PDP for a desktop action. Returns :allow, :deny, or :ask.
+   Respects deny_tools: [computer] and deny_tools: [computer:<action>]."
+  (if (in (harness/computer-use-deny-tools) "computer")
+    "deny"
+    (if (in (harness/computer-use-deny-tools) (string "computer:" action))
+      "deny"
+      "ask")))
 "#;
 
 /// Janet wrappers for the LSP bridge. Installed after the C function is


### PR DESCRIPTION
## What

Addresses the four review items raised in [#415](https://github.com/dirge-code/dirge/pull/415):

1. **Close single-character injection hole in `validate-key`** — replaces open single-char pass-through with an allowlist table that excludes shell metacharacters (`;`, `|`, `$`, backtick, quotes, backslash)
2. **Eliminate predictable temp files** — `sh-capture` and screenshot helpers now use `mktemp` instead of `os/time`-based paths
3. **Deduplicate bash CONTRACT hint** — the CONTRACT line was appearing twice (once embedded in the base description, once appended by `with_contract_hint`); removed the embedded copy
4. **Route computer-use desktop actions through the permission PDP** — Janet-side `harness/check-computer-action` gates desktop actions against the active prompt's `deny_tools`, pushed from Rust's `apply_prompt_deny`

## How verified

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features` — only pre-existing warnings
- `cargo test --bin dirge --all-features` permission tests (142 passed)
- `cargo test --bin dirge --all-features` plugin tests (190 passed)
- `cargo test --bin dirge --all-features` bash tests (69 passed)
- New test: `bash_description_has_exactly_one_contract_line`
- `janet -k plugins/computer_use.janet` — clean (harness/log not resolved in standalone mode, as expected)