### PR TITLE
Add SQL semantic support (tree-sitter-sequel)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-sequel",
  "tree-sitter-typescript",
  "unicode-width",
  "url",
@@ -5174,6 +5175,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ default = [
     'semantic-c',
     'semantic-cpp',
     'semantic-elixir',
+    'semantic-sql',
     'slash-completion',
     'mcp-server',
 ]
@@ -103,6 +104,7 @@ windows-default = [
     'semantic-c',
     'semantic-cpp',
     'semantic-elixir',
+    'semantic-sql',
     'slash-completion',
     'mcp-server',
 ]
@@ -131,6 +133,7 @@ semantic-java = ["semantic", "dep:tree-sitter-java"]
 semantic-c = ["semantic", "dep:tree-sitter-c"]
 semantic-cpp = ["semantic", "dep:tree-sitter-cpp"]
 semantic-elixir = ["semantic", "dep:tree-sitter-elixir"]
+semantic-sql = ["semantic", "dep:tree-sitter-sequel"]
 plugin = ["dep:janetrs"]
 lsp = ["dep:lsp-types"]
 dap = ["dep:which", "dep:dap"]
@@ -263,6 +266,7 @@ html2text = "0.17"
 indexmap = "2"
 lsp-types = { version = "0.97", optional = true }
 tree-sitter-elixir = { version = "0.3.5", optional = true }
+tree-sitter-sequel = { version = "0.3", optional = true }
 rusqlite = { version = "0.31", features = ["bundled"] }
 # DAP (Debug Adapter Protocol) — optional feature for driving
 # debuggers (lldb-dap, dlv, debugpy, node) to fix crashes instead

--- a/src/semantic/adapters/mod.rs
+++ b/src/semantic/adapters/mod.rs
@@ -7,6 +7,8 @@ mod clojure;
 mod cpp;
 #[cfg(feature = "semantic-elixir")]
 mod elixir;
+#[cfg(feature = "semantic-sql")]
+mod sql;
 #[cfg(feature = "semantic-go")]
 mod go;
 #[cfg(feature = "semantic-java")]
@@ -28,6 +30,8 @@ pub use clojure::ClojureAdapter;
 pub use cpp::CppAdapter;
 #[cfg(feature = "semantic-elixir")]
 pub use elixir::ElixirAdapter;
+#[cfg(feature = "semantic-sql")]
+pub use sql::SqlAdapter;
 #[cfg(feature = "semantic-go")]
 pub use go::GoAdapter;
 #[cfg(feature = "semantic-java")]

--- a/src/semantic/adapters/mod.rs
+++ b/src/semantic/adapters/mod.rs
@@ -7,8 +7,6 @@ mod clojure;
 mod cpp;
 #[cfg(feature = "semantic-elixir")]
 mod elixir;
-#[cfg(feature = "semantic-sql")]
-mod sql;
 #[cfg(feature = "semantic-go")]
 mod go;
 #[cfg(feature = "semantic-java")]
@@ -19,6 +17,8 @@ mod python;
 mod ruby;
 #[cfg(feature = "semantic-rust")]
 mod rust;
+#[cfg(feature = "semantic-sql")]
+mod sql;
 #[cfg(feature = "semantic-ts")]
 mod typescript;
 
@@ -30,8 +30,6 @@ pub use clojure::ClojureAdapter;
 pub use cpp::CppAdapter;
 #[cfg(feature = "semantic-elixir")]
 pub use elixir::ElixirAdapter;
-#[cfg(feature = "semantic-sql")]
-pub use sql::SqlAdapter;
 #[cfg(feature = "semantic-go")]
 pub use go::GoAdapter;
 #[cfg(feature = "semantic-java")]
@@ -42,6 +40,8 @@ pub use python::PythonAdapter;
 pub use ruby::RubyAdapter;
 #[cfg(feature = "semantic-rust")]
 pub use rust::RustAdapter;
+#[cfg(feature = "semantic-sql")]
+pub use sql::SqlAdapter;
 #[cfg(feature = "semantic-ts")]
 pub use typescript::TypescriptAdapter;
 

--- a/src/semantic/adapters/sql.rs
+++ b/src/semantic/adapters/sql.rs
@@ -1,0 +1,218 @@
+use std::path::Path;
+
+use tree_sitter::{Node, Parser};
+
+use crate::semantic::adapter::LanguageAdapter;
+use crate::semantic::common::{node_text, signature_first_line};
+use crate::semantic::types::{ByteRange, ExtractedFile, Symbol, SymbolKind};
+
+/// Tree-sitter adapter for SQL (DerekStride/tree-sitter-sql grammar,
+/// published as the `tree-sitter-sequel` crate). SQL has no call
+/// graph, so `find_callees_in_range` returns an empty list — the
+/// value of this adapter is `list_symbols` / `get_symbol_body` /
+/// `find_definition` over DDL objects.
+///
+/// `SymbolKind` is reused (SQL has no native fit, same as Ruby maps
+/// `module`→Interface): tables/views/materialized views → `Class`
+/// (a named schema object); functions → `Function`;
+/// indexes → `Variable`; types → `TypeAlias`. The `signature` field
+/// carries the full `CREATE …` line so the kind is only a coarse
+/// filter.
+pub struct SqlAdapter;
+
+impl SqlAdapter {
+    /// The object name is the first `identifier` leaf in document
+    /// order: DDL always names the object before any column /
+    /// parameter / body list, so the first identifier encountered is
+    /// the object name (`CREATE TABLE users (...)` → `users`,
+    /// `CREATE INDEX idx ON users(col)` → `idx`). Keywords are
+    /// `keyword_*` nodes, never `identifier`, so `IF NOT EXISTS` and
+    /// `TEMPORARY` don't interfere.
+    fn first_identifier(&self, n: Node, s: &[u8]) -> Option<String> {
+        if n.kind() == "identifier" {
+            return Some(node_text(n, s).to_string());
+        }
+        let mut cursor = n.walk();
+        for child in n.named_children(&mut cursor) {
+            if let Some(name) = self.first_identifier(child, s) {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    fn emit(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>, kind: SymbolKind) {
+        let Some(name) = self.first_identifier(n, s) else {
+            return;
+        };
+        symbols.push(Symbol {
+            kind,
+            is_exported: true,
+            name,
+            range: ByteRange::from(n),
+            signature: signature_first_line(n, s),
+            parent_class: None,
+        });
+    }
+
+    /// Recursively scan for DDL nodes. The grammar wraps each
+    /// top-level statement in `statement` (and `create_statement`),
+    /// which we recurse through transparently. `create_*` nodes never
+    /// nest, so each fires exactly once.
+    fn walk(&self, n: Node, s: &[u8], symbols: &mut Vec<Symbol>) {
+        match n.kind() {
+            "create_table" | "create_view" | "create_materialized_view" => {
+                self.emit(n, s, symbols, SymbolKind::Class);
+            }
+            "create_function" => {
+                self.emit(n, s, symbols, SymbolKind::Function);
+            }
+            "create_index" => {
+                self.emit(n, s, symbols, SymbolKind::Variable);
+            }
+            "create_type" => {
+                self.emit(n, s, symbols, SymbolKind::TypeAlias);
+            }
+            _ => {}
+        }
+        let mut cursor = n.walk();
+        for child in n.named_children(&mut cursor) {
+            self.walk(child, s, symbols);
+        }
+    }
+}
+
+impl LanguageAdapter for SqlAdapter {
+    fn extensions(&self) -> &[&str] {
+        &[".sql"]
+    }
+
+    fn extract(&self, file_path: &Path, source: &str) -> Result<ExtractedFile, String> {
+        let lang: tree_sitter::Language = tree_sitter_sequel::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser
+            .set_language(&lang)
+            .map_err(|e| format!("Failed to set language: {e}"))?;
+        let tree = parser.parse(source, None).ok_or("Failed to parse source")?;
+        let root = tree.root_node();
+        let source_bytes = source.as_bytes();
+
+        let mut symbols = Vec::new();
+        let mut warnings = Vec::new();
+
+        if root.has_error() {
+            warnings.push("tree-sitter reported syntax errors".to_string());
+        }
+
+        self.walk(root, source_bytes, &mut symbols);
+
+        let exports: Vec<String> = symbols.iter().map(|s| s.name.clone()).collect();
+
+        Ok(ExtractedFile {
+            file_path: file_path.to_path_buf(),
+            symbols,
+            imports: vec![],
+            exports,
+            warnings,
+            mtime: std::time::SystemTime::now(),
+            size: 0,
+            head_hash: 0,
+        })
+    }
+
+    fn find_callees_in_range(
+        &self,
+        _source: &str,
+        _file_path: &Path,
+        _range: ByteRange,
+    ) -> Result<Vec<String>, String> {
+        // SQL has no call graph — DDL objects aren't invoked. Return
+        // empty so find_callees / find_callers no-op for SQL.
+        Ok(vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pb(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(name)
+    }
+
+    #[test]
+    fn extracts_create_table_and_view() {
+        let src = "CREATE TABLE users (\n  id INT PRIMARY KEY,\n  email TEXT NOT NULL\n);\n\
+                   CREATE VIEW active_users AS SELECT * FROM users WHERE active;\n";
+        let f = SqlAdapter.extract(&pb("schema.sql"), src).unwrap();
+        let t = f.symbols.iter().find(|s| s.name == "users").unwrap();
+        assert!(matches!(t.kind, SymbolKind::Class));
+        let v = f.symbols.iter().find(|s| s.name == "active_users").unwrap();
+        assert!(matches!(v.kind, SymbolKind::Class));
+    }
+
+    #[test]
+    fn extracts_function() {
+        let src = "CREATE FUNCTION add(a INT, b INT) RETURNS INT AS $$ SELECT a + b $$ LANGUAGE SQL;\n";
+        let f = SqlAdapter.extract(&pb("fns.sql"), src).unwrap();
+        assert!(f.symbols.iter().any(|s| s.name == "add"
+            && matches!(s.kind, SymbolKind::Function)));
+    }
+
+    #[test]
+    fn extracts_index_and_type() {
+        let src = "CREATE INDEX idx_email ON users(email);\n\
+                   CREATE TYPE mood AS ENUM ('happy','sad');\n";
+        let f = SqlAdapter.extract(&pb("misc.sql"), src).unwrap();
+        assert!(f.symbols.iter().any(|s| s.name == "idx_email"
+            && matches!(s.kind, SymbolKind::Variable)));
+        assert!(f.symbols.iter().any(|s| s.name == "mood"
+            && matches!(s.kind, SymbolKind::TypeAlias)));
+    }
+
+    #[test]
+    fn find_callees_is_empty() {
+        let src = "CREATE FUNCTION f() RETURNS INT AS $$ SELECT 1 $$ LANGUAGE SQL;\n";
+        let f = SqlAdapter.extract(&pb("f.sql"), src).unwrap();
+        let sym = f.symbols.first().unwrap();
+        let callees = SqlAdapter
+            .find_callees_in_range(src, &pb("f.sql"), sym.range)
+            .unwrap();
+        assert!(callees.is_empty());
+    }
+
+    #[test]
+    fn extracts_materialized_view() {
+        let src = "CREATE MATERIALIZED VIEW mv_stats AS SELECT count(*) FROM events;\n";
+        let f = SqlAdapter.extract(&pb("mv.sql"), src).unwrap();
+        assert!(f.warnings.is_empty());
+        let mv = f.symbols.iter().find(|s| s.name == "mv_stats").unwrap();
+        assert!(matches!(mv.kind, SymbolKind::Class));
+    }
+
+    #[test]
+    fn broken_sql_emits_warning() {
+        let src = "CREATE TABLE users (id INT;\n";
+        let f = SqlAdapter.extract(&pb("bad.sql"), src).unwrap();
+        assert!(!f.warnings.is_empty());
+    }
+
+    #[test]
+    fn pure_select_extracts_nothing() {
+        let src = "SELECT id, name FROM users WHERE active = TRUE;\n";
+        let f = SqlAdapter.extract(&pb("q.sql"), src).unwrap();
+        assert!(f.symbols.is_empty());
+        assert!(f.warnings.is_empty());
+    }
+
+    #[test]
+    fn qualified_name_yields_schema_not_table() {
+        // Known v1 limitation: the first identifier leaf in document
+        // order is the schema qualifier, not the table name. Locks in
+        // current behavior so a grammar fix surfaces as a failure.
+        let src = "CREATE TABLE public.users (id INT);\n";
+        let f = SqlAdapter.extract(&pb("schema.sql"), src).unwrap();
+        assert!(f.symbols.iter().any(|s| s.name == "public"));
+        assert!(!f.symbols.iter().any(|s| s.name == "users"));
+    }
+}

--- a/src/semantic/adapters/sql.rs
+++ b/src/semantic/adapters/sql.rs
@@ -153,10 +153,14 @@ mod tests {
 
     #[test]
     fn extracts_function() {
-        let src = "CREATE FUNCTION add(a INT, b INT) RETURNS INT AS $$ SELECT a + b $$ LANGUAGE SQL;\n";
+        let src =
+            "CREATE FUNCTION add(a INT, b INT) RETURNS INT AS $$ SELECT a + b $$ LANGUAGE SQL;\n";
         let f = SqlAdapter.extract(&pb("fns.sql"), src).unwrap();
-        assert!(f.symbols.iter().any(|s| s.name == "add"
-            && matches!(s.kind, SymbolKind::Function)));
+        assert!(
+            f.symbols
+                .iter()
+                .any(|s| s.name == "add" && matches!(s.kind, SymbolKind::Function))
+        );
     }
 
     #[test]
@@ -164,10 +168,16 @@ mod tests {
         let src = "CREATE INDEX idx_email ON users(email);\n\
                    CREATE TYPE mood AS ENUM ('happy','sad');\n";
         let f = SqlAdapter.extract(&pb("misc.sql"), src).unwrap();
-        assert!(f.symbols.iter().any(|s| s.name == "idx_email"
-            && matches!(s.kind, SymbolKind::Variable)));
-        assert!(f.symbols.iter().any(|s| s.name == "mood"
-            && matches!(s.kind, SymbolKind::TypeAlias)));
+        assert!(
+            f.symbols
+                .iter()
+                .any(|s| s.name == "idx_email" && matches!(s.kind, SymbolKind::Variable))
+        );
+        assert!(
+            f.symbols
+                .iter()
+                .any(|s| s.name == "mood" && matches!(s.kind, SymbolKind::TypeAlias))
+        );
     }
 
     #[test]

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -65,6 +65,9 @@ impl SemanticManager {
         #[cfg(feature = "semantic-elixir")]
         adapters.push(Box::new(adapters::ElixirAdapter));
 
+        #[cfg(feature = "semantic-sql")]
+        adapters.push(Box::new(adapters::SqlAdapter));
+
         let registry = Arc::new(adapters::AdapterRegistry::new(adapters));
         let index = Arc::new(RwLock::new(SymbolIndex::new(registry)));
 

--- a/src/semantic/syntax_validator.rs
+++ b/src/semantic/syntax_validator.rs
@@ -116,6 +116,9 @@ fn language_for_path(path: &Path) -> Option<tree_sitter::Language> {
         #[cfg(feature = "semantic-bash")]
         "sh" | "bash" => Some(tree_sitter_bash::LANGUAGE.into()),
 
+        #[cfg(feature = "semantic-sql")]
+        "sql" => Some(tree_sitter_sequel::LANGUAGE.into()),
+
         _ => None,
     }
 }


### PR DESCRIPTION
The semantic layer had adapters for every tree-sitter language dirge ships except SQL. Add a `semantic-sql` feature backed by the [DerekStride/tree-sitter-sql](https://github.com/DerekStride/tree-sitter-sql) grammar, which publishes its Rust binding as `tree-sitter-sequel` (v0.3.11) https://lib.rs/crates/tree-sitter-sequel — the crates.io crate literally named `tree-sitter-sql` is a different, stale grammar pinning tree-sitter ^0.19 and won't build here. `tree-sitter-sequel` builds against tree-sitter ~0.25, matching the rest of the semantic layer.

SqlAdapter mirrors the existing adapter contract: `extract` parses and walks DDL nodes, `find_callees_in_range` returns empty (SQL has no call graph — the value here is list_symbols / get_symbol_body / find_definition over schema objects). SymbolKind is reused since SQL has no native fit, consistent with how Ruby maps
non-OOP constructs: tables / views / materialized views -> Class, functions ->
Function, indexes -> Variable, types -> TypeAlias. The signature field carries the full CREATE line so the kind is only a coarse filter.

Object name is the first `identifier` leaf in document order. DDL always names the object before any column / parameter / body list, so this is the object name for unqualified DDL (`CREATE TABLE users` -> `users`). Known v1 limitation: qualified names (`CREATE TABLE public.users`) yield `public`, not `users`, since the schema qualifier is the first identifier leaf — acceptable for v1, pinned by a test so a grammar fix surfaces as a failure to revisit.

`create_procedure` is a `// TODO: procedure` in the resolved grammar (0.3.11), so `CREATE PROCEDURE` parses as an ERROR node rather than its own kind; the adapter handles only `create_function`. Re-adding a match arm is trivial if a future grammar version ships it.

Wired through the same three registration points as every other language: Cargo.toml (feature + optional dep, added to `default` and `windows-default`), adapters/mod.rs (module + re-export), semantic/mod.rs (adapter push), and syntax_validator.rs (`.sql` -> tree_sitter_sequel::LANGUAGE, pre-write syntax validation). No minify adapter by design — `.sql` falls back to plain read.

8 unit tests cover each create-kind (incl. materialized views), the error -> warning path, DML-only -> no-symbols, the qualified-name limitation, and the empty callees contract. Full semantic suite green (154 passed); clippy clean.