### PR TITLE
Add config-driven aliases for built-in slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.12.4] - 2026-06-25
 
+### Added
+- **Config-driven aliases for built-in slash commands.** A top-level
+  `slash_aliases` map renames a built-in or adds a short alias — `{"exit":
+  "quit", "q": "/quit"}` makes `/exit` and `/q` both run `/quit`. A leading `/`
+  on either side is optional, arguments after the alias pass through verbatim,
+  and an alias inherits its target's safety class (so an alias for `/quit` works
+  mid-run). Resolved once at startup; bad targets and keys that shadow a built-in
+  warn on the same path as keymap warnings. Aliases register in tab-completion,
+  the ghost suffix, and `/help`. (#522; thanks @nikolap)
+
 ### Fixed
 - **`--print --output-format stream-json` now streams incrementally.** The
   headless run loop received the agent's per-turn and per-tool events but, in

--- a/docs/config.md
+++ b/docs/config.md
@@ -699,6 +699,38 @@ Notes:
 - Unrecognized chords or unknown commands are skipped with a warning on
   startup; the rest of the config still loads.
 
+## Slash-command aliases
+
+Rename a built-in slash command, or give it a short alias, with the
+top-level `slash_aliases` map. The key is what you type (with or without a
+leading `/`); the value is the built-in command it runs (again with or
+without a leading `/`). Arguments you type after the alias are passed
+through to the target.
+
+```json
+{
+  "slash_aliases": {
+    "exit": "quit",
+    "q": "/quit",
+    "cls": "/clear"
+  }
+}
+```
+
+With the above, `/exit`, `/q`, and `/cls` all run `/quit` or `/clear`. The
+alias is resolved once before dispatch, so it inherits its target's
+behavior (e.g. an alias for `/quit` works while the agent is running).
+
+- Aliases don't replace the built-in — both names work unless they
+  collide (an alias key that matches a built-in shadows it).
+- A leading `/` on either side is optional and normalized.
+- A target that isn't a known built-in produces a startup warning (likely
+  a typo) but is still passed through — it may resolve to a plugin
+  command. Plugin-command targets can't be validated ahead of time.
+- An empty alias key is ignored (with a warning); it would otherwise make
+  a bare `/` run the target.
+- Configured aliases are listed under `slash aliases` in `/help`.
+
 ## Environment variables
 
 | Variable | Purpose |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -585,6 +585,13 @@ pub struct Config {
     /// arrives within this many milliseconds. Absent = wait indefinitely
     /// (emacs default); Esc/Ctrl+G always cancels regardless.
     pub chord_timeout_ms: Option<u64>,
+    /// User-defined aliases for built-in slash commands: `{alias: command}`.
+    /// `{"exit": "quit"}` makes `/exit` run `/quit`. A leading `/` on either
+    /// side is optional. Targets that aren't known built-ins warn at startup
+    /// (likely typos); plugin-command targets pass through unvalidated.
+    /// Aliases are expanded before dispatch (`ui::slash::aliases`) and are
+    /// NOT built-ins — they don't appear in `slash_command_names()`.
+    pub slash_aliases: Option<HashMap<String, String>>,
     pub tools: Option<ToolsConfig>,
     /// dirge-4hld: long-term memory retrieval tuning (hybrid dense+BM25).
     pub memory: Option<MemoryConfig>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -231,6 +231,17 @@ pub async fn run_interactive(
     }
     let keymap = keymaps.global;
     input.set_keymap(keymaps.input);
+    // User-defined slash-command aliases (`slash_aliases` config): resolve
+    // once at startup and surface bad targets, mirroring the keymap-warning
+    // path above. The map is consulted by `expand_alias` at the single
+    // `handle_slash` call site below.
+    let (aliases, alias_warnings) = crate::ui::slash::aliases::build_alias_map(cfg);
+    for w in &alias_warnings {
+        eprintln!("warning: {w}");
+    }
+    // Surface alias names in tab-completion + ghost suffix.
+    #[cfg(feature = "slash-completion")]
+    crate::ui::slash::register_alias_commands(aliases.names());
     // Pending prefix of an in-progress emacs-style chord sequence (#234).
     // Empty unless the user has pressed the first key(s) of a multi-key
     // global binding (e.g. `ctrl-x` of `ctrl-x ctrl-s`); shown in the
@@ -2229,6 +2240,13 @@ pub async fn run_interactive(
                                 continue;
                             }
                             if text.starts_with('/') {
+                                // Resolve a user-configured slash alias
+                                // (`slash_aliases`) once, before the busy-gate
+                                // and dispatch, so an alias inherits its
+                                // target's safety class and runs as the target.
+                                // The echo below still shows what the user typed.
+                                let expanded =
+                                    crate::ui::slash::aliases::expand_alias(&text, &aliases);
                                 // dirge-nfa: read-only inspection
                                 // commands run during agent activity.
                                 // The busy gate ONLY blocks commands
@@ -2252,7 +2270,7 @@ pub async fn run_interactive(
                                 // matches alone; if there's an
                                 // argument, treat as potentially
                                 // mutating and gate.
-                                let safe_during_agent = is_safe_during_agent(&text);
+                                let safe_during_agent = is_safe_during_agent(&expanded);
                                 if ui.is_running && !safe_during_agent {
                                     write_outside_chamber(
                                         &mut renderer,
@@ -2272,7 +2290,7 @@ pub async fn run_interactive(
                                 // /help) have no UserMessage event, so we keep the echo.
                                 write_user_lines(&mut renderer, &text)?;
                                 renderer.write_line("", Color::White)?;
-                                let result = handle_slash(&text, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut ui.show_reasoning, &mut ui.is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut ui.todo_tools_enabled, &bg_store, &sandbox, #[cfg(unix)] &user_tx, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut ui.plan_phase).await;
+                                let result = handle_slash(&expanded, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut ui.show_reasoning, &mut ui.is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut ui.todo_tools_enabled, &bg_store, &sandbox, #[cfg(unix)] &user_tx, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut ui.plan_phase).await;
                                 match result {
                                 Err(e) if e.to_string().starts_with("DEFER_COMPRESS:") => {
                                     let err_msg = e.to_string();

--- a/src/ui/slash/aliases.rs
+++ b/src/ui/slash/aliases.rs
@@ -1,0 +1,259 @@
+//! Config-driven aliases for built-in slash commands.
+//!
+//! A user can rename a built-in command (or add a short alias) via the
+//! `slash_aliases` config map — `{"exit": "quit"}` makes `/exit` run
+//! `/quit`. The raw config is just data; this module resolves it into an
+//! [`AliasMap`] and warns about targets that don't name a known built-in
+//! (likely typos). Expansion happens at the single `handle_slash` call
+//! site, so aliases never reach the dispatch `match` — they are not
+//! built-ins and don't belong in `slash_command_names()`.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::config::Config;
+
+/// Resolved slash-command aliases: alias name (no leading `/`) -> target
+/// command (WITH leading `/`, e.g. `"/quit"`). Built from the user's
+/// `slash_aliases` config by [`build_alias_map`].
+#[derive(Debug, Default, Clone)]
+pub(crate) struct AliasMap {
+    map: HashMap<String, String>,
+}
+
+impl AliasMap {
+    /// Alias names (without leading `/`) — for tab-completion registration.
+    pub(crate) fn names(&self) -> Vec<String> {
+        self.map.keys().cloned().collect()
+    }
+}
+
+/// Resolve the user's `slash_aliases` config into an [`AliasMap`] plus
+/// startup warnings. Both alias keys and target commands are normalized
+/// to tolerate a leading `/` on either side (alias key stored without,
+/// target stored with). A target that isn't a known built-in command
+/// produces a warning (likely a typo) but is still stored — plugin
+/// commands can't be validated here and resolve naturally at dispatch.
+pub(crate) fn build_alias_map(cfg: &Config) -> (AliasMap, Vec<String>) {
+    let mut map = HashMap::new();
+    let mut warnings = Vec::new();
+    let Some(raw) = cfg.slash_aliases.as_ref() else {
+        return (AliasMap { map }, warnings);
+    };
+    for (alias, target) in raw {
+        let alias_key = alias.trim_start_matches('/').to_string();
+        let target_cmd = if target.starts_with('/') {
+            target.clone()
+        } else {
+            format!("/{target}")
+        };
+        if alias_key.is_empty() {
+            // A bare "/" must never dispatch: an empty alias key would make
+            // "/" expand to the target (e.g. quit the app). Drop it.
+            warnings.push(format!(
+                "slash_aliases: {:?} -> {:?}: empty alias key is ignored \
+                 (it would make bare \"/\" run {target_cmd})",
+                alias, target,
+            ));
+            continue;
+        }
+        if !super::is_known_slash_command(&target_cmd) {
+            warnings.push(format!(
+                "slash_aliases: {:?} -> {:?}: {:?} is not a known built-in command \
+                 (see /help); it will be passed through but may not resolve",
+                alias, target, target_cmd,
+            ));
+        }
+        map.insert(alias_key, target_cmd);
+    }
+    (AliasMap { map }, warnings)
+}
+
+/// Expand a leading alias in `text`, if any. Only the first token (the
+/// command name) is rewritten to the alias's target; any arguments the
+/// user typed are passed through verbatim. Non-alias input (an unknown
+/// command, text without a leading `/`, or empty) is returned unchanged
+/// (borrowed, no allocation).
+pub(crate) fn expand_alias<'a>(text: &'a str, aliases: &AliasMap) -> Cow<'a, str> {
+    let Some(rest) = text.strip_prefix('/') else {
+        return Cow::Borrowed(text);
+    };
+    let (name, args) = match rest.find(char::is_whitespace) {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    let Some(target) = aliases.map.get(name) else {
+        return Cow::Borrowed(text);
+    };
+    if args.is_empty() {
+        Cow::Owned(target.clone())
+    } else {
+        Cow::Owned(format!("{target}{args}"))
+    }
+}
+
+/// User-facing alias lines for `/help`: one `"/alias -> /target"` per
+/// configured alias, sorted by alias name. The empty-key footgun is
+/// excluded (same normalization + rejection as [`build_alias_map`]).
+pub(crate) fn display_entries(cfg: &Config) -> Vec<String> {
+    let (am, _warnings) = build_alias_map(cfg);
+    let mut entries: Vec<(String, String)> = am.map.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+        .into_iter()
+        .map(|(alias, target)| format!("/{alias} -> {target}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_deserializes_slash_aliases_flat_map() {
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "exit": "quit" } }"#).unwrap();
+        let map = cfg.slash_aliases.expect("slash_aliases should deserialize");
+        assert_eq!(map.get("exit").map(String::as_str), Some("quit"));
+
+        let cfg: Config = serde_json::from_str(r"{}").unwrap();
+        assert!(cfg.slash_aliases.is_none(), "absent key -> None");
+    }
+
+    #[test]
+    fn build_alias_map_normalizes_leading_slashes() {
+        // key with slash + target without, and key without + target with,
+        // both normalize to `exit`/`q` -> `/quit`.
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "/exit": "quit", "q": "/quit" } }"#)
+                .unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert_eq!(am.map.get("exit").map(String::as_str), Some("/quit"));
+        assert_eq!(am.map.get("q").map(String::as_str), Some("/quit"));
+        assert!(
+            warnings.is_empty(),
+            "quit is a known built-in: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn build_alias_map_warns_on_unknown_target() {
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "exit": "qiut" } }"#).unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        // Still stored — passed through (might be a plugin command).
+        assert_eq!(am.map.get("exit").map(String::as_str), Some("/qiut"));
+        assert_eq!(warnings.len(), 1, "exactly one warning: {warnings:?}");
+        assert!(
+            warnings[0].contains("/qiut") && warnings[0].contains("not a known built-in"),
+            "warning should name the target: {}",
+            warnings[0],
+        );
+    }
+
+    #[test]
+    fn build_alias_map_no_warnings_for_known_targets() {
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "bye": "quit", "cls": "clear" } }"#)
+                .unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert_eq!(am.map.get("bye").map(String::as_str), Some("/quit"));
+        assert_eq!(am.map.get("cls").map(String::as_str), Some("/clear"));
+        assert!(
+            warnings.is_empty(),
+            "both targets are known built-ins: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn build_alias_map_absent_config_is_empty() {
+        let cfg = Config::default();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert!(am.map.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn build_alias_map_empty_map_is_empty() {
+        let cfg: Config = serde_json::from_str(r#"{ "slash_aliases": {} }"#).unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert!(am.map.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    fn map_from(pairs: impl IntoIterator<Item = (&'static str, &'static str)>) -> AliasMap {
+        AliasMap {
+            map: pairs
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn expand_alias_rewrites_command_name_only() {
+        let am = map_from([("exit", "/quit")]);
+        assert_eq!(expand_alias("/exit", &am), "/quit");
+        assert_eq!(expand_alias("/exit keep recent", &am), "/quit keep recent");
+        // whitespace between command and args is preserved
+        assert_eq!(expand_alias("/exit  two", &am), "/quit  two");
+    }
+
+    #[test]
+    fn expand_alias_passes_through_unaliased_commands() {
+        let am = map_from([("exit", "/quit")]);
+        assert_eq!(expand_alias("/model gpt", &am), "/model gpt");
+        // the target itself isn't an alias key -> no rewrite
+        assert_eq!(expand_alias("/quit", &am), "/quit");
+    }
+
+    #[test]
+    fn expand_alias_passes_through_non_slash_and_empty() {
+        let am = map_from([("exit", "/quit")]);
+        assert_eq!(expand_alias("hello world", &am), "hello world");
+        assert_eq!(expand_alias("", &am), "");
+    }
+
+    #[test]
+    fn expand_alias_empty_map_passes_through() {
+        let am = AliasMap::default();
+        assert_eq!(expand_alias("/exit", &am), "/exit");
+        assert_eq!(expand_alias("/exit x", &am), "/exit x");
+    }
+
+    #[test]
+    fn build_alias_map_rejects_empty_alias_key() {
+        // An empty alias key is a footgun: it would make bare "/" expand to
+        // the target (e.g. quit the app). Reject it with a warning; keep the
+        // valid entry.
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "": "quit", "exit": "quit" } }"#).unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert!(!am.map.contains_key(""), "empty alias key must be dropped");
+        assert_eq!(am.map.get("exit").map(String::as_str), Some("/quit"));
+        assert!(
+            warnings.iter().any(|w| w.contains("empty")),
+            "should warn about the dropped empty key: {warnings:?}",
+        );
+    }
+
+    #[test]
+    fn display_entries_lists_normalized_aliases_sorted() {
+        let cfg: Config = serde_json::from_str(
+            r#"{ "slash_aliases": { "bye": "/quit", "cls": "clear", "": "quit" } }"#,
+        )
+        .unwrap();
+        // leading-slash normalized, empty key dropped, sorted by alias name
+        assert_eq!(
+            display_entries(&cfg),
+            vec!["/bye -> /quit", "/cls -> /clear"]
+        );
+    }
+
+    #[test]
+    fn display_entries_empty_when_no_aliases() {
+        assert!(display_entries(&Config::default()).is_empty());
+        let cfg: Config = serde_json::from_str(r#"{ "slash_aliases": {} }"#).unwrap();
+        assert!(display_entries(&cfg).is_empty());
+    }
+}

--- a/src/ui/slash/aliases.rs
+++ b/src/ui/slash/aliases.rs
@@ -23,6 +23,10 @@ pub(crate) struct AliasMap {
 
 impl AliasMap {
     /// Alias names (without leading `/`) — for tab-completion registration.
+    /// Gated to `slash-completion` — its only caller
+    /// (`register_alias_commands` in `ui::mod`) is, so without the feature
+    /// this would be dead code on a `--no-default-features` build.
+    #[cfg(feature = "slash-completion")]
     pub(crate) fn names(&self) -> Vec<String> {
         self.map.keys().cloned().collect()
     }
@@ -62,6 +66,18 @@ pub(crate) fn build_alias_map(cfg: &Config) -> (AliasMap, Vec<String>) {
                 "slash_aliases: {:?} -> {:?}: {:?} is not a known built-in command \
                  (see /help); it will be passed through but may not resolve",
                 alias, target, target_cmd,
+            ));
+        }
+        // Shadowing a real built-in is allowed (the doc'd use case is
+        // renaming one), but it's also a common footgun — `{"quit":
+        // "clear"}` silently makes `/quit` run `/clear` and locks the user
+        // out of the real command. Warn so it's a deliberate choice, not a
+        // typo that swallows a command.
+        if super::is_known_slash_command(&format!("/{alias_key}")) {
+            warnings.push(format!(
+                "slash_aliases: {:?} -> {:?}: alias key {:?} shadows the built-in \
+                 /{alias_key}, which can no longer be run by that name",
+                alias, target, alias_key,
             ));
         }
         map.insert(alias_key, target_cmd);
@@ -162,6 +178,23 @@ mod tests {
         assert!(
             warnings.is_empty(),
             "both targets are known built-ins: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn build_alias_map_warns_when_key_shadows_builtin() {
+        // `/quit` is a built-in; aliasing the key `quit` to `/clear`
+        // shadows it. Still stored (intended use case is renaming), but it
+        // must warn so it isn't a silent footgun.
+        let cfg: Config =
+            serde_json::from_str(r#"{ "slash_aliases": { "quit": "clear" } }"#).unwrap();
+        let (am, warnings) = build_alias_map(&cfg);
+        assert_eq!(am.map.get("quit").map(String::as_str), Some("/clear"));
+        assert_eq!(warnings.len(), 1, "exactly one warning: {warnings:?}");
+        assert!(
+            warnings[0].contains("shadows") && warnings[0].contains("/quit"),
+            "warning should name the shadowed built-in: {}",
+            warnings[0],
         );
     }
 

--- a/src/ui/slash/cmd/help.rs
+++ b/src/ui/slash/cmd/help.rs
@@ -65,6 +65,15 @@ pub(crate) async fn cmd_help(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
         renderer.write_line(&format!("  {}", cmd), c_result())?;
     }
 
+    let aliases = crate::ui::slash::aliases::display_entries(ctx.cfg);
+    if !aliases.is_empty() {
+        renderer.write_line("", c_agent())?;
+        renderer.write_line("slash aliases (from your config):", c_agent())?;
+        for line in &aliases {
+            renderer.write_line(&format!("  {line}"), c_result())?;
+        }
+    }
+
     #[cfg(feature = "plugin")]
     if let Some(pm_arc) = crate::plugin::hook::global() {
         let cmds = {

--- a/src/ui/slash/completion.rs
+++ b/src/ui/slash/completion.rs
@@ -18,6 +18,12 @@ use crate::sync_util::LockExt;
 /// Populated by `register_plugin_commands` after plugin init.
 static PLUGIN_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
+/// User-configured alias command names (without leading `/`), from the
+/// `slash_aliases` config. Populated by `register_alias_commands` once at
+/// startup from `run_interactive`. Separate from `PLUGIN_COMMANDS`
+/// (config vs. plugin-discovered) but merged identically in `all_commands`.
+static ALIAS_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
 /// Register plugin command names for tab completion.
 /// Called from `main.rs` after plugin init. Only the `plugin` feature
 /// has anything to register — without it the setter is dead (the
@@ -27,6 +33,14 @@ static PLUGIN_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 #[cfg(feature = "plugin")]
 pub fn register_plugin_commands(cmds: Vec<String>) {
     *PLUGIN_COMMANDS.lock_ignore_poison() = cmds;
+}
+
+/// Register slash-alias names (without leading `/`) for tab completion.
+/// Called once from `run_interactive` right after `build_alias_map`.
+/// Gated to `slash-completion`, which owns the only reader (`all_commands`).
+#[cfg(feature = "slash-completion")]
+pub fn register_alias_commands(cmds: Vec<String>) {
+    *ALIAS_COMMANDS.lock_ignore_poison() = cmds;
 }
 
 /// All completable slash commands: built-ins + plugin-registered.
@@ -39,6 +53,13 @@ pub fn all_commands() -> Vec<String> {
         .collect();
     let guard = PLUGIN_COMMANDS.lock_ignore_poison();
     for name in guard.iter() {
+        let with_slash = format!("/{}", name);
+        if !cmds.contains(&with_slash) {
+            cmds.push(with_slash);
+        }
+    }
+    let alias_guard = ALIAS_COMMANDS.lock_ignore_poison();
+    for name in alias_guard.iter() {
         let with_slash = format!("/{}", name);
         if !cmds.contains(&with_slash) {
             cmds.push(with_slash);
@@ -611,5 +632,28 @@ mod tests {
     fn plugin_command_ghost_suffix() {
         register_plugin_commands(vec!["myplugin".to_string()]);
         assert_eq!(ghost_suffix("/mypl").as_deref(), Some("ugin"));
+    }
+
+    #[cfg(feature = "slash-completion")]
+    #[test]
+    fn alias_command_in_all_commands() {
+        register_alias_commands(vec!["exit".to_string()]);
+        let cmds = all_commands();
+        assert!(cmds.contains(&"/exit".to_string()));
+    }
+
+    #[cfg(feature = "slash-completion")]
+    #[test]
+    fn alias_command_completion_cycles() {
+        register_alias_commands(vec!["exit".to_string()]);
+        let r = try_complete("/ex", 3).unwrap();
+        assert_eq!(r.new_buffer, "/exit");
+    }
+
+    #[cfg(feature = "slash-completion")]
+    #[test]
+    fn alias_command_ghost_suffix() {
+        register_alias_commands(vec!["exit".to_string()]);
+        assert_eq!(ghost_suffix("/ex").as_deref(), Some("it"));
     }
 }

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -20,6 +20,7 @@ use crate::ui::input::InputEditor;
 use crate::ui::renderer::Renderer;
 use crate::ui::theme;
 
+pub(crate) mod aliases;
 mod cmd;
 #[cfg(feature = "slash-completion")]
 mod completion;
@@ -30,6 +31,9 @@ pub use completion::{CompletionResult, format_completion_preview, ghost_suffix, 
 // plugin-less build (e.g. windows-default) doesn't re-export a dead fn.
 #[cfg(all(feature = "slash-completion", feature = "plugin"))]
 pub use completion::register_plugin_commands;
+
+#[cfg(feature = "slash-completion")]
+pub use completion::register_alias_commands;
 
 #[inline]
 pub(super) fn c_agent() -> Color {


### PR DESCRIPTION
The keybindings config already lets users rebind chords; this extends the same idea to slash commands. A top-level `slash_aliases` map renames a built-in or adds a short alias -- `{"exit": "quit", "q": "/quit"}` makes `/exit` and `/q` both run `/quit`. A leading `/` on either the key or the value is optional and normalized, and arguments typed after the alias pass through to the target verbatim.

The map is resolved once at startup into `AliasMap` (src/ui/slash/aliases.rs), surfacing bad targets as warnings on the same path as keymap warnings. Expansion happens at the single `handle_slash` call site, before the busy-gate and `is_safe_during_agent`, so an alias inherits its target's safety class and runs exactly as the target would (e.g. an alias for `/quit` works mid-run). Aliases are deliberately not built-ins: they never reach the dispatch `match`, don't appear in `slash_command_names()`, and the echo still shows what the user typed.

A target that isn't a known built-in warns at startup (likely a typo) but is still passed through -- plugin commands can't be validated ahead of time and resolve naturally at dispatch. An empty alias key is rejected outright; it would otherwise make a bare `/` expand to the target.

Configured aliases register in tab-completion and the ghost suffix and are listed under a `slash aliases` block in `/help`; docs/config.md gains a section mirroring the keybindings one.