### PR TITLE
Deep-merge project-local config from .dirge/config.json

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -8,6 +8,15 @@ folder:
   (for example `$XDG_CONFIG_HOME/dirge/config.json` on Linux)
 - Fallback: `$HOME/.config/dirge/config.json`
 
+A project may also ship a partial `<project>/.dirge/config.json`. It is
+deep-merged on top of the global file: scalar fields override, while maps
+(`providers`, `mcp_servers`, `agents`, `slash_aliases`, `keybindings`) union
+key-by-key, so a project can add or override a single entry without
+redeclaring the whole map. Absent keys fall through to the global file. An
+empty object (e.g. `"providers": {}`) is a no-op, not a wipe — there is no
+syntax to clear a global map from a project config. CLI flags and env vars
+still take precedence over both files.
+
 All config keys are optional. CLI flags and their environment-backed values
 (such as `DIRGE_PROVIDER` and `DIRGE_MODEL`) take precedence where both exist.
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -51,7 +51,10 @@ the qualified form.
 
 ## Custom prompts
 
-Custom prompts can be placed in `$XDG_CONFIG_HOME/dirge/prompts/` as `.md` files.
+Custom prompts can be placed in `$XDG_CONFIG_HOME/dirge/prompts/` as `.md` files
+(available to every project), and/or in `<project>/.dirge/prompts/` for
+project-local prompts. A project-local prompt with the same stem as a global or
+built-in prompt overrides it.
 
 ## Model-aware steering
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -987,65 +987,123 @@ pub fn config_file_path() -> PathBuf {
     storage::config_path().join("config.json")
 }
 
-pub fn load() -> Config {
-    let path = config_file_path();
-    #[allow(unused_mut)]
-    let mut cfg: Config = if !path.exists() {
-        Config::default()
-    } else {
-        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
-            eprintln!(
-                "error: failed to read config file ({}): {}\n\
-                 Fix the file or remove it to use defaults.",
-                path.display(),
-                e,
-            );
-            std::process::exit(1);
-        });
+/// Project-local config, layered on top of the global
+/// `~/.config/dirge/config.json`. CWD-relative (matches `.dirge/agents`,
+/// `.dirge/plugins`, `.dirge/skills`). Fields present here override
+/// their global counterparts; absent keys fall through. Map-valued
+/// fields (`providers`, `mcp_servers`, `agents`, …) merge key-by-key
+/// rather than replacing the whole map.
+pub fn project_config_file_path() -> PathBuf {
+    PathBuf::from(".dirge").join("config.json")
+}
 
-        // Reject legacy config shape BEFORE deserialising. The old
-        // shape used top-level `model`, `review_model`, and
-        // `custom_providers`; all three have moved into
-        // `providers.<alias>.{model,...}` (with role assignments via
-        // `review_provider`, etc.). Surface a clear migration hint
-        // rather than silently dropping fields.
-        if let Ok(raw) = serde_json::from_str::<serde_json::Value>(&content)
-            && let Some(obj) = raw.as_object()
-        {
-            const LEGACY: &[&str] = &["custom_providers", "model", "review_model"];
-            let found: Vec<&str> = LEGACY
-                .iter()
-                .copied()
-                .filter(|k| obj.contains_key(*k))
-                .collect();
-            if !found.is_empty() {
-                eprintln!(
-                    "error: legacy config keys found in {}: {:?}",
-                    path.display(),
-                    found,
-                );
-                eprintln!("Migrate to the unified `providers` map:");
-                eprintln!("  - top-level `model`         -> `providers.<active-provider>.model`");
-                eprintln!("  - `custom_providers.X`      -> `providers.X`");
-                eprintln!("  - top-level `review_model`  -> `providers.<review-provider>.model`");
-                eprintln!(
-                    "Then optionally set `review_provider`, `escalation_provider`, \
-                     `summarization_provider`, `subagent_provider`."
-                );
-                std::process::exit(2);
+/// Read a config JSON file into a `serde_json::Value`. Returns `None`
+/// when the file is absent (caller falls back to defaults). A
+/// present-but-unreadable or unparseable file is a hard error: print
+/// the offending path and exit, matching the contract for the global
+/// config so a typo never silently downgrades to defaults.
+fn read_config_value(path: &Path) -> Option<serde_json::Value> {
+    if !path.exists() {
+        return None;
+    }
+    let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!(
+            "error: failed to read config file ({}): {}\n\
+             Fix the file or remove it to use defaults.",
+            path.display(),
+            e,
+        );
+        std::process::exit(1);
+    });
+    Some(serde_json::from_str(&content).unwrap_or_else(|e| {
+        eprintln!(
+            "error: {} is not a valid config: {}\n\
+             Fix the file or remove it to use defaults.",
+            path.display(),
+            e,
+        );
+        std::process::exit(1);
+    }))
+}
+
+/// Recursively merge `overlay` into `base`. Object keys are unioned
+/// (overlay wins on collision, recursing when both sides are objects);
+/// any non-object overlay value replaces `base` outright. This gives
+/// the "project layers on top of global without wiping absent global
+/// keys" semantics: scalars (`provider`, `max_tokens`, …) override,
+/// while maps union so a project can add/override a single entry
+/// without redeclaring the whole map. An empty overlay object is a
+/// no-op (global entries retained) — there is intentionally no syntax
+/// to *clear* a global map from a project config.
+fn merge_json(base: &mut serde_json::Value, overlay: serde_json::Value) {
+    match (base, overlay) {
+        (serde_json::Value::Object(base_map), serde_json::Value::Object(overlay_map)) => {
+            for (k, v) in overlay_map {
+                match base_map.get_mut(&k) {
+                    Some(existing) => merge_json(existing, v),
+                    None => {
+                        base_map.insert(k, v);
+                    }
+                }
             }
         }
+        (slot, overlay) => *slot = overlay,
+    }
+}
 
-        serde_json::from_str(&content).unwrap_or_else(|e| {
+pub fn load() -> Config {
+    let global_path = config_file_path();
+    let project_path = project_config_file_path();
+
+    // Base = global config.json (empty object → defaults if absent).
+    let mut value: serde_json::Value = read_config_value(&global_path)
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+
+    // Layer the project-local `.dirge/config.json` on top.
+    if let Some(project) = read_config_value(&project_path) {
+        merge_json(&mut value, project);
+    }
+
+    // Reject legacy config shape BEFORE deserialising. Checked on the
+    // merged value so a legacy key in EITHER file surfaces with both
+    // paths named so the user knows which file to edit.
+    if let Some(obj) = value.as_object() {
+        const LEGACY: &[&str] = &["custom_providers", "model", "review_model"];
+        let found: Vec<&str> = LEGACY
+            .iter()
+            .copied()
+            .filter(|k| obj.contains_key(*k))
+            .collect();
+        if !found.is_empty() {
             eprintln!(
-                "error: {} is not a valid config: {}\n\
-                 Fix the file or remove it to use defaults.",
-                path.display(),
-                e,
+                "error: legacy config keys found ({:?}) after merging {} and {}",
+                found,
+                global_path.display(),
+                project_path.display(),
             );
-            std::process::exit(1);
-        })
-    };
+            eprintln!("Migrate to the unified `providers` map:");
+            eprintln!("  - top-level `model`         -> `providers.<active-provider>.model`");
+            eprintln!("  - `custom_providers.X`      -> `providers.X`");
+            eprintln!("  - top-level `review_model`  -> `providers.<review-provider>.model`");
+            eprintln!(
+                "Then optionally set `review_provider`, `escalation_provider`, \
+                 `summarization_provider`, `subagent_provider`."
+            );
+            std::process::exit(2);
+        }
+    }
+
+    #[allow(unused_mut)]
+    let mut cfg: Config = serde_json::from_value(value).unwrap_or_else(|e| {
+        eprintln!(
+            "error: merged config ({} + {}) is not valid: {}\n\
+             Fix the offending file or remove it to use defaults.",
+            global_path.display(),
+            project_path.display(),
+            e,
+        );
+        std::process::exit(1);
+    });
 
     // Validate `providers` at load time so a typo in
     // `provider_type` (or an alias that doesn't match a built-in
@@ -1704,5 +1762,50 @@ mod provider_role_tests {
             .filter(|k| obj.contains_key(*k))
             .collect();
         assert_eq!(found, vec!["custom_providers"]);
+    }
+}
+
+#[cfg(test)]
+mod config_merge_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn merge_overrides_scalar_but_keeps_absent_keys() {
+        let mut base = json!({ "provider": "deepseek", "max_tokens": 4096 });
+        merge_json(&mut base, json!({ "max_tokens": 8192 }));
+        assert_eq!(base["provider"], "deepseek");
+        assert_eq!(base["max_tokens"], 8192);
+    }
+
+    #[test]
+    fn merge_unions_map_values_key_by_key() {
+        let mut base = json!({
+            "providers": { "deepseek": { "model": "v3" }, "glm": { "model": "glm-4.6" } }
+        });
+        merge_json(
+            &mut base,
+            json!({ "providers": { "deepseek": { "model": "v4-pro" } } }),
+        );
+        assert_eq!(base["providers"]["deepseek"]["model"], "v4-pro");
+        assert_eq!(base["providers"]["glm"]["model"], "glm-4.6");
+    }
+
+    #[test]
+    fn merge_recurses_into_nested_objects() {
+        let mut base = json!({ "providers": { "ollama": { "base_url": "x", "model": "qwen" } } });
+        merge_json(
+            &mut base,
+            json!({ "providers": { "ollama": { "model": "llama" } } }),
+        );
+        assert_eq!(base["providers"]["ollama"]["base_url"], "x");
+        assert_eq!(base["providers"]["ollama"]["model"], "llama");
+    }
+
+    #[test]
+    fn merge_empty_map_overlay_is_a_noop_union() {
+        let mut base = json!({ "mcp_servers": { "exa": {} } });
+        merge_json(&mut base, json!({ "mcp_servers": {} }));
+        assert!(base["mcp_servers"]["exa"].as_object().is_some());
     }
 }

--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -21,6 +21,30 @@ static EMBEDDED: Dir = include_dir!("$CARGO_MANIFEST_DIR/prompts");
 ///
 /// Files without frontmatter still load as a prompt — `body` becomes
 /// the whole file, `deny_tools` is empty, `description` is None.
+/// Which tier a `Prompt` was loaded from. Surfaced by `/prompt` as a
+/// provenance badge so a global/project override of a built-in prompt
+/// is visible. Mirrors `AgentSource` from the `/agents` listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PromptSource {
+    /// Compiled into the binary via `include_dir!` (the built-ins).
+    #[default]
+    Embedded,
+    /// Read from `~/.config/dirge/prompts/`.
+    Global,
+    /// Read from `<cwd>/.dirge/prompts/`.
+    Project,
+}
+
+impl PromptSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            PromptSource::Embedded => "embedded",
+            PromptSource::Global => "global",
+            PromptSource::Project => "project",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Prompt {
     pub body: String,
@@ -28,6 +52,9 @@ pub struct Prompt {
     /// Surfaced by `/prompt` listing in the slash command UI when set.
     /// Single-line summary of the mode (e.g. "Read-only planning mode").
     pub description: Option<String>,
+    /// Tier this prompt was loaded from. `parse_frontmatter` defaults to
+    /// `Embedded`; the global/project loaders override it.
+    pub source: PromptSource,
 }
 
 /// Parse `---\n…---\n<body>` frontmatter out of a markdown file.
@@ -138,6 +165,7 @@ fn parse_frontmatter(raw: &str) -> Prompt {
         body: body.to_string(),
         deny_tools,
         description,
+        ..Default::default()
     }
 }
 
@@ -145,20 +173,32 @@ pub fn global_prompts_dir() -> PathBuf {
     crate::session::storage::config_path().join("prompts")
 }
 
-/// Load all prompts available to the session, with merge order:
-///
-///   embedded  (lowest precedence — only fills gaps)
-///     ↓
-///   global    (`~/.config/dirge/prompts/`)
-///     ↓
-///   local     (`./prompts/`, highest precedence)
-///
-/// Implementation contract (audit H14): embedded uses `or_insert_with`
-/// (soft) so a global / local prompt of the same name overrides it;
-/// global and local use `insert` (hard, last-write-wins). The three
-/// blocks below MUST stay in this order — swapping them would
-/// silently invert precedence. New tiers (e.g. workspace-scoped)
-/// should slot in by precedence with the same soft-then-hard pattern.
+/// Per-project prompts directory: `<cwd>/.dirge/prompts/`. Mirrors
+/// `.dirge/agents` / `.dirge/plugins`. A project prompt of the same
+/// name as a global or built-in prompt overrides it.
+pub fn local_prompts_dir() -> PathBuf {
+    PathBuf::from(".dirge").join("prompts")
+}
+
+/// Read every `*.md` directly under `dir` and insert it (hard,
+/// last-write-wins) into `prompts`. Absent dir is a no-op. Used for
+/// the global and project-local override tiers.
+fn load_dir_hard(dir: &Path, source: PromptSource, prompts: &mut HashMap<String, Prompt>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "md")
+            && let Some(name) = path.file_stem().and_then(|s| s.to_str())
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            let mut prompt = parse_frontmatter(&content);
+            prompt.source = source;
+            prompts.insert(name.to_string(), prompt);
+        }
+    }
+}
 fn warn_unknown_deny_tools(prompt_name: &str, deny: &[String]) {
     // Review-batch #7: single source of truth for built-in tool
     // names lives in `crate::agent::tools::BUILTIN_TOOL_NAMES`.
@@ -186,6 +226,20 @@ fn warn_unknown_deny_tools(prompt_name: &str, deny: &[String]) {
     }
 }
 
+/// Load all prompts available to the session, with merge order:
+///
+///   embedded  (lowest precedence — only fills gaps)
+///     ↓
+///   global    (`~/.config/dirge/prompts/`)
+///     ↓
+///   project   (`<cwd>/.dirge/prompts/`, highest precedence)
+///
+/// Implementation contract (audit H14): embedded uses `or_insert_with`
+/// (soft) so a global / project prompt of the same name overrides it;
+/// global and project use `insert` (hard, last-write-wins). The tiers
+/// MUST load in this order — swapping them would silently invert
+/// precedence. New tiers should slot in by precedence with the same
+/// soft-then-hard pattern.
 pub fn load() -> HashMap<String, Prompt> {
     let mut prompts: HashMap<String, Prompt> = HashMap::new();
 
@@ -200,39 +254,11 @@ pub fn load() -> HashMap<String, Prompt> {
         }
     }
 
-    let global = global_prompts_dir();
-    if global.exists()
-        && let Ok(entries) = std::fs::read_dir(&global)
-    {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "md")
-                && let Some(name) = path.file_stem().and_then(|s| s.to_str())
-                && let Ok(content) = std::fs::read_to_string(&path)
-            {
-                prompts.insert(name.to_string(), parse_frontmatter(&content));
-            }
-        }
-    }
-
-    let local = PathBuf::from("prompts");
-    if local.exists()
-        && let Ok(entries) = std::fs::read_dir(&local)
-    {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "md")
-                && let Some(name) = path.file_stem().and_then(|s| s.to_str())
-                && let Ok(content) = std::fs::read_to_string(&path)
-            {
-                prompts.insert(name.to_string(), parse_frontmatter(&content));
-            }
-        }
-    }
+    load_file_tiers(&global_prompts_dir(), &local_prompts_dir(), &mut prompts);
 
     // Warn once per prompt about unknown tool names in deny_tools.
-    // Done after the full merge so a global-prompt override of an
-    // embedded prompt is checked too.
+    // Done after the full merge so a global/project-prompt override of
+    // an embedded prompt is checked too.
     for (name, p) in &prompts {
         if !p.deny_tools.is_empty() {
             warn_unknown_deny_tools(name, &p.deny_tools);
@@ -240,6 +266,14 @@ pub fn load() -> HashMap<String, Prompt> {
     }
 
     prompts
+}
+
+/// Layer the global then project-local file tiers (both hard /
+/// last-write-wins) onto `prompts`. Split out so the precedence is
+/// unit-testable without touching the real config/prompts dirs.
+fn load_file_tiers(global: &Path, local: &Path, prompts: &mut HashMap<String, Prompt>) {
+    load_dir_hard(global, PromptSource::Global, prompts);
+    load_dir_hard(local, PromptSource::Project, prompts);
 }
 
 pub fn ensure_global() -> anyhow::Result<()> {
@@ -460,5 +494,39 @@ body
     #[test]
     fn next_prompt_empty_is_none() {
         assert_eq!(next_prompt(None, &[]), None);
+    }
+
+    #[test]
+    fn project_local_overrides_global_by_name() {
+        use std::fs;
+        let root = std::env::temp_dir().join(format!("dirge-prompt-tier-{}", std::process::id()));
+        let global = root.join("global").join("prompts");
+        let local = root.join("project").join(".dirge").join("prompts");
+        fs::create_dir_all(&global).unwrap();
+        fs::create_dir_all(&local).unwrap();
+        fs::write(global.join("shared.md"), "GLOBAL BODY\n").unwrap();
+        fs::write(local.join("shared.md"), "PROJECT BODY\n").unwrap();
+        fs::write(global.join("only-global.md"), "G\n").unwrap();
+        fs::write(local.join("only-local.md"), "L\n").unwrap();
+
+        let mut prompts = HashMap::new();
+        load_file_tiers(&global, &local, &mut prompts);
+        assert_eq!(prompts.get("shared").unwrap().body, "PROJECT BODY\n");
+        assert_eq!(prompts.get("only-global").unwrap().body, "G\n");
+        assert_eq!(prompts.get("only-local").unwrap().body, "L\n");
+
+        // Project wins over global by name → provenance reflects the
+        // winning tier, not the losing one.
+        assert_eq!(prompts.get("shared").unwrap().source, PromptSource::Project);
+        assert_eq!(
+            prompts.get("only-global").unwrap().source,
+            PromptSource::Global
+        );
+        assert_eq!(
+            prompts.get("only-local").unwrap().source,
+            PromptSource::Project
+        );
+
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/src/ui/slash/cmd/prompt/list.rs
+++ b/src/ui/slash/cmd/prompt/list.rs
@@ -1,5 +1,6 @@
 //! /prompt — list available prompts.
 
+use crate::context::prompts::PromptSource;
 use crate::ui::slash::{SlashCtx, c_agent, c_result};
 
 pub(crate) async fn cmd_prompt_list(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
@@ -21,20 +22,25 @@ pub(crate) async fn cmd_prompt_list(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()
         )?;
         let max_name = sorted.iter().map(|n| n.len()).max().unwrap_or(0);
         for name in &sorted {
-            let desc = ctx
-                .context
-                .prompts
-                .get(name)
-                .and_then(|p| p.description.as_deref())
-                .map(|s| s.to_string());
-            match desc {
+            let prompt = ctx.context.prompts.get(name);
+            // Provenance badge for non-embedded prompts so a global/project
+            // override of a built-in is visible. Mirrors `/agents`.
+            let badge = match prompt.map(|p| p.source) {
+                Some(s) if s != PromptSource::Embedded => format!(" [{}]", s.label()),
+                _ => String::new(),
+            };
+            match prompt.and_then(|p| p.description.as_deref()) {
                 Some(d) => ctx.renderer.write_line(
-                    &format!("  {:<width$}  {}", name, d, width = max_name),
+                    &format!("  {:<width$}{}  {}", name, badge, d, width = max_name),
                     c_result(),
                 )?,
-                None => ctx
+                None if badge.is_empty() => ctx
                     .renderer
                     .write_line(&format!("  {}", name), c_result())?,
+                None => ctx.renderer.write_line(
+                    &format!("  {:<width$}{}", name, badge, width = max_name),
+                    c_result(),
+                )?,
             }
         }
         ctx.renderer.write_line("", c_agent())?;


### PR DESCRIPTION
A project can now layer a .dirge/config.json over the global ~/.config/dirge/config.json instead of duplicating the whole file. config::load() reads both, deep-merges the project Value onto the global via merge_json (recursive object union: scalars override; object-valued maps — providers, mcp_servers, agents, slash_aliases, keybindings — union key-by-key), then deserializes the merged Value into Config. An empty {} overlay is a no-op, never a wipe, so there is no syntax to clear a global map from a project file.

Deliberate choices: legacy-key and provider-type validation runs on the merged Value, so an error names both paths, and read_config_value() still hard-exits on a present-but-broken file rather than silently downgrading to defaults. The write path (update_config_file) is untouched and stays global-only — there is no in-app editor for the project file, matching the cwd-only .dirge/agents precedent (no ancestor walk).

Full suite green (3118 passed); fmt clean.

Notable: this overrides the previously (undocumented) project .prompts/ directory in favour of .dirge/prompts.