### PR TITLE
history: seed Up-arrow recall from prior same-project sessions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,6 +103,7 @@ Accepted top-level keys:
 | `show_tool_details`       | boolean | Show tool-result output in the TUI. Default: `true`.                                                                                                                         |
 | `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
 | `show_reasoning`          | boolean | Show the model's thinking/reasoning by default, instead of having to press `Ctrl+O` each turn. Default: `false`.                                                            |
+| `max_sessions`            | integer | How many of the most-recent prior sessions in the same project (same working dir) to mine for Up-arrow / Ctrl+F command history, seeded ahead of the current session's prompts. Default: `3`. Set `0` to keep recall to the current session only. See [Command history](#command-history-cross-session-recall). |
 | `display`                 | string  | Preferred startup pane layout: a `\|`/`,`/space-separated subset of `left`, `main`, `right` (e.g. `"main\|right"`, `"main"`). The main pane is always shown; this picks which side panels appear. Override at runtime with `/display`. Default: automatic (side panels shown at ≥152 cols). |
 | `tool_result_max_chars`   | integer | Hard ceiling on characters per tool result. Default: `500`. Combined with `tool_result_max_lines` (lines applied first; chars trim what's left).                                |
 | `tool_result_max_lines`   | integer | Body lines shown inside a tool chamber before collapsing to `↓ N more lines (Ctrl+O to expand)`. Default: `4`. Press `Ctrl+O` to re-print the most recent collapsed result in full. `edit`, `apply_patch`, `question`, `task`, and `task_status` are exempt (their body IS the value). |
@@ -707,6 +708,23 @@ Notes:
   a plugin. See [plugins.md](plugins.md#keyboard-shortcuts).
 - Unrecognized chords or unknown commands are skipped with a warning on
   startup; the rest of the config still loads.
+
+## Command history (cross-session recall)
+
+Pressing **Up** in the input box recalls previous prompts, and **Ctrl+F**
+opens a reverse-i-search over them. By default the recall pool is the
+*current* session's prompts. Set top-level `max_sessions` to an integer
+`N` (default `3`) to additionally mine the `N` most-recent *prior*
+sessions in the same project (matching `working_dir`) for their user
+prompts. Those older prompts are seeded ahead of the current session's
+own, so Up starts from your newest command and walks back through earlier
+conversations in the project.
+
+The scan is scoped to the same project and excludes the current
+conversation's own compaction-fold rotations, so a fold doesn't double its
+prompts into history. Set `"max_sessions": 0` to keep recall limited to
+the current session. Synthetic turns (system-reminder wrappers, mid-turn
+steering, auto-continue markers) never enter history.
 
 ## Slash-command aliases
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -585,6 +585,13 @@ pub struct Config {
     /// arrives within this many milliseconds. Absent = wait indefinitely
     /// (emacs default); Esc/Ctrl+G always cancels regardless.
     pub chord_timeout_ms: Option<u64>,
+    /// Cross-session Up-arrow history: how many of the most-recent prior
+    /// sessions in the same project (same working directory) to mine for
+    /// command history. Their user prompts are seeded into history ahead
+    /// of the current session's own, so pressing Up in a fresh session
+    /// recalls commands typed in earlier conversations. `None` (default)
+    /// → 3. Set 0 to keep history scoped to the current session only.
+    pub max_sessions: Option<usize>,
     /// User-defined aliases for built-in slash commands: `{alias: command}`.
     /// `{"exit": "quit"}` makes `/exit` run `/quit`. A leading `/` on either
     /// side is optional. Targets that aren't known built-ins warn at startup
@@ -847,6 +854,12 @@ impl Config {
     /// Defaults to false — reasoning stays hidden until toggled with Ctrl+O.
     pub fn resolve_show_reasoning(&self) -> bool {
         self.show_reasoning.unwrap_or(false)
+    }
+
+    /// Resolve the cross-session history depth (how many prior
+    /// same-project sessions are mined for Up-arrow recall). Default 3.
+    pub fn resolve_max_sessions(&self) -> usize {
+        self.max_sessions.unwrap_or(3)
     }
 
     /// Resolve the sandbox mode, preferring the nested `sandbox.mode`.
@@ -1239,6 +1252,23 @@ mod tests {
         assert!(cfg.chord_timeout_ms.is_none());
         let cfg: Config = serde_json::from_str(r#"{ "chord_timeout_ms": 1500 }"#).unwrap();
         assert_eq!(cfg.chord_timeout_ms, Some(1500));
+    }
+
+    /// Cross-session Up-arrow history depth: absent by default (→3),
+    /// parses from the documented key, and resolve applies the default.
+    #[test]
+    fn max_sessions_absent_and_parses() {
+        let cfg: Config = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(cfg.max_sessions.is_none());
+        assert_eq!(cfg.resolve_max_sessions(), 3, "default depth is 3");
+
+        let cfg: Config = serde_json::from_str(r#"{ "max_sessions": 5 }"#).unwrap();
+        assert_eq!(cfg.max_sessions, Some(5));
+        assert_eq!(cfg.resolve_max_sessions(), 5);
+
+        // 0 is a valid opt-out: mine zero prior sessions.
+        let cfg: Config = serde_json::from_str(r#"{ "max_sessions": 0 }"#).unwrap();
+        assert_eq!(cfg.resolve_max_sessions(), 0);
     }
 
     #[test]

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -367,6 +367,99 @@ mod tests {
         );
     }
 
+    /// Cross-session Up-arrow history: `recent_project_sessions` returns
+    /// the `max_sessions` most-recent OTHER sessions in the same project
+    /// (same `working_dir`, different conversation origin), oldest-first,
+    /// and excludes other-project sessions plus the current conversation's
+    /// own fold-chain members.
+    #[test]
+    fn recent_project_sessions_filters_and_orders() {
+        use crate::session::{MessageRole, Session, SessionMessage};
+        let dir = session_dir();
+        let _ = std::fs::create_dir_all(&dir);
+        // Unique project per run so other tests' session files can't leak in.
+        let proj = format!(
+            "/tmp/dirge-hist-proj-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let other = "/tmp/dirge-hist-other-project";
+
+        let seed = |id: &str, origin: Option<&str>, updated: &str, wd: &str, msgs: &[&str]| {
+            let mut s = Session::new("p", "m", 0);
+            s.id = compact_str::CompactString::new(id);
+            s.origin_id = origin.map(compact_str::CompactString::new);
+            s.updated_at = compact_str::CompactString::new(updated);
+            s.working_dir = compact_str::CompactString::new(wd);
+            s.messages = msgs
+                .iter()
+                .map(|t| SessionMessage {
+                    role: MessageRole::User,
+                    content: compact_str::CompactString::new(*t),
+                    estimated_tokens: 0,
+                    id: compact_str::CompactString::new("m"),
+                    timestamp: 0,
+                    tool_calls: Vec::new(),
+                })
+                .collect();
+            let path = dir.join(format!("{id}.json"));
+            std::fs::write(&path, serde_json::to_string(&s).unwrap()).unwrap();
+            id.to_string()
+        };
+
+        let t1 = "2026-01-01T00:00:00+00:00";
+        let t2 = "2026-02-01T00:00:00+00:00";
+        let t3 = "2026-03-01T00:00:00+00:00";
+        let t4 = "2026-04-01T00:00:00+00:00";
+        let t5 = "2026-05-01T00:00:00+00:00";
+
+        // A < B < C are real same-project priors of increasing recency.
+        let a = seed("hist-a", None, t1, &proj, &["a1"]);
+        let b = seed("hist-b", None, t2, &proj, &["b1", "b2"]);
+        let c = seed("hist-c", None, t3, &proj, &["c1"]);
+        // D: newest of all, but a DIFFERENT project → must be dropped.
+        let _d = seed("hist-d", None, t4, other, &["d1"]);
+        // F: same project, newest, but shares the current conversation's
+        // origin (a stale fold rotation) → must be dropped.
+        let _f = seed("hist-f", Some("hist-current"), t5, &proj, &["f1"]);
+
+        // Current session lives only in memory (brand-new, not yet saved).
+        let mut current = Session::new("p", "m", 0);
+        current.id = compact_str::CompactString::new("hist-current");
+        current.working_dir = compact_str::CompactString::new(&proj);
+
+        // Cap at 2: the two most-recent priors are C and B, returned
+        // oldest-first → [B, C]. A is too old; D (other project) and F
+        // (current's own origin) are excluded.
+        let out = recent_project_sessions(&current, 2);
+        let ids: Vec<&str> = out.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["hist-b", "hist-c"]);
+
+        // Messages survive the round-trip and stay in entry order.
+        assert_eq!(
+            out[0]
+                .messages
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["b1", "b2"],
+        );
+
+        // Uncapped → all three same-project priors, oldest-first.
+        let out_all = recent_project_sessions(&current, 10);
+        let ids_all: Vec<&str> = out_all.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids_all, vec!["hist-a", "hist-b", "hist-c"]);
+
+        // max_sessions 0 disables mining entirely.
+        assert!(recent_project_sessions(&current, 0).is_empty());
+
+        for id in [a.as_str(), b.as_str(), c.as_str(), "hist-d", "hist-f"] {
+            let _ = std::fs::remove_file(dir.join(format!("{id}.json")));
+        }
+    }
+
     #[test]
     fn validate_session_id_accepts_uuids() {
         assert!(validate_session_id("a1b2c3d4-e5f6-7890-abcd-ef1234567890").is_ok());
@@ -1132,6 +1225,80 @@ pub fn find_recent_sessions(limit: usize) -> anyhow::Result<Vec<Session>> {
     // window by mtime. (A chain occupying the window can yield slightly
     // fewer than `limit` rows — acceptable for a recents list.)
     Ok(dedup_by_origin(sessions))
+}
+
+/// Cross-session Up-arrow history: the `max_sessions` most-recent OTHER
+/// sessions in the same project (same `working_dir`, different
+/// conversation origin than `current`). Returned OLDEST-first so the
+/// caller can append their prompts ahead of the current session's own,
+/// keeping the newest command at the tail of history (where Up-arrow
+/// recall starts).
+///
+/// A cheap partial parse (`ProjMeta`) filters and ranks candidate files
+/// by `working_dir` + `updated_at` before fully deserializing only the
+/// few winners — mirroring `load_session_tip`'s scan so a large session
+/// store isn't loaded wholesale on startup.
+pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Session> {
+    if max_sessions == 0 {
+        return Vec::new();
+    }
+    let dir = session_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let current_origin = current.effective_origin();
+    let current_wd = current.working_dir.as_str();
+
+    #[derive(serde::Deserialize)]
+    struct ProjMeta {
+        id: String,
+        #[serde(default)]
+        origin_id: Option<String>,
+        #[serde(default)]
+        working_dir: Option<String>,
+        updated_at: String,
+    }
+
+    // Rank same-project, other-origin sessions newest-first via the
+    // cheap partial parse. A vanished or unparseable sibling is skipped
+    // rather than aborting the whole scan (concurrent fold/cleanup can
+    // delete or rewrite a file mid-iteration).
+    let mut ranked: Vec<(String, std::path::PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        let Ok(json) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<ProjMeta>(&json) else {
+            continue;
+        };
+        if meta.working_dir.as_deref() != Some(current_wd) {
+            continue;
+        }
+        let origin = meta.origin_id.as_deref().unwrap_or(&meta.id);
+        if origin == current_origin {
+            continue;
+        }
+        ranked.push((meta.updated_at, path));
+    }
+    ranked.sort_by(|a, b| b.0.cmp(&a.0));
+    ranked.truncate(max_sessions);
+    // Oldest-first: appending then yields oldest-session prompts first,
+    // so the newest prior session sits just behind the current session.
+    ranked.reverse();
+
+    let mut out = Vec::with_capacity(ranked.len());
+    for (_, path) in ranked {
+        if let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(session) = serde_json::from_str::<Session>(&json)
+        {
+            out.push(session);
+        }
+    }
+    out
 }
 
 pub fn agents_path() -> PathBuf {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -460,6 +460,73 @@ mod tests {
         }
     }
 
+    /// A prior conversation that folded leaves several rotation files
+    /// sharing one origin. `recent_project_sessions` must collapse them to
+    /// the chain tip so `max_sessions` counts conversations, not rotations,
+    /// and overlapping prompts aren't seeded twice.
+    #[test]
+    fn recent_project_sessions_collapses_fold_chains() {
+        use crate::session::{MessageRole, Session, SessionMessage};
+        let dir = session_dir();
+        let _ = std::fs::create_dir_all(&dir);
+        let proj = format!(
+            "/tmp/dirge-hist-fold-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+
+        let seed = |id: &str, origin: Option<&str>, updated: &str, wd: &str, msgs: &[&str]| {
+            let mut s = Session::new("p", "m", 0);
+            s.id = compact_str::CompactString::new(id);
+            s.origin_id = origin.map(compact_str::CompactString::new);
+            s.updated_at = compact_str::CompactString::new(updated);
+            s.working_dir = compact_str::CompactString::new(wd);
+            s.messages = msgs
+                .iter()
+                .map(|t| SessionMessage {
+                    role: MessageRole::User,
+                    content: compact_str::CompactString::new(*t),
+                    estimated_tokens: 0,
+                    id: compact_str::CompactString::new("m"),
+                    timestamp: 0,
+                    tool_calls: Vec::new(),
+                })
+                .collect();
+            std::fs::write(
+                dir.join(format!("{id}.json")),
+                serde_json::to_string(&s).unwrap(),
+            )
+            .unwrap();
+            id.to_string()
+        };
+
+        let t1 = "2026-01-01T00:00:00+00:00";
+        let t2 = "2026-02-01T00:00:00+00:00";
+        let t3 = "2026-03-01T00:00:00+00:00";
+
+        // One prior conversation, three rotations sharing origin "fold-r1".
+        // r1 (the origin file) is oldest; r3 is the tip.
+        let r1 = seed("fold-r1", None, t1, &proj, &["old"]);
+        let r2 = seed("fold-r2", Some("fold-r1"), t2, &proj, &["mid"]);
+        let r3 = seed("fold-r3", Some("fold-r1"), t3, &proj, &["tip"]);
+
+        let mut current = Session::new("p", "m", 0);
+        current.id = compact_str::CompactString::new("fold-current");
+        current.working_dir = compact_str::CompactString::new(&proj);
+
+        // Even uncapped, the three rotations collapse to a single session —
+        // the tip (newest updated_at) — not three separate slots.
+        let out = recent_project_sessions(&current, 10);
+        let ids: Vec<&str> = out.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["fold-r3"], "fold chain collapses to its tip");
+
+        for id in [r1.as_str(), r2.as_str(), r3.as_str()] {
+            let _ = std::fs::remove_file(dir.join(format!("{id}.json")));
+        }
+    }
+
     #[test]
     fn validate_session_id_accepts_uuids() {
         assert!(validate_session_id("a1b2c3d4-e5f6-7890-abcd-ef1234567890").is_ok());
@@ -1237,7 +1304,10 @@ pub fn find_recent_sessions(limit: usize) -> anyhow::Result<Vec<Session>> {
 /// A cheap partial parse (`ProjMeta`) filters and ranks candidate files
 /// by `working_dir` + `updated_at` before fully deserializing only the
 /// few winners — mirroring `load_session_tip`'s scan so a large session
-/// store isn't loaded wholesale on startup.
+/// store isn't loaded wholesale on startup. Fold chains are collapsed by
+/// origin (keeping each conversation's tip, like `find_recent_sessions`),
+/// so `max_sessions` counts distinct prior conversations rather than
+/// rotation files and a folded prior can't seed overlapping prompts.
 pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Session> {
     if max_sessions == 0 {
         return Vec::new();
@@ -1263,7 +1333,7 @@ pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Se
     // cheap partial parse. A vanished or unparseable sibling is skipped
     // rather than aborting the whole scan (concurrent fold/cleanup can
     // delete or rewrite a file mid-iteration).
-    let mut ranked: Vec<(String, std::path::PathBuf)> = Vec::new();
+    let mut ranked: Vec<(String, String, std::path::PathBuf)> = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().is_none_or(|e| e != "json") {
@@ -1278,20 +1348,26 @@ pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Se
         if meta.working_dir.as_deref() != Some(current_wd) {
             continue;
         }
-        let origin = meta.origin_id.as_deref().unwrap_or(&meta.id);
+        let origin = meta.origin_id.unwrap_or(meta.id);
         if origin == current_origin {
             continue;
         }
-        ranked.push((meta.updated_at, path));
+        ranked.push((meta.updated_at, origin, path));
     }
     ranked.sort_by(|a, b| b.0.cmp(&a.0));
+    // Collapse fold chains: keep only the newest file per origin (its
+    // tip) so a folded prior conversation occupies one slot, not one per
+    // rotation. Dedup before truncating so `max_sessions` bounds distinct
+    // conversations.
+    let mut seen = std::collections::HashSet::new();
+    ranked.retain(|(_, origin, _)| seen.insert(origin.clone()));
     ranked.truncate(max_sessions);
     // Oldest-first: appending then yields oldest-session prompts first,
     // so the newest prior session sits just behind the current session.
     ranked.reverse();
 
     let mut out = Vec::with_capacity(ranked.len());
-    for (_, path) in ranked {
+    for (_, _, path) in ranked {
         if let Ok(json) = std::fs::read_to_string(&path)
             && let Ok(session) = serde_json::from_str::<Session>(&json)
         {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -73,7 +73,7 @@ use crate::provider::{AnyAgent, AnyClient};
 use crate::sandbox::Sandbox;
 #[cfg(feature = "semantic")]
 use crate::semantic::SemanticManager;
-use crate::session::{MessageRole, PermissionAllowEntry, Session};
+use crate::session::{MessageRole, PermissionAllowEntry, Session, SessionMessage};
 use crate::shell;
 #[cfg(feature = "plugin")]
 use crate::ui::agent_io::render_plugin_entry;
@@ -130,6 +130,23 @@ use tool_display::*;
 /// Cached state for a collapsed tool result, so Ctrl+O can re-render
 /// it as a fresh chamber with the full body. We hold only the last
 /// one — older collapses live in chat history but aren't addressable.
+/// Real user-typed prompt text from `msg`, or `None` for synthetic turns
+/// (non-user roles, system-reminder wrappers, mid-turn steers, and
+/// auto-continue messages) that must never pollute command history.
+fn real_user_prompt(msg: &SessionMessage) -> Option<&str> {
+    if msg.role != MessageRole::User {
+        return None;
+    }
+    let content = strip_leading_system_reminder(&msg.content);
+    if content.is_empty()
+        || content.starts_with("[Mid-turn steer")
+        || content == "Continue based on the background task results above."
+    {
+        return None;
+    }
+    Some(content)
+}
+
 // Interactive entry point — every collaborator (client, agent, CLI,
 // config, session, context, hooks, plugin manager, …) is threaded in
 // explicitly so the TUI loop owns no globals. Refactoring into a
@@ -255,20 +272,23 @@ pub async fn run_interactive(
         cfg.chord_timeout_ms.map(std::time::Duration::from_millis);
     let mut chord_deadline: Option<tokio::time::Instant> = None;
     const TOOL_ACTIVITY_CAP: usize = 8;
-    // Seed the editor's history from the session so Up/Down arrow
-    // navigation and Ctrl+F search work across restarts.
-    // Skip synthetic prompts (system-reminder wrappers, mid-turn
-    // steer wrappers, auto-continue messages) — only real user
-    // input belongs in the searchable history.
-    for msg in &session.messages {
-        if msg.role == MessageRole::User {
-            let content = strip_leading_system_reminder(&msg.content);
-            if content.is_empty()
-                || content.starts_with("[Mid-turn steer")
-                || content == "Continue based on the background task results above."
-            {
-                continue;
+    // Seed Up/Down + Ctrl+F history. Prior same-project sessions are
+    // mined first (oldest→newest, capped at `max_sessions`) so the
+    // current session's own prompts stay most-recent at the tail of
+    // history — the spot Up-arrow recall starts from. Synthetic turns
+    // (system-reminder wrappers, mid-turn steers, auto-continues) never
+    // enter history.
+    for prior in
+        crate::session::storage::recent_project_sessions(session, cfg.resolve_max_sessions())
+    {
+        for msg in &prior.messages {
+            if let Some(content) = real_user_prompt(msg) {
+                input.load_history_entry(content);
             }
+        }
+    }
+    for msg in &session.messages {
+        if let Some(content) = real_user_prompt(msg) {
             input.load_history_entry(content);
         }
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -109,6 +109,23 @@ use tool_display::*;
 //     open_rewind_picker / rewind_session                   → ui::search_rewind
 //   - run_shell_command                                     → ui::shell_exec
 
+/// Real user-typed prompt text from `msg`, or `None` for synthetic turns
+/// (non-user roles, system-reminder wrappers, mid-turn steers, and
+/// auto-continue messages) that must never pollute command history.
+fn real_user_prompt(msg: &SessionMessage) -> Option<&str> {
+    if msg.role != MessageRole::User {
+        return None;
+    }
+    let content = strip_leading_system_reminder(&msg.content);
+    if content.is_empty()
+        || content.starts_with("[Mid-turn steer")
+        || content == "Continue based on the background task results above."
+    {
+        return None;
+    }
+    Some(content)
+}
+
 /// Formats a tool call showing only the primary file/command parameter.
 /// - read/write/edit → path
 /// - grep → pattern (and path if both present)
@@ -130,23 +147,6 @@ use tool_display::*;
 /// Cached state for a collapsed tool result, so Ctrl+O can re-render
 /// it as a fresh chamber with the full body. We hold only the last
 /// one — older collapses live in chat history but aren't addressable.
-/// Real user-typed prompt text from `msg`, or `None` for synthetic turns
-/// (non-user roles, system-reminder wrappers, mid-turn steers, and
-/// auto-continue messages) that must never pollute command history.
-fn real_user_prompt(msg: &SessionMessage) -> Option<&str> {
-    if msg.role != MessageRole::User {
-        return None;
-    }
-    let content = strip_leading_system_reminder(&msg.content);
-    if content.is_empty()
-        || content.starts_with("[Mid-turn steer")
-        || content == "Continue based on the background task results above."
-    {
-        return None;
-    }
-    Some(content)
-}
-
 // Interactive entry point — every collaborator (client, agent, CLI,
 // config, session, context, hooks, plugin manager, …) is threaded in
 // explicitly so the TUI loop owns no globals. Refactoring into a

--- a/src/ui/mod_tests.rs
+++ b/src/ui/mod_tests.rs
@@ -948,3 +948,58 @@ fn expanded_thinking_wrapped_rows_keep_the_bar() {
         );
     }
 }
+
+// ============================================================
+// real_user_prompt — history seeding filter
+// ============================================================
+use crate::session::{MessageRole, SessionMessage};
+
+fn user_msg(content: &str) -> SessionMessage {
+    SessionMessage {
+        role: MessageRole::User,
+        content: compact_str::CompactString::new(content),
+        estimated_tokens: 0,
+        id: compact_str::CompactString::new("m"),
+        timestamp: 0,
+        tool_calls: Vec::new(),
+    }
+}
+
+#[test]
+fn real_user_prompt_passes_real_input() {
+    assert_eq!(
+        super::real_user_prompt(&user_msg("run tests")),
+        Some("run tests")
+    );
+}
+
+#[test]
+fn real_user_prompt_strips_system_reminder_wrapper() {
+    let m = user_msg("<system-reminder>\nctx\n</system-reminder>\n\nwhat's next?");
+    assert_eq!(super::real_user_prompt(&m), Some("what's next?"));
+}
+
+#[test]
+fn real_user_prompt_rejects_synthetic_turns() {
+    // Non-user role.
+    let mut m = user_msg("x");
+    m.role = MessageRole::Assistant;
+    assert_eq!(super::real_user_prompt(&m), None);
+    // Empty after strip.
+    assert_eq!(super::real_user_prompt(&user_msg("")), None);
+    assert_eq!(
+        super::real_user_prompt(&user_msg("<system-reminder>x</system-reminder>")),
+        None,
+    );
+    // Mid-turn steer + auto-continue markers.
+    assert_eq!(
+        super::real_user_prompt(&user_msg("[Mid-turn steer from user] hey")),
+        None,
+    );
+    assert_eq!(
+        super::real_user_prompt(&user_msg(
+            "Continue based on the background task results above."
+        )),
+        None,
+    );
+}


### PR DESCRIPTION
Up/Down and Ctrl+F previously only saw the current session's prompts, so a fresh session in a project started with an empty recall pool until you typed. Now the editor also mines the N most-recent prior sessions in the same project (matching working_dir) for their user prompts, seeded oldest->newest ahead of the current session's own, so Up still starts from your newest command and walks back through earlier conversations.

- max_sessions (top-level config, default 3) caps how many prior sessions are loaded; 0 keeps recall scoped to the current session only. Kept it an opt-out rather than off-by-default because the flat merged list is cheap and the cap bounds the startup scan.

- recent_project_sessions ranks candidates with a cheap partial parse (ProjMeta: id / origin / working_dir / updated_at) and truncates before the full deserialize, mirroring load_session_tip's scan so a large session store isn't read wholesale on startup. The current conversation's own fold rotations are excluded by origin, so a fold can't double its prompts into history.

- real_user_prompt extracts the synthetic-turn filter (system-reminder wrappers, mid-turn steers, auto-continue markers) that lived inline in the seed loop, so prior sessions and the current session share one filter instead of duplicating it.

Tests: max_sessions config field + default + opt-out; recent_project_sessions filters by project, excludes the current origin, returns oldest-first and respects the cap; real_user_prompt passes real input, strips the reminder wrapper, and rejects synthetic turns.

Docs: config.md table row + a "Command history (cross-session recall)" subsection.

Full suite green (3125 passed); fmt clean; no new clippy.