### PR TITLE
feat(issues): native issue tracker with harness turn-start injection

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -358,6 +358,10 @@ const MAX_CONSECUTIVE_COMPACTION_FAILURES: u32 = 3;
 /// when the task matches fewer exemplars.
 const EXEMPLAR_TOP_K: usize = 3;
 
+/// Max live issues surfaced in the turn-start board reminder. The rest are
+/// summarized as a "+N more" hint so a large backlog can't flood context.
+const ISSUE_BOARD_TOP_N: usize = 7;
+
 /// What the LLM-summary stage of a compaction pass did, so `run_loop`
 /// can drive the circuit-breaker counter. (The cheap prune always runs
 /// regardless of this outcome.)
@@ -912,6 +916,25 @@ pub async fn run_agent_loop(
             Err(e) => {
                 tracing::debug!(target: "dirge::memory", error = %e, "pre-recall task join failed")
             }
+        }
+    }
+
+    // Native issue board: surface the agent's persistent kanban at the top of
+    // each user-initiated run, so it doesn't have to remember to list it. Like
+    // pre-recall, this is model-facing context only (never persisted) and is
+    // gated on `memory_provider` — the same safety net that excludes the forked
+    // review/curator runners (they build with `memory_provider: None`). Bounded
+    // to the top N live issues with a "see the rest" hint, so a large backlog
+    // can't flood the context.
+    if memory_provider.is_some() {
+        let db_path = std::env::current_dir()
+            .map(|c| crate::extras::dirge_paths::ProjectPaths::new(&c).session_db_path())
+            .unwrap_or_else(|_| std::path::PathBuf::from(".dirge/sessions/state.db"));
+        if let Ok(store) = crate::extras::issue_db::IssueStore::open_at(&db_path)
+            && let Ok(Some(block)) = store.board_reminder(ISSUE_BOARD_TOP_N)
+        {
+            let msg = LoopMessage::User(super::message::UserMessage { content: block });
+            context.messages.push(loop_message_to_value(&msg));
         }
     }
 

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -507,6 +507,20 @@ pub async fn build_loop_tools(
         .await,
     );
 
+    // Persistent issue/kanban board — mutates the project DB, so Sequential.
+    tools.push(
+        wrap(
+            tools::IssueTool::new(
+                session_db_path.clone(),
+                session_id.clone(),
+                permission.clone(),
+                ask_tx.clone(),
+            ),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+
     // Entity/relation graph search — read-only; feature-gated.
     #[cfg(feature = "experimental-graph-search")]
     tools.push(

--- a/src/agent/tools/issue.rs
+++ b/src/agent/tools/issue.rs
@@ -1,0 +1,315 @@
+//! `issue` — the model's persistent issue/kanban board, stored in the
+//! per-project session DB via [`crate::extras::issue_db::IssueStore`].
+//!
+//! Unlike `write_todo_list` (ephemeral, single-session checklist), issues
+//! persist across sessions and are surfaced by the harness at turn start, so
+//! the model doesn't have to remember to list them. This tool is the WRITE +
+//! on-demand-read surface; routine reads are injected automatically.
+
+use std::path::PathBuf;
+
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use serde::Deserialize;
+
+use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
+use crate::extras::issue_db::{IssueStore, parse_issue_id};
+
+#[derive(Deserialize)]
+pub struct IssueArgs {
+    /// create | list | show | start | block | close | update | search
+    pub action: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+    /// Issue id for show/update/start/block/close. Accepts 7 or "#7".
+    #[serde(default)]
+    pub id: Option<serde_json::Value>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Filter for `list` (status) or term for `search`.
+    #[serde(default)]
+    pub query: Option<String>,
+}
+
+/// Coerce the `id` field, which the model may send as a number or a string
+/// like "#7".
+fn coerce_id(v: &Option<serde_json::Value>) -> Option<i64> {
+    match v.as_ref()? {
+        serde_json::Value::Number(n) => n.as_i64(),
+        serde_json::Value::String(s) => parse_issue_id(s),
+        _ => None,
+    }
+}
+
+pub struct IssueTool {
+    db_path: PathBuf,
+    session_id: Option<String>,
+    permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
+}
+
+impl IssueTool {
+    pub fn new(
+        db_path: PathBuf,
+        session_id: Option<String>,
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+    ) -> Self {
+        IssueTool {
+            db_path,
+            session_id,
+            permission,
+            ask_tx,
+        }
+    }
+
+    fn store(&self) -> Result<IssueStore, ToolError> {
+        IssueStore::open_at(&self.db_path).map_err(ToolError::Msg)
+    }
+}
+
+fn render_issue(i: &crate::extras::issue_db::Issue) -> String {
+    let mut out = format!("#{} [{}] ({})\n  {}", i.id, i.status, i.priority, i.title);
+    if !i.body.trim().is_empty() {
+        out.push_str(&format!("\n  {}", i.body.replace('\n', "\n  ")));
+    }
+    out.push_str(&format!(
+        "\n  created {} · updated {}",
+        i.created_at, i.updated_at
+    ));
+    out
+}
+
+impl Tool for IssueTool {
+    const NAME: &'static str = "issue";
+
+    type Error = ToolError;
+    type Args = IssueArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "issue".to_string(),
+            description: "Persistent issue/kanban board for tracking work ACROSS sessions (stored in the project DB). The harness shows your open board at the start of each turn, so you don't need to list it constantly. Use this for durable tasks/features/bugs; use `write_todo_list` for throwaway within-turn steps. Actions: \
+                create (title, optional body/priority high|normal|low); \
+                start (id → in_progress); block (id → blocked); close (id → done); \
+                update (id, optional status/priority/body); \
+                show (id); list (optional status filter); search (query). \
+                Ids accept 7 or \"#7\". Create issues as you discover work; start one when you begin it; close it when done.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "action": { "type": "string", "description": "create | list | show | start | block | close | update | search" },
+                    "title": { "type": "string", "description": "Title (create)" },
+                    "body": { "type": "string", "description": "Optional details (create/update)" },
+                    "id": { "type": ["integer", "string"], "description": "Issue id for show/update/start/block/close (e.g. 7 or \"#7\")" },
+                    "status": { "type": "string", "description": "open | in_progress | blocked | done (update)" },
+                    "priority": { "type": "string", "description": "high | normal | low (create/update)" },
+                    "query": { "type": "string", "description": "Status filter for list, or search term for search" }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: IssueArgs) -> Result<String, ToolError> {
+        let action = args.action.trim().to_ascii_lowercase();
+        let is_write = matches!(
+            action.as_str(),
+            "create" | "start" | "block" | "close" | "update"
+        );
+        if is_write {
+            check_perm(&self.permission, &self.ask_tx, "issue", &action).await?;
+        }
+        let store = self.store()?;
+
+        let need_id = |args: &IssueArgs| -> Result<i64, ToolError> {
+            coerce_id(&args.id).ok_or_else(|| {
+                ToolError::Msg(format!(
+                    "action '{action}' needs an `id` (e.g. 7 or \"#7\")"
+                ))
+            })
+        };
+
+        match action.as_str() {
+            "create" => {
+                let title = args
+                    .title
+                    .as_deref()
+                    .ok_or_else(|| ToolError::Msg("create needs a `title`".to_string()))?;
+                let id = store
+                    .create(
+                        title,
+                        args.body.as_deref().unwrap_or(""),
+                        args.priority.as_deref(),
+                        self.session_id.as_deref(),
+                    )
+                    .map_err(ToolError::Msg)?;
+                Ok(format!("Created issue #{id}: {}", title.trim()))
+            }
+            "start" | "block" | "close" => {
+                let id = need_id(&args)?;
+                let status = match action.as_str() {
+                    "start" => "in_progress",
+                    "block" => "blocked",
+                    _ => "done",
+                };
+                if store.set_status(id, status).map_err(ToolError::Msg)? {
+                    Ok(format!("Issue #{id} → {status}"))
+                } else {
+                    Err(ToolError::Msg(format!("no issue #{id}")))
+                }
+            }
+            "update" => {
+                let id = need_id(&args)?;
+                let mut changed = Vec::new();
+                if let Some(status) = args.status.as_deref() {
+                    if !store.set_status(id, status).map_err(ToolError::Msg)? {
+                        return Err(ToolError::Msg(format!("no issue #{id}")));
+                    }
+                    changed.push("status");
+                }
+                if let Some(priority) = args.priority.as_deref() {
+                    if !store.set_priority(id, priority).map_err(ToolError::Msg)? {
+                        return Err(ToolError::Msg(format!("no issue #{id}")));
+                    }
+                    changed.push("priority");
+                }
+                if changed.is_empty() {
+                    return Err(ToolError::Msg(
+                        "update needs at least one of: status, priority".to_string(),
+                    ));
+                }
+                Ok(format!("Updated issue #{id} ({})", changed.join(", ")))
+            }
+            "show" => {
+                let id = need_id(&args)?;
+                match store.get(id).map_err(ToolError::Msg)? {
+                    Some(issue) => Ok(render_issue(&issue)),
+                    None => Err(ToolError::Msg(format!("no issue #{id}"))),
+                }
+            }
+            "list" => {
+                let issues = match args
+                    .query
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    Some(status) => store.list_by_status(status).map_err(ToolError::Msg)?,
+                    None => store.board(None).map_err(ToolError::Msg)?,
+                };
+                if issues.is_empty() {
+                    return Ok("no matching issues".to_string());
+                }
+                let lines: Vec<String> = issues.iter().map(|i| i.one_line()).collect();
+                Ok(format!("{} issue(s):\n{}", lines.len(), lines.join("\n")))
+            }
+            "search" => {
+                let query = args
+                    .query
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| ToolError::Msg("search needs a `query`".to_string()))?;
+                let hits = store.search(query, 20).map_err(ToolError::Msg)?;
+                if hits.is_empty() {
+                    return Ok(format!("no issues match '{query}'"));
+                }
+                let lines: Vec<String> = hits.iter().map(|i| i.one_line()).collect();
+                Ok(format!("{} match(es):\n{}", lines.len(), lines.join("\n")))
+            }
+            other => Err(ToolError::Msg(format!(
+                "unknown action '{other}' (use create|list|show|start|block|close|update|search)"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool() -> IssueTool {
+        let dir = std::env::temp_dir().join(format!(
+            "dirge-issuetool-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        IssueTool::new(dir.join("state.db"), Some("sess-1".into()), None, None)
+    }
+
+    fn args(action: &str) -> IssueArgs {
+        IssueArgs {
+            action: action.into(),
+            title: None,
+            body: None,
+            id: None,
+            status: None,
+            priority: None,
+            query: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_then_list_then_close_flow() {
+        let t = tool();
+        let created = t
+            .call(IssueArgs {
+                title: Some("Build auth".into()),
+                priority: Some("high".into()),
+                ..args("create")
+            })
+            .await
+            .unwrap();
+        assert!(created.starts_with("Created issue #1"), "{created}");
+
+        let listed = t.call(args("list")).await.unwrap();
+        assert!(listed.contains("#1"));
+        assert!(listed.contains("Build auth"));
+
+        // start then close via convenience verbs, with "#1" string id.
+        let started = t
+            .call(IssueArgs {
+                id: Some(serde_json::json!("#1")),
+                ..args("start")
+            })
+            .await
+            .unwrap();
+        assert!(started.contains("in_progress"), "{started}");
+
+        let closed = t
+            .call(IssueArgs {
+                id: Some(serde_json::json!(1)),
+                ..args("close")
+            })
+            .await
+            .unwrap();
+        assert!(closed.contains("done"), "{closed}");
+
+        // closed issue drops off the default board.
+        let after = t.call(args("list")).await.unwrap();
+        assert!(after.contains("no matching issues"), "{after}");
+    }
+
+    #[tokio::test]
+    async fn create_requires_title_and_close_requires_id() {
+        let t = tool();
+        assert!(t.call(args("create")).await.is_err());
+        assert!(t.call(args("close")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_action_errors() {
+        let t = tool();
+        assert!(t.call(args("frobnicate")).await.is_err());
+    }
+}

--- a/src/agent/tools/issue.rs
+++ b/src/agent/tools/issue.rs
@@ -166,23 +166,43 @@ impl Tool for IssueTool {
             }
             "update" => {
                 let id = need_id(&args)?;
-                let mut changed = Vec::new();
-                if let Some(status) = args.status.as_deref() {
-                    if !store.set_status(id, status).map_err(ToolError::Msg)? {
-                        return Err(ToolError::Msg(format!("no issue #{id}")));
-                    }
-                    changed.push("status");
-                }
-                if let Some(priority) = args.priority.as_deref() {
-                    if !store.set_priority(id, priority).map_err(ToolError::Msg)? {
-                        return Err(ToolError::Msg(format!("no issue #{id}")));
-                    }
-                    changed.push("priority");
-                }
-                if changed.is_empty() {
+                if args.status.is_none() && args.priority.is_none() {
                     return Err(ToolError::Msg(
                         "update needs at least one of: status, priority".to_string(),
                     ));
+                }
+                // Pre-validate BOTH fields before mutating: set_status and
+                // set_priority are two separate writes with no surrounding
+                // transaction, so validating after the first write would let an
+                // invalid second field leave a half-applied update (e.g. status
+                // committed, then an invalid priority returns Err).
+                use crate::extras::issue_db::{normalize_priority, normalize_status};
+                if let Some(status) = args.status.as_deref() {
+                    normalize_status(status).ok_or_else(|| {
+                        ToolError::Msg(format!(
+                            "unknown status '{status}' (use open|in_progress|blocked|done)"
+                        ))
+                    })?;
+                }
+                if let Some(priority) = args.priority.as_deref() {
+                    normalize_priority(priority).ok_or_else(|| {
+                        ToolError::Msg(format!(
+                            "unknown priority '{priority}' (use high|normal|low)"
+                        ))
+                    })?;
+                }
+                // Existence check up front so a missing id fails before any write.
+                if store.get(id).map_err(ToolError::Msg)?.is_none() {
+                    return Err(ToolError::Msg(format!("no issue #{id}")));
+                }
+                let mut changed = Vec::new();
+                if let Some(status) = args.status.as_deref() {
+                    store.set_status(id, status).map_err(ToolError::Msg)?;
+                    changed.push("status");
+                }
+                if let Some(priority) = args.priority.as_deref() {
+                    store.set_priority(id, priority).map_err(ToolError::Msg)?;
+                    changed.push("priority");
                 }
                 Ok(format!("Updated issue #{id} ({})", changed.join(", ")))
             }
@@ -311,5 +331,39 @@ mod tests {
     async fn unknown_action_errors() {
         let t = tool();
         assert!(t.call(args("frobnicate")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn update_with_invalid_priority_does_not_half_apply_status() {
+        let t = tool();
+        t.call(IssueArgs {
+            title: Some("x".into()),
+            ..args("create")
+        })
+        .await
+        .unwrap();
+        // status valid, priority invalid → must error WITHOUT committing the
+        // status change (no transaction wraps the two writes).
+        let res = t
+            .call(IssueArgs {
+                id: Some(serde_json::json!(1)),
+                status: Some("done".into()),
+                priority: Some("bogus".into()),
+                ..args("update")
+            })
+            .await;
+        assert!(res.is_err(), "invalid priority should error");
+        // The issue must still be open (status not half-applied).
+        let shown = t
+            .call(IssueArgs {
+                id: Some(serde_json::json!(1)),
+                ..args("show")
+            })
+            .await
+            .unwrap();
+        assert!(
+            shown.contains("[open]"),
+            "status must not have been applied: {shown}"
+        );
     }
 }

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -12,6 +12,7 @@ mod edit_minified;
 mod find_files;
 mod glob;
 mod grep;
+mod issue;
 pub(crate) mod line_hash;
 mod list_dir;
 #[cfg(feature = "lsp")]
@@ -57,6 +58,7 @@ pub use glob::GlobTool;
 #[cfg(feature = "experimental-graph-search")]
 pub use graph::GraphTool;
 pub use grep::GrepTool;
+pub use issue::IssueTool;
 pub use list_dir::ListDirTool;
 #[cfg(feature = "lsp")]
 pub use lsp::LspTool;
@@ -113,6 +115,7 @@ pub const BUILTIN_TOOL_NAMES: &[&str] = &[
     "glob",
     "list_dir",
     "write_todo_list",
+    "issue",
     "apply_patch",
     "memory",
     "skill",

--- a/src/extras/issue_db.rs
+++ b/src/extras/issue_db.rs
@@ -1,0 +1,461 @@
+//! Native issue tracker — a lightweight, agent-facing kanban stored in the
+//! per-project session DB (`.dirge/sessions/state.db`).
+//!
+//! Issues are a stateful extension of the memory model: open issues are the
+//! agent's working board (surfaced by the harness at turn start), and closed
+//! issues fade like ordinary procedural memory. The store deliberately owns
+//! its schema via idempotent `CREATE TABLE IF NOT EXISTS` on open rather than a
+//! versioned migration — the session DB's `user_version` chain is feature-gated
+//! (v14/v15 exist only under `experimental-graph-search`), so threading a new
+//! linear version would either collide with those or break the "enable the
+//! feature later" property. An additive, self-owned table sidesteps all of it.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::session_db::SessionDb;
+use crate::sync_util::LockExt;
+
+// Lifecycle states (open / in_progress / blocked / done) and priorities
+// (high / normal / low) are defined by the `normalize_*` vocabulary below.
+
+/// Normalize a user/agent-supplied status to a canonical value, or `None` if
+/// unrecognized. Accepts a few intuitive aliases.
+pub fn normalize_status(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "open" | "todo" | "backlog" => Some("open"),
+        "in_progress" | "in-progress" | "started" | "doing" | "wip" => Some("in_progress"),
+        "blocked" | "block" => Some("blocked"),
+        "done" | "closed" | "complete" | "completed" | "finished" => Some("done"),
+        _ => None,
+    }
+}
+
+/// Normalize a priority, or `None` if unrecognized.
+pub fn normalize_priority(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "high" | "p0" | "p1" | "urgent" => Some("high"),
+        "normal" | "medium" | "med" | "p2" | "" => Some("normal"),
+        "low" | "p3" | "p4" | "minor" => Some("low"),
+        _ => None,
+    }
+}
+
+/// Parse an issue id from intuitive forms: `7`, `#7`, `iss-7`, `issue 7`.
+pub fn parse_issue_id(raw: &str) -> Option<i64> {
+    let s = raw.trim();
+    let s = s.strip_prefix("issue").map(str::trim).unwrap_or(s);
+    let s = s.strip_prefix('#').unwrap_or(s);
+    let s = s.strip_prefix("iss-").unwrap_or(s);
+    let s = s.strip_prefix("drg-").unwrap_or(s);
+    s.trim().parse::<i64>().ok()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Issue {
+    pub id: i64,
+    pub title: String,
+    pub body: String,
+    pub status: String,
+    pub priority: String,
+    pub session_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub closed_at: Option<String>,
+}
+
+impl Issue {
+    /// Intuitive one-line rendering for the board / lists: `#7 [in_progress]
+    /// (high) Build auth middleware`.
+    pub fn one_line(&self) -> String {
+        format!(
+            "#{} [{}] ({}) {}",
+            self.id, self.status, self.priority, self.title
+        )
+    }
+}
+
+fn now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+fn row_to_issue(row: &rusqlite::Row<'_>) -> rusqlite::Result<Issue> {
+    Ok(Issue {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        body: row.get(2)?,
+        status: row.get(3)?,
+        priority: row.get(4)?,
+        session_id: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+        closed_at: row.get(8)?,
+    })
+}
+
+const COLS: &str =
+    "id, title, body, status, priority, session_id, created_at, updated_at, closed_at";
+
+/// SQLite-backed issue tracker over the per-project session DB. Mirrors
+/// [`super::spec_db::SpecStore`] — holds its own connection.
+pub struct IssueStore {
+    conn: Mutex<Connection>,
+}
+
+impl IssueStore {
+    /// Open against a project's session DB, creating the `issues` table if
+    /// needed.
+    pub fn open(paths: &super::dirge_paths::ProjectPaths) -> Result<Self, String> {
+        Self::open_at(&paths.session_db_path())
+    }
+
+    /// Open against an explicit DB path (used by tests and callers that
+    /// already resolved the path).
+    pub fn open_at(path: &Path) -> Result<Self, String> {
+        let db = SessionDb::open(path)?;
+        let store = Self {
+            conn: Mutex::new(db.conn),
+        };
+        store.ensure_schema()?;
+        Ok(store)
+    }
+
+    fn ensure_schema(&self) -> Result<(), String> {
+        let conn = self.conn.lock_ignore_poison();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS issues (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                title       TEXT NOT NULL,
+                body        TEXT NOT NULL DEFAULT '',
+                status      TEXT NOT NULL DEFAULT 'open',
+                priority    TEXT NOT NULL DEFAULT 'normal',
+                session_id  TEXT,
+                created_at  TEXT NOT NULL,
+                updated_at  TEXT NOT NULL,
+                closed_at   TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_issues_status ON issues(status);",
+        )
+        .map_err(|e| format!("ensure issues schema: {e}"))
+    }
+
+    /// Create a new issue. `priority` and `session_id` are optional; an unknown
+    /// priority falls back to `normal`.
+    pub fn create(
+        &self,
+        title: &str,
+        body: &str,
+        priority: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<i64, String> {
+        let title = title.trim();
+        if title.is_empty() {
+            return Err("issue title must not be empty".to_string());
+        }
+        let priority = priority.and_then(normalize_priority).unwrap_or("normal");
+        let conn = self.conn.lock_ignore_poison();
+        let now = now();
+        conn.execute(
+            "INSERT INTO issues (title, body, status, priority, session_id, created_at, updated_at)
+             VALUES (?1, ?2, 'open', ?3, ?4, ?5, ?5)",
+            params![title, body.trim(), priority, session_id, now],
+        )
+        .map_err(|e| format!("create issue: {e}"))?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn get(&self, id: i64) -> Result<Option<Issue>, String> {
+        let conn = self.conn.lock_ignore_poison();
+        conn.query_row(
+            &format!("SELECT {COLS} FROM issues WHERE id = ?1"),
+            params![id],
+            row_to_issue,
+        )
+        .optional()
+        .map_err(|e| format!("get issue: {e}"))
+    }
+
+    /// Update status (validated). Setting `done` stamps `closed_at`; moving off
+    /// `done` clears it. Returns false if the issue doesn't exist.
+    pub fn set_status(&self, id: i64, status: &str) -> Result<bool, String> {
+        let status = normalize_status(status).ok_or_else(|| {
+            format!("unknown status '{status}' (use open|in_progress|blocked|done)")
+        })?;
+        let conn = self.conn.lock_ignore_poison();
+        let now = now();
+        let n = if status == "done" {
+            conn.execute(
+                "UPDATE issues SET status = ?2, updated_at = ?3, closed_at = ?3 WHERE id = ?1",
+                params![id, status, now],
+            )
+        } else {
+            conn.execute(
+                "UPDATE issues SET status = ?2, updated_at = ?3, closed_at = NULL WHERE id = ?1",
+                params![id, status, now],
+            )
+        }
+        .map_err(|e| format!("set status: {e}"))?;
+        Ok(n > 0)
+    }
+
+    pub fn set_priority(&self, id: i64, priority: &str) -> Result<bool, String> {
+        let priority = normalize_priority(priority)
+            .ok_or_else(|| format!("unknown priority '{priority}' (use high|normal|low)"))?;
+        let conn = self.conn.lock_ignore_poison();
+        let n = conn
+            .execute(
+                "UPDATE issues SET priority = ?2, updated_at = ?3 WHERE id = ?1",
+                params![id, priority, now()],
+            )
+            .map_err(|e| format!("set priority: {e}"))?;
+        Ok(n > 0)
+    }
+
+    /// All issues with the given status, newest first.
+    pub fn list_by_status(&self, status: &str) -> Result<Vec<Issue>, String> {
+        let status =
+            normalize_status(status).ok_or_else(|| format!("unknown status '{status}'"))?;
+        let conn = self.conn.lock_ignore_poison();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {COLS} FROM issues WHERE status = ?1 ORDER BY updated_at DESC"
+            ))
+            .map_err(|e| format!("list: {e}"))?;
+        let rows = stmt
+            .query_map(params![status], row_to_issue)
+            .map_err(|e| format!("list: {e}"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("list: {e}"))
+    }
+
+    /// The live board: open / in_progress / blocked issues ordered the way the
+    /// harness surfaces them — in_progress first, then blocked, then open;
+    /// within a state, high priority first, then most-recently-touched.
+    /// `limit` caps the rows (the caller bounds context); `None` = all.
+    pub fn board(&self, limit: Option<usize>) -> Result<Vec<Issue>, String> {
+        let conn = self.conn.lock_ignore_poison();
+        let sql = format!(
+            "SELECT {COLS} FROM issues
+             WHERE status IN ('open','in_progress','blocked')
+             ORDER BY
+               CASE status WHEN 'in_progress' THEN 0 WHEN 'blocked' THEN 1 ELSE 2 END,
+               CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+               updated_at DESC
+             {}",
+            match limit {
+                Some(n) => format!("LIMIT {n}"),
+                None => String::new(),
+            }
+        );
+        let mut stmt = conn.prepare(&sql).map_err(|e| format!("board: {e}"))?;
+        let rows = stmt
+            .query_map([], row_to_issue)
+            .map_err(|e| format!("board: {e}"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("board: {e}"))
+    }
+
+    /// Count of live (non-done) issues — used for the "N more" injection hint.
+    pub fn open_count(&self) -> Result<usize, String> {
+        let conn = self.conn.lock_ignore_poison();
+        conn.query_row(
+            "SELECT COUNT(*) FROM issues WHERE status != 'done'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n as usize)
+        .map_err(|e| format!("open_count: {e}"))
+    }
+
+    /// Build the harness's turn-start board reminder: the top `top_n` live
+    /// issues, wrapped in a `<system-reminder>` block, with a hint to see the
+    /// rest when there are more. Returns `None` when the board is empty (so the
+    /// caller injects nothing). Token-bounded by `top_n` — the caller owns the
+    /// budget the same way the post-compaction snapshot cap does.
+    pub fn board_reminder(&self, top_n: usize) -> Result<Option<String>, String> {
+        let issues = self.board(Some(top_n))?;
+        if issues.is_empty() {
+            return Ok(None);
+        }
+        let total = self.open_count()?;
+        let mut s = String::from(
+            "<system-reminder>\nIssue board (your persistent kanban — surfaced automatically; you did not ask for it). \
+             As you work: `issue` tool with action=start when you begin one, action=close when done, action=create for newly-discovered work.\n",
+        );
+        for i in &issues {
+            s.push_str(&format!("- {}\n", i.one_line()));
+        }
+        let shown = issues.len();
+        if total > shown {
+            s.push_str(&format!(
+                "… and {} more open issue(s) not shown. Use the `issue` tool (action=list) or /issues to see all.\n",
+                total - shown
+            ));
+        }
+        s.push_str("</system-reminder>");
+        Ok(Some(s))
+    }
+
+    /// Substring search over title + body (case-insensitive), newest first.
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<Issue>, String> {
+        let conn = self.conn.lock_ignore_poison();
+        let like = format!("%{}%", query.trim());
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {COLS} FROM issues
+                 WHERE title LIKE ?1 COLLATE NOCASE OR body LIKE ?1 COLLATE NOCASE
+                 ORDER BY updated_at DESC LIMIT ?2"
+            ))
+            .map_err(|e| format!("search: {e}"))?;
+        let rows = stmt
+            .query_map(params![like, limit as i64], row_to_issue)
+            .map_err(|e| format!("search: {e}"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("search: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> IssueStore {
+        let dir = std::env::temp_dir().join(format!(
+            "dirge-issue-test-{}-{}",
+            std::process::id(),
+            // monotonic-ish unique suffix without Date::now in workflows (this
+            // is a normal test, so SystemTime is fine here)
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        IssueStore::open_at(&dir.join("state.db")).unwrap()
+    }
+
+    #[test]
+    fn create_and_get_roundtrip() {
+        let s = store();
+        let id = s
+            .create("Build auth", "use PKCE", Some("high"), Some("sess-1"))
+            .unwrap();
+        let issue = s.get(id).unwrap().expect("issue exists");
+        assert_eq!(issue.title, "Build auth");
+        assert_eq!(issue.body, "use PKCE");
+        assert_eq!(issue.status, "open");
+        assert_eq!(issue.priority, "high");
+        assert_eq!(issue.session_id.as_deref(), Some("sess-1"));
+        assert!(issue.closed_at.is_none());
+    }
+
+    #[test]
+    fn empty_title_rejected() {
+        let s = store();
+        assert!(s.create("   ", "", None, None).is_err());
+    }
+
+    #[test]
+    fn unknown_priority_falls_back_to_normal() {
+        let s = store();
+        let id = s.create("x", "", Some("supercritical"), None).unwrap();
+        assert_eq!(s.get(id).unwrap().unwrap().priority, "normal");
+    }
+
+    #[test]
+    fn set_status_done_stamps_closed_at_and_clears_on_reopen() {
+        let s = store();
+        let id = s.create("x", "", None, None).unwrap();
+        assert!(s.set_status(id, "done").unwrap());
+        let done = s.get(id).unwrap().unwrap();
+        assert_eq!(done.status, "done");
+        assert!(done.closed_at.is_some());
+        // reopen clears closed_at
+        assert!(s.set_status(id, "in_progress").unwrap());
+        let reopened = s.get(id).unwrap().unwrap();
+        assert_eq!(reopened.status, "in_progress");
+        assert!(reopened.closed_at.is_none());
+    }
+
+    #[test]
+    fn set_status_aliases_normalize() {
+        let s = store();
+        let id = s.create("x", "", None, None).unwrap();
+        assert!(s.set_status(id, "WIP").unwrap());
+        assert_eq!(s.get(id).unwrap().unwrap().status, "in_progress");
+    }
+
+    #[test]
+    fn set_status_unknown_rejected_and_missing_id_is_false() {
+        let s = store();
+        let id = s.create("x", "", None, None).unwrap();
+        assert!(s.set_status(id, "nonsense").is_err());
+        assert!(!s.set_status(999, "done").unwrap());
+    }
+
+    #[test]
+    fn board_orders_in_progress_then_priority_and_excludes_done() {
+        let s = store();
+        let _low_open = s.create("low open", "", Some("low"), None).unwrap();
+        let high_open = s.create("high open", "", Some("high"), None).unwrap();
+        let wip = s.create("wip", "", Some("low"), None).unwrap();
+        s.set_status(wip, "in_progress").unwrap();
+        let done = s.create("done", "", Some("high"), None).unwrap();
+        s.set_status(done, "done").unwrap();
+
+        let board = s.board(None).unwrap();
+        let ids: Vec<i64> = board.iter().map(|i| i.id).collect();
+        // in_progress first regardless of priority, then high open, then low open.
+        assert_eq!(ids, vec![wip, high_open, _low_open]);
+        // done excluded
+        assert!(!ids.contains(&done));
+    }
+
+    #[test]
+    fn board_limit_caps_rows() {
+        let s = store();
+        for i in 0..5 {
+            s.create(&format!("issue {i}"), "", None, None).unwrap();
+        }
+        assert_eq!(s.board(Some(2)).unwrap().len(), 2);
+        assert_eq!(s.open_count().unwrap(), 5);
+    }
+
+    #[test]
+    fn search_matches_title_and_body_case_insensitive() {
+        let s = store();
+        s.create("Refactor auth", "", None, None).unwrap();
+        s.create("Other", "touches AUTH layer", None, None).unwrap();
+        s.create("Unrelated", "nope", None, None).unwrap();
+        let hits = s.search("auth", 10).unwrap();
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn board_reminder_none_when_empty_and_hints_overflow() {
+        let s = store();
+        assert!(
+            s.board_reminder(5).unwrap().is_none(),
+            "empty board → no reminder"
+        );
+        for i in 0..4 {
+            s.create(&format!("issue {i}"), "", None, None).unwrap();
+        }
+        let block = s.board_reminder(2).unwrap().expect("non-empty board");
+        assert!(block.starts_with("<system-reminder>"));
+        assert!(block.trim_end().ends_with("</system-reminder>"));
+        // Only 2 shown, 4 live → overflow hint mentions the remaining 2.
+        assert!(block.contains("2 more open issue"), "{block}");
+    }
+
+    #[test]
+    fn parse_issue_id_accepts_intuitive_forms() {
+        assert_eq!(parse_issue_id("7"), Some(7));
+        assert_eq!(parse_issue_id("#7"), Some(7));
+        assert_eq!(parse_issue_id("iss-7"), Some(7));
+        assert_eq!(parse_issue_id("issue 7"), Some(7));
+        assert_eq!(parse_issue_id("nope"), None);
+    }
+}

--- a/src/extras/issue_db.rs
+++ b/src/extras/issue_db.rs
@@ -12,10 +12,10 @@
 
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::Duration;
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 
-use super::session_db::SessionDb;
 use crate::sync_util::LockExt;
 
 // Lifecycle states (open / in_progress / blocked / done) and priorities
@@ -113,10 +113,31 @@ impl IssueStore {
 
     /// Open against an explicit DB path (used by tests and callers that
     /// already resolved the path).
+    ///
+    /// Opens a plain connection rather than going through `SessionDb::open`:
+    /// the issues table is self-owned (idempotent `ensure_schema`), so it does
+    /// NOT need the session DB's versioned `migrate()` — and crucially avoids
+    /// the `BEGIN EXCLUSIVE` migration lock that `migrate()` takes on every
+    /// open, which the harness would otherwise pay on every turn + tool call
+    /// on the shared `state.db`. A busy timeout lets a concurrent writer (the
+    /// session-persistence / memory connections share this file) yield a short
+    /// wait instead of an immediate `SQLITE_BUSY`.
     pub fn open_at(path: &Path) -> Result<Self, String> {
-        let db = SessionDb::open(path)?;
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
+        )
+        .map_err(|e| format!("open issue db at {}: {e}", path.display()))?;
+        let _ = conn.busy_timeout(Duration::from_secs(5));
+        // WAL is a persistent property of the file once any opener sets it
+        // (session persistence does); setting it here is a harmless no-op then,
+        // and the right default if issues happen to open the file first.
+        let _ = conn.pragma_update(None, "journal_mode", "WAL");
         let store = Self {
-            conn: Mutex::new(db.conn),
+            conn: Mutex::new(conn),
         };
         store.ensure_schema()?;
         Ok(store)

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -25,6 +25,7 @@ pub mod entity_search;
 pub mod curator_clock;
 pub mod dirge_paths;
 pub mod fts;
+pub mod issue_db;
 pub mod memory_curator;
 pub mod memory_db;
 pub mod memory_hybrid;

--- a/src/ui/slash/cmd/issues.rs
+++ b/src/ui/slash/cmd/issues.rs
@@ -1,0 +1,131 @@
+//! `/issues` handler — human view over the native issue board (the same
+//! `IssueStore` the agent's `issue` tool writes and the harness injects at
+//! turn start).
+//!
+//!   /issues              list the live board (open / in_progress / blocked)
+//!   /issues list [status]   filter by a status
+//!   /issues search <q>   substring search over title + body
+//!   /issues <id>         show one issue's details (accepts 7 or #7)
+
+use std::path::Path;
+
+use crate::extras::dirge_paths::ProjectPaths;
+use crate::extras::issue_db::{IssueStore, parse_issue_id};
+use crate::ui::slash::{SlashCtx, c_agent, c_error, c_result};
+
+pub(crate) async fn cmd_issues(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow::Result<()> {
+    let paths = ProjectPaths::new(Path::new(ctx.session.working_dir.as_str()));
+    let store = match IssueStore::open(&paths) {
+        Ok(s) => s,
+        Err(e) => {
+            ctx.renderer
+                .write_line(&format!("issues unavailable: {e}"), c_error())?;
+            return Ok(());
+        }
+    };
+
+    let sub = parts.get(1).copied().unwrap_or("").trim();
+    match sub {
+        "" | "list" => {
+            let status = parts
+                .get(2)
+                .copied()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+            list(ctx, &store, status)
+        }
+        "search" => {
+            let query = parts.get(2..).map(|r| r.join(" ")).unwrap_or_default();
+            search(ctx, &store, query.trim())
+        }
+        // Anything else is treated as an id (7 / #7 / iss-7).
+        maybe_id => match parse_issue_id(maybe_id) {
+            Some(id) => show(ctx, &store, id),
+            None => {
+                ctx.renderer.write_line(
+                    "usage: /issues [list [status]] | /issues search <query> | /issues <id>",
+                    c_error(),
+                )?;
+                Ok(())
+            }
+        },
+    }
+}
+
+fn list(ctx: &mut SlashCtx<'_>, store: &IssueStore, status: Option<&str>) -> anyhow::Result<()> {
+    let issues = match status {
+        Some(s) => match store.list_by_status(s) {
+            Ok(v) => v,
+            Err(e) => {
+                ctx.renderer.write_line(&e.to_string(), c_error())?;
+                return Ok(());
+            }
+        },
+        None => store.board(None).unwrap_or_default(),
+    };
+    if issues.is_empty() {
+        ctx.renderer.write_line("no matching issues", c_agent())?;
+        return Ok(());
+    }
+    let header = match status {
+        Some(s) => format!("issues ({s}):"),
+        None => format!("issue board ({} live):", issues.len()),
+    };
+    ctx.renderer.write_line(&header, c_agent())?;
+    for i in &issues {
+        ctx.renderer
+            .write_line(&format!("  {}", i.one_line()), c_result())?;
+    }
+    Ok(())
+}
+
+fn search(ctx: &mut SlashCtx<'_>, store: &IssueStore, query: &str) -> anyhow::Result<()> {
+    if query.is_empty() {
+        ctx.renderer
+            .write_line("usage: /issues search <query>", c_error())?;
+        return Ok(());
+    }
+    let hits = store.search(query, 30).unwrap_or_default();
+    if hits.is_empty() {
+        ctx.renderer
+            .write_line(&format!("no issues match '{query}'"), c_agent())?;
+        return Ok(());
+    }
+    ctx.renderer
+        .write_line(&format!("{} match(es):", hits.len()), c_agent())?;
+    for i in &hits {
+        ctx.renderer
+            .write_line(&format!("  {}", i.one_line()), c_result())?;
+    }
+    Ok(())
+}
+
+fn show(ctx: &mut SlashCtx<'_>, store: &IssueStore, id: i64) -> anyhow::Result<()> {
+    match store.get(id) {
+        Ok(Some(i)) => {
+            ctx.renderer.write_line(
+                &format!("#{} [{}] ({})", i.id, i.status, i.priority),
+                c_agent(),
+            )?;
+            ctx.renderer
+                .write_line(&format!("  {}", i.title), c_result())?;
+            if !i.body.trim().is_empty() {
+                ctx.renderer
+                    .write_line(&format!("  {}", i.body.replace('\n', "\n  ")), c_result())?;
+            }
+            let mut meta = format!("  created {} · updated {}", i.created_at, i.updated_at);
+            if let Some(closed) = &i.closed_at {
+                meta.push_str(&format!(" · closed {closed}"));
+            }
+            ctx.renderer.write_line(&meta, c_agent())?;
+        }
+        Ok(None) => {
+            ctx.renderer
+                .write_line(&format!("no issue #{id}"), c_error())?;
+        }
+        Err(e) => {
+            ctx.renderer.write_line(&e.to_string(), c_error())?;
+        }
+    }
+    Ok(())
+}

--- a/src/ui/slash/cmd/mod.rs
+++ b/src/ui/slash/cmd/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod clone;
 pub(crate) mod fork;
 pub(crate) mod graph;
 pub(crate) mod help;
+pub(crate) mod issues;
 pub(crate) mod kill;
 #[cfg(feature = "mcp")]
 pub(crate) mod mcp;

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -610,6 +610,7 @@ pub async fn handle_slash(
         "/why" => cmd::allow::why::cmd_why(&mut ctx, &parts).await?,
         "/help" => cmd::help::cmd_help(&mut ctx).await?,
         "/graph" => cmd::graph::cmd_graph(&mut ctx, &parts).await?,
+        "/issues" => cmd::issues::cmd_issues(&mut ctx, &parts).await?,
         "/memory" => cmd::memory::cmd_memory(&mut ctx, &parts).await?,
         "/kill" => cmd::kill::cmd_kill(&mut ctx, &parts).await?,
         #[cfg(unix)]
@@ -724,6 +725,7 @@ pub fn slash_command_names() -> Vec<&'static str> {
         "/fork",
         "/graph",
         "/help",
+        "/issues",
         "/kill",
         "/memory",
         "/mode",


### PR DESCRIPTION
## Native issue tracker with harness-driven turn-start injection

A persistent, agent-facing kanban built on the **existing per-project session DB** (`.dirge/sessions/state.db`) — no Dolt, no new storage engine. Issues are framed as a stateful extension of the memory model: open issues are the agent's working board, surfaced automatically; closed ones fade.

The core idea (vs. shelling out to `bd`): **the harness injects the board at the start of each user run**, so the model never has to remember to poll for its work.

### What's here

- **`IssueStore`** (`src/extras/issue_db.rs`) — `issues` table with idempotent `CREATE TABLE IF NOT EXISTS` (self-owned schema; deliberately sidesteps the feature-gated `migrate()` version chain). create / status / priority / list / board / search / `board_reminder`. Opens a plain connection with a busy timeout — no migration lock on the hot path.
- **`issue` tool** — model-facing surface with intuitive verbs: `create / start / block / close / update / show / list / search`. Priorities `high|normal|low`; ids accept `7` or `#7`.
- **Turn-start injection** (`run_agent_loop`) — the top-7 live issues as a `<system-reminder>` board, with a "+N more" overflow hint so a large backlog can't flood context. Gated on `memory_provider` so forked review/curator runners are excluded (subagents don't reach this path).
- **`/issues`** slash command — `list` / `<id>` / `search` for the human view, over the same store.

### Validated live (headless, deepseek-flash)

1. Model created two issues + listed them via the tool.
2. **Fresh session, tools forbidden** → model correctly reported the board (`#1 high`, `#2 normal`) — proving the harness injected it, no polling.
3. start #1 / close #2.
4. **Fresh session, tools forbidden** → injected board correctly showed only `#1 [in_progress]`, done item dropped.
5. DB verified: both rows persisted with `session_id` provenance.

### Code-review fixes applied in this PR

- **Dropped the per-open `BEGIN EXCLUSIVE` migration lock.** `open_at` now opens a plain connection (the table is self-owned), so the harness no longer takes an exclusive lock on the shared `state.db` on every turn + every tool call. Added a 5s busy timeout and parent-dir creation.
- **Made `update` atomic-ish.** It now pre-validates status *and* priority before any write, so an invalid priority can't leave a half-applied status change (the two setters are separate writes).

### Known limitations / follow-ups (not blocking)

- **Path resolution**: the tool + injection resolve the DB via `current_dir()`; `/issues` uses `session.working_dir` (consistent with other slash commands). These agree in normal operation but could diverge under session-restore-with-different-working-dir or some worktree layouts. Worth unifying to one threaded path.
- **Per-turn reopen**: the injection still opens the (now cheap, lock-free) store each turn; holding an `Arc<IssueStore>` like `SpecTool` does would avoid even that.
- **LIKE search** doesn't escape `%`/`_` metacharacters; **sub-second timestamp ties** order lexically (matches the existing `spec_db` pattern).
- Deferred from the larger design: dependency/ready graph, wisps (ephemeral squash), memory-formation on close, multi-machine sync.

Tests: 18 (store + tool flow + board bounding + atomic-update). fmt clean, no new clippy warnings.
