### PR TITLE
fix(provider/config): /model provider switch, --provider model, keyless hint, XDG_CONFIG_HOME

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,6 +313,19 @@ impl Cli {
         if let Some(m) = self.model.as_deref() {
             return CompactString::new(m);
         }
+        // When `--provider` overrides the config default, take the model from
+        // THAT provider's entry — otherwise `--provider ollama` switches the
+        // endpoint but still loads the config default provider's model (the
+        // `Default` role below tracks `cfg.provider`, not the CLI override).
+        if let Some(provider) = self.provider.as_deref().filter(|p| !p.is_empty())
+            && let Some(providers) = cfg.providers.as_ref()
+            && let Some(entry) = providers
+                .get(provider)
+                .or_else(|| providers.get(&provider.to_ascii_lowercase()))
+            && let Some(m) = entry.model.as_deref()
+        {
+            return CompactString::new(m);
+        }
         if let Some((_, entry)) = cfg.resolve_role(config::ConfigRole::Default)
             && let Some(m) = entry.model
         {
@@ -441,6 +454,64 @@ mod tests {
         assert!(openai_help.contains("browser OAuth"));
         assert!(openai_help.contains("device-code auth"));
         assert!(openai_help.contains("ChatGPT Codex security settings"));
+    }
+
+    fn cfg_with_glm_default_and_ollama() -> config::Config {
+        use std::collections::HashMap;
+        let providers = HashMap::from([
+            (
+                "glm".to_string(),
+                config::ProviderEntry {
+                    provider_type: Some("glm".to_string()),
+                    model: Some("glm-5.2".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "ollama".to_string(),
+                config::ProviderEntry {
+                    provider_type: Some("openai".to_string()),
+                    base_url: Some("http://127.0.0.1:11434/v1".to_string()),
+                    model: Some("vibe-thinker:latest".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        config::Config {
+            provider: Some("glm".to_string()),
+            providers: Some(providers),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_model_honors_provider_override() {
+        // `--provider ollama` (no --model) must take ollama's pinned model, not
+        // the config default provider's (glm) — otherwise the endpoint switches
+        // but the model stays glm-5.2.
+        let cli = Cli::parse_from(["dirge", "--provider", "ollama"]);
+        assert_eq!(
+            cli.resolve_model(&cfg_with_glm_default_and_ollama()),
+            "vibe-thinker:latest"
+        );
+    }
+
+    #[test]
+    fn resolve_model_without_override_uses_config_default() {
+        let cli = Cli::parse_from(["dirge"]);
+        assert_eq!(
+            cli.resolve_model(&cfg_with_glm_default_and_ollama()),
+            "glm-5.2"
+        );
+    }
+
+    #[test]
+    fn resolve_model_explicit_model_flag_wins_over_provider() {
+        let cli = Cli::parse_from(["dirge", "--provider", "ollama", "--model", "llama3.1"]);
+        assert_eq!(
+            cli.resolve_model(&cfg_with_glm_default_and_ollama()),
+            "llama3.1"
+        );
     }
 
     #[test]

--- a/src/provider/resolve.rs
+++ b/src/provider/resolve.rs
@@ -503,14 +503,23 @@ where
         return Ok(String::new());
     }
 
+    // OpenAI-compatible endpoints that need no key (a local ollama / vLLM /
+    // LM Studio server) should use `provider_type: "custom"` (or "ollama"),
+    // which are keyless — point the user there rather than just demanding a key.
+    let keyless_hint = if kind == ProviderKind::OpenAI {
+        " For a keyless OpenAI-compatible endpoint (e.g. a local ollama/vLLM server), set `provider_type` to \"custom\" (or \"ollama\") instead of \"openai\"."
+    } else {
+        ""
+    };
+
     let fallbacks = provider_env_var_fallbacks(kind);
     if fallbacks.is_empty() {
         anyhow::bail!(
-            "No API key found for {kind:?}. Set the {env_var} environment variable or pass --api-key."
+            "No API key found for {kind:?}. Set the {env_var} environment variable or pass --api-key.{keyless_hint}"
         )
     } else {
         anyhow::bail!(
-            "No API key found for {kind:?}. Set {env_var} (or one of: {}) or pass --api-key.",
+            "No API key found for {kind:?}. Set {env_var} (or one of: {}) or pass --api-key.{keyless_hint}",
             fallbacks.join(", ")
         )
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -44,10 +44,33 @@ pub(crate) fn global_memory_db_path() -> PathBuf {
 }
 
 pub(crate) fn config_path() -> PathBuf {
-    if let Some(dir) = std::env::var_os("DIRGE_CONFIG_DIR") {
+    config_path_from(
+        std::env::var_os("DIRGE_CONFIG_DIR"),
+        std::env::var_os("XDG_CONFIG_HOME"),
+        dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+    )
+}
+
+/// Resolve the dirge config directory, precedence:
+///   1. `DIRGE_CONFIG_DIR` — explicit dirge override.
+///   2. `$XDG_CONFIG_HOME/dirge` — the XDG base-dir spec (only when set to an
+///      absolute path, as the spec requires; relative values are ignored).
+///   3. `~/.config/dirge` — the XDG default.
+/// Pure (env values passed in) so it's testable without touching process env.
+fn config_path_from(
+    dirge_config_dir: Option<std::ffi::OsString>,
+    xdg_config_home: Option<std::ffi::OsString>,
+    home: PathBuf,
+) -> PathBuf {
+    if let Some(dir) = dirge_config_dir.filter(|d| !d.is_empty()) {
         return PathBuf::from(dir);
     }
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    if let Some(xdg) = xdg_config_home.filter(|d| !d.is_empty()) {
+        let xdg = PathBuf::from(xdg);
+        if xdg.is_absolute() {
+            return xdg.join("dirge");
+        }
+    }
     home.join(".config").join("dirge")
 }
 
@@ -256,6 +279,55 @@ pub fn delete_session(id: &str) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn config_path_prefers_dirge_config_dir() {
+        let p = config_path_from(
+            Some(OsString::from("/explicit/dirge")),
+            Some(OsString::from("/xdg")),
+            PathBuf::from("/home/u"),
+        );
+        assert_eq!(p, PathBuf::from("/explicit/dirge"));
+    }
+
+    #[test]
+    fn config_path_honors_xdg_config_home() {
+        let p = config_path_from(
+            None,
+            Some(OsString::from("/xdg/cfg")),
+            PathBuf::from("/home/u"),
+        );
+        assert_eq!(p, PathBuf::from("/xdg/cfg/dirge"));
+    }
+
+    #[test]
+    fn config_path_ignores_relative_xdg_and_falls_back_to_home() {
+        // The XDG spec says XDG_CONFIG_HOME must be absolute; a relative value
+        // is treated as unset.
+        let p = config_path_from(
+            None,
+            Some(OsString::from("relative/cfg")),
+            PathBuf::from("/home/u"),
+        );
+        assert_eq!(p, PathBuf::from("/home/u/.config/dirge"));
+    }
+
+    #[test]
+    fn config_path_defaults_to_home_config_dirge() {
+        let p = config_path_from(None, None, PathBuf::from("/home/u"));
+        assert_eq!(p, PathBuf::from("/home/u/.config/dirge"));
+    }
+
+    #[test]
+    fn config_path_treats_empty_overrides_as_unset() {
+        let p = config_path_from(
+            Some(OsString::from("")),
+            Some(OsString::from("")),
+            PathBuf::from("/home/u"),
+        );
+        assert_eq!(p, PathBuf::from("/home/u/.config/dirge"));
+    }
 
     /// dirge-sn1k: under test, the data dir must route to a per-process
     /// temp location (never the user's real ~/.../dirge), so persistence

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -56,6 +56,7 @@ pub(crate) fn config_path() -> PathBuf {
 ///   2. `$XDG_CONFIG_HOME/dirge` — the XDG base-dir spec (only when set to an
 ///      absolute path, as the spec requires; relative values are ignored).
 ///   3. `~/.config/dirge` — the XDG default.
+///
 /// Pure (env values passed in) so it's testable without touching process env.
 fn config_path_from(
     dirge_config_dir: Option<std::ffi::OsString>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -153,7 +153,7 @@ fn real_user_prompt(msg: &SessionMessage) -> Option<&str> {
 // context struct is tracked separately; silence the lint.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub async fn run_interactive(
-    client: AnyClient,
+    mut client: AnyClient,
     mut agent: AnyAgent,
     cli: &Cli,
     cfg: &Config,
@@ -2332,7 +2332,7 @@ pub async fn run_interactive(
                                 // /help) have no UserMessage event, so we keep the echo.
                                 write_user_lines(&mut renderer, &text)?;
                                 renderer.write_line("", Color::White)?;
-                                let result = handle_slash(&expanded, &mut agent, &client, &mut renderer, session, cli, cfg, context, &mut ui.show_reasoning, &mut ui.is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut ui.todo_tools_enabled, &bg_store, &sandbox, #[cfg(unix)] &user_tx, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut ui.plan_phase).await;
+                                let result = handle_slash(&expanded, &mut agent, &mut client, &mut renderer, session, cli, cfg, context, &mut ui.show_reasoning, &mut ui.is_running, &mut input, &permission, &ask_tx, &question_tx, &plan_tx, &mut ui.todo_tools_enabled, &bg_store, &sandbox, #[cfg(unix)] &user_tx, #[cfg(feature = "loop")] &mut loop_state, #[cfg(feature = "mcp")] mcp_manager.as_ref(), #[cfg(feature = "semantic")] semantic_manager, #[cfg(feature = "lsp")] lsp_manager.as_ref(), &mut ui.plan_phase).await;
                                 match result {
                                 Err(e) if e.to_string().starts_with("DEFER_COMPRESS:") => {
                                     let err_msg = e.to_string();

--- a/src/ui/slash/cmd/model.rs
+++ b/src/ui/slash/cmd/model.rs
@@ -31,6 +31,24 @@ fn configured_models(
     rows
 }
 
+/// If `model` is the model pinned by a configured provider *other than*
+/// `active`, return that provider's alias — signalling that `/model <model>`
+/// should switch the live client to it, not just rename the model on the
+/// active provider. Returns `None` for a free-form id or a model on the active
+/// provider (keep the current client).
+fn cross_provider_target(
+    providers: &HashMap<String, ProviderEntry>,
+    active: &str,
+    model: &str,
+) -> Option<String> {
+    providers
+        .iter()
+        .find(|(alias, entry)| {
+            entry.model.as_deref() == Some(model) && !alias.eq_ignore_ascii_case(active)
+        })
+        .map(|(alias, _)| alias.clone())
+}
+
 pub(crate) async fn cmd_model(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow::Result<()> {
     if parts.len() < 2 {
         ctx.renderer
@@ -57,6 +75,37 @@ pub(crate) async fn cmd_model(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow:
         }
     } else {
         let new_model = CompactString::new(parts[1].trim());
+
+        // If the chosen model is one a *different* configured provider pins,
+        // switch the live client to that provider too — otherwise we'd send its
+        // model name to the active provider's endpoint (e.g. an ollama model to
+        // GLM, which 400s). Free-form ids and same-provider models keep the
+        // current client. The `/model` list shows `model · alias` rows, so this
+        // makes selecting a listed cross-provider model actually route there.
+        let providers = ctx.cfg.providers_map();
+        let target_alias = cross_provider_target(
+            &providers,
+            ctx.session.provider.as_str(),
+            new_model.as_str(),
+        );
+
+        let mut switched_to: Option<String> = None;
+        if let Some(alias) = target_alias {
+            match crate::provider::create_client_with_auth(&alias, None, &providers, ctx.cfg.auth) {
+                Ok(new_client) => {
+                    *ctx.client = new_client;
+                    switched_to = Some(alias);
+                }
+                Err(e) => {
+                    ctx.renderer.write_line(
+                        &format!("could not switch to provider '{alias}': {e}"),
+                        c_error(),
+                    )?;
+                    return Ok(());
+                }
+            }
+        }
+
         let model = ctx.client.completion_model(new_model.to_string());
         *ctx.agent = crate::provider::build_agent(
             model,
@@ -79,14 +128,25 @@ pub(crate) async fn cmd_model(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow:
         )
         .await;
         ctx.session.model = new_model.clone();
-        ctx.session.provider = ctx.cli.resolve_provider(ctx.cfg);
+        // On a cross-provider switch the active provider IS the target alias;
+        // otherwise it stays whatever the CLI/config resolves to.
+        ctx.session.provider = match &switched_to {
+            Some(alias) => CompactString::new(alias),
+            None => ctx.cli.resolve_provider(ctx.cfg),
+        };
         let new_ctx = ctx.cfg.resolve_context_window(new_model.as_str());
         let old_ctx = ctx.session.context_window;
         if new_ctx != old_ctx {
             ctx.session.context_window = new_ctx;
         }
-        ctx.renderer
-            .write_line(&format!("switched to model: {}", new_model), c_agent())?;
+        let provider_note = switched_to
+            .as_deref()
+            .map(|a| format!("  ·  {a}"))
+            .unwrap_or_default();
+        ctx.renderer.write_line(
+            &format!("switched to model: {new_model}{provider_note}"),
+            c_agent(),
+        )?;
         let reserve = ctx.cfg.resolve_reserve_tokens();
         let budget = new_ctx.saturating_sub(reserve);
         if new_ctx < old_ctx && ctx.session.total_estimated_tokens > budget {
@@ -124,6 +184,34 @@ mod tests {
             model: model.map(str::to_string),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn cross_provider_target_finds_other_providers_model() {
+        let providers = HashMap::from([
+            ("glm".to_string(), entry(Some("glm-5.2"))),
+            ("ollama".to_string(), entry(Some("vibe-thinker:latest"))),
+        ]);
+        // Active = glm; picking ollama's model routes to the ollama provider.
+        assert_eq!(
+            cross_provider_target(&providers, "glm", "vibe-thinker:latest").as_deref(),
+            Some("ollama")
+        );
+    }
+
+    #[test]
+    fn cross_provider_target_none_for_active_providers_model() {
+        let providers = HashMap::from([
+            ("glm".to_string(), entry(Some("glm-5.2"))),
+            ("ollama".to_string(), entry(Some("vibe-thinker:latest"))),
+        ]);
+        // The model belongs to the active provider → no client swap.
+        assert_eq!(cross_provider_target(&providers, "glm", "glm-5.2"), None);
+        // A free-form id no provider pins → no swap (rename on current client).
+        assert_eq!(
+            cross_provider_target(&providers, "glm", "some-other-model"),
+            None
+        );
     }
 
     #[test]

--- a/src/ui/slash/mod.rs
+++ b/src/ui/slash/mod.rs
@@ -52,7 +52,9 @@ pub(super) fn c_error() -> Color {
 /// Keeps individual handler signatures tractable.
 pub(super) struct SlashCtx<'a> {
     pub agent: &'a mut AnyAgent,
-    pub client: &'a AnyClient,
+    // `&mut` so `/model` can swap the live client when switching to a model
+    // that belongs to a different configured provider.
+    pub client: &'a mut AnyClient,
     pub renderer: &'a mut Renderer,
     pub session: &'a mut Session,
     pub cli: &'a Cli,
@@ -495,7 +497,7 @@ fn split_command_parts(text: &str) -> SmallVec<[&str; 3]> {
 pub async fn handle_slash(
     text: &str,
     agent: &mut AnyAgent,
-    client: &AnyClient,
+    client: &mut AnyClient,
     renderer: &mut Renderer,
     session: &mut Session,
     cli: &Cli,


### PR DESCRIPTION
Four provider/model/config-routing fixes surfaced while wiring up a local ollama provider.

### 1. `/model <id>` now switches providers
The `/model` list shows one row per configured provider's pinned model (`vibe-thinker:latest · ollama`), but selecting a model belonging to a *different* provider only renamed the model on the **active** client — so picking an ollama model while on GLM sent `vibe-thinker:latest` to GLM's endpoint and 400'd. Now it rebuilds the live client for that provider (`SlashCtx.client` is `&mut`) and repoints the session. Free-form ids / same-provider models keep the current client. Decision logic in `cross_provider_target`, unit-tested.

### 2. `--provider` now picks that provider's model
`resolve_model` read the config default role (tracks `cfg.provider`) when no `--model` was given, so `--provider ollama` switched the endpoint but loaded the glm model. It now takes the overridden provider's pinned model. Unit-tested.

### 3. Actionable "no API key" error for keyless endpoints
`provider_type: "openai"` is keyed by design; `"custom"`/`"ollama"` are keyless. The bare "No API key found for OpenAI" now adds: *"…set `provider_type` to "custom" (or "ollama")…"*. The keyed-vs-keyless invariant is unchanged.

### 4. Honor `XDG_CONFIG_HOME` for the config dir
`config_path` resolved `DIRGE_CONFIG_DIR` → `~/.config/dirge`, skipping XDG. Now: `DIRGE_CONFIG_DIR` → `$XDG_CONFIG_HOME/dirge` → `~/.config/dirge` (relative XDG values ignored per spec). Pure `config_path_from` helper, unit-tested.

Tests: provider/slash/cli/storage suites all pass. fmt clean, no new clippy warnings.
