### PR TITLE
fix(permission): auto-allow the issue tool by default

### DIFF
--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -978,6 +978,28 @@ fn memory_tool_standard_mode_auto_approved() {
     }
 }
 
+/// The issue tracker is auto-approved (Meta op) for every action — the
+/// model records its own work in a local, user-viewable (`/issues`),
+/// reversible DB, so prompting per create/start/close is friction without
+/// security value. Mirrors `write_todo_list`.
+#[test]
+fn issue_tool_standard_mode_auto_approved() {
+    let mut checker = PermissionChecker::new(
+        &PermissionConfig::default(),
+        SecurityMode::Standard,
+        Some(std::path::PathBuf::from("/tmp")),
+    );
+    for action in [
+        "create", "start", "block", "close", "update", "list", "show",
+    ] {
+        let result = checker.check("issue", action);
+        assert!(
+            matches!(result, CheckResult::Allowed),
+            "issue.{action} must auto-allow in Standard; got {result:?}",
+        );
+    }
+}
+
 /// dirge-sm9w: Restrictive mode (`-R`) still prompts for memory.
 /// Restrictive's contract is "every WRITE action confirms" —
 /// the builtin Allow rule installed for Standard/Accept must

--- a/src/permission/engine/build.rs
+++ b/src/permission/engine/build.rs
@@ -63,8 +63,11 @@ pub fn tool_operation(tool: &str) -> Operation {
         "skill" => Operation::Skill,
         // Recursive sub-agent execution: high-risk, not auto-allowed.
         "task" => Operation::Agent,
-        // Internal no-effect tools: builtin-allowed.
-        "task_status" | "question" | "write_todo_list" => Operation::Meta,
+        // Internal bookkeeping tools, builtin-allowed: read-only meta
+        // (`task_status`, `question`) plus the agent's own task surfaces
+        // (`write_todo_list`, `issue`) — local, user-viewable (`/issues`),
+        // reversible, so the model shouldn't be prompted to track its work.
+        "task_status" | "question" | "write_todo_list" | "issue" => Operation::Meta,
         // Unknown (plugin/MCP) tools: not auto-allowed; fall to
         // configured rules or the default (Accept-coercible).
         _ => Operation::Other,
@@ -272,6 +275,10 @@ mod tests {
         assert_eq!(tool_operation("memory"), Operation::Memory);
         assert_eq!(tool_operation("skill"), Operation::Skill);
         assert_eq!(tool_operation("question"), Operation::Meta);
+        assert_eq!(tool_operation("write_todo_list"), Operation::Meta);
+        // The issue tracker is auto-allowed like the todo list — the model
+        // shouldn't have to ask to record its own work.
+        assert_eq!(tool_operation("issue"), Operation::Meta);
     }
 
     #[test]


### PR DESCRIPTION
The native issue tracker (0.13.6) gated its write actions (create/start/block/close/update) through the permission engine, so in Standard mode the model was prompted every time it tracked work.

Classify the `issue` tool as `Operation::Meta` (builtin-allowed), alongside `write_todo_list`: the agent records its own work in a local, user-viewable (`/issues`), reversible DB, so per-action prompts were friction without security value. It stays overridable via explicit deny rules. Adds the mapping assertion and a Standard-mode auto-allow test (mirrors the memory-tool test).