### PR TITLE
feat(issues): back write_todo_list with the issue board

### DIFF
--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -481,19 +481,25 @@ pub async fn build_loop_tools(
         .await,
     );
 
-    // Mutates internal todo state — Sequential.
-    tools.push(
-        wrap(
-            tools::WriteTodoList::new(permission.clone(), ask_tx.clone()),
-            Some(ToolExecutionMode::Sequential),
-        )
-        .await,
-    );
-
     // Session search — read-only DB queries.
     let session_db_path = std::env::current_dir()
         .map(|c| crate::extras::dirge_paths::ProjectPaths::new(&c).session_db_path())
         .unwrap_or_else(|_| std::path::PathBuf::from(".dirge/sessions/state.db"));
+
+    // Bulk planning surface over the persistent issue board — writes to the
+    // project DB, so Sequential. Shares the `issues` table with `IssueTool`.
+    tools.push(
+        wrap(
+            tools::WriteTodoList::new(
+                session_db_path.clone(),
+                session_id.clone(),
+                permission.clone(),
+                ask_tx.clone(),
+            ),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
     tools.push(
         wrap(
             build_session_search_tool(

--- a/src/agent/plan/mod.rs
+++ b/src/agent/plan/mod.rs
@@ -26,7 +26,7 @@
 //! |---------|-------|-----------|---------|----------|-------|
 //! | **Phased `/plan` workflow** | `agent::plan` (this module) | explore→plan→implement→review for one complex request | user runs `/plan <req>` (needs `phased_workflow_enabled`) | one request | [`runtime::ActivePlan`] / [`runtime::PlanKickoff`] (ephemeral) |
 //! | **Plan *mode*** | [`crate::agent::tools::plan`] (`plan_enter`/`plan_exit`) | a read-only session lock: the model proposes before touching anything | model calls `plan_enter`, or a prompt's `deny_tools` | until `plan_exit` | `PlanSwitchRequest` channel → session mode |
-//! | **Todo list** | `crate::agent::tools::todo` (`write_todo_list`) | an in-session checklist the model maintains and is nudged to finish | model calls `write_todo_list` | the session | a process-global `TODO_LIST` |
+//! | **Todo list** | `crate::agent::tools::todo` (`write_todo_list`) | bulk planning over the persistent issue board — a todo IS an issue; the model is nudged to finish open ones | model calls `write_todo_list` (or the `issue` tool) | durable (in the `issues` table; session-scoped for panel/nudge) | the `issues` table; `TODO_LIST` is a render mirror |
 //! | **Task / subagent** | `crate::agent::tools::task` (`task` + `task_status`) | spawn a background subagent for independent work | model calls `task` | per background job | `BackgroundStore` + abort registry |
 //!
 //! **Plan-mode × phased `/plan`:** orthogonal and composable. Plan-mode is a

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -103,7 +103,7 @@ Available tools:
 - skill: Load a skill by name to get detailed instructions for a specific task or domain.";
 
 pub const TODO_TOOLS_PROMPT: &str = "\
-- write_todo_list: Create or update a structured task list to track progress in the current coding session. Use this for complex multi-step tasks. Replaces any existing todo list.";
+- write_todo_list: Lay out or update a multi-step plan; each item is a tracked issue on your persistent board (same board as the `issue` tool), matched by title. Use it for complex multi-step tasks. Items you omit aren't auto-closed — restate an item as completed/cancelled to close it.";
 
 /// Heading + lead-in injected into the agent preamble when the project
 /// has discoverable skills. The bullet list of skills is appended after

--- a/src/agent/tools/issue.rs
+++ b/src/agent/tools/issue.rs
@@ -1,9 +1,10 @@
 //! `issue` — the model's persistent issue/kanban board, stored in the
 //! per-project session DB via [`crate::extras::issue_db::IssueStore`].
 //!
-//! Unlike `write_todo_list` (ephemeral, single-session checklist), issues
-//! persist across sessions and are surfaced by the harness at turn start, so
-//! the model doesn't have to remember to list them. This tool is the WRITE +
+//! The incremental, single-item surface over the board; `write_todo_list`
+//! writes to the SAME store in bulk for laying out a plan. Issues persist
+//! across sessions and are surfaced by the harness at turn start, so the model
+//! doesn't have to remember to list them. This tool is the WRITE +
 //! on-demand-read surface; routine reads are injected automatically.
 
 use std::path::PathBuf;
@@ -127,10 +128,11 @@ impl Tool for IssueTool {
         }
         let store = self.store()?;
 
-        // After a write, re-sync the right-pane / nudge mirror from the board so
-        // the panel reflects issue-tool edits, not just `write_todo_list` ones.
-        let refresh = |this: &Self| {
-            crate::agent::tools::todo::refresh_board(&this.db_path, this.session_id.as_deref());
+        // After a write, re-sync the right-pane / nudge mirror from the store we
+        // already hold open (no second DB open), so the panel reflects
+        // issue-tool edits, not just `write_todo_list` ones.
+        let refresh = || {
+            crate::agent::tools::todo::refresh_board_from(&store, self.session_id.as_deref());
         };
 
         let need_id = |args: &IssueArgs| -> Result<i64, ToolError> {
@@ -155,7 +157,7 @@ impl Tool for IssueTool {
                         self.session_id.as_deref(),
                     )
                     .map_err(ToolError::Msg)?;
-                refresh(self);
+                refresh();
                 Ok(format!("Created issue #{id}: {}", title.trim()))
             }
             "start" | "block" | "close" => {
@@ -166,7 +168,7 @@ impl Tool for IssueTool {
                     _ => "done",
                 };
                 if store.set_status(id, status).map_err(ToolError::Msg)? {
-                    refresh(self);
+                    refresh();
                     Ok(format!("Issue #{id} → {status}"))
                 } else {
                     Err(ToolError::Msg(format!("no issue #{id}")))
@@ -212,7 +214,7 @@ impl Tool for IssueTool {
                     store.set_priority(id, priority).map_err(ToolError::Msg)?;
                     changed.push("priority");
                 }
-                refresh(self);
+                refresh();
                 Ok(format!("Updated issue #{id} ({})", changed.join(", ")))
             }
             "show" => {

--- a/src/agent/tools/issue.rs
+++ b/src/agent/tools/issue.rs
@@ -94,10 +94,10 @@ impl Tool for IssueTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "issue".to_string(),
-            description: "Persistent issue/kanban board for tracking work ACROSS sessions (stored in the project DB). The harness shows your open board at the start of each turn, so you don't need to list it constantly. Use this for durable tasks/features/bugs; use `write_todo_list` for throwaway within-turn steps. Actions: \
+            description: "Persistent issue/kanban board for tracking work (stored in the project DB, persists ACROSS sessions). The harness shows your open board at the start of each turn, so you don't need to list it constantly. This is the incremental, single-item surface; `write_todo_list` writes to the SAME board in bulk for laying out a multi-step plan. Actions: \
                 create (title, optional body/priority high|normal|low); \
                 start (id → in_progress); block (id → blocked); close (id → done); \
-                update (id, optional status/priority/body); \
+                update (id, optional status open|in_progress|blocked|done|cancelled / priority / body); \
                 show (id); list (optional status filter); search (query). \
                 Ids accept 7 or \"#7\". Create issues as you discover work; start one when you begin it; close it when done.".to_string(),
             parameters: serde_json::json!({
@@ -107,7 +107,7 @@ impl Tool for IssueTool {
                     "title": { "type": "string", "description": "Title (create)" },
                     "body": { "type": "string", "description": "Optional details (create/update)" },
                     "id": { "type": ["integer", "string"], "description": "Issue id for show/update/start/block/close (e.g. 7 or \"#7\")" },
-                    "status": { "type": "string", "description": "open | in_progress | blocked | done (update)" },
+                    "status": { "type": "string", "description": "open | in_progress | blocked | done | cancelled (update)" },
                     "priority": { "type": "string", "description": "high | normal | low (create/update)" },
                     "query": { "type": "string", "description": "Status filter for list, or search term for search" }
                 },
@@ -126,6 +126,12 @@ impl Tool for IssueTool {
             check_perm(&self.permission, &self.ask_tx, "issue", &action).await?;
         }
         let store = self.store()?;
+
+        // After a write, re-sync the right-pane / nudge mirror from the board so
+        // the panel reflects issue-tool edits, not just `write_todo_list` ones.
+        let refresh = |this: &Self| {
+            crate::agent::tools::todo::refresh_board(&this.db_path, this.session_id.as_deref());
+        };
 
         let need_id = |args: &IssueArgs| -> Result<i64, ToolError> {
             coerce_id(&args.id).ok_or_else(|| {
@@ -149,6 +155,7 @@ impl Tool for IssueTool {
                         self.session_id.as_deref(),
                     )
                     .map_err(ToolError::Msg)?;
+                refresh(self);
                 Ok(format!("Created issue #{id}: {}", title.trim()))
             }
             "start" | "block" | "close" => {
@@ -159,6 +166,7 @@ impl Tool for IssueTool {
                     _ => "done",
                 };
                 if store.set_status(id, status).map_err(ToolError::Msg)? {
+                    refresh(self);
                     Ok(format!("Issue #{id} → {status}"))
                 } else {
                     Err(ToolError::Msg(format!("no issue #{id}")))
@@ -180,7 +188,7 @@ impl Tool for IssueTool {
                 if let Some(status) = args.status.as_deref() {
                     normalize_status(status).ok_or_else(|| {
                         ToolError::Msg(format!(
-                            "unknown status '{status}' (use open|in_progress|blocked|done)"
+                            "unknown status '{status}' (use open|in_progress|blocked|done|cancelled)"
                         ))
                     })?;
                 }
@@ -204,6 +212,7 @@ impl Tool for IssueTool {
                     store.set_priority(id, priority).map_err(ToolError::Msg)?;
                     changed.push("priority");
                 }
+                refresh(self);
                 Ok(format!("Updated issue #{id} ({})", changed.join(", ")))
             }
             "show" => {

--- a/src/agent/tools/todo.rs
+++ b/src/agent/tools/todo.rs
@@ -27,7 +27,9 @@ use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
-use crate::extras::issue_db::{IssueStore, normalize_status};
+use crate::extras::issue_db::{
+    IssueStore, is_terminal_status, normalize_priority, normalize_status,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TodoItem {
@@ -52,9 +54,16 @@ pub static TODO_LIST: std::sync::Mutex<Vec<TodoItem>> = std::sync::Mutex::new(Ve
 /// as-is (transient lock) rather than blanking the panel. `session_id = None`
 /// matches issues with a NULL session.
 pub fn refresh_board(db_path: &Path, session_id: Option<&str>) {
-    let Ok(store) = IssueStore::open_at(db_path) else {
-        return;
-    };
+    if let Ok(store) = IssueStore::open_at(db_path) {
+        refresh_board_from(&store, session_id);
+    }
+}
+
+/// Refresh the mirror from an already-open store. Callers that just wrote to
+/// the board (the `write_todo_list` and `issue` tools) use this to avoid
+/// re-opening the DB — a second `open_at` would re-run `CREATE TABLE IF NOT
+/// EXISTS` and the WAL pragma and add lock contention on the shared file.
+pub fn refresh_board_from(store: &IssueStore, session_id: Option<&str>) {
     if let Ok(board) = store.board_for_session(session_id, None) {
         let items: Vec<TodoItem> = board
             .into_iter()
@@ -80,13 +89,14 @@ pub fn snapshot() -> Vec<TodoItem> {
 /// gone). Used by the agent loop to nudge the model not to stop with unfinished
 /// planned work.
 pub fn unfinished_count() -> usize {
+    // The mirror only ever holds normalized DB statuses (open / in_progress /
+    // blocked), so this need only match the two that count as unfinished.
+    // Blocked is deliberately parked and doesn't nudge.
     TODO_LIST
         .lock()
         .map(|list| {
             list.iter()
-                .filter(|t| {
-                    matches!(t.status.as_str(), "open" | "pending" | "in_progress")
-                })
+                .filter(|t| matches!(t.status.as_str(), "open" | "in_progress"))
                 .count()
         })
         .unwrap_or(0)
@@ -164,6 +174,38 @@ impl Tool for WriteTodoList {
             )));
         }
 
+        // No active session (e.g. `--no-session`): the user opted out of
+        // persistence, so keep the plan ephemeral in the mirror only rather
+        // than writing durable rows that would leak into the project-wide
+        // turn-start board reminder of every future session. Mirrors the old
+        // in-memory `write_todo_list` for this mode: replace the whole list,
+        // normalized and minus terminal items (which leave the board).
+        let Some(session_id) = self.session_id.as_deref() else {
+            let items: Vec<TodoItem> = args
+                .todos
+                .iter()
+                .filter_map(|t| {
+                    let content = t.content.trim();
+                    let status = normalize_status(&t.status).unwrap_or("open");
+                    if content.is_empty() || is_terminal_status(status) {
+                        return None;
+                    }
+                    Some(TodoItem {
+                        content: content.to_string(),
+                        status: status.to_string(),
+                        priority: normalize_priority(&t.priority)
+                            .unwrap_or("normal")
+                            .to_string(),
+                    })
+                })
+                .collect();
+            let live = items.len();
+            *TODO_LIST.lock_ignore_poison() = items;
+            return Ok(format!(
+                "Tracked {live} live item(s) (not persisted — no active session)."
+            ));
+        };
+
         let triples: Vec<(&str, &str, &str)> = args
             .todos
             .iter()
@@ -172,34 +214,14 @@ impl Tool for WriteTodoList {
 
         let store = IssueStore::open_at(&self.db_path).map_err(ToolError::Msg)?;
         let applied = store
-            .sync_todos(self.session_id.as_deref(), &triples)
+            .sync_todos(Some(session_id), &triples)
             .map_err(ToolError::Msg)?;
 
-        // Refresh the panel/nudge mirror from the freshly-written board.
-        refresh_board(&self.db_path, self.session_id.as_deref());
-
-        // Summarize against what the model asked for (normalized), since closed
-        // items have already dropped off the live board and wouldn't show in a
-        // board-derived count.
-        let mut open = 0;
-        let mut in_progress = 0;
-        let mut blocked = 0;
-        let mut done = 0;
-        let mut cancelled = 0;
-        for t in &args.todos {
-            match normalize_status(&t.status).unwrap_or("open") {
-                "in_progress" => in_progress += 1,
-                "blocked" => blocked += 1,
-                "done" => done += 1,
-                "cancelled" => cancelled += 1,
-                _ => open += 1,
-            }
-        }
+        // Refresh the panel/nudge mirror from the store we already hold open.
+        refresh_board_from(&store, Some(session_id));
         let live = TODO_LIST.lock_ignore_poison().len();
         Ok(format!(
-            "Synced {applied} item(s) to the board: {open} open, {in_progress} in progress, \
-             {blocked} blocked, {done} done, {cancelled} cancelled. \
-             {live} live item(s) now on this session's board."
+            "Synced {applied} item(s) to the board; {live} live item(s) now on this session's board."
         ))
     }
 }

--- a/src/agent/tools/todo.rs
+++ b/src/agent/tools/todo.rs
@@ -1,10 +1,24 @@
-//! `write_todo_list` — the model's in-session checklist of discrete work
-//! items, kept in a process-global `TODO_LIST`; the loop nudges the model to
-//! finish or clear pending items before stopping.
+//! `write_todo_list` — the model's bulk planning surface over the persistent
+//! issue board.
 //!
-//! One of four similarly-named work-tracking surfaces — NOT the phased
-//! `/plan` workflow, plan-**mode**, or background `task`s. See the canonical
-//! map in [`crate::agent::plan`].
+//! Historically this was a throwaway in-memory checklist separate from the
+//! `issue` tool. The two have been consolidated: a todo IS an issue. Each
+//! `write_todo_list` call upserts its items into the project's `issues` table
+//! (see [`crate::extras::issue_db`]), scoped to the current session, so bulk
+//! planning gains the full issue lifecycle (open / in_progress / blocked /
+//! done / cancelled) and the model can rely on which items are still open.
+//!
+//! [`TODO_LIST`] is no longer the source of truth — it's a fast in-memory
+//! mirror of this session's live board that the right-pane panel and the
+//! end-of-turn nudge read without touching SQLite on every frame. Both tools
+//! ([`WriteTodoList`] and [`super::issue::IssueTool`]) refresh it after a write,
+//! and `session::rehydrate` refreshes it on resume.
+//!
+//! One of four similarly-named work-tracking surfaces — NOT the phased `/plan`
+//! workflow, plan-**mode**, or background `task`s. See the canonical map in
+//! [`crate::agent::plan`].
+
+use std::path::{Path, PathBuf};
 
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
@@ -13,6 +27,7 @@ use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
+use crate::extras::issue_db::{IssueStore, normalize_status};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TodoItem {
@@ -26,44 +41,77 @@ pub struct TodoWriteArgs {
     pub todos: Vec<TodoItem>,
 }
 
+/// In-memory mirror of the current session's live board (open / in_progress /
+/// blocked), refreshed from the `issues` table after every write. The
+/// right-pane TODOS panel and the end-of-turn nudge read this so neither has to
+/// hit SQLite on every redraw. The DB is authoritative; this is a cache.
 pub static TODO_LIST: std::sync::Mutex<Vec<TodoItem>> = std::sync::Mutex::new(Vec::new());
 
-/// Empty the todo list. Hooked into /clear so the TODOS panel resets along
-/// with the conversation, mirroring `modified::clear_modified`.
-pub fn clear() {
-    TODO_LIST.lock_ignore_poison().clear();
+/// Re-query the session's live board from the issue DB and replace the
+/// [`TODO_LIST`] mirror. Best-effort: a DB open/read failure leaves the mirror
+/// as-is (transient lock) rather than blanking the panel. `session_id = None`
+/// matches issues with a NULL session.
+pub fn refresh_board(db_path: &Path, session_id: Option<&str>) {
+    let Ok(store) = IssueStore::open_at(db_path) else {
+        return;
+    };
+    if let Ok(board) = store.board_for_session(session_id, None) {
+        let items: Vec<TodoItem> = board
+            .into_iter()
+            .map(|i| TodoItem {
+                content: i.title,
+                status: i.status,
+                priority: i.priority,
+            })
+            .collect();
+        *TODO_LIST.lock_ignore_poison() = items;
+    }
 }
 
-/// Snapshot the current todo list. `save_session` persists this with the
-/// session so a resumed session restores the TODOS panel even when a
-/// compaction has dropped the originating `write_todo_list` call from the
-/// message history.
+/// Snapshot the current mirror. `save_session` persists this with the session
+/// so the TODOS panel shows immediately on resume, before the first tool call
+/// re-runs `refresh_board`.
 pub fn snapshot() -> Vec<TodoItem> {
     TODO_LIST.lock_ignore_poison().clone()
 }
 
-/// Number of todos still `pending` or `in_progress`. Used by the agent loop
-/// to nudge the model not to stop with unfinished planned work (ported from
-/// vix's end-of-turn TODO-completion nudge, session.go:1551).
+/// Number of unfinished items on the mirrored board — anything still open or
+/// in progress (blocked items are deliberately parked, terminal items are
+/// gone). Used by the agent loop to nudge the model not to stop with unfinished
+/// planned work.
 pub fn unfinished_count() -> usize {
     TODO_LIST
         .lock()
         .map(|list| {
             list.iter()
-                .filter(|t| t.status == "pending" || t.status == "in_progress")
+                .filter(|t| {
+                    matches!(t.status.as_str(), "open" | "pending" | "in_progress")
+                })
                 .count()
         })
         .unwrap_or(0)
 }
 
 pub struct WriteTodoList {
-    pub permission: Option<PermCheck>,
-    pub ask_tx: Option<AskSender>,
+    db_path: PathBuf,
+    session_id: Option<String>,
+    permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
 }
 
 impl WriteTodoList {
-    pub fn new(permission: Option<PermCheck>, ask_tx: Option<AskSender>) -> Self {
-        WriteTodoList { permission, ask_tx }
+    pub fn new(
+        db_path: PathBuf,
+        session_id: Option<String>,
+        permission: Option<PermCheck>,
+        ask_tx: Option<AskSender>,
+    ) -> Self {
+        WriteTodoList {
+            db_path,
+            session_id,
+            permission,
+            ask_tx,
+        }
     }
 }
 
@@ -77,7 +125,7 @@ impl Tool for WriteTodoList {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "write_todo_list".to_string(),
-            description: "Create or update a structured todo list to track progress on a COMPLEX, MULTI-STEP task in the current session. Each call REPLACES the whole list. Keep statuses current (pending / in_progress / completed / cancelled) — the loop nudges you to finish or clear pending items before ending a turn. Skip this for trivial single-step work. To delegate independent work to a background subagent instead, use `task`.".to_string(),
+            description: "Lay out or update a structured plan for a COMPLEX, MULTI-STEP task. Each item is a tracked issue on your persistent board (the same board the `issue` tool and /issues use), scoped to this session. Listing an item creates it or updates a matching one by title; statuses follow the issue lifecycle (pending|in_progress|completed|cancelled, plus blocked). Items you omit are NOT auto-closed — to finish one, restate it with status completed (or cancelled); the loop nudges you to finish or close open items before ending a turn. Use the `issue` tool for incremental single-item edits or cross-session work. Skip this for trivial single-step work; use `task` to delegate independent work to a background subagent.".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -86,9 +134,9 @@ impl Tool for WriteTodoList {
                         "items": {
                             "type": "object",
                             "properties": {
-                                "content": { "type": "string", "description": "Task description" },
-                                "status": { "type": "string", "description": "pending, in_progress, completed, or cancelled" },
-                                "priority": { "type": "string", "description": "high, medium, or low" }
+                                "content": { "type": "string", "description": "Task description (matched by title on later calls)" },
+                                "status": { "type": "string", "description": "pending, in_progress, blocked, completed, or cancelled" },
+                                "priority": { "type": "string", "description": "high, normal, or low" }
                             },
                             "required": ["content", "status", "priority"]
                         },
@@ -103,11 +151,10 @@ impl Tool for WriteTodoList {
     async fn call(&self, args: TodoWriteArgs) -> Result<String, ToolError> {
         check_perm(&self.permission, &self.ask_tx, "write_todo_list", "").await?;
 
-        // Cap the todo list so a pathological agent can't bloat
-        // memory + every subsequent prompt by spamming hundreds of
-        // todos. 50 is generous for any reasonable plan; lists
-        // longer than that are usually a sign the agent should
-        // break the task into a separate plan/loop pass.
+        // Cap the plan so a pathological agent can't bloat the board (and every
+        // subsequent prompt's reminder) by spamming hundreds of items. 50 is
+        // generous for any reasonable plan; longer lists usually mean the work
+        // should be split across turns.
         const MAX_TODOS: usize = 50;
         if args.todos.len() > MAX_TODOS {
             return Err(ToolError::Msg(format!(
@@ -117,39 +164,110 @@ impl Tool for WriteTodoList {
             )));
         }
 
-        let mut list = TODO_LIST.lock_ignore_poison();
-        *list = args.todos;
+        let triples: Vec<(&str, &str, &str)> = args
+            .todos
+            .iter()
+            .map(|t| (t.content.as_str(), t.status.as_str(), t.priority.as_str()))
+            .collect();
 
-        if list.is_empty() {
-            return Ok("Todo list cleared.".to_string());
+        let store = IssueStore::open_at(&self.db_path).map_err(ToolError::Msg)?;
+        let applied = store
+            .sync_todos(self.session_id.as_deref(), &triples)
+            .map_err(ToolError::Msg)?;
+
+        // Refresh the panel/nudge mirror from the freshly-written board.
+        refresh_board(&self.db_path, self.session_id.as_deref());
+
+        // Summarize against what the model asked for (normalized), since closed
+        // items have already dropped off the live board and wouldn't show in a
+        // board-derived count.
+        let mut open = 0;
+        let mut in_progress = 0;
+        let mut blocked = 0;
+        let mut done = 0;
+        let mut cancelled = 0;
+        for t in &args.todos {
+            match normalize_status(&t.status).unwrap_or("open") {
+                "in_progress" => in_progress += 1,
+                "blocked" => blocked += 1,
+                "done" => done += 1,
+                "cancelled" => cancelled += 1,
+                _ => open += 1,
+            }
         }
+        let live = TODO_LIST.lock_ignore_poison().len();
+        Ok(format!(
+            "Synced {applied} item(s) to the board: {open} open, {in_progress} in progress, \
+             {blocked} blocked, {done} done, {cancelled} cancelled. \
+             {live} live item(s) now on this session's board."
+        ))
+    }
+}
 
-        let total = list.len();
-        let completed = list.iter().filter(|t| t.status == "completed").count();
-        let in_progress = list.iter().filter(|t| t.status == "in_progress").count();
-        let pending = list.iter().filter(|t| t.status == "pending").count();
+#[cfg(test)]
+mod tool_tests {
+    use super::*;
 
-        let mut result = format!("Todo list ({} items, {} done):\n", total, completed);
-        for item in list.iter() {
-            let icon = match item.status.as_str() {
-                "completed" => "[x]",
-                "in_progress" => "[>]",
-                "cancelled" => "[-]",
-                _ => "[ ]",
-            };
-            result.push_str(&format!(
-                "  {} [{}] {}\n",
-                icon, item.priority, item.content
-            ));
-        }
-        result.push_str(&format!(
-            "\nSummary: {} pending, {} in progress, {} completed, {} cancelled",
-            pending,
-            in_progress,
-            completed,
-            list.iter().filter(|t| t.status == "cancelled").count()
+    fn tmp_db() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "dirge-todotool-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
         ));
-        Ok(result)
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("state.db")
+    }
+
+    /// `write_todo_list` writes its plan through to the session's issue board,
+    /// upserting by title across calls (no duplicate rows, omitted items kept).
+    #[tokio::test]
+    async fn write_todo_list_persists_to_the_issue_board() {
+        let db = tmp_db();
+        let tool = WriteTodoList::new(db.clone(), Some("sess-1".into()), None, None);
+
+        tool.call(TodoWriteArgs {
+            todos: vec![
+                TodoItem {
+                    content: "Design API".into(),
+                    status: "in_progress".into(),
+                    priority: "high".into(),
+                },
+                TodoItem {
+                    content: "Write tests".into(),
+                    status: "pending".into(),
+                    priority: "low".into(),
+                },
+            ],
+        })
+        .await
+        .unwrap();
+
+        let store = IssueStore::open_at(&db).unwrap();
+        let board = store.board_for_session(Some("sess-1"), None).unwrap();
+        assert_eq!(board.len(), 2);
+        // in_progress sorts ahead of open.
+        assert_eq!(board[0].title, "Design API");
+        assert_eq!(board[0].status, "in_progress");
+
+        // Second call completes one item; the other is omitted but must stay.
+        tool.call(TodoWriteArgs {
+            todos: vec![TodoItem {
+                content: "Design API".into(),
+                status: "completed".into(),
+                priority: "high".into(),
+            }],
+        })
+        .await
+        .unwrap();
+
+        let board = store.board_for_session(Some("sess-1"), None).unwrap();
+        let titles: Vec<&str> = board.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(titles, vec!["Write tests"], "omitted item stays live");
+        // No duplicate "Design API" — it was upserted, then closed.
+        assert_eq!(store.search("Design API", 10).unwrap().len(), 1);
     }
 }
 
@@ -157,28 +275,28 @@ impl Tool for WriteTodoList {
 mod nudge_tests {
     use super::*;
 
-    /// `unfinished_count` counts pending + in_progress, ignores
-    /// completed/cancelled. (Sole mutator of the global TODO_LIST in tests.)
+    /// `unfinished_count` counts open/pending + in_progress, ignoring
+    /// blocked/done/cancelled. (Mutates the global TODO_LIST mirror directly.)
     #[test]
-    fn unfinished_count_counts_pending_and_in_progress() {
+    fn unfinished_count_counts_open_and_in_progress() {
         let item = |status: &str| TodoItem {
             content: "x".into(),
             status: status.into(),
-            priority: "medium".into(),
+            priority: "normal".into(),
         };
         {
             let mut list = TODO_LIST.lock_ignore_poison();
             *list = vec![
-                item("completed"),
-                item("pending"),
+                item("done"),
+                item("open"),
                 item("in_progress"),
-                item("cancelled"),
+                item("blocked"),
             ];
         }
         assert_eq!(unfinished_count(), 2);
         {
             let mut list = TODO_LIST.lock_ignore_poison();
-            *list = vec![item("completed"), item("cancelled")];
+            *list = vec![item("done"), item("blocked")];
         }
         assert_eq!(unfinished_count(), 0);
         // Leave the global clean for any other consumer.

--- a/src/extras/issue_db.rs
+++ b/src/extras/issue_db.rs
@@ -268,26 +268,7 @@ impl IssueStore {
     /// within a state, high priority first, then most-recently-touched.
     /// `limit` caps the rows (the caller bounds context); `None` = all.
     pub fn board(&self, limit: Option<usize>) -> Result<Vec<Issue>, String> {
-        let conn = self.conn.lock_ignore_poison();
-        let sql = format!(
-            "SELECT {COLS} FROM issues
-             WHERE status IN ('open','in_progress','blocked')
-             ORDER BY
-               CASE status WHEN 'in_progress' THEN 0 WHEN 'blocked' THEN 1 ELSE 2 END,
-               CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
-               updated_at DESC
-             {}",
-            match limit {
-                Some(n) => format!("LIMIT {n}"),
-                None => String::new(),
-            }
-        );
-        let mut stmt = conn.prepare(&sql).map_err(|e| format!("board: {e}"))?;
-        let rows = stmt
-            .query_map([], row_to_issue)
-            .map_err(|e| format!("board: {e}"))?;
-        rows.collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(|e| format!("board: {e}"))
+        self.board_query(None, limit)
     }
 
     /// The live board scoped to one session: open / in_progress / blocked
@@ -301,28 +282,49 @@ impl IssueStore {
         session_id: Option<&str>,
         limit: Option<usize>,
     ) -> Result<Vec<Issue>, String> {
+        self.board_query(Some(session_id), limit)
+    }
+
+    /// Shared live-board query for [`Self::board`] (project-wide) and
+    /// [`Self::board_for_session`] (session-scoped), so the column list and the
+    /// status/priority ordering can't drift between them. `session = None` means
+    /// no session filter; `session = Some(sid)` filters `session_id IS sid`
+    /// (where `sid = None` matches a NULL session). A trailing `id DESC` makes
+    /// the order total — a single `sync_todos` batch stamps every row with the
+    /// same `updated_at`, so without it the within-bucket order would be
+    /// nondeterministic.
+    fn board_query(
+        &self,
+        session: Option<Option<&str>>,
+        limit: Option<usize>,
+    ) -> Result<Vec<Issue>, String> {
         let conn = self.conn.lock_ignore_poison();
+        let where_session = if session.is_some() {
+            "session_id IS ?1 AND "
+        } else {
+            ""
+        };
         let sql = format!(
             "SELECT {COLS} FROM issues
-             WHERE session_id IS ?1 AND status IN ('open','in_progress','blocked')
+             WHERE {where_session}status IN ('open','in_progress','blocked')
              ORDER BY
                CASE status WHEN 'in_progress' THEN 0 WHEN 'blocked' THEN 1 ELSE 2 END,
                CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
-               updated_at DESC
+               updated_at DESC, id DESC
              {}",
             match limit {
                 Some(n) => format!("LIMIT {n}"),
                 None => String::new(),
             }
         );
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| format!("session board: {e}"))?;
-        let rows = stmt
-            .query_map(params![session_id], row_to_issue)
-            .map_err(|e| format!("session board: {e}"))?;
+        let mut stmt = conn.prepare(&sql).map_err(|e| format!("board: {e}"))?;
+        let rows = match session {
+            Some(sid) => stmt.query_map(params![sid], row_to_issue),
+            None => stmt.query_map([], row_to_issue),
+        }
+        .map_err(|e| format!("board: {e}"))?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(|e| format!("session board: {e}"))
+            .map_err(|e| format!("board: {e}"))
     }
 
     /// Bulk reconcile a `write_todo_list`-style plan into this session's issues,
@@ -382,15 +384,20 @@ impl IssueStore {
             }
             applied += 1;
         }
-        tx.commit().map_err(|e| format!("sync todos (commit): {e}"))?;
+        tx.commit()
+            .map_err(|e| format!("sync todos (commit): {e}"))?;
         Ok(applied)
     }
 
-    /// Count of live (non-done) issues — used for the "N more" injection hint.
+    /// Count of live issues — used for the "N more" injection hint. Must match
+    /// [`Self::board`]'s membership (open / in_progress / blocked) so the
+    /// overflow hint is consistent: both terminal states (`done` and
+    /// `cancelled`) are excluded, otherwise cancelled issues would inflate the
+    /// "and N more" count for rows the model can never list.
     pub fn open_count(&self) -> Result<usize, String> {
         let conn = self.conn.lock_ignore_poison();
         conn.query_row(
-            "SELECT COUNT(*) FROM issues WHERE status != 'done'",
+            "SELECT COUNT(*) FROM issues WHERE status NOT IN ('done','cancelled')",
             [],
             |row| row.get::<_, i64>(0),
         )
@@ -589,6 +596,21 @@ mod tests {
         assert!(c.closed_at.is_some(), "cancelled should stamp closed_at");
         // Terminal → off the live board.
         assert!(s.board(None).unwrap().iter().all(|i| i.id != id));
+    }
+
+    #[test]
+    fn open_count_excludes_both_terminal_states() {
+        let s = store();
+        let live = s.create("live", "", None, None).unwrap();
+        let _ = live;
+        let done = s.create("done", "", None, None).unwrap();
+        s.set_status(done, "done").unwrap();
+        let cancelled = s.create("cancelled", "", None, None).unwrap();
+        s.set_status(cancelled, "cancelled").unwrap();
+        // Only the one live issue counts — cancelled must not inflate it (it's
+        // excluded from board(), so the "N more" hint would otherwise lie).
+        assert_eq!(s.open_count().unwrap(), 1);
+        assert_eq!(s.board(None).unwrap().len(), 1);
     }
 
     #[test]

--- a/src/extras/issue_db.rs
+++ b/src/extras/issue_db.rs
@@ -22,15 +22,26 @@ use crate::sync_util::LockExt;
 // (high / normal / low) are defined by the `normalize_*` vocabulary below.
 
 /// Normalize a user/agent-supplied status to a canonical value, or `None` if
-/// unrecognized. Accepts a few intuitive aliases.
+/// unrecognized. Accepts a few intuitive aliases. `pending` maps to `open` and
+/// `cancelled` is a distinct terminal state — both come in via the bulk
+/// `write_todo_list` vocabulary (pending / in_progress / completed / cancelled),
+/// which shares this store.
 pub fn normalize_status(raw: &str) -> Option<&'static str> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "open" | "todo" | "backlog" => Some("open"),
+        "open" | "todo" | "backlog" | "pending" => Some("open"),
         "in_progress" | "in-progress" | "started" | "doing" | "wip" => Some("in_progress"),
         "blocked" | "block" => Some("blocked"),
         "done" | "closed" | "complete" | "completed" | "finished" => Some("done"),
+        "cancelled" | "canceled" | "wontfix" | "drop" | "dropped" => Some("cancelled"),
         _ => None,
     }
+}
+
+/// Whether a status is terminal (closed) — `done` or `cancelled`. Terminal
+/// issues stamp `closed_at`, drop off the live board, and don't count toward
+/// the unfinished-work nudge.
+pub fn is_terminal_status(status: &str) -> bool {
+    status == "done" || status == "cancelled"
 }
 
 /// Normalize a priority, or `None` if unrecognized.
@@ -198,15 +209,16 @@ impl IssueStore {
         .map_err(|e| format!("get issue: {e}"))
     }
 
-    /// Update status (validated). Setting `done` stamps `closed_at`; moving off
-    /// `done` clears it. Returns false if the issue doesn't exist.
+    /// Update status (validated). Setting a terminal status (`done` /
+    /// `cancelled`) stamps `closed_at`; moving off one clears it. Returns false
+    /// if the issue doesn't exist.
     pub fn set_status(&self, id: i64, status: &str) -> Result<bool, String> {
         let status = normalize_status(status).ok_or_else(|| {
-            format!("unknown status '{status}' (use open|in_progress|blocked|done)")
+            format!("unknown status '{status}' (use open|in_progress|blocked|done|cancelled)")
         })?;
         let conn = self.conn.lock_ignore_poison();
         let now = now();
-        let n = if status == "done" {
+        let n = if is_terminal_status(status) {
             conn.execute(
                 "UPDATE issues SET status = ?2, updated_at = ?3, closed_at = ?3 WHERE id = ?1",
                 params![id, status, now],
@@ -276,6 +288,102 @@ impl IssueStore {
             .map_err(|e| format!("board: {e}"))?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .map_err(|e| format!("board: {e}"))
+    }
+
+    /// The live board scoped to one session: open / in_progress / blocked
+    /// issues created or last touched under `session_id`, ordered like
+    /// [`Self::board`]. This is what the right-pane panel and the
+    /// finish-your-work nudge read — both are session-scoped, unlike the
+    /// project-wide turn-start reminder. `session_id = None` matches issues
+    /// with a NULL session.
+    pub fn board_for_session(
+        &self,
+        session_id: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<Issue>, String> {
+        let conn = self.conn.lock_ignore_poison();
+        let sql = format!(
+            "SELECT {COLS} FROM issues
+             WHERE session_id IS ?1 AND status IN ('open','in_progress','blocked')
+             ORDER BY
+               CASE status WHEN 'in_progress' THEN 0 WHEN 'blocked' THEN 1 ELSE 2 END,
+               CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+               updated_at DESC
+             {}",
+            match limit {
+                Some(n) => format!("LIMIT {n}"),
+                None => String::new(),
+            }
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| format!("session board: {e}"))?;
+        let rows = stmt
+            .query_map(params![session_id], row_to_issue)
+            .map_err(|e| format!("session board: {e}"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("session board: {e}"))
+    }
+
+    /// Bulk reconcile a `write_todo_list`-style plan into this session's issues,
+    /// in one transaction. Each `(title, status, priority)` triple is upserted
+    /// by `(session_id, title)`: a matching issue is updated (status + priority,
+    /// stamping/clearing `closed_at` as the status crosses the terminal line),
+    /// and a missing one is created. Empty titles are skipped.
+    ///
+    /// Deliberately NOT a full replace: issues absent from the list are left
+    /// untouched rather than closed, so a partial plan can't silently wipe work
+    /// the model (or the `issue` tool) is still tracking. The model closes an
+    /// item by restating it with status `completed` / `cancelled`. Returns the
+    /// number of items applied.
+    pub fn sync_todos(
+        &self,
+        session_id: Option<&str>,
+        items: &[(&str, &str, &str)],
+    ) -> Result<usize, String> {
+        let mut conn = self.conn.lock_ignore_poison();
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("sync todos (begin): {e}"))?;
+        let now = now();
+        let mut applied = 0usize;
+        for (title, status, priority) in items {
+            let title = title.trim();
+            if title.is_empty() {
+                continue;
+            }
+            let status = normalize_status(status).unwrap_or("open");
+            let priority = normalize_priority(priority).unwrap_or("normal");
+            let closed: Option<&str> = is_terminal_status(status).then_some(now.as_str());
+            let existing: Option<i64> = tx
+                .query_row(
+                    "SELECT id FROM issues WHERE session_id IS ?1 AND title = ?2 ORDER BY id DESC LIMIT 1",
+                    params![session_id, title],
+                    |r| r.get(0),
+                )
+                .optional()
+                .map_err(|e| format!("sync todos (lookup): {e}"))?;
+            match existing {
+                Some(id) => {
+                    tx.execute(
+                        "UPDATE issues SET status = ?2, priority = ?3, updated_at = ?4, closed_at = ?5 WHERE id = ?1",
+                        params![id, status, priority, now, closed],
+                    )
+                    .map_err(|e| format!("sync todos (update): {e}"))?;
+                }
+                None => {
+                    tx.execute(
+                        "INSERT INTO issues (title, body, status, priority, session_id, created_at, updated_at, closed_at)
+                         VALUES (?1, '', ?2, ?3, ?4, ?5, ?5, ?6)",
+                        params![title, status, priority, session_id, now, closed],
+                    )
+                    .map_err(|e| format!("sync todos (insert): {e}"))?;
+                }
+            }
+            applied += 1;
+        }
+        tx.commit().map_err(|e| format!("sync todos (commit): {e}"))?;
+        Ok(applied)
     }
 
     /// Count of live (non-done) issues — used for the "N more" injection hint.
@@ -469,6 +577,74 @@ mod tests {
         assert!(block.trim_end().ends_with("</system-reminder>"));
         // Only 2 shown, 4 live → overflow hint mentions the remaining 2.
         assert!(block.contains("2 more open issue"), "{block}");
+    }
+
+    #[test]
+    fn cancelled_is_terminal_stamps_closed_at_and_leaves_board() {
+        let s = store();
+        let id = s.create("x", "", None, Some("sess-1")).unwrap();
+        assert!(s.set_status(id, "cancelled").unwrap());
+        let c = s.get(id).unwrap().unwrap();
+        assert_eq!(c.status, "cancelled");
+        assert!(c.closed_at.is_some(), "cancelled should stamp closed_at");
+        // Terminal → off the live board.
+        assert!(s.board(None).unwrap().iter().all(|i| i.id != id));
+    }
+
+    #[test]
+    fn board_for_session_scopes_to_session_and_excludes_terminal() {
+        let s = store();
+        let mine = s.create("mine open", "", None, Some("sess-1")).unwrap();
+        let mine_done = s.create("mine done", "", None, Some("sess-1")).unwrap();
+        s.set_status(mine_done, "done").unwrap();
+        let _other = s.create("other", "", None, Some("sess-2")).unwrap();
+
+        let board = s.board_for_session(Some("sess-1"), None).unwrap();
+        let ids: Vec<i64> = board.iter().map(|i| i.id).collect();
+        assert_eq!(ids, vec![mine], "only this session's live issues");
+    }
+
+    #[test]
+    fn sync_todos_upserts_by_title_and_does_not_close_omitted() {
+        let s = store();
+        // First plan: two items.
+        let n = s
+            .sync_todos(
+                Some("sess-1"),
+                &[
+                    ("Build auth", "pending", "high"),
+                    ("Write tests", "in_progress", "low"),
+                ],
+            )
+            .unwrap();
+        assert_eq!(n, 2);
+        let board = s.board_for_session(Some("sess-1"), None).unwrap();
+        assert_eq!(board.len(), 2);
+
+        // Restate with one completed; the other is omitted (must stay live).
+        s.sync_todos(Some("sess-1"), &[("Build auth", "completed", "high")])
+            .unwrap();
+        let board = s.board_for_session(Some("sess-1"), None).unwrap();
+        let titles: Vec<&str> = board.iter().map(|i| i.title.as_str()).collect();
+        // "Build auth" closed (off the board), "Write tests" untouched (still live).
+        assert_eq!(titles, vec!["Write tests"], "omitted item not auto-closed");
+        // No duplicate "Build auth" row was created on the second sync.
+        assert_eq!(s.search("Build auth", 10).unwrap().len(), 1);
+        let done = s.search("Build auth", 10).unwrap().pop().unwrap();
+        assert_eq!(done.status, "done");
+        assert!(done.closed_at.is_some());
+    }
+
+    #[test]
+    fn sync_todos_reopen_clears_closed_at() {
+        let s = store();
+        s.sync_todos(Some("sess-1"), &[("task", "completed", "normal")])
+            .unwrap();
+        s.sync_todos(Some("sess-1"), &[("task", "in_progress", "normal")])
+            .unwrap();
+        let issue = s.search("task", 10).unwrap().pop().unwrap();
+        assert_eq!(issue.status, "in_progress");
+        assert!(issue.closed_at.is_none(), "reopen must clear closed_at");
     }
 
     #[test]

--- a/src/session/rehydrate.rs
+++ b/src/session/rehydrate.rs
@@ -107,11 +107,16 @@ pub fn derive_panel_state(session: &Session) -> PanelState {
 /// replay yields the same result (an uncompacted history agrees with the
 /// snapshot; a compacted one has nothing left to replay).
 pub fn restore_panels(session: &Session) {
-    use crate::sync_util::LockExt;
-
     let state = selected_panel_state(session);
 
-    *crate::agent::tools::todo::TODO_LIST.lock_ignore_poison() = state.todos;
+    // Todos are now durable issues. Refresh the panel/nudge mirror straight
+    // from this session's live board in the issue DB — the authoritative
+    // source — rather than the persisted snapshot or a history replay.
+    let db_path = crate::extras::dirge_paths::ProjectPaths::new(std::path::Path::new(
+        session.working_dir.as_str(),
+    ))
+    .session_db_path();
+    crate::agent::tools::todo::refresh_board(&db_path, Some(session.id.as_str()));
 
     // Replay through `mark_modified` so canonicalization, dedup, the 256-entry
     // cap and the panel's version counter all match the live write path.

--- a/src/ui/panel_render.rs
+++ b/src/ui/panel_render.rs
@@ -137,6 +137,9 @@ pub(crate) fn build_panel_data(
     #[cfg(not(feature = "lsp"))]
     let lsp: Vec<(String, String, bool)> = Vec::new();
 
+    // The TODOS panel mirrors this session's live issue board (open /
+    // in_progress / blocked). Terminal items (done / cancelled) have already
+    // dropped off the board, so no completed glyph is needed here.
     let todos: Vec<(String, String)> = {
         let list = crate::agent::tools::todo::TODO_LIST.lock_ignore_poison();
         list.iter()
@@ -144,7 +147,7 @@ pub(crate) fn build_panel_data(
             .map(|t| {
                 let status = match t.status.as_str() {
                     "in_progress" => "[~]",
-                    "completed" => "[x]",
+                    "blocked" => "[!]",
                     _ => "[ ]",
                 };
                 (status.to_string(), t.content.to_string())

--- a/src/ui/slash/cmd/clear.rs
+++ b/src/ui/slash/cmd/clear.rs
@@ -13,7 +13,14 @@ pub(crate) async fn cmd_clear(ctx: &mut SlashCtx<'_>) -> anyhow::Result<()> {
     ctx.session.tree.leaf_id = None;
     crate::agent::tools::modified::clear_modified();
     crate::agent::tools::snapshots::clear();
-    crate::agent::tools::todo::clear();
+    // Todos are durable issues now, so /clear doesn't delete them — it just
+    // resyncs the panel mirror to this session's live board (clearing the
+    // conversation doesn't change what work is still open).
+    let db_path = crate::extras::dirge_paths::ProjectPaths::new(std::path::Path::new(
+        ctx.session.working_dir.as_str(),
+    ))
+    .session_db_path();
+    crate::agent::tools::todo::refresh_board(&db_path, Some(ctx.session.id.as_str()));
     render_session(ctx.renderer, ctx.session, ctx.cli, ctx.cfg, ctx.context)?;
     Ok(())
 }


### PR DESCRIPTION
Consolidate the two work-tracking surfaces that did the same thing. The right-pane TODOS panel and the end-of-turn nudge were driven by an in-memory write_todo_list checklist that was entirely separate from the durable issue tracker. They are now one thing: a todo is an issue.

write_todo_list upserts its plan into the issues table scoped to the current session, so bulk planning gains the full issue lifecycle (open / in_progress / blocked / done / cancelled) and the model can rely on which items are still open. Items are matched by title across calls, and omitted items are no longer silently dropped, the model closes one by restating it completed or cancelled.

The in-memory TODO_LIST is kept as a fast render mirror of this session's live board so the panel does not hit SQLite on every frame. Both write_todo_list and the issue tool refresh it after a write, and resume and /clear repopulate it from the DB. The panel and the nudge are session-scoped; the project-wide turn-start board reminder is unchanged.

Adds a cancelled terminal status, session-scoped board_for_session, and a transactional sync_todos to IssueStore, with tests covering upsert by title, no-auto-close of omitted items, reopen clearing closed_at, and the tool writing through to the board.