### PR TITLE
ci: add clippy gate and fix all clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,31 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+  # dirge-clippy: lint gate. CI already promotes rustc warnings to errors
+  # via the top-level `RUSTFLAGS: "-D warnings"`, but clippy was never run,
+  # so clippy lints (incl. the deny-by-default `correctness` group) had no
+  # gate and accumulated. We lint the two configs CI actually ships:
+  # the batteries-included default set, and the Janet-free `windows-default`
+  # set (the only non-`plugin` / `loop` code path). `-D warnings` fails the
+  # build on any clippy lint. Extending coverage to `dap` / `sandbox-microvm`
+  # / `--all-features` is a follow-up (those need extra native deps in CI).
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Clippy (default features)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Clippy (windows-default)
+        run: cargo clippy --no-default-features --features windows-default --all-targets -- -D warnings
+
   # The `validate_all_plugins_compile` Rust test (mod_tests.rs) loads every
   # plugin against the full dirge harness surface.  It runs in the
   # --all-features test variant below.  That's the canonical gate; there is

--- a/src/agent/agent_loop/context_manager.rs
+++ b/src/agent/agent_loop/context_manager.rs
@@ -226,9 +226,7 @@ impl CheckpointSchedule {
 
     /// Clear crossed state after a destructive fold rebuilt the context.
     pub fn reset(&mut self) {
-        for c in &mut self.crossed {
-            *c = false;
-        }
+        self.crossed.fill(false);
     }
 }
 
@@ -911,15 +909,11 @@ mod tests {
     // Threshold constant sanity
     // ============================================================
 
-    #[test]
-    fn thresholds_are_strictly_ordered() {
-        assert!(FORCE_SUMMARY_THRESHOLD > HISTORY_FOLD_AGGRESSIVE_THRESHOLD);
-        assert!(HISTORY_FOLD_AGGRESSIVE_THRESHOLD > HISTORY_FOLD_THRESHOLD);
-        assert!(HISTORY_FOLD_THRESHOLD > HISTORY_FOLD_MIN_SAVINGS_FRACTION);
-    }
-
-    #[test]
-    fn aggressive_tail_is_smaller_than_normal_tail() {
-        assert!(HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION < HISTORY_FOLD_TAIL_FRACTION);
-    }
+    // Compile-time invariants: a violation is now a build error rather
+    // than a test failure. (clippy::assertions_on_constants flagged the
+    // former runtime `assert!`s because both operands are consts.)
+    const _: () = assert!(FORCE_SUMMARY_THRESHOLD > HISTORY_FOLD_AGGRESSIVE_THRESHOLD);
+    const _: () = assert!(HISTORY_FOLD_AGGRESSIVE_THRESHOLD > HISTORY_FOLD_THRESHOLD);
+    const _: () = assert!(HISTORY_FOLD_THRESHOLD > HISTORY_FOLD_MIN_SAVINGS_FRACTION);
+    const _: () = assert!(HISTORY_FOLD_AGGRESSIVE_TAIL_FRACTION < HISTORY_FOLD_TAIL_FRACTION);
 }

--- a/src/agent/agent_loop/stream.rs
+++ b/src/agent/agent_loop/stream.rs
@@ -377,11 +377,22 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    // Aliases for the `LoopConfig` callback types — clippy's
+    // `type_complexity` lint flags the bare `Arc<dyn Fn…>` spellings.
+    type ConvertToLlmFn = Arc<dyn Fn(&[serde_json::Value]) -> Vec<serde_json::Value> + Send + Sync>;
+    type TransformContextFn = Arc<
+        dyn Fn(
+                Vec<serde_json::Value>,
+            )
+                -> Pin<Box<dyn std::future::Future<Output = Vec<serde_json::Value>> + Send>>
+            + Send
+            + Sync,
+    >;
+
     /// Identity convertToLlm — passes through user/assistant/
     /// toolResult messages, drops anything else. Mirrors pi's
     /// `identityConverter` at test file line 79.
-    fn identity_converter()
-    -> Arc<dyn Fn(&[serde_json::Value]) -> Vec<serde_json::Value> + Send + Sync> {
+    fn identity_converter() -> ConvertToLlmFn {
         Arc::new(|messages: &[serde_json::Value]| {
             messages
                 .iter()
@@ -412,9 +423,7 @@ mod tests {
         })
     }
 
-    fn build_config(
-        convert: Arc<dyn Fn(&[serde_json::Value]) -> Vec<serde_json::Value> + Send + Sync>,
-    ) -> LoopConfig {
+    fn build_config(convert: ConvertToLlmFn) -> LoopConfig {
         LoopConfig {
             convert_to_llm: convert,
             transform_context: None,
@@ -636,17 +645,16 @@ mod tests {
         // Inspector closure — records what convertToLlm received.
         let received = Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
         let received_clone = received.clone();
-        let convert: Arc<dyn Fn(&[serde_json::Value]) -> Vec<serde_json::Value> + Send + Sync> =
-            Arc::new(move |messages| {
-                let mut slot = received_clone.lock().unwrap();
-                *slot = messages.to_vec();
-                // Filter notifications out for the LLM.
-                messages
-                    .iter()
-                    .filter(|m| m.get("role").and_then(|r| r.as_str()) != Some("notification"))
-                    .cloned()
-                    .collect()
-            });
+        let convert: ConvertToLlmFn = Arc::new(move |messages| {
+            let mut slot = received_clone.lock().unwrap();
+            *slot = messages.to_vec();
+            // Filter notifications out for the LLM.
+            messages
+                .iter()
+                .filter(|m| m.get("role").and_then(|r| r.as_str()) != Some("notification"))
+                .cloned()
+                .collect()
+        });
 
         let config = build_config(convert);
         let signal = AbortSignal::new();
@@ -696,14 +704,7 @@ mod tests {
         let counter = Arc::new(AtomicUsize::new(0));
 
         let transform_order = counter.clone();
-        let transform: Arc<
-            dyn Fn(
-                    Vec<serde_json::Value>,
-                )
-                    -> Pin<Box<dyn std::future::Future<Output = Vec<serde_json::Value>> + Send>>
-                + Send
-                + Sync,
-        > = Arc::new(move |messages| {
+        let transform: TransformContextFn = Arc::new(move |messages| {
             let order = transform_order.clone();
             Box::pin(async move {
                 let n = order.fetch_add(1, Ordering::SeqCst);
@@ -723,13 +724,12 @@ mod tests {
         let convert_order = counter.clone();
         let received_convert = Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
         let received_clone = received_convert.clone();
-        let convert: Arc<dyn Fn(&[serde_json::Value]) -> Vec<serde_json::Value> + Send + Sync> =
-            Arc::new(move |messages| {
-                let n = convert_order.fetch_add(1, Ordering::SeqCst);
-                assert_eq!(n, 1, "convert_to_llm must run after transform_context");
-                *received_clone.lock().unwrap() = messages.to_vec();
-                messages.to_vec()
-            });
+        let convert: ConvertToLlmFn = Arc::new(move |messages| {
+            let n = convert_order.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(n, 1, "convert_to_llm must run after transform_context");
+            *received_clone.lock().unwrap() = messages.to_vec();
+            messages.to_vec()
+        });
 
         let config = LoopConfig {
             convert_to_llm: convert,

--- a/src/agent/agent_loop/tool_input_repair/hints.rs
+++ b/src/agent/agent_loop/tool_input_repair/hints.rs
@@ -69,6 +69,24 @@ pub fn contract_hint_for(tool_name: &str) -> Option<&'static str> {
     }
 }
 
+/// Compose a tool description with its contract hint appended.
+/// Convenience wrapper around `contract_hint_for` so a tool's
+/// `definition()` impl reads as a single function call:
+///
+///     description: with_contract_hint(
+///         "read",
+///         "Read the contents of a file. …",
+///     ),
+///
+/// Tools without a registered hint just get their base description
+/// back unchanged.
+pub fn with_contract_hint(tool_name: &str, base_description: &str) -> String {
+    match contract_hint_for(tool_name) {
+        Some(hint) => format!("{base_description}\n\n{hint}"),
+        None => base_description.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod phase2_tests {
     use super::super::*;
@@ -205,23 +223,5 @@ mod phase2_tests {
         let args = json!({"thing": "[a.rs](http://a.rs)"});
         let result = validate_and_repair(&schema, &args).unwrap().unwrap();
         assert_eq!(result.repaired["thing"], "a.rs");
-    }
-}
-
-/// Compose a tool description with its contract hint appended.
-/// Convenience wrapper around `contract_hint_for` so a tool's
-/// `definition()` impl reads as a single function call:
-///
-///     description: with_contract_hint(
-///         "read",
-///         "Read the contents of a file. …",
-///     ),
-///
-/// Tools without a registered hint just get their base description
-/// back unchanged.
-pub fn with_contract_hint(tool_name: &str, base_description: &str) -> String {
-    match contract_hint_for(tool_name) {
-        Some(hint) => format!("{base_description}\n\n{hint}"),
-        None => base_description.to_string(),
     }
 }

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -287,7 +287,7 @@ async fn test_handle_tool_calls_and_results() {
     drop(tx);
 
     // Tool executed; args reached `execute`.
-    let recorded = echo.executed_args.lock().unwrap();
+    let recorded = echo.executed_args.lock().unwrap().clone();
     assert_eq!(recorded.len(), 1);
     assert_eq!(recorded[0]["value"], "hello");
     drop(recorded);
@@ -362,7 +362,7 @@ async fn test_before_tool_call_mutates_args() {
     while rx.recv().await.is_some() {}
 
     // The tool must have observed the MUTATED args.
-    let recorded = echo.executed_args.lock().unwrap();
+    let recorded = echo.executed_args.lock().unwrap().clone();
     assert_eq!(recorded.len(), 1);
     assert_eq!(recorded[0]["value"], serde_json::json!(123));
 }
@@ -652,6 +652,7 @@ async fn test_before_tool_call_block_with_reason() {
 ///   - empty batch → false
 ///   - some terminate=false → false
 ///   - all terminate=true → true
+///
 /// Faithful port of pi line 544.
 #[test]
 fn should_terminate_invariants() {
@@ -758,10 +759,10 @@ async fn test_tool_execution_end_completion_order_results_source_order() {
             LoopEvent::ToolExecutionEnd { tool_call_id, .. } => {
                 tool_execution_end_ids.push(tool_call_id.clone());
             }
-            LoopEvent::MessageEnd { message } => {
-                if let LoopMessage::ToolResult(t) = message {
-                    tool_result_message_end_ids.push(t.tool_call_id.clone());
-                }
+            LoopEvent::MessageEnd {
+                message: LoopMessage::ToolResult(t),
+            } => {
+                tool_result_message_end_ids.push(t.tool_call_id.clone());
             }
             _ => {}
         }
@@ -1363,7 +1364,7 @@ async fn truncation_repair_end_to_end_through_dispatch() {
 
     // 1. Tool was called — args reached `execute` AS A PARSED
     //    OBJECT, not the raw truncated string.
-    let recorded = echo.executed_args.lock().unwrap();
+    let recorded = echo.executed_args.lock().unwrap().clone();
     assert_eq!(
         recorded.len(),
         1,

--- a/src/agent/builder/reminder_tests.rs
+++ b/src/agent/builder/reminder_tests.rs
@@ -590,6 +590,9 @@ async fn build_agent_inner_emits_assembled_preamble() {
 /// shows up in the assembled preamble. `dirs::home_dir()` reads
 /// `$HOME` live on Unix; serialize the override so parallel tests
 /// don't observe the temporary HOME.
+// Serialization: `dirs::home_dir()` reads `$HOME` live, so the guard
+// below is intentionally held across this test's `.await`s.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn preamble_lists_global_tier_skills() {
     use crate::context::ContextFiles;

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -403,7 +403,7 @@ mod tests {
 
         for forbidden in forbidden_actions {
             assert!(
-                !words.iter().any(|w| *w == forbidden),
+                !words.contains(&forbidden),
                 "memory tool prompt mentions unsupported action '{}': {}",
                 forbidden,
                 memory_line
@@ -411,7 +411,7 @@ mod tests {
         }
         for action in real_actions {
             assert!(
-                words.iter().any(|w| *w == action),
+                words.contains(&action),
                 "memory tool prompt missing real action '{}': {}",
                 action,
                 memory_line

--- a/src/agent/tools/bash/tests.rs
+++ b/src/agent/tools/bash/tests.rs
@@ -423,18 +423,18 @@ async fn redirect_target_routes_through_write_rules() {
     );
 }
 
-/// Sibling check: a redirect target inside the working directory
-/// (non-external) passes the write-rules check. Without this, a
-/// regression that over-broadly denied all redirects could pass
-/// the negative case above and ship.
-///
-/// Uses an in-cwd path because the catch-all at
-/// `permission/checker.rs:434` upgrades unmatched-Allow to Ask
-/// for EXTERNAL paths — so `/tmp/x` (external to the test's cwd
-/// of the dirge repo) would test the external-path catch-all,
-/// not the write-rules-allow path we want to exercise here.
-/// M3 is intentionally tightening external bash-redirects to
-/// prompt; this test pins the in-cwd happy path.
+// Sibling check: a redirect target inside the working directory
+// (non-external) passes the write-rules check. Without this, a
+// regression that over-broadly denied all redirects could pass
+// the negative case above and ship.
+//
+// Uses an in-cwd path because the catch-all at
+// `permission/checker.rs:434` upgrades unmatched-Allow to Ask
+// for EXTERNAL paths — so `/tmp/x` (external to the test's cwd
+// of the dirge repo) would test the external-path catch-all,
+// not the write-rules-allow path we want to exercise here.
+// M3 is intentionally tightening external bash-redirects to
+// prompt; this test pins the in-cwd happy path.
 // F1 (dirge-dvy) — bash arg-side path checks. Pin that
 // file-mutating commands route their positional path args
 // through the write rules, independent of the bash command-

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -942,7 +942,7 @@ mod tests {
         )
         .await;
         assert!(
-            matches!(result, Err(_)),
+            result.is_err(),
             "edit deny should propagate to write; got {result:?}",
         );
 
@@ -954,7 +954,7 @@ mod tests {
         )
         .await;
         assert!(
-            matches!(result, Err(_)),
+            result.is_err(),
             "edit deny should propagate to apply_patch; got {result:?}",
         );
     }
@@ -985,7 +985,7 @@ mod tests {
             Scope::PathResolve("/etc/passwd"),
         )
         .await;
-        assert!(matches!(result, Err(_)));
+        assert!(result.is_err());
 
         // `/tmp/x.rs`: write/edit/apply_patch now share Operation::Edit,
         // so both rules live in ONE ruleset, last-match-wins. The
@@ -1020,7 +1020,7 @@ mod tests {
         )
         .await;
         assert!(
-            matches!(result, Ok(_)),
+            result.is_ok(),
             "read isn't aliased to edit; should pass via builtin-allow; got {result:?}",
         );
     }

--- a/src/agent/tools/output_relay.rs
+++ b/src/agent/tools/output_relay.rs
@@ -488,10 +488,13 @@ mod tests {
         let two_days_ago =
             std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 60 * 60);
         // Use libc/utimensat indirectly via std::fs::set_file_times (1.75+).
-        if let Err(_) = std::fs::File::open(&stale).and_then(|f| {
-            f.set_modified(two_days_ago)?;
-            Ok(())
-        }) {
+        if std::fs::File::open(&stale)
+            .and_then(|f| {
+                f.set_modified(two_days_ago)?;
+                Ok(())
+            })
+            .is_err()
+        {
             // Best-effort: skip if mtime setting unsupported.
             let _ = std::fs::remove_dir_all(&pid_dir);
             return;

--- a/src/agent/tools/session_search.rs
+++ b/src/agent/tools/session_search.rs
@@ -161,7 +161,7 @@ mod tests {
         dir.join("state.db")
     }
 
-    fn seed_session(db_path: &PathBuf, id: &str) {
+    fn seed_session(db_path: &std::path::Path, id: &str) {
         let db = SessionDb::open(db_path).unwrap();
         db.insert_session(id, "cli", "gpt-5", "openai", "2025-01-15T10:00:00Z")
             .unwrap();

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -997,6 +997,10 @@ mod tests {
     /// The test exercises the racer directly because `btw_query`
     /// requires a real provider. The racer is the same code path
     /// the production `call()` runs.
+    // Serialization guard: intentionally held across the test's `.await`s
+    // so the global abort registry isn't shared with a concurrently-
+    // running test.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn subagent_complete_after_kill_returns_aborted_result() {
         let _guard = registry_test_lock();

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -689,8 +689,7 @@ mod tests {
         let long_word_count = 200;
         // Build a paragraph that, without wrapping, would be ~one extremely
         // long line.
-        let paragraph: String = std::iter::repeat("lorem")
-            .take(long_word_count)
+        let paragraph: String = std::iter::repeat_n("lorem", long_word_count)
             .collect::<Vec<_>>()
             .join(" ");
         let html = format!("<p>{}</p>", paragraph);

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -319,7 +319,7 @@ async fn exa_mcp_search(
         return Err(ToolError::Msg(format!(
             "websearch returned {}: {}",
             status.as_u16(),
-            &body.chars().take(300).collect::<String>()
+            body.chars().take(300).collect::<String>()
         )));
     }
 
@@ -379,7 +379,7 @@ async fn parallel_mcp_search(
         return Err(ToolError::Msg(format!(
             "websearch (parallel) returned {}: {}",
             status.as_u16(),
-            &body.chars().take(300).collect::<String>()
+            body.chars().take(300).collect::<String>()
         )));
     }
 

--- a/src/context/prompts.rs
+++ b/src/context/prompts.rs
@@ -545,14 +545,14 @@ body
 
     #[test]
     fn next_prompt_starts_at_head_from_base() {
-        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let names = ["a".to_string(), "b".to_string(), "c".to_string()];
         let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(None, &names), Some(Some("a")));
     }
 
     #[test]
     fn next_prompt_advances_then_returns_to_base() {
-        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let names = ["a".to_string(), "b".to_string(), "c".to_string()];
         let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(Some("a"), &names), Some(Some("b")));
         assert_eq!(next_prompt(Some("b"), &names), Some(Some("c")));
@@ -563,7 +563,7 @@ body
 
     #[test]
     fn next_prompt_single_prompt_alternates_with_base() {
-        let names = vec!["only".to_string()];
+        let names = ["only".to_string()];
         let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(None, &names), Some(Some("only")));
         assert_eq!(next_prompt(Some("only"), &names), Some(None));
@@ -571,7 +571,7 @@ body
 
     #[test]
     fn next_prompt_unknown_current_starts_at_head() {
-        let names = vec!["a".to_string(), "b".to_string()];
+        let names = ["a".to_string(), "b".to_string()];
         let names: Vec<&String> = names.iter().collect();
         assert_eq!(next_prompt(Some("zzz"), &names), Some(Some("a")));
     }

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -456,6 +456,25 @@ fn spawn_acp_ask_drain(
     });
 }
 
+fn resolve_acp_mode(cli: &Cli, cfg: &Config) -> SecurityMode {
+    if cli.yolo || cfg.yolo.unwrap_or(false) {
+        SecurityMode::Yolo
+    } else if cli.accept_all || cfg.accept_all.unwrap_or(false) {
+        SecurityMode::Accept
+    } else if cli.restrictive || cfg.restrictive.unwrap_or(false) {
+        SecurityMode::Restrictive
+    } else if let Some(m) = &cfg.default_permission_mode {
+        match m.as_str() {
+            "yolo" => SecurityMode::Yolo,
+            "accept" => SecurityMode::Accept,
+            "restrictive" => SecurityMode::Restrictive,
+            _ => SecurityMode::Standard,
+        }
+    } else {
+        SecurityMode::Standard
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -665,24 +684,5 @@ mod tests {
                 .expect("reply channel dropped");
             assert!(matches!(resp, crate::permission::ask::UserDecision::Deny));
         }
-    }
-}
-
-fn resolve_acp_mode(cli: &Cli, cfg: &Config) -> SecurityMode {
-    if cli.yolo || cfg.yolo.unwrap_or(false) {
-        SecurityMode::Yolo
-    } else if cli.accept_all || cfg.accept_all.unwrap_or(false) {
-        SecurityMode::Accept
-    } else if cli.restrictive || cfg.restrictive.unwrap_or(false) {
-        SecurityMode::Restrictive
-    } else if let Some(m) = &cfg.default_permission_mode {
-        match m.as_str() {
-            "yolo" => SecurityMode::Yolo,
-            "accept" => SecurityMode::Accept,
-            "restrictive" => SecurityMode::Restrictive,
-            _ => SecurityMode::Standard,
-        }
-    } else {
-        SecurityMode::Standard
     }
 }

--- a/src/extras/skills/format.rs
+++ b/src/extras/skills/format.rs
@@ -162,11 +162,10 @@ fn split_frontmatter(content: &str) -> Option<(String, String)> {
     let (fm, body) = if let Some(pos) = content.find("\n---") {
         let (a, b) = content.split_at(pos);
         (a.to_string(), b[4..].to_string())
-    } else if let Some(pos) = content.find("\r\n---") {
+    } else {
+        let pos = content.find("\r\n---")?;
         let (a, b) = content.split_at(pos);
         (a.to_string(), b[5..].to_string())
-    } else {
-        return None;
     };
 
     Some((fm, body))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1435,6 +1435,12 @@ async fn main() -> anyhow::Result<()> {
                 .await
             };
 
+            // In `--loop` mode the body only re-iterates on a plugin-driven
+            // model swap; without the `plugin` feature the sole match arm
+            // returns, so clippy's (correct) `never_loop` fires for a config
+            // that intentionally runs the body exactly once. Scope the allow
+            // to that config so the lint stays live under `plugin`.
+            #[cfg_attr(not(feature = "plugin"), allow(clippy::never_loop))]
             loop {
                 let exit = run_headless_loop(
                     &current_agent,

--- a/src/permission/checker_tests.rs
+++ b/src/permission/checker_tests.rs
@@ -642,8 +642,10 @@ fn regression_session_allowlist_cd_star_matches_path_arg() {
 // the session-allowlist contribution in isolation from the default.
 #[test]
 fn path_tool_session_allowlist_keeps_one_segment_semantics() {
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     // The CWD-scoped builtin-allow rule for write/edit/apply_patch
     // would otherwise intercept any path under `working_dir` and
     // mask the session-allowlist semantics under test. Pin
@@ -680,8 +682,10 @@ fn path_tool_session_allowlist_keeps_one_segment_semantics() {
 /// combined result is Ask — infinite re-prompt loop.
 #[test]
 fn add_session_allowlist_mirrors_write_to_edit() {
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     let mut checker = PermissionChecker::new(
         &cfg,
         SecurityMode::Standard,
@@ -775,8 +779,10 @@ fn add_session_allowlist_mirrors_write_to_edit() {
 // entry intact, so a "revoked" grant kept auto-allowing.
 #[test]
 fn remove_session_allowlist_revokes_engine_grant() {
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     let mut checker = PermissionChecker::new(
         &cfg,
         SecurityMode::Standard,
@@ -1206,8 +1212,10 @@ fn accept_mode_auto_approves_edit_inside_cwd_through_symlink() {
 /// SAME folder must hit the session allowlist — no re-prompt.
 #[test]
 fn allow_always_folder_persists_in_session_allowlist() {
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     // Use a working_dir OUTSIDE the test paths so the CWD-allow
     // installer doesn't intercept and mask the session allowlist
     // under test.
@@ -1240,8 +1248,10 @@ fn allow_always_folder_persists_in_session_allowlist() {
 /// The session allowlist entry is `<cwd>/src/**`.
 #[test]
 fn allow_always_folder_covers_subsequent_writes_to_same_folder() {
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     let mut checker = PermissionChecker::new(
         &cfg,
         SecurityMode::Standard,
@@ -1303,8 +1313,10 @@ fn allow_always_folder_resolves_through_symlinks() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_dir(&real, &link).unwrap();
 
-    let mut cfg = PermissionConfig::default();
-    cfg.default = Some(Action::Ask);
+    let cfg = PermissionConfig {
+        default: Some(Action::Ask),
+        ..Default::default()
+    };
     // Put the cwd somewhere OFF the test paths so the CWD-allow
     // rule doesn't mask the allowlist behavior under test.
     let mut checker = PermissionChecker::new(

--- a/src/permission/pattern.rs
+++ b/src/permission/pattern.rs
@@ -80,6 +80,88 @@ fn expand_home(pattern: &str) -> String {
     pattern.to_string()
 }
 
+fn glob_to_regex(pattern: &str, path_style: bool) -> String {
+    // F3 (dirge-efw): trailing ` *` becomes ` (?:.*)?$` — opencode's
+    // `util/wildcard.ts:13-15` semantic. Lets a session-allowlist
+    // pattern like `ls *` match BOTH `ls` (no args) and `ls -la`
+    // (with args). Without this rewrite, `ls *` compiles to
+    // `^ls .*$` which requires the trailing space, so the user
+    // gets re-prompted for bare `ls`.
+    //
+    // Applies only to command-style patterns (path_style=false).
+    // Path patterns like `src/*` legitimately require at least
+    // one character after the slash; relaxing those would let
+    // `src/` (the directory itself, no file) match a per-file
+    // rule. Command tools use shell-style globbing where the
+    // optional-trailing-arg semantic is the user expectation.
+    // dirge-9zbd: also covers a trailing ` **`. For COMMAND patterns `*`
+    // and `**` both compile to `.*`, so `cargo test *` and `cargo test **`
+    // are equivalent — the only purpose of this rewrite is making the
+    // trailing args OPTIONAL. Without it, `cargo test **` compiled to
+    // `^cargo test .*$`, which requires a trailing space, so the BARE
+    // command `cargo test` (no args) silently re-prompted — and most
+    // `default_bash_rules` entries use the ` **` form.
+    if !path_style && !pattern.ends_with("\\ *") {
+        if let Some(head) = pattern
+            .strip_suffix(" **")
+            .or_else(|| pattern.strip_suffix(" *"))
+        {
+            let head_regex = glob_to_regex_inner(head, path_style);
+            return format!("^{head_regex}(?: .*)?$");
+        }
+    }
+    // PERM-4: a user-written `/etc/**` should match BOTH the
+    // directory itself and everything beneath it. Default inner
+    // semantics emit `^/etc/.*$` for that pattern, which requires
+    // a slash + content and silently misses the bare-directory
+    // case. Trailing `/**` rewrites the tail to `(?:/.*)?` so both
+    // forms hit. Path-style only; command patterns don't have
+    // this idiom.
+    if path_style && pattern.ends_with("/**") && pattern.len() >= 3 {
+        let head = &pattern[..pattern.len() - 3];
+        let head_regex = glob_to_regex_inner(head, path_style);
+        return format!("^{head_regex}(?:/.*)?$");
+    }
+    format!("^{}$", glob_to_regex_inner(pattern, path_style))
+}
+
+/// Inner glob → regex without the leading `^` and trailing `$`
+/// anchors. Separated so the F3 trailing-space-star rewrite can
+/// wrap the head independently.
+fn glob_to_regex_inner(pattern: &str, path_style: bool) -> String {
+    let mut re = String::with_capacity(pattern.len() * 2);
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next();
+                    if chars.peek() == Some(&'/') {
+                        chars.next();
+                        re.push_str("(?:.*/)?");
+                    } else {
+                        re.push_str(".*");
+                    }
+                } else if path_style {
+                    re.push_str("[^/]*");
+                } else {
+                    re.push_str(".*");
+                }
+            }
+            '?' if path_style => re.push_str("[^/]"),
+            '?' => re.push('.'),
+            '.' => re.push_str("\\."),
+            '\\' => re.push_str("\\\\"),
+            '(' | ')' | '[' | ']' | '{' | '}' | '+' | '^' | '$' | '|' => {
+                re.push('\\');
+                re.push(c);
+            }
+            _ => re.push(c),
+        }
+    }
+    re
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,86 +371,4 @@ mod tests {
         // Sibling that shares a prefix must NOT match.
         assert!(!pat.matches("/etcetera/foo"));
     }
-}
-
-fn glob_to_regex(pattern: &str, path_style: bool) -> String {
-    // F3 (dirge-efw): trailing ` *` becomes ` (?:.*)?$` — opencode's
-    // `util/wildcard.ts:13-15` semantic. Lets a session-allowlist
-    // pattern like `ls *` match BOTH `ls` (no args) and `ls -la`
-    // (with args). Without this rewrite, `ls *` compiles to
-    // `^ls .*$` which requires the trailing space, so the user
-    // gets re-prompted for bare `ls`.
-    //
-    // Applies only to command-style patterns (path_style=false).
-    // Path patterns like `src/*` legitimately require at least
-    // one character after the slash; relaxing those would let
-    // `src/` (the directory itself, no file) match a per-file
-    // rule. Command tools use shell-style globbing where the
-    // optional-trailing-arg semantic is the user expectation.
-    // dirge-9zbd: also covers a trailing ` **`. For COMMAND patterns `*`
-    // and `**` both compile to `.*`, so `cargo test *` and `cargo test **`
-    // are equivalent — the only purpose of this rewrite is making the
-    // trailing args OPTIONAL. Without it, `cargo test **` compiled to
-    // `^cargo test .*$`, which requires a trailing space, so the BARE
-    // command `cargo test` (no args) silently re-prompted — and most
-    // `default_bash_rules` entries use the ` **` form.
-    if !path_style && !pattern.ends_with("\\ *") {
-        if let Some(head) = pattern
-            .strip_suffix(" **")
-            .or_else(|| pattern.strip_suffix(" *"))
-        {
-            let head_regex = glob_to_regex_inner(head, path_style);
-            return format!("^{head_regex}(?: .*)?$");
-        }
-    }
-    // PERM-4: a user-written `/etc/**` should match BOTH the
-    // directory itself and everything beneath it. Default inner
-    // semantics emit `^/etc/.*$` for that pattern, which requires
-    // a slash + content and silently misses the bare-directory
-    // case. Trailing `/**` rewrites the tail to `(?:/.*)?` so both
-    // forms hit. Path-style only; command patterns don't have
-    // this idiom.
-    if path_style && pattern.ends_with("/**") && pattern.len() >= 3 {
-        let head = &pattern[..pattern.len() - 3];
-        let head_regex = glob_to_regex_inner(head, path_style);
-        return format!("^{head_regex}(?:/.*)?$");
-    }
-    format!("^{}$", glob_to_regex_inner(pattern, path_style))
-}
-
-/// Inner glob → regex without the leading `^` and trailing `$`
-/// anchors. Separated so the F3 trailing-space-star rewrite can
-/// wrap the head independently.
-fn glob_to_regex_inner(pattern: &str, path_style: bool) -> String {
-    let mut re = String::with_capacity(pattern.len() * 2);
-    let mut chars = pattern.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '*' => {
-                if chars.peek() == Some(&'*') {
-                    chars.next();
-                    if chars.peek() == Some(&'/') {
-                        chars.next();
-                        re.push_str("(?:.*/)?");
-                    } else {
-                        re.push_str(".*");
-                    }
-                } else if path_style {
-                    re.push_str("[^/]*");
-                } else {
-                    re.push_str(".*");
-                }
-            }
-            '?' if path_style => re.push_str("[^/]"),
-            '?' => re.push('.'),
-            '.' => re.push_str("\\."),
-            '\\' => re.push_str("\\\\"),
-            '(' | ')' | '[' | ']' | '{' | '}' | '+' | '^' | '$' | '|' => {
-                re.push('\\');
-                re.push(c);
-            }
-            _ => re.push(c),
-        }
-    }
-    re
 }

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -1664,9 +1664,9 @@ unsafe fn read_string_array_arg(
         // it sat at argv[idx]. Doable because read_string_arg only uses
         // the raw Janet, not its position.
         let elt_ptr = unsafe { data.add(idx) } as *mut janetrs::lowlevel::Janet;
-        match unsafe { read_string_arg(elt_ptr, 0) } {
-            Some(s) => out.push(s),
-            None => return None,
+        {
+            let s = unsafe { read_string_arg(elt_ptr, 0) }?;
+            out.push(s)
         }
     }
     Some(out)

--- a/src/session/mod_tests.rs
+++ b/src/session/mod_tests.rs
@@ -879,7 +879,7 @@ fn convert_history_pairs_interrupted_tool_calls_with_error_marker() {
     let history = crate::agent::runner::convert_history(&s);
     // 2 messages: Assistant(text + tool_use) + User(tool_result-interrupted).
     assert_eq!(history.len(), 2);
-    let last_str = format!("{:?}", &history[1]);
+    let last_str = format!("{:?}", history[1]);
     assert!(
         last_str.contains("tc_99"),
         "interrupted result must reference call id: {last_str}",

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -26,7 +26,7 @@ pub(crate) fn dirs_path() -> PathBuf {
     // (DIRGE_DATA_DIR still wins, so tests can pick their own location).
     #[cfg(test)]
     {
-        return std::env::temp_dir().join(format!("dirge-test-data-{}", std::process::id()));
+        std::env::temp_dir().join(format!("dirge-test-data-{}", std::process::id()))
     }
     #[cfg(not(test))]
     {
@@ -275,6 +275,267 @@ pub fn delete_session(id: &str) -> anyhow::Result<()> {
         std::fs::remove_file(path)?;
     }
     Ok(())
+}
+
+/// Collapse fold chains to one entry per conversation: keep only the
+/// first session seen for each [`Session::effective_origin`]. Callers
+/// pass a newest-first list, so the survivor is the chain tip and the
+/// stale older rotations drop out — the session list shows a folded
+/// conversation once, not once per rotation. Pure for testability.
+fn dedup_by_origin(sessions: Vec<Session>) -> Vec<Session> {
+    let mut seen = std::collections::HashSet::new();
+    sessions
+        .into_iter()
+        .filter(|s| seen.insert(s.effective_origin().to_string()))
+        .collect()
+}
+
+/// Resume helper: resolve `id` to the TIP of its fold chain. A compaction
+/// fold rotates the session id and leaves the older file behind unchanged
+/// (pre-fold state), so resuming *any* member of a chain must hop to the
+/// newest session that shares the same [`Session::effective_origin`] —
+/// otherwise resume silently loads a stale snapshot. Falls back to the
+/// directly-loaded session when nothing newer shares its origin (the
+/// common case: the user already named the tip, or the session never
+/// folded). Filtering by origin makes the directory scan robust to
+/// unrelated sessions.
+pub fn load_session_tip(id: &str) -> anyhow::Result<Session> {
+    let requested = load_session(id)?;
+    let origin = requested.effective_origin().to_string();
+    let dir = session_dir();
+    if !dir.exists() {
+        return Ok(requested);
+    }
+
+    // Find the chain tip with a CHEAP partial parse. A fold leaves the older
+    // (often large) session file behind, so these accumulate; fully
+    // deserializing every one — every message, tool result, and the
+    // `message_store` map — on each resume was the dominant cost of
+    // `--session` startup. `TipMeta` pulls only the three fields the scan
+    // compares; serde skips everything else via `IgnoredAny`, never
+    // allocating the message structures. We then fully load just the winner.
+    #[derive(serde::Deserialize)]
+    struct TipMeta {
+        id: String,
+        #[serde(default)]
+        origin_id: Option<String>,
+        #[serde(default)]
+        updated_at: String,
+    }
+
+    let mut tip_id = requested.id.to_string();
+    let mut tip_updated = requested.updated_at.to_string();
+    for entry in std::fs::read_dir(&dir)? {
+        // Skip a bad directory entry rather than aborting resume: a
+        // concurrent fold/cleanup can delete a sibling file mid-scan, and
+        // the seed session already loaded fine — a plain load would have
+        // succeeded, so the tip scan must degrade to it, not error out.
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "json")
+            && let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(meta) = serde_json::from_str::<TipMeta>(&json)
+        {
+            let meta_origin = meta.origin_id.as_deref().unwrap_or(&meta.id);
+            if meta_origin == origin && meta.updated_at > tip_updated {
+                tip_updated = meta.updated_at;
+                tip_id = meta.id;
+            }
+        }
+    }
+
+    if tip_id.as_str() == requested.id.as_str() {
+        // Seed is already the tip — no second load.
+        Ok(requested)
+    } else {
+        // Fully deserialize only the winner. If it vanished between the scan
+        // and this load (concurrent fold/cleanup), fall back to the seed we
+        // already have rather than failing the resume.
+        Ok(load_session(&tip_id).unwrap_or(requested))
+    }
+}
+
+pub fn find_sessions_by_prefix(prefix: &str) -> anyhow::Result<Vec<Session>> {
+    // SESS-5: `stem.starts_with("")` matches every session file, so
+    // `/sessions ` or `/sessions delete ` (trailing space) would
+    // enumerate or operate on ALL sessions instead of a prefix
+    // match. Reject empty prefix so callers must supply at least
+    // one character.
+    if prefix.is_empty() {
+        anyhow::bail!("session prefix must not be empty");
+    }
+    let dir = session_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut sessions: Vec<Session> = Vec::new();
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "json")
+            && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            && stem.starts_with(prefix)
+            && let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(session) = serde_json::from_str::<Session>(&json)
+        {
+            sessions.push(session);
+        }
+    }
+    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    // Collapse fold chains so a prefix that spans a rotated conversation
+    // returns the single tip, not every rotation.
+    Ok(dedup_by_origin(sessions))
+}
+
+pub fn find_recent_sessions(limit: usize) -> anyhow::Result<Vec<Session>> {
+    let dir = session_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    // Audit L10: previously read + parsed every `*.json` then sorted
+    // by `updated_at` then truncated. For a user with 5 000 stored
+    // sessions this is 5 000 file reads + parses on every `/sessions`
+    // invocation. Sort by filesystem mtime first (cheap; uses the
+    // metadata already read by `read_dir`), then parse only the top
+    // `limit`. mtime corresponds closely to `updated_at` since both
+    // are bumped on every `save_session` write.
+    let mut entries: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        entries.push((path, mtime));
+    }
+    // Newest first.
+    entries.sort_by_key(|e| std::cmp::Reverse(e.1));
+    entries.truncate(limit);
+
+    let mut sessions: Vec<Session> = Vec::with_capacity(entries.len());
+    for (path, _) in entries {
+        if let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(session) = serde_json::from_str::<Session>(&json)
+        {
+            sessions.push(session);
+        }
+    }
+    // Refine ordering by the in-file updated_at — mtime is a good
+    // proxy but `updated_at` is canonical. Cheap on the already-
+    // truncated list.
+    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    // Show one row per conversation: a just-folded chain can have both
+    // its tip and a recent older rotation inside the window; keep the
+    // tip. Stale rotations from older folds already sink below the
+    // window by mtime. (A chain occupying the window can yield slightly
+    // fewer than `limit` rows — acceptable for a recents list.)
+    Ok(dedup_by_origin(sessions))
+}
+
+/// Cross-session Up-arrow history: the `max_sessions` most-recent OTHER
+/// sessions in the same project (same `working_dir`, different
+/// conversation origin than `current`). Returned OLDEST-first so the
+/// caller can append their prompts ahead of the current session's own,
+/// keeping the newest command at the tail of history (where Up-arrow
+/// recall starts).
+///
+/// Candidate files are ordered by filesystem mtime (free from `read_dir`
+/// metadata) and visited newest-first, so only enough files to find the
+/// `max_sessions` most-recent same-project conversations are read — a
+/// large session store isn't loaded wholesale on startup. mtime tracks
+/// `updated_at` (both bumped on every `save_session` write), the same
+/// recency proxy `find_recent_sessions` relies on. A cheap partial parse
+/// (`ProjMeta`) filters by `working_dir` before the few winners are fully
+/// deserialized. Fold chains are collapsed by origin — the first file
+/// seen for an origin is its newest-mtime tip — so `max_sessions` counts
+/// distinct prior conversations, not rotation files, and a folded prior
+/// can't seed overlapping prompts.
+pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Session> {
+    if max_sessions == 0 {
+        return Vec::new();
+    }
+    let dir = session_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let current_origin = current.effective_origin();
+    let current_wd = current.working_dir.as_str();
+
+    #[derive(serde::Deserialize)]
+    struct ProjMeta {
+        id: String,
+        #[serde(default)]
+        origin_id: Option<String>,
+        #[serde(default)]
+        working_dir: Option<String>,
+    }
+
+    // Order by mtime newest-first using only the directory metadata — no
+    // file content read yet.
+    let mut files: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "json") {
+            continue;
+        }
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        files.push((path, mtime));
+    }
+    files.sort_by_key(|f| std::cmp::Reverse(f.1));
+
+    // Walk newest-first, partial-parsing only until the `max_sessions`
+    // most-recent same-project conversations are found. Pre-seeding `seen`
+    // with the current origin skips the current session's own fold chain;
+    // the first file seen for any other origin is its tip, so the set also
+    // collapses rotations. A vanished or unparseable sibling is skipped
+    // rather than aborting (concurrent fold/cleanup can rewrite a file
+    // mid-scan).
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    seen.insert(current_origin.to_string());
+    let mut picked: Vec<std::path::PathBuf> = Vec::new();
+    for (path, _) in files {
+        if picked.len() == max_sessions {
+            break;
+        }
+        let Ok(json) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<ProjMeta>(&json) else {
+            continue;
+        };
+        if meta.working_dir.as_deref() != Some(current_wd) {
+            continue;
+        }
+        let origin = meta.origin_id.unwrap_or(meta.id);
+        if !seen.insert(origin) {
+            continue;
+        }
+        picked.push(path);
+    }
+    // Oldest-first: appending then yields oldest-session prompts first,
+    // so the newest prior session sits just behind the current session.
+    picked.reverse();
+
+    let mut out = Vec::with_capacity(picked.len());
+    for path in picked {
+        if let Ok(json) = std::fs::read_to_string(&path)
+            && let Ok(session) = serde_json::from_str::<Session>(&json)
+        {
+            out.push(session);
+        }
+    }
+    out
+}
+
+pub fn agents_path() -> PathBuf {
+    config_path().join("agent").join("AGENTS.md")
 }
 
 #[cfg(test)]
@@ -1214,265 +1475,4 @@ mod tests {
             "alternative approach..."
         );
     }
-}
-
-/// Collapse fold chains to one entry per conversation: keep only the
-/// first session seen for each [`Session::effective_origin`]. Callers
-/// pass a newest-first list, so the survivor is the chain tip and the
-/// stale older rotations drop out — the session list shows a folded
-/// conversation once, not once per rotation. Pure for testability.
-fn dedup_by_origin(sessions: Vec<Session>) -> Vec<Session> {
-    let mut seen = std::collections::HashSet::new();
-    sessions
-        .into_iter()
-        .filter(|s| seen.insert(s.effective_origin().to_string()))
-        .collect()
-}
-
-/// Resume helper: resolve `id` to the TIP of its fold chain. A compaction
-/// fold rotates the session id and leaves the older file behind unchanged
-/// (pre-fold state), so resuming *any* member of a chain must hop to the
-/// newest session that shares the same [`Session::effective_origin`] —
-/// otherwise resume silently loads a stale snapshot. Falls back to the
-/// directly-loaded session when nothing newer shares its origin (the
-/// common case: the user already named the tip, or the session never
-/// folded). Filtering by origin makes the directory scan robust to
-/// unrelated sessions.
-pub fn load_session_tip(id: &str) -> anyhow::Result<Session> {
-    let requested = load_session(id)?;
-    let origin = requested.effective_origin().to_string();
-    let dir = session_dir();
-    if !dir.exists() {
-        return Ok(requested);
-    }
-
-    // Find the chain tip with a CHEAP partial parse. A fold leaves the older
-    // (often large) session file behind, so these accumulate; fully
-    // deserializing every one — every message, tool result, and the
-    // `message_store` map — on each resume was the dominant cost of
-    // `--session` startup. `TipMeta` pulls only the three fields the scan
-    // compares; serde skips everything else via `IgnoredAny`, never
-    // allocating the message structures. We then fully load just the winner.
-    #[derive(serde::Deserialize)]
-    struct TipMeta {
-        id: String,
-        #[serde(default)]
-        origin_id: Option<String>,
-        #[serde(default)]
-        updated_at: String,
-    }
-
-    let mut tip_id = requested.id.to_string();
-    let mut tip_updated = requested.updated_at.to_string();
-    for entry in std::fs::read_dir(&dir)? {
-        // Skip a bad directory entry rather than aborting resume: a
-        // concurrent fold/cleanup can delete a sibling file mid-scan, and
-        // the seed session already loaded fine — a plain load would have
-        // succeeded, so the tip scan must degrade to it, not error out.
-        let Ok(entry) = entry else { continue };
-        let path = entry.path();
-        if path.extension().is_some_and(|e| e == "json")
-            && let Ok(json) = std::fs::read_to_string(&path)
-            && let Ok(meta) = serde_json::from_str::<TipMeta>(&json)
-        {
-            let meta_origin = meta.origin_id.as_deref().unwrap_or(&meta.id);
-            if meta_origin == origin && meta.updated_at > tip_updated {
-                tip_updated = meta.updated_at;
-                tip_id = meta.id;
-            }
-        }
-    }
-
-    if tip_id.as_str() == requested.id.as_str() {
-        // Seed is already the tip — no second load.
-        Ok(requested)
-    } else {
-        // Fully deserialize only the winner. If it vanished between the scan
-        // and this load (concurrent fold/cleanup), fall back to the seed we
-        // already have rather than failing the resume.
-        Ok(load_session(&tip_id).unwrap_or(requested))
-    }
-}
-
-pub fn find_sessions_by_prefix(prefix: &str) -> anyhow::Result<Vec<Session>> {
-    // SESS-5: `stem.starts_with("")` matches every session file, so
-    // `/sessions ` or `/sessions delete ` (trailing space) would
-    // enumerate or operate on ALL sessions instead of a prefix
-    // match. Reject empty prefix so callers must supply at least
-    // one character.
-    if prefix.is_empty() {
-        anyhow::bail!("session prefix must not be empty");
-    }
-    let dir = session_dir();
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    let mut sessions: Vec<Session> = Vec::new();
-    for entry in std::fs::read_dir(&dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().is_some_and(|e| e == "json")
-            && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
-            && stem.starts_with(prefix)
-            && let Ok(json) = std::fs::read_to_string(&path)
-            && let Ok(session) = serde_json::from_str::<Session>(&json)
-        {
-            sessions.push(session);
-        }
-    }
-    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-    // Collapse fold chains so a prefix that spans a rotated conversation
-    // returns the single tip, not every rotation.
-    Ok(dedup_by_origin(sessions))
-}
-
-pub fn find_recent_sessions(limit: usize) -> anyhow::Result<Vec<Session>> {
-    let dir = session_dir();
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-    // Audit L10: previously read + parsed every `*.json` then sorted
-    // by `updated_at` then truncated. For a user with 5 000 stored
-    // sessions this is 5 000 file reads + parses on every `/sessions`
-    // invocation. Sort by filesystem mtime first (cheap; uses the
-    // metadata already read by `read_dir`), then parse only the top
-    // `limit`. mtime corresponds closely to `updated_at` since both
-    // are bumped on every `save_session` write.
-    let mut entries: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
-    for entry in std::fs::read_dir(&dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().is_none_or(|e| e != "json") {
-            continue;
-        }
-        let mtime = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        entries.push((path, mtime));
-    }
-    // Newest first.
-    entries.sort_by_key(|e| std::cmp::Reverse(e.1));
-    entries.truncate(limit);
-
-    let mut sessions: Vec<Session> = Vec::with_capacity(entries.len());
-    for (path, _) in entries {
-        if let Ok(json) = std::fs::read_to_string(&path)
-            && let Ok(session) = serde_json::from_str::<Session>(&json)
-        {
-            sessions.push(session);
-        }
-    }
-    // Refine ordering by the in-file updated_at — mtime is a good
-    // proxy but `updated_at` is canonical. Cheap on the already-
-    // truncated list.
-    sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-    // Show one row per conversation: a just-folded chain can have both
-    // its tip and a recent older rotation inside the window; keep the
-    // tip. Stale rotations from older folds already sink below the
-    // window by mtime. (A chain occupying the window can yield slightly
-    // fewer than `limit` rows — acceptable for a recents list.)
-    Ok(dedup_by_origin(sessions))
-}
-
-/// Cross-session Up-arrow history: the `max_sessions` most-recent OTHER
-/// sessions in the same project (same `working_dir`, different
-/// conversation origin than `current`). Returned OLDEST-first so the
-/// caller can append their prompts ahead of the current session's own,
-/// keeping the newest command at the tail of history (where Up-arrow
-/// recall starts).
-///
-/// Candidate files are ordered by filesystem mtime (free from `read_dir`
-/// metadata) and visited newest-first, so only enough files to find the
-/// `max_sessions` most-recent same-project conversations are read — a
-/// large session store isn't loaded wholesale on startup. mtime tracks
-/// `updated_at` (both bumped on every `save_session` write), the same
-/// recency proxy `find_recent_sessions` relies on. A cheap partial parse
-/// (`ProjMeta`) filters by `working_dir` before the few winners are fully
-/// deserialized. Fold chains are collapsed by origin — the first file
-/// seen for an origin is its newest-mtime tip — so `max_sessions` counts
-/// distinct prior conversations, not rotation files, and a folded prior
-/// can't seed overlapping prompts.
-pub fn recent_project_sessions(current: &Session, max_sessions: usize) -> Vec<Session> {
-    if max_sessions == 0 {
-        return Vec::new();
-    }
-    let dir = session_dir();
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    let current_origin = current.effective_origin();
-    let current_wd = current.working_dir.as_str();
-
-    #[derive(serde::Deserialize)]
-    struct ProjMeta {
-        id: String,
-        #[serde(default)]
-        origin_id: Option<String>,
-        #[serde(default)]
-        working_dir: Option<String>,
-    }
-
-    // Order by mtime newest-first using only the directory metadata — no
-    // file content read yet.
-    let mut files: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_none_or(|e| e != "json") {
-            continue;
-        }
-        let mtime = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        files.push((path, mtime));
-    }
-    files.sort_by_key(|f| std::cmp::Reverse(f.1));
-
-    // Walk newest-first, partial-parsing only until the `max_sessions`
-    // most-recent same-project conversations are found. Pre-seeding `seen`
-    // with the current origin skips the current session's own fold chain;
-    // the first file seen for any other origin is its tip, so the set also
-    // collapses rotations. A vanished or unparseable sibling is skipped
-    // rather than aborting (concurrent fold/cleanup can rewrite a file
-    // mid-scan).
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    seen.insert(current_origin.to_string());
-    let mut picked: Vec<std::path::PathBuf> = Vec::new();
-    for (path, _) in files {
-        if picked.len() == max_sessions {
-            break;
-        }
-        let Ok(json) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(meta) = serde_json::from_str::<ProjMeta>(&json) else {
-            continue;
-        };
-        if meta.working_dir.as_deref() != Some(current_wd) {
-            continue;
-        }
-        let origin = meta.origin_id.unwrap_or(meta.id);
-        if !seen.insert(origin) {
-            continue;
-        }
-        picked.push(path);
-    }
-    // Oldest-first: appending then yields oldest-session prompts first,
-    // so the newest prior session sits just behind the current session.
-    picked.reverse();
-
-    let mut out = Vec::with_capacity(picked.len());
-    for path in picked {
-        if let Ok(json) = std::fs::read_to_string(&path)
-            && let Ok(session) = serde_json::from_str::<Session>(&json)
-        {
-            out.push(session);
-        }
-    }
-    out
-}
-
-pub fn agents_path() -> PathBuf {
-    config_path().join("agent").join("AGENTS.md")
 }

--- a/src/tests/semantic_tests.rs
+++ b/src/tests/semantic_tests.rs
@@ -1,4 +1,7 @@
 #[cfg(test)]
+// The file is already module `tests::semantic_tests`; the same-named
+// inner module is dirge's per-file test convention, not a mistake.
+#[allow(clippy::module_inception)]
 mod semantic_tests {
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -14,8 +17,10 @@ mod semantic_tests {
             .join("fixtures")
     }
 
+    // The adapter pushes below are all `#[cfg(feature = …)]`-gated, so this
+    // can't be written as a single `vec![…]` literal.
+    #[allow(unused_mut, clippy::vec_init_then_push)]
     fn mk_registry() -> Arc<AdapterRegistry> {
-        #[allow(unused_mut)]
         let mut adapters: Vec<Box<dyn LanguageAdapter>> = Vec::new();
 
         #[cfg(feature = "semantic-ts")]

--- a/src/ui/compaction.rs
+++ b/src/ui/compaction.rs
@@ -45,6 +45,7 @@ pub(crate) enum CompactionThen {
     ///   - otherwise (pure first-token overflow, nothing streamed): re-send the
     ///     `prompt` against the compacted history (the trailing user message is
     ///     dropped + not re-recorded).
+    ///
     /// If compaction made no progress, the user is told to recover manually.
     RetryAfterOverflow { prompt: String, made_progress: bool },
 }
@@ -73,30 +74,6 @@ pub(crate) fn overflow_recovery(compacted: bool, made_progress: bool) -> Overflo
         (true, true) => OverflowRecovery::Continue,
         (true, false) => OverflowRecovery::Resend,
         (false, _) => OverflowRecovery::GiveUp,
-    }
-}
-
-#[cfg(test)]
-mod recovery_tests {
-    use super::{OverflowRecovery, overflow_recovery};
-
-    #[test]
-    fn made_progress_resumes_as_continuation() {
-        // dirge-b899: the failed turn ran tools / streamed text — resume the
-        // task, do NOT strand it (the old code refused when tools had run).
-        assert_eq!(overflow_recovery(true, true), OverflowRecovery::Continue);
-    }
-
-    #[test]
-    fn no_progress_resends_prompt() {
-        // Pure first-token overflow: nothing streamed, safe to re-send.
-        assert_eq!(overflow_recovery(true, false), OverflowRecovery::Resend);
-    }
-
-    #[test]
-    fn uncompacted_gives_up_regardless_of_progress() {
-        assert_eq!(overflow_recovery(false, true), OverflowRecovery::GiveUp);
-        assert_eq!(overflow_recovery(false, false), OverflowRecovery::GiveUp);
     }
 }
 
@@ -168,5 +145,29 @@ pub(crate) fn spawn(req: CompactionRequest, then: CompactionThen) -> CompactionP
         cut_idx,
         tokens_before,
         then,
+    }
+}
+
+#[cfg(test)]
+mod recovery_tests {
+    use super::{OverflowRecovery, overflow_recovery};
+
+    #[test]
+    fn made_progress_resumes_as_continuation() {
+        // dirge-b899: the failed turn ran tools / streamed text — resume the
+        // task, do NOT strand it (the old code refused when tools had run).
+        assert_eq!(overflow_recovery(true, true), OverflowRecovery::Continue);
+    }
+
+    #[test]
+    fn no_progress_resends_prompt() {
+        // Pure first-token overflow: nothing streamed, safe to re-send.
+        assert_eq!(overflow_recovery(true, false), OverflowRecovery::Resend);
+    }
+
+    #[test]
+    fn uncompacted_gives_up_regardless_of_progress() {
+        assert_eq!(overflow_recovery(false, true), OverflowRecovery::GiveUp);
+        assert_eq!(overflow_recovery(false, false), OverflowRecovery::GiveUp);
     }
 }

--- a/src/ui/notifications.rs
+++ b/src/ui/notifications.rs
@@ -110,6 +110,42 @@ pub fn sender() -> Option<Sender<Notification>> {
     slot.clone()
 }
 
+pub fn notify_mcp_log(server: &str, line: &str) {
+    notify_send(Notification::McpLog {
+        server: server.to_string(),
+        line: line.to_string(),
+    });
+}
+
+/// Generic send helper — used by future Info/Warn/Error producers
+/// so they share the orphan-detection + bounded-drop semantics.
+#[allow(dead_code)]
+pub fn notify_send(notif: Notification) {
+    let Some(tx) = sender() else {
+        return;
+    };
+    if tx.try_send(notif).is_err() {
+        // Either the channel is full (drop the line, can't keep up
+        // with a runaway producer — better than OOM) or the
+        // receiver was dropped (UI exited / restarted). Clear the
+        // slot in the latter case so subsequent producers don't
+        // keep retrying against a dead channel. Capacity-full
+        // would just transiently shed; we accept the redundant
+        // slot-clear there.
+        if tx.is_closed() {
+            let mut slot = TX.write().unwrap_or_else(|e| e.into_inner());
+            // Only clear if the slot still points at THIS dead
+            // sender. A concurrent `install()` may have already
+            // swapped in a fresh one — don't trample it.
+            if let Some(current) = slot.as_ref()
+                && current.same_channel(&tx)
+            {
+                *slot = None;
+            }
+        }
+    }
+}
+
 /// Send an MCP log line through the notification channel.
 /// Convenience wrapper for the stderr forwarder. Uses `try_send`
 /// — drops the line if the queue is full (review #4), and detects
@@ -172,41 +208,5 @@ mod tests {
         }
         assert_eq!(accepted, NOTIF_CAP);
         assert_eq!(dropped, 10);
-    }
-}
-
-pub fn notify_mcp_log(server: &str, line: &str) {
-    notify_send(Notification::McpLog {
-        server: server.to_string(),
-        line: line.to_string(),
-    });
-}
-
-/// Generic send helper — used by future Info/Warn/Error producers
-/// so they share the orphan-detection + bounded-drop semantics.
-#[allow(dead_code)]
-pub fn notify_send(notif: Notification) {
-    let Some(tx) = sender() else {
-        return;
-    };
-    if tx.try_send(notif).is_err() {
-        // Either the channel is full (drop the line, can't keep up
-        // with a runaway producer — better than OOM) or the
-        // receiver was dropped (UI exited / restarted). Clear the
-        // slot in the latter case so subsequent producers don't
-        // keep retrying against a dead channel. Capacity-full
-        // would just transiently shed; we accept the redundant
-        // slot-clear there.
-        if tx.is_closed() {
-            let mut slot = TX.write().unwrap_or_else(|e| e.into_inner());
-            // Only clear if the slot still points at THIS dead
-            // sender. A concurrent `install()` may have already
-            // swapped in a fresh one — don't trample it.
-            if let Some(current) = slot.as_ref()
-                && current.same_channel(&tx)
-            {
-                *slot = None;
-            }
-        }
     }
 }

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -296,7 +296,7 @@ fn fresh_with_lines_scrollable(n: usize, min_scroll_margin: usize) -> Renderer {
     let need = (visible + min_scroll_margin).max(n);
     for i in 0..need {
         r.buffer.push(LineEntry {
-            text: CompactString::new(&format!("line {i}")),
+            text: CompactString::new(format!("line {i}")),
             color: Color::White,
         });
     }
@@ -340,7 +340,7 @@ fn regression_scrolled_up_view_stays_anchored_through_appends() {
     // Stream in 8 new lines while the user is scrolled up.
     for i in 0..8 {
         r.push_buffer_line(LineEntry {
-            text: CompactString::new(&format!("new {i}")),
+            text: CompactString::new(format!("new {i}")),
             color: Color::White,
         });
     }
@@ -371,7 +371,7 @@ fn regression_replace_from_keeps_view_anchored_when_scrolled_up() {
     let repl_start = total.saturating_sub(10);
     let new_lines: Vec<LineEntry> = (0..20)
         .map(|i| LineEntry {
-            text: CompactString::new(&format!("repl {i}")),
+            text: CompactString::new(format!("repl {i}")),
             color: Color::White,
         })
         .collect();
@@ -390,7 +390,7 @@ fn regression_replace_from_keeps_view_anchored_when_scrolled_up() {
     let repl_start = total.saturating_sub(8);
     let shorter: Vec<LineEntry> = (0..3)
         .map(|i| LineEntry {
-            text: CompactString::new(&format!("sh {i}")),
+            text: CompactString::new(format!("sh {i}")),
             color: Color::White,
         })
         .collect();
@@ -412,7 +412,7 @@ fn at_bottom_view_follows_new_content() {
 
     for i in 0..5 {
         r.push_buffer_line(LineEntry {
-            text: CompactString::new(&format!("new {i}")),
+            text: CompactString::new(format!("new {i}")),
             color: Color::White,
         });
     }
@@ -440,7 +440,7 @@ fn selection_indices_stay_absolute_under_streaming_appends() {
 
     for i in 0..7 {
         r.push_buffer_line(LineEntry {
-            text: CompactString::new(&format!("new {i}")),
+            text: CompactString::new(format!("new {i}")),
             color: Color::White,
         });
     }

--- a/src/ui/run_handlers/dirge_5h5_repro.rs
+++ b/src/ui/run_handlers/dirge_5h5_repro.rs
@@ -284,7 +284,7 @@ async fn drive(n: usize, result_order: Vec<usize>) -> Vec<Chamber> {
             .expect("handle_tool_result");
     }
 
-    drop(ctx);
+    let _ = ctx;
     collect_chambers(&renderer)
 }
 
@@ -402,7 +402,7 @@ async fn dirge_5h5_repro_interleaved_baseline() {
             .await
             .expect("handle_tool_result");
     }
-    drop(ctx);
+    let _ = ctx;
     let chambers = collect_chambers(&renderer);
     assert_all_chambers_have_body(&chambers, 7);
 }
@@ -464,7 +464,7 @@ async fn dirge_5h5_repro_add_chat_during_burst() {
     }
     let _post = ctx.renderer.add_chat("subagent-post");
 
-    drop(ctx);
+    let _ = ctx;
     let chambers = collect_chambers(&renderer);
     assert_all_chambers_have_body(&chambers, 7);
 }
@@ -498,7 +498,7 @@ async fn dirge_5h5_repro_buffer_integrity_after_burst() {
             .expect("handle_tool_result");
     }
 
-    drop(ctx);
+    let _ = ctx;
 
     // Every chamber must have >= 1 body row distinct from TOP and BOTTOM.
     let chambers = collect_chambers(&renderer);
@@ -591,7 +591,7 @@ async fn dirge_5h5_repro_subagent_writes_between_tool_results() {
         );
     }
 
-    drop(ctx);
+    let _ = ctx;
     let chambers = collect_chambers(&renderer);
     assert_all_chambers_have_body(&chambers, 7);
 }
@@ -769,7 +769,7 @@ async fn dirge_5h5_repro_full_issue_shape() {
         );
     }
 
-    drop(ctx);
+    let _ = ctx;
     let chambers = collect_chambers(&renderer);
 
     // Every one of the 7 parent reads must have a body row.

--- a/src/ui/slash/cmd/plugins.rs
+++ b/src/ui/slash/cmd/plugins.rs
@@ -91,7 +91,7 @@ async fn cmd_load(ctx: &mut SlashCtx<'_>, args: &[&str]) -> anyhow::Result<()> {
             "plugins are disabled in this build (enable the 'plugin' feature)",
             c_error(),
         )?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(feature = "plugin")]
@@ -231,10 +231,11 @@ async fn load_all(
                 continue;
             }
 
-            match {
+            let res = {
                 let mut mgr = pm_arc.lock_ignore_poison();
                 crate::plugin::load_plugin(&mut mgr, &path)
-            } {
+            };
+            match res {
                 Ok(desc) => {
                     loaded += 1;
                     ctx.renderer.write_line(

--- a/src/ui/slash/cmd/sessions/delete.rs
+++ b/src/ui/slash/cmd/sessions/delete.rs
@@ -19,7 +19,7 @@ pub(crate) async fn cmd_sessions_delete(
             let preview = s
                 .messages
                 .last()
-                .map(|m| format!("...{}", &m.content.chars().take(40).collect::<String>()))
+                .map(|m| format!("...{}", m.content.chars().take(40).collect::<String>()))
                 .unwrap_or_default();
             if let Err(e) = crate::session::storage::delete_session(&id) {
                 ctx.renderer

--- a/src/ui/slash/cmd/sessions/mod.rs
+++ b/src/ui/slash/cmd/sessions/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn distinct_id_len(ids: &[&str]) -> usize {
     // UUID ids have their first `-` at index 8, so they stay at 8.
     let floor = ids
         .iter()
-        .map(|s| s.find('-').unwrap_or_else(|| s.len()).min(s.len()))
+        .map(|s| s.find('-').unwrap_or(s.len()).min(s.len()))
         .max()
         .unwrap_or(8)
         .max(8);

--- a/src/ui/text_output.rs
+++ b/src/ui/text_output.rs
@@ -34,40 +34,6 @@ pub(crate) fn strip_leading_system_reminder(content: &str) -> &str {
     after.trim_start_matches(['\n', '\r', ' ', '\t'])
 }
 
-#[cfg(test)]
-mod strip_system_reminder_tests {
-    use super::strip_leading_system_reminder;
-
-    #[test]
-    fn passes_plain_text_through() {
-        assert_eq!(strip_leading_system_reminder("hello"), "hello");
-    }
-
-    #[test]
-    fn strips_block_and_trailing_blank_lines() {
-        let input = "<system-reminder>\nTask 1 done\n</system-reminder>\n\nwhat's next?";
-        assert_eq!(strip_leading_system_reminder(input), "what's next?");
-    }
-
-    #[test]
-    fn does_not_strip_mid_message_reminder() {
-        let input = "see <system-reminder>nope</system-reminder>";
-        assert_eq!(strip_leading_system_reminder(input), input);
-    }
-
-    #[test]
-    fn handles_leading_whitespace_before_reminder() {
-        let input = "  \n<system-reminder>x</system-reminder>\nhi";
-        assert_eq!(strip_leading_system_reminder(input), "hi");
-    }
-
-    #[test]
-    fn missing_close_tag_leaves_input_alone() {
-        let input = "<system-reminder>oops";
-        assert_eq!(strip_leading_system_reminder(input), input);
-    }
-}
-
 /// Print a (possibly multi-line) prefixed message to the chat log as a
 /// single visual block: the first line gets `prefix`, continuation lines
 /// are indented to align under it, blank lines stay blank (so an expanded
@@ -163,4 +129,38 @@ pub(crate) fn sanitize_single_line(s: &str, max_chars: usize) -> String {
         count += 1;
     }
     out
+}
+
+#[cfg(test)]
+mod strip_system_reminder_tests {
+    use super::strip_leading_system_reminder;
+
+    #[test]
+    fn passes_plain_text_through() {
+        assert_eq!(strip_leading_system_reminder("hello"), "hello");
+    }
+
+    #[test]
+    fn strips_block_and_trailing_blank_lines() {
+        let input = "<system-reminder>\nTask 1 done\n</system-reminder>\n\nwhat's next?";
+        assert_eq!(strip_leading_system_reminder(input), "what's next?");
+    }
+
+    #[test]
+    fn does_not_strip_mid_message_reminder() {
+        let input = "see <system-reminder>nope</system-reminder>";
+        assert_eq!(strip_leading_system_reminder(input), input);
+    }
+
+    #[test]
+    fn handles_leading_whitespace_before_reminder() {
+        let input = "  \n<system-reminder>x</system-reminder>\nhi";
+        assert_eq!(strip_leading_system_reminder(input), "hi");
+    }
+
+    #[test]
+    fn missing_close_tag_leaves_input_alone() {
+        let input = "<system-reminder>oops";
+        assert_eq!(strip_leading_system_reminder(input), input);
+    }
 }

--- a/src/ui/tool_display.rs
+++ b/src/ui/tool_display.rs
@@ -1020,7 +1020,7 @@ mod tests {
     #[test]
     fn chamber_row_styled_aligns_despite_ansi() {
         let inner = 30;
-        let content = format!("\x1b[32mfn\x1b[0m main() {{}}");
+        let content = "\x1b[32mfn\x1b[0m main() {}".to_string();
         let row = chamber_row_styled(&content, inner, Color::Green);
         assert_eq!(crate::ui::wrap::visible_width(&row), inner + 4);
         assert!(row.starts_with("│ ") && row.ends_with(" │"));

--- a/src/ui/tui/panels.rs
+++ b/src/ui/tui/panels.rs
@@ -1202,8 +1202,10 @@ mod tests {
     /// RightPanel stacks sub-panels and shows their titles.
     #[test]
     fn right_panel_stacks_sub_panels() {
-        let mut data = PanelData::default();
-        data.mcp = vec![("server1".into(), true)];
+        let data = PanelData {
+            mcp: vec![("server1".into(), true)],
+            ..Default::default()
+        };
         let layout = Layout::new(160, 30, 1);
         let mut backend = TestBackend::new(160, 30);
         let mut terminal = Terminal::new(backend.clone()).unwrap();
@@ -1268,8 +1270,10 @@ mod tests {
     /// rows plus one row per modified file — while it still fits.
     #[test]
     fn modified_rect_grows_with_file_count() {
-        let mut data = PanelData::default();
-        data.modified = vec!["a.rs".into(), "b.rs".into(), "c.rs".into()];
+        let data = PanelData {
+            modified: vec!["a.rs".into(), "b.rs".into(), "c.rs".into()],
+            ..Default::default()
+        };
         let area = Rect::new(0, 0, 40, 30);
         let rect = compute_modified_rect(&data, area).expect("rect");
         assert_eq!(rect.height, 5, "3 files → 2 borders + 3 rows");
@@ -1280,8 +1284,10 @@ mod tests {
     /// over) rather than overflowing the panel or its natural height.
     #[test]
     fn modified_rect_caps_at_remaining_space() {
-        let mut data = PanelData::default();
-        data.modified = (0..100).map(|i| format!("f{i}.rs")).collect();
+        let data = PanelData {
+            modified: (0..100).map(|i| format!("f{i}.rs")).collect(),
+            ..Default::default()
+        };
         let area = Rect::new(0, 0, 40, 30);
         let rect = compute_modified_rect(&data, area).expect("rect");
         assert!(
@@ -1340,13 +1346,15 @@ mod tests {
     /// 6-row box on a tall panel.
     #[test]
     fn modified_box_grows_to_content_height_with_files() {
-        let mut data = PanelData::default();
-        data.modified = vec![
-            "src/verify.ts".into(),
-            "test/todatests.test.ts".into(),
-            "src/graph.ts".into(),
-            "src/interpreter.ts".into(),
-        ];
+        let data = PanelData {
+            modified: vec![
+                "src/verify.ts".into(),
+                "test/todatests.test.ts".into(),
+                "src/graph.ts".into(),
+                "src/interpreter.ts".into(),
+            ],
+            ..Default::default()
+        };
         let layout = Layout::new(160, 40, 1);
         let backend = TestBackend::new(160, 40);
         let mut terminal = Terminal::new(backend).unwrap();


### PR DESCRIPTION
CI ran rustfmt + cargo build/test under RUSTFLAGS=-D warnings but never ran clippy, so clippy lints (incl. the deny-by-default correctness group) had no gate and accumulated. `cargo clippy` could not pass.

## What this does
- **main.rs**: the only outright failure was `never_loop` — in non-plugin builds the `--loop` body's sole match arm returns (the looping `ModelSwap` arm is `#[cfg(feature = "plugin")]`). Scoped the allow to `not(feature = "plugin")`.
- Cleared all 67 remaining warnings on **default** + **windows-default** (`--all-targets`): `clippy --fix` for the mechanical set (incl. `items_after_test_module` relocations — pure moves), `field_reassign_with_default` → struct-update, `type_complexity` → type aliases, `drop_non_drop` → `let _ = ctx`, two `await_holding_lock` reads cloned out of the guard + two serialization-guard tests get scoped allows, and the threshold-ordering tests become compile-time `const _` asserts.
- **.github/workflows/ci.yml**: new `clippy` job linting default + windows-default with `-D warnings`. `dap` / `sandbox-microvm` / `--all-features` coverage is left as a follow-up (extra native deps).

## Verification (stable toolchain, matching CI)
- `cargo +stable clippy --all-targets -- -D warnings` → 0 warnings (default **and** windows-default)
- `cargo +stable fmt --all --check` → clean
- targeted tests pass (panels, permission checker, storage, session_search, context_manager)

The large `src/session/storage.rs` diff is a pure test-module relocation by `clippy --fix` (1478 lines before/after).