### PR TITLE
feat(clipboard): add tooltip for clipboard copy notifications

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -443,6 +443,9 @@ pub struct Renderer {
     /// must NOT extend/clear that selection (it would collapse the word
     /// to the click point). Consumed on the next mouse-up.
     pub suppress_next_mouseup: bool,
+    /// Timestamp of the most recent clipboard copy, for "Copied!" tooltip.
+    /// `None` when no copy has happened this session.
+    copied_at: Option<std::time::Instant>,
     /// Visibility mode for the left / right side panels, controlled
     /// independently (`/display`, `/panel`, and the `display` config).
     /// The main conversation pane is always shown.
@@ -592,6 +595,7 @@ impl Renderer {
             selection_end: None,
             last_click: None,
             suppress_next_mouseup: false,
+            copied_at: None,
             left_panel_mode: PanelMode::Auto,
             right_panel_mode: PanelMode::Auto,
             panel_data: PanelData::default(),
@@ -631,6 +635,22 @@ impl Renderer {
             #[cfg(feature = "experimental-ui-terminal-tab")]
             last_tool_name: None,
         })
+    }
+
+    /// Record that text was just copied to clipboard, so a "Copied!"
+    /// tooltip appears on the next redraw.
+    pub fn notify_copied(&mut self) {
+        self.copied_at = Some(std::time::Instant::now());
+    }
+
+    /// If text was copied within the last 2 seconds, returns the
+    /// tooltip text to display (e.g. `"Copied!"`). Otherwise returns
+    /// `None` so the tooltip disappears.
+    fn current_tooltip(&self) -> Option<&'static str> {
+        match self.copied_at {
+            Some(t) if t.elapsed() < std::time::Duration::from_secs(2) => Some("Copied!"),
+            _ => None,
+        }
     }
 
     /// Phase 6 paint entry point. Builds a `Scene` from current
@@ -687,6 +707,9 @@ impl Renderer {
         let show_left_panel = self.left_panel_visible();
         let show_right_panel = self.right_panel_visible();
         let frame_color = crate::ui::theme::header();
+
+        // Compute tooltip before the split borrow destructuring.
+        let tooltip = self.current_tooltip().unwrap_or("");
 
         // Split borrows on Self so we can hold &mut tui_terminal
         // and immutable references to the data fields at the same
@@ -877,6 +900,7 @@ impl Renderer {
             background: crate::ui::theme::background(),
             picker: picker_overlay.as_ref(),
             right_panel_mode: *right_panel_mode,
+            tooltip,
             #[cfg(feature = "dap")]
             debug_panel_data: self.debug_panel_data.as_ref(),
         };

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -65,6 +65,7 @@ fn handle_inner(ev: &UserEvent, renderer: &mut Renderer) -> Outcome {
                     return match renderer.selected_text() {
                         Some(t) => {
                             copy_to_clipboard(&t);
+                            renderer.notify_copied();
                             Outcome::RepaintAndCopied
                         }
                         None => Outcome::Repaint,
@@ -107,6 +108,7 @@ fn handle_inner(ev: &UserEvent, renderer: &mut Renderer) -> Outcome {
             match text {
                 Some(t) => {
                     copy_to_clipboard(&t);
+                    renderer.notify_copied();
                     Outcome::RepaintAndCopied
                 }
                 None => Outcome::Repaint,

--- a/src/ui/tui/chat.rs
+++ b/src/ui/tui/chat.rs
@@ -38,6 +38,9 @@ pub struct ChatPane<'a> {
     /// coordinates. Cells inside this range have REVERSED applied on
     /// top of their underlying style.
     selection: Option<SelectionRange>,
+    /// Brief tooltip text (e.g. "Copied!") shown briefly in the
+    /// bottom-right of the chat area. Empty means no tooltip.
+    tooltip: &'a str,
 }
 
 impl<'a> ChatPane<'a> {
@@ -48,6 +51,7 @@ impl<'a> ChatPane<'a> {
             scroll_offset,
             border_style: Style::default().fg(RColor::Green),
             selection: None,
+            tooltip: "",
         }
     }
 
@@ -60,6 +64,12 @@ impl<'a> ChatPane<'a> {
     /// Highlight cells inside the given selection range with REVERSED.
     pub fn selection(mut self, sel: SelectionRange) -> Self {
         self.selection = Some(sel);
+        self
+    }
+
+    /// Set a brief tooltip shown in the bottom-right corner of the chat.
+    pub fn tooltip(mut self, text: &'a str) -> Self {
+        self.tooltip = text;
         self
     }
 }
@@ -106,6 +116,24 @@ impl<'a> Widget for ChatPane<'a> {
             if let Some(sel) = self.selection {
                 let line_idx = start + i;
                 apply_selection_to_row(buf, l.chat.x, y, text_w, entry, line_idx, &sel);
+            }
+        }
+
+        // ── "Copied!" tooltip toast ──
+        if !self.tooltip.is_empty() {
+            let tooltip_w = self.tooltip.len() as u16 + 2; // padding on each side
+            if tooltip_w + 2 < l.chat.width {
+                let tooltip_x = l.chat.x + l.chat.width - tooltip_w - 1;
+                let tooltip_y = l.chat.y + l.chat.height.saturating_sub(1);
+                let style = Style::default()
+                    .fg(RColor::White)
+                    .bg(RColor::DarkGray);
+                for cx in tooltip_x..tooltip_x + tooltip_w {
+                    let cell = &mut buf[(cx, tooltip_y)];
+                    cell.set_symbol(" ");
+                    cell.set_style(style);
+                }
+                buf.set_string(tooltip_x + 1, tooltip_y, self.tooltip, style);
             }
         }
     }

--- a/src/ui/tui/chat.rs
+++ b/src/ui/tui/chat.rs
@@ -125,9 +125,7 @@ impl<'a> Widget for ChatPane<'a> {
             if tooltip_w + 2 < l.chat.width {
                 let tooltip_x = l.chat.x + l.chat.width - tooltip_w - 1;
                 let tooltip_y = l.chat.y + l.chat.height.saturating_sub(1);
-                let style = Style::default()
-                    .fg(RColor::White)
-                    .bg(RColor::DarkGray);
+                let style = Style::default().fg(RColor::White).bg(RColor::DarkGray);
                 for cx in tooltip_x..tooltip_x + tooltip_w {
                     let cell = &mut buf[(cx, tooltip_y)];
                     cell.set_symbol(" ");

--- a/src/ui/tui/scene.rs
+++ b/src/ui/tui/scene.rs
@@ -109,10 +109,9 @@ pub fn render_frame(scene: &Scene, f: &mut Frame<'_>) {
     }
 
     // Chat region (content + │ verticals).
-    let mut chat =
-        ChatPane::new(&layout, scene.chat_buffer, scene.scroll_offset)
-            .border_style(frame_style)
-            .tooltip(scene.tooltip);
+    let mut chat = ChatPane::new(&layout, scene.chat_buffer, scene.scroll_offset)
+        .border_style(frame_style)
+        .tooltip(scene.tooltip);
     if let Some(sel) = scene.chat_selection {
         chat = chat.selection(sel);
     }

--- a/src/ui/tui/scene.rs
+++ b/src/ui/tui/scene.rs
@@ -79,6 +79,9 @@ pub struct Scene<'a> {
     /// bottom rows of the chat region just above the input box. `None` when no
     /// picker is open [dirge-92em].
     pub picker: Option<&'a crate::ui::picker::PickerOverlay>,
+    /// Brief tooltip text shown in the chat area (e.g. "Copied!").
+    /// Empty string means no tooltip.
+    pub tooltip: &'a str,
 }
 
 /// Paint the entire UI into `f`. Computes layout from the frame's
@@ -107,7 +110,9 @@ pub fn render_frame(scene: &Scene, f: &mut Frame<'_>) {
 
     // Chat region (content + │ verticals).
     let mut chat =
-        ChatPane::new(&layout, scene.chat_buffer, scene.scroll_offset).border_style(frame_style);
+        ChatPane::new(&layout, scene.chat_buffer, scene.scroll_offset)
+            .border_style(frame_style)
+            .tooltip(scene.tooltip);
     if let Some(sel) = scene.chat_selection {
         chat = chat.selection(sel);
     }
@@ -327,6 +332,7 @@ pub fn empty_scene<'a>(
         frame_color: crossterm::style::Color::Green,
         background: crossterm::style::Color::Reset,
         picker: None,
+        tooltip: "",
     }
 }
 
@@ -467,6 +473,7 @@ mod tests {
             frame_color: crossterm::style::Color::Green,
             background: crossterm::style::Color::Reset,
             picker: None,
+            tooltip: "",
         };
 
         let mut backend = TestBackend::new(160, 30);
@@ -724,6 +731,7 @@ mod tests {
             frame_color: crossterm::style::Color::Green,
             background: crossterm::style::Color::Reset,
             picker: None,
+            tooltip: "",
         };
         terminal.draw(|f| render_frame(&s1, f)).unwrap();
 
@@ -756,6 +764,7 @@ mod tests {
             frame_color: crossterm::style::Color::Green,
             background: crossterm::style::Color::Reset,
             picker: None,
+            tooltip: "",
         };
         terminal.draw(|f| render_frame(&s2, f)).unwrap();
         backend = terminal.backend().clone();


### PR DESCRIPTION
This pr is trying to solve issue (#509) This is a workaround for the lack of native copy feedback in terminal environments. On macOS, the terminal does not provide any visual indication when text is programmatically copied, unlike VSCode which surfaces native OS copy notifications. This tooltip bridges that gap until full VSCode extension support is implemented, where native editor copy gestures and OS-level feedback can be leveraged instead.