### PR TITLE
Surface failed MCP servers in info panel

### DIFF
--- a/src/extras/mcp/mod.rs
+++ b/src/extras/mcp/mod.rs
@@ -35,6 +35,11 @@ pub struct McpClientManager {
     /// tool-side auto-reconnect (same server → same tools). `std::sync::Mutex`
     /// because the critical sections are sync (no await held).
     tool_cache: std::sync::Mutex<HashMap<String, Vec<rmcp::model::Tool>>>,
+    /// Names of servers whose initial `connect` failed (GH #541). The
+    /// manager still drops the live connection, but recording the name
+    /// lets the info panel surface it as broken (`○`) instead of
+    /// silently omitting it — mirroring how LSP shows broken servers.
+    failed: Vec<String>,
 }
 
 /// Bound on a per-server `list_tools` round-trip (dirge-fn8h). A wedged server
@@ -68,6 +73,7 @@ impl McpClientManager {
 
         let mut connections = HashMap::new();
         let mut reconnect_locks = HashMap::new();
+        let mut failed = Vec::new();
         for (name, result) in connect_results {
             match result {
                 Ok(conn) => {
@@ -76,6 +82,11 @@ impl McpClientManager {
                     reconnect_locks.insert(name, Arc::new(Mutex::new(0u64)));
                 }
                 Err(e) => {
+                    // Record the name so the info panel can surface a
+                    // failed server as broken (GH #541) instead of
+                    // silently omitting it. The live connection is still
+                    // dropped — reconnect keeps working from `configs`.
+                    failed.push(name.clone());
                     // ALSO emit to stderr so users running without
                     // RUST_LOG / --verbose see that an MCP server
                     // failed to register. Without this, configured
@@ -94,6 +105,7 @@ impl McpClientManager {
             reconnect_locks,
             configs: configs.clone(),
             tool_cache: std::sync::Mutex::new(HashMap::new()),
+            failed,
         }
     }
 
@@ -251,6 +263,14 @@ impl McpClientManager {
             .collect()
     }
 
+    /// Names of servers whose initial `connect` failed (GH #541). The
+    /// info panel renders these as broken (`○`) alongside healthy ones,
+    /// so a misconfigured or timed-out server is visible instead of
+    /// silently omitted.
+    pub fn failed_servers(&self) -> Vec<String> {
+        self.failed.clone()
+    }
+
     pub async fn shutdown(self) {
         for (name, conn) in self.connections {
             conn.shutdown().await;
@@ -294,6 +314,26 @@ mod tests {
         assert_eq!(mgr.reconnect_locks.len(), 0);
         assert_eq!(mgr.configs.len(), 2, "configs retained for /mcp reconnect");
         assert!(mgr.connections_snapshot().is_empty());
+    }
+
+    /// GH #541: a server that fails to connect must still be VISIBLE to
+    /// the user. Previously the only signal was a one-line stderr warning,
+    /// and the info panel (which reads only live connections) rendered
+    /// `· (none)` — so a misconfigured / timed-out MCP server was
+    /// completely invisible. The manager now records the names of servers
+    /// that failed their initial connect so the panel can surface them as
+    /// broken (parity with how LSP shows broken servers).
+    #[tokio::test]
+    async fn connect_all_records_failed_server_names() {
+        let mut configs = HashMap::new();
+        configs.insert("bogus-a".to_string(), bogus_server());
+        configs.insert("bogus-b".to_string(), bogus_server());
+
+        let mgr = McpClientManager::connect_all(&configs).await;
+
+        let mut failed = mgr.failed_servers();
+        failed.sort();
+        assert_eq!(failed, vec!["bogus-a".to_string(), "bogus-b".to_string()]);
     }
 
     /// Empty config set → an empty, well-formed manager (no panic, no

--- a/src/ui/panel_render.rs
+++ b/src/ui/panel_render.rs
@@ -101,10 +101,18 @@ pub(crate) fn build_panel_data(
     #[cfg(feature = "mcp")]
     let mcp: Vec<(String, bool)> = mcp_manager
         .map(|m| {
-            m.connections_snapshot()
+            // Live connections render as healthy (`●`). GH #541: a server
+            // whose initial connect failed is appended afterwards as
+            // broken (`○`) so it's visible instead of silently omitted.
+            let mut rows: Vec<(String, bool)> = m
+                .connections_snapshot()
                 .into_iter()
                 .map(|(name, _conn)| (name, true))
-                .collect()
+                .collect();
+            for name in m.failed_servers() {
+                rows.push((name, false));
+            }
+            rows
         })
         .unwrap_or_default();
     #[cfg(not(feature = "mcp"))]
@@ -172,5 +180,51 @@ pub(crate) fn build_panel_data(
         todos,
         modified,
         sysload: sysload.map(|s| s.snapshot()),
+    }
+}
+
+#[cfg(all(test, feature = "mcp"))]
+mod tests {
+    use super::*;
+    use crate::extras::mcp::McpClientManager;
+    use crate::extras::mcp::config::McpServerConfig;
+    use std::collections::HashMap;
+
+    fn bogus_server() -> McpServerConfig {
+        // A binary that can't exist → spawn fails immediately, so `connect`
+        // returns Err well inside the init timeout (no 10s wait).
+        McpServerConfig::Command {
+            command: "dirge-nonexistent-mcp-binary".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            allow_external_paths: false,
+        }
+    }
+
+    /// GH #541: a server that fails its initial connect must still show
+    /// up in the info panel as broken (`○`), not vanish entirely. Before
+    /// the fix `build_panel_data` enumerated only live connections, so a
+    /// misconfigured server rendered as `· (none)`.
+    #[tokio::test]
+    async fn build_panel_data_surfaces_failed_mcp_servers_as_broken() {
+        let mut configs: HashMap<String, McpServerConfig> = HashMap::new();
+        configs.insert("ghost".to_string(), bogus_server());
+        let mgr = McpClientManager::connect_all(&configs).await;
+
+        let session = crate::session::Session::new("p", "m", 100_000);
+        let data = build_panel_data(
+            &session,
+            None,
+            Some(&mgr),
+            #[cfg(feature = "lsp")]
+            None,
+        );
+
+        assert_eq!(data.mcp.len(), 1, "failed server must still be listed");
+        assert_eq!(data.mcp[0].0, "ghost");
+        assert!(
+            !data.mcp[0].1,
+            "failed server must render as broken (ok=false)"
+        );
     }
 }


### PR DESCRIPTION
Fixes #541 (the MCP half).

## Problem

A configured MCP server that fails its initial `connect` was invisible in the TUI info panel — it rendered as `· (none)`, making the failure look like "no servers configured" rather than "this server is broken".

Root cause: `connect_all` drops servers whose `connect` returns `Err` (retaining only the config so `/mcp reconnect` still works), and the only signal was a one-line stderr warning. The info panel read exclusively from `connections_snapshot()`, so a dropped server had no path to the panel at all — unlike LSP, which already has a broken-server panel path.

## Fix

- `McpClientManager` now records the names of servers whose initial connect failed and exposes them via `failed_servers()`. The live connection is still dropped, so reconnect behavior is unchanged.
- `build_panel_data` appends failed servers with `ok=false` after live connections, so they render as `○` (broken) — parity with how LSP shows broken servers.

## Tests (TDD)

- `connect_all_records_failed_server_names` — manager records every failed name.
- `build_panel_data_surfaces_failed_mcp_servers_as_broken` — a failed server appears in the panel as `ok=false`.

Both written failing-first, then made to pass. Full suite green: `3185 passed` with `mcp lsp loop` features.

## Out of scope (not addressed here)

- **Init timeout**: the reporter's `npx`-backed server hit the 10s default. Now it shows as `○ <name>` so the failure is visible and `/mcp reconnect` is actionable. Bumping/raising the default is a separate tuning decision.
- **LSP "configured but not started"**: LSP servers spawn lazily on first file touch by design. That's separate from this bug and a larger change if we want to surface them pre-spawn.
- Two unrelated config typos in the reporter's config (`permissions` → `permission`, `roles.escalation` → `escalation_provider`) are silently ignored but **not** the cause of the missing panel row — flagged separately.