### PR TITLE
fix(stream): retry mid-assembly chunk timeouts instead of halting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -594,7 +594,7 @@ above is the one exception with richer per-provider precedence;
 | Field | Default | What it bounds |
 |---|---|---|
 | `stream_chunk_secs` | 300 | Per-chunk read deadline for a streaming LLM response (fallback for the per-provider key above) |
-| `tool_call_gap_secs` | 30 | Stall window while a tool call is mid-assembly in the stream |
+| `tool_call_gap_secs` | 60 | Stall window while a tool call is mid-assembly in the stream. A timeout here is retried automatically (the partial, incomplete tool call is discarded and the request restarted); raise it only if your provider legitimately pauses longer than 60s between tool-call deltas. |
 | `mcp_call_secs` | 120 | Total budget for one MCP tool call, including reconnect + retry |
 | `mcp_init_secs` | 10 | MCP server `initialize` handshake |
 | `lsp_request_secs` | 30 | Any non-`initialize` LSP request |

--- a/src/agent/agent_loop/retry.rs
+++ b/src/agent/agent_loop/retry.rs
@@ -128,21 +128,32 @@ pub fn retrying_stream_fn_with_non_retryable(
                         StreamEvent::Error { error } => {
                             // Decide on retry vs surface BEFORE
                             // yielding the Error event downstream.
-                            if !committed {
-                                if non_retryable(error) {
-                                    yield evt;
-                                    return;
-                                }
-                                let kind = classify_error(error);
-                                if policy.should_retry(attempts, kind) {
-                                    retry_msg = Some(error.clone());
-                                    // Don't yield this Error — we're
-                                    // about to retry.
-                                    break;
-                                }
+                            if non_retryable(error) {
+                                yield evt;
+                                return;
                             }
-                            // Either retry exhausted, non-retryable
-                            // kind, or committed → surface.
+                            let kind = classify_error(error);
+                            // #545: a stream-chunk TIMEOUT is
+                            // retryable even after content has
+                            // committed. A timeout means the
+                            // provider stalled mid-emission, so the
+                            // partial is incomplete; the consumer
+                            // discards it on StreamEvent::Retry
+                            // (stream.rs PROV-5 reset) and the next
+                            // attempt starts clean. Other committed
+                            // errors (hard resets, auth, …) still
+                            // surface — retrying those would
+                            // duplicate tokens already shown.
+                            let retryable = policy.should_retry(attempts, kind)
+                                && (!committed || is_timeout_error(error));
+                            if retryable {
+                                retry_msg = Some(error.clone());
+                                // Don't yield this Error — we're
+                                // about to retry.
+                                break;
+                            }
+                            // Retry exhausted, non-retryable kind,
+                            // or a committed non-timeout → surface.
                             yield evt;
                             return;
                         }
@@ -476,6 +487,64 @@ mod tests {
             }
         ));
         assert!(matches!(events[2], StreamEvent::Error { .. }));
+    }
+
+    /// #545: a stream-chunk TIMEOUT after content has committed is
+    /// still retried. Unlike a hard "connection reset", a timeout
+    /// means the provider stalled mid-emission — the partial is
+    /// incomplete and the consumer discards it on
+    /// `StreamEvent::Retry` (stream.rs PROV-5 reset), so retrying is
+    /// safe. This is what keeps a reasoning model that thinks, then
+    /// stalls mid-tool-call, from halting the whole run.
+    #[tokio::test]
+    async fn retries_timeout_after_content_committed() {
+        let (factory, counter) = counted_canned(vec![
+            vec![
+                StreamEvent::Start {
+                    partial: empty_assistant(),
+                },
+                // Real content streamed → committed.
+                StreamEvent::Delta {
+                    partial: assistant_with("partial "),
+                    phase: DeltaPhase::TextStart,
+                },
+                // Mid-assembly stream-chunk timeout (verbatim shape
+                // produced by rig_stream.rs).
+                StreamEvent::Error {
+                    error: "stream chunk timed out after 29s while a tool call was mid-assembly"
+                        .to_string(),
+                },
+            ],
+            vec![StreamEvent::Done {
+                reason: StopReason::Stop,
+                message: assistant_with("ok"),
+                usage: None,
+            }],
+        ]);
+        let wrapped = retrying_stream_fn(factory, RecoveryPolicy::default());
+
+        tokio::time::pause();
+        let task = tokio::spawn(async move {
+            drain(wrapped(
+                ctx(),
+                crate::agent::agent_loop::StreamOptions::from_signal(AbortSignal::new()),
+            ))
+            .await
+        });
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        let events = task.await.unwrap();
+
+        // Retried once → second attempt succeeded.
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+        // A Retry notice was emitted between attempts (the consumer
+        // uses it to reset partial state + show a banner instead of
+        // freezing).
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::Retry { .. }))
+        );
+        assert!(matches!(events.last(), Some(StreamEvent::Done { .. })));
     }
 
     /// Rate-limit error retries, retry-after-ms gets honoured

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -116,10 +116,10 @@ where
         // interleaves text + tool-call deltas keeps making
         // forward progress and never trips the gap timeout; only
         // a true mid-assembly stall (no chunks of ANY kind for
-        // 30s while a tool call is open) fires.
+        // the gap window while a tool call is open) fires.
         //
         // This addresses the review finding that the prior
-        // "any chunk subject to the 30s timeout while a tool
+        // "any chunk subject to the gap timeout while a tool
         // call is open" semantic spuriously killed providers
         // that interleave reasoning between tool-call deltas.
         let mut open_tool_calls: std::collections::HashSet<String> =
@@ -187,8 +187,9 @@ where
                         // retry. Matches runner.rs:301-304.
                         let detail = if !open_tool_calls.is_empty() {
                             format!(
-                                "stream chunk timed out after {}s while a tool call was mid-assembly (provider stalled emitting tool-call deltas — common DeepSeek symptom; the harness narrows to {}s while assembling tool calls)",
+                                "stream chunk timed out after {}s while a tool call was mid-assembly (provider stalled emitting tool-call deltas — common DeepSeek symptom; the harness narrows to {}s while assembling tool calls). This is retried automatically; if your model legitimately pauses longer than {}s between deltas, raise `timeouts.tool_call_gap_secs` in config.json.",
                                 t.as_secs(),
+                                tool_call_gap_timeout.as_secs(),
                                 tool_call_gap_timeout.as_secs(),
                             )
                         } else {
@@ -1440,9 +1441,9 @@ mod tests {
                         ))
                     }
                     2 => {
-                        // Sleep another 20s — still under 30s
-                        // since the previous text delta reset
-                        // the budget.
+                        // Sleep another 20s — still under the
+                        // 60s gap budget since the previous text
+                        // delta reset it.
                         tokio::time::sleep(Duration::from_secs(20)).await;
                         Some((
                             Ok(StreamedAssistantContent::Text(Text {
@@ -1467,7 +1468,7 @@ mod tests {
         let events = drain_task.await.unwrap();
 
         // The stream should complete naturally (Done) rather
-        // than timeout. The 30s gap budget never expires
+        // than timeout. The 60s gap budget never expires
         // because each ~20s wait is followed by a chunk.
         let has_timeout_error = events.iter().any(|e| {
             matches!(
@@ -1478,18 +1479,18 @@ mod tests {
         assert!(
             !has_timeout_error,
             "gap timeout should NOT fire when forward progress \
-             (text deltas) keeps arriving within the 30s window: \
+             (text deltas) keeps arriving within the 60s window: \
              events = {events:?}",
         );
     }
 
     /// Phase-1 #4: when a tool call is mid-assembly, the chunk
-    /// timeout narrows to the gap-timeout (30s) even if the
-    /// configured `chunk_timeout` is much larger. Without this,
-    /// a provider stalled emitting tool-call deltas would wait
-    /// the full 300s default before erroring.
+    /// timeout narrows to the gap-timeout (default 60s) even if
+    /// the configured `chunk_timeout` is much larger. Without
+    /// this, a provider stalled emitting tool-call deltas would
+    /// wait the full 300s default before erroring.
     #[tokio::test]
-    async fn tool_call_gap_timeout_fires_within_30s_even_with_large_chunk_timeout() {
+    async fn tool_call_gap_timeout_fires_even_with_large_chunk_timeout() {
         tokio::time::pause();
         let raw = tool_call_delta_then_stall();
         let drain_task = tokio::spawn(async move {
@@ -1502,7 +1503,7 @@ mod tests {
         });
         // Advance just past the gap timeout. The broad 300s
         // timeout would not have fired yet.
-        tokio::time::advance(Duration::from_secs(31)).await;
+        tokio::time::advance(Duration::from_secs(61)).await;
         let events = drain_task.await.unwrap();
 
         let last = events.last().expect("must have events");
@@ -1515,6 +1516,11 @@ mod tests {
                 assert!(
                     error.contains("tool call was mid-assembly") || error.contains("tool-call"),
                     "error should explain the tighter tool-call timeout: {error}"
+                );
+                // Actionable: point the user at the config knob.
+                assert!(
+                    error.contains("tool_call_gap_secs"),
+                    "error should name the configurable knob: {error}"
                 );
             }
             other => panic!("expected Error, got {other:?}"),

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -103,7 +103,7 @@ pub struct Timeouts {
 
 impl Timeouts {
     pub const DEFAULT_STREAM_CHUNK_SECS: u64 = 300;
-    pub const DEFAULT_TOOL_CALL_GAP_SECS: u64 = 30;
+    pub const DEFAULT_TOOL_CALL_GAP_SECS: u64 = 60;
     pub const DEFAULT_MCP_CALL_SECS: u64 = 120;
     pub const DEFAULT_MCP_INIT_SECS: u64 = 10;
     pub const DEFAULT_LSP_REQUEST_SECS: u64 = 30;
@@ -196,7 +196,7 @@ mod tests {
     fn defaults_match_documented_values() {
         let t = Timeouts::DEFAULT;
         assert_eq!(t.stream_chunk, Duration::from_secs(300));
-        assert_eq!(t.tool_call_gap, Duration::from_secs(30));
+        assert_eq!(t.tool_call_gap, Duration::from_secs(60));
         assert_eq!(t.mcp_call, Duration::from_secs(120));
         assert_eq!(t.mcp_init, Duration::from_secs(10));
         assert_eq!(t.lsp_request, Duration::from_secs(30));


### PR DESCRIPTION
Closes #545.

## Problem

When a provider stalled while a tool call was mid-assembly, the stream-chunk timeout fired as a hard error and the run halted (`Once I see the error, everything halts, essentially.`). A retry layer already existed, but it never engaged: any thinking/text delta streamed before the tool call marked the attempt `committed`, and the retry layer refused to replay a committed attempt. For reasoning models (e.g. ChatGPT-5.5) that emit thinking before a tool call, a single stall was fatal.

All of the recovery machinery was already in place — the consumer discards the partial assistant message on `StreamEvent::Retry` (PROV-5) and shows a retry banner. The only thing blocking recovery was the `if !committed` guard.

## Changes

- **`src/agent/agent_loop/retry.rs`** — retry timeout errors even after content has committed. The partial is stalled/incomplete, so discarding it on `Retry` and restarting is correct. Non-timeout committed errors (hard resets, auth) still surface to avoid duplicating tokens already shown.
- **`src/timeout.rs`** — `DEFAULT_TOOL_CALL_GAP_SECS` 30 → 60. 30s was too tight for reasoning models behind proxies.
- **`src/agent/agent_loop/rig_stream.rs`** — the mid-assembly error now states it is retried automatically and names `timeouts.tool_call_gap_secs`.
- **`docs/config.md`** — updated default + note that this timeout is auto-retried.

## Verification

- New test `retries_timeout_after_content_committed` (TDD: red → green).
- Existing `does_not_retry_after_content_committed` (`connection reset`) stays green by design — only timeouts carve out the committed guard.
- Modules green: `agent_loop` 523, `recovery` 33, `retry` 13, `rig_stream` 23, `timeout` 5.
- `cargo clippy --bin dirge` and `cargo fmt --check` clean.

On retry exhaustion (5 attempts) the error still surfaces cleanly via `TurnEnd` and returns to idle — worst case is a recoverable prompt, not a freeze.