### PR TITLE
fix(windows): stop leaking `\?\` verbatim paths from path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "crossterm",
  "dap",
  "dirs",
+ "dunce",
  "futures",
  "hex",
  "html2text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,10 @@ jsonschema = "0.46"
 janetrs = { version = "0.8", optional = true }
 html2text = "0.17"
 indexmap = "2"
+# Windows-safe canonicalize: returns non-verbatim paths (no `\\?\` prefix)
+# unless the path genuinely needs it (long/reserved). Drop-in for
+# std::fs::canonicalize; identical behavior on non-Windows.
+dunce = "1"
 lsp-types = { version = "0.97", optional = true }
 tree-sitter-elixir = { version = "0.3.5", optional = true }
 tree-sitter-sequel = { version = "0.3", optional = true }

--- a/src/agent/tools/modified.rs
+++ b/src/agent/tools/modified.rs
@@ -40,7 +40,7 @@ const MAX_MODIFIED: usize = 256;
 /// Best-effort canonicalize; falls back to the path as given when the file
 /// doesn't exist yet or canonicalize fails.
 pub fn mark_modified(path: &Path) {
-    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let canonical = crate::permission::path::canonical_or_self(path);
     let mut set = MODIFIED_FILES.lock_ignore_poison();
     // IndexSet preserves insertion order and dedups; we want the most-recent
     // touch to surface at the end, so re-insert moves the entry.

--- a/src/agent/tools/snapshots.rs
+++ b/src/agent/tools/snapshots.rs
@@ -131,7 +131,7 @@ fn intern(store: &mut Store, bytes: Vec<u8>) -> Arc<Vec<u8>> {
 ///
 /// Call this from a mutating tool *before* writing.
 pub fn capture(path: &Path) {
-    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let canonical = crate::permission::path::canonical_or_self(path);
 
     // Read pre-state before locking the store (I/O outside the lock).
     let capture = match std::fs::metadata(&canonical) {
@@ -175,7 +175,7 @@ pub fn capture(path: &Path) {
 /// edit was based on. Use [`capture`] instead when the file may be
 /// absent (create) or when the pre-content isn't already available.
 pub fn capture_bytes(path: &Path, content: &[u8]) {
-    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let canonical = crate::permission::path::canonical_or_self(path);
     if content.len() as u64 > MAX_SNAPSHOT_BYTES {
         return;
     }

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -48,7 +48,14 @@ pub fn nearest_root(
     // the loop would walk past stop_at all the way to `/`, picking
     // up the nearest Cargo.toml it finds. Guard: cursor must start
     // with stop_at as prefix; otherwise bail immediately.
-    if !cursor.starts_with(&stop_at) {
+    //
+    // NOT a raw `Path::starts_with`: on Windows `canonical_or_self`
+    // (dunce) yields mixed forms within one tree — simplified for short
+    // paths, verbatim `\\?\C:\...` for >MAX_PATH or reserved-name
+    // components — and a component-wise prefix test never matches
+    // across forms, silently disabling root detection for that file.
+    // Same reason the loop's stop_at comparison is normalized.
+    if !crate::permission::path::path_starts_with(&cursor, &stop_at) {
         return None;
     }
     loop {
@@ -62,7 +69,7 @@ pub fn nearest_root(
                 return Some(cursor);
             }
         }
-        if cursor == stop_at {
+        if crate::permission::path::paths_equivalent(&cursor, &stop_at) {
             break;
         }
         match cursor.parent() {
@@ -96,7 +103,10 @@ pub fn rust_workspace_root(file: &Path, stop_at: &Path) -> Option<PathBuf> {
         {
             return Some(cursor);
         }
-        if cursor == stop_at_canon {
+        // Normalized comparison for the same Windows mixed-form reason
+        // as in `nearest_root` — a verbatim cursor never `==` a
+        // simplified stop_at, and the walk would escape the boundary.
+        if crate::permission::path::paths_equivalent(&cursor, &stop_at_canon) {
             break;
         }
         match cursor.parent() {

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -603,7 +603,7 @@ fn canonicalize_path_pattern(pattern_str: &str, working_dir: &str) -> Option<Str
             return Some(out);
         }
     }
-    let canonical_head = std::fs::canonicalize(head_trimmed)
+    let canonical_head = dunce::canonicalize(head_trimmed)
         .ok()
         .map(|p| p.to_string_lossy().into_owned())
         .or_else(|| {
@@ -652,7 +652,7 @@ fn project_canonical_from_existing_ancestor(path: &str) -> Option<String> {
                     tail_components.push(name);
                 }
                 anchor = parent;
-                if let Ok(canonical) = std::fs::canonicalize(anchor) {
+                if let Ok(canonical) = dunce::canonicalize(anchor) {
                     let mut out = canonical;
                     for name in tail_components.iter().rev() {
                         out.push(name);

--- a/src/permission/path.rs
+++ b/src/permission/path.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 /// string so the `starts_with` comparisons in `is_external_path`
 /// still work for the literal form.
 pub(crate) fn canonicalize_for_cache(working_dir: &str) -> String {
-    std::fs::canonicalize(working_dir)
+    dunce::canonicalize(working_dir)
         .ok()
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|| working_dir.to_string())
@@ -27,7 +27,7 @@ pub(crate) fn canonicalize_for_cache(working_dir: &str) -> String {
 /// home for the `path.canonicalize().unwrap_or_else(|_| path.into())`
 /// idiom that was copy-pasted with varied fallbacks (dirge-b2g7).
 pub fn canonical_or_self(path: &Path) -> std::path::PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Normalize a path string for prefix comparison. On Windows
@@ -85,7 +85,7 @@ pub(crate) fn resolve_absolute(path: &str, working_dir: &str) -> String {
     } else {
         Path::new(working_dir).join(p)
     };
-    match std::fs::canonicalize(&joined) {
+    match dunce::canonicalize(&joined) {
         Ok(canonical) => canonical.to_string_lossy().to_string(),
         Err(_) => {
             // The full path doesn't exist on disk (e.g. a write to a
@@ -116,7 +116,7 @@ pub(crate) fn resolve_absolute(path: &str, working_dir: &str) -> String {
             let mut ancestor = normalized.as_path();
             let mut tail: Vec<std::ffi::OsString> = Vec::new();
             loop {
-                if let Ok(canonical_ancestor) = std::fs::canonicalize(ancestor) {
+                if let Ok(canonical_ancestor) = dunce::canonicalize(ancestor) {
                     let mut out = canonical_ancestor;
                     for seg in tail.iter().rev() {
                         out.push(seg);
@@ -244,6 +244,38 @@ mod tests {
         assert!(!path_is_within(r"\\?\C:\proj-other\a.dfy", r"C:\proj"));
     }
 
+    /// Regression: `resolve_absolute` must NOT leak a Windows verbatim
+    /// (`\\?\`) prefix into the string it returns. That form flowed into
+    /// tool `resolved_path`s (apply_patch, edit, read-gate cache keys) and
+    /// surfaced to the model as `\\?\C:\...\file.dfy`. `dunce::canonicalize`
+    /// strips it for normal-length paths. Applies to both existing files
+    /// and not-yet-created ones (the ancestor-walk branch).
+    #[cfg(windows)]
+    #[test]
+    fn resolve_absolute_has_no_verbatim_prefix() {
+        let dir = std::env::temp_dir().join(format!("dirge-verbatim-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let existing = dir.join("here.dfy");
+        std::fs::write(&existing, "x").unwrap();
+
+        let r1 = resolve_absolute(existing.to_str().unwrap(), "/");
+        assert!(
+            !r1.starts_with(r"\\?\"),
+            "existing file leaked verbatim prefix: {r1}"
+        );
+
+        // Nonexistent file (create path) — exercises the ancestor-walk branch.
+        let missing = dir.join("newdir").join("not-yet.dfy");
+        let r2 = resolve_absolute(missing.to_str().unwrap(), dir.to_str().unwrap());
+        assert!(
+            !r2.starts_with(r"\\?\"),
+            "new-file path leaked verbatim prefix: {r2}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// F7: `resolve_absolute` must follow symlinks so a symlink
     /// pointing at a deny-listed path can't bypass the rule.
     #[test]
@@ -259,10 +291,17 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink(&target, &link).unwrap();
         #[cfg(windows)]
-        std::os::windows::fs::symlink_file(&target, &link).unwrap();
+        if let Err(e) = std::os::windows::fs::symlink_file(&target, &link) {
+            // Creating symlinks on Windows needs SeCreateSymbolicLinkPrivilege
+            // (Developer Mode or admin; OS error 1314 otherwise). Skip
+            // gracefully where it's unavailable instead of failing the suite.
+            eprintln!("skipping resolve_absolute_follows_symlinks: cannot create symlink: {e}");
+            let _ = std::fs::remove_dir_all(&dir);
+            return;
+        }
 
         let resolved = resolve_absolute(link.to_str().unwrap(), "/");
-        let expected = std::fs::canonicalize(&target)
+        let expected = dunce::canonicalize(&target)
             .unwrap()
             .to_string_lossy()
             .into_owned();
@@ -289,14 +328,29 @@ mod tests {
         let link = base.join("link_proj");
         #[cfg(unix)]
         std::os::unix::fs::symlink(&real, &link).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&real, &link) {
+            // Needs SeCreateSymbolicLinkPrivilege on Windows (OS error 1314
+            // without Developer Mode / admin). Skip gracefully.
+            eprintln!(
+                "skipping resolve_absolute_walks_to_deepest_existing_ancestor_through_symlink: \
+                 cannot create symlink: {e}"
+            );
+            let _ = std::fs::remove_dir_all(&base);
+            return;
+        }
 
         // newdir/sub do NOT exist yet; only `link_proj` (→ real_proj) does.
         let target = link.join("newdir/sub/file.rs");
         let resolved = resolve_absolute(target.to_str().unwrap(), link.to_str().unwrap());
 
-        let expected = std::fs::canonicalize(&real)
+        // Build the tail with per-component joins so the separators match how
+        // `resolve_absolute` reattaches them (platform-native: `\` on Windows).
+        let expected = dunce::canonicalize(&real)
             .unwrap()
-            .join("newdir/sub/file.rs")
+            .join("newdir")
+            .join("sub")
+            .join("file.rs")
             .to_string_lossy()
             .into_owned();
         assert_eq!(
@@ -327,7 +381,7 @@ mod tests {
         let traversal = "newdir/../../../../../../etc/passwd";
         let resolved = resolve_absolute(traversal, &cwd);
 
-        let cwd_canonical = std::fs::canonicalize(&real).unwrap();
+        let cwd_canonical = dunce::canonicalize(&real).unwrap();
         let resolved_path = std::path::PathBuf::from(&resolved);
         assert!(
             !resolved_path.starts_with(&cwd_canonical),
@@ -350,7 +404,7 @@ mod tests {
         let new_file = dir.join("does-not-exist-yet.txt");
 
         let resolved = resolve_absolute(new_file.to_str().unwrap(), "/");
-        let expected_parent = std::fs::canonicalize(&dir).unwrap();
+        let expected_parent = dunce::canonicalize(&dir).unwrap();
         let expected = expected_parent
             .join("does-not-exist-yet.txt")
             .to_string_lossy()
@@ -381,7 +435,7 @@ mod tests {
 
         let resolved = resolve_absolute(traversal, &cwd);
 
-        let cwd_canonical = std::fs::canonicalize(&cwd).unwrap();
+        let cwd_canonical = dunce::canonicalize(&cwd).unwrap();
         let resolved_path = std::path::PathBuf::from(&resolved);
         assert!(
             !resolved_path.starts_with(&cwd_canonical) && !resolved_path.starts_with(&cwd),

--- a/src/permission/path.rs
+++ b/src/permission/path.rs
@@ -72,6 +72,36 @@ pub(crate) fn path_is_within(child: &str, base: &str) -> bool {
     child == base || child.starts_with(&format!("{base}/"))
 }
 
+/// Drop-in replacement for `Path::starts_with` when the two sides may
+/// come back from canonicalization in different Windows forms. dunce
+/// returns MIXED forms within one tree: short paths get simplified
+/// (`C:\proj`) while >MAX_PATH or reserved-name (aux/nul) paths stay
+/// verbatim (`\\?\C:\...`). `Path::starts_with` compares prefix
+/// components (`VerbatimDisk` vs `Disk`) and returns false, so prefix
+/// guards silently fail. Compares the [`normalize_for_prefix`] forms
+/// instead, boundary-safe. Unlike [`path_is_within`] a root `base`
+/// matches (same as `Path::starts_with`) — callers like the LSP
+/// root walk own their boundary semantics. No-op normalization on
+/// Unix, so behavior there is identical to `Path::starts_with`.
+pub(crate) fn path_starts_with(child: &Path, base: &Path) -> bool {
+    let child = normalize_for_prefix(&child.to_string_lossy());
+    let base = normalize_for_prefix(&base.to_string_lossy());
+    let base = base.trim_end_matches('/');
+    if base.is_empty() {
+        // `base` was the filesystem root (`/`): every absolute path is
+        // under it, matching `Path::starts_with`.
+        return child.starts_with('/');
+    }
+    child == base || child.starts_with(&format!("{base}/"))
+}
+
+/// Path equality over the [`normalize_for_prefix`] forms — the `==`
+/// analogue of [`path_starts_with`], for the same mixed
+/// verbatim-vs-simplified reason. No-op normalization on Unix.
+pub(crate) fn paths_equivalent(a: &Path, b: &Path) -> bool {
+    normalize_for_prefix(&a.to_string_lossy()) == normalize_for_prefix(&b.to_string_lossy())
+}
+
 /// `c:` / `Z:` — a normalized drive root with no path component.
 fn is_drive_root(s: &str) -> bool {
     let b = s.as_bytes();
@@ -215,6 +245,85 @@ pub fn validate_path(path: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn path_starts_with_basic_and_boundary() {
+        assert!(path_starts_with(
+            Path::new("/proj/src/a.rs"),
+            Path::new("/proj")
+        ));
+        assert!(path_starts_with(Path::new("/proj"), Path::new("/proj")));
+        // Boundary-safe: a sibling sharing a name prefix is NOT within.
+        assert!(!path_starts_with(
+            Path::new("/proj-other/a.rs"),
+            Path::new("/proj")
+        ));
+        assert!(!path_starts_with(
+            Path::new("/elsewhere/a.rs"),
+            Path::new("/proj")
+        ));
+        // Unlike `path_is_within`, a root base matches (Path::starts_with
+        // semantics — nearest_root callers may legitimately stop at `/`).
+        assert!(path_starts_with(Path::new("/a/b"), Path::new("/")));
+    }
+
+    #[test]
+    fn paths_equivalent_basic() {
+        assert!(paths_equivalent(
+            Path::new("/proj/src"),
+            Path::new("/proj/src")
+        ));
+        assert!(!paths_equivalent(
+            Path::new("/proj/src"),
+            Path::new("/proj")
+        ));
+    }
+
+    /// The LSP regression: dunce returns MIXED forms within one tree on
+    /// Windows — short paths simplified (`C:\proj`), >MAX_PATH or
+    /// reserved-name (aux/nul) paths verbatim (`\\?\C:\...`). A raw
+    /// `Path::starts_with` compares VerbatimDisk vs Disk prefix components
+    /// and always fails, so `nearest_root` bailed and LSP root detection
+    /// silently stopped for that file.
+    #[cfg(windows)]
+    #[test]
+    fn path_starts_with_windows_verbatim_vs_simplified() {
+        assert!(path_starts_with(
+            Path::new(r"\\?\C:\proj\aux\src\a.rs"),
+            Path::new(r"C:\proj"),
+        ));
+        assert!(path_starts_with(
+            Path::new(r"C:\proj\src\a.rs"),
+            Path::new(r"\\?\C:\proj"),
+        ));
+        // Drive-letter case and mixed separators.
+        assert!(path_starts_with(
+            Path::new(r"\\?\c:\proj/src/a.rs"),
+            Path::new(r"C:\proj"),
+        ));
+        // Boundary still enforced under normalization.
+        assert!(!path_starts_with(
+            Path::new(r"\\?\C:\proj-other\a.rs"),
+            Path::new(r"C:\proj"),
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn paths_equivalent_windows_verbatim_vs_simplified() {
+        assert!(paths_equivalent(
+            Path::new(r"\\?\C:\proj"),
+            Path::new(r"C:\proj")
+        ));
+        assert!(paths_equivalent(
+            Path::new(r"\\?\c:\proj"),
+            Path::new(r"C:\proj")
+        ));
+        assert!(!paths_equivalent(
+            Path::new(r"\\?\C:\proj2"),
+            Path::new(r"C:\proj")
+        ));
+    }
 
     #[test]
     fn path_is_within_basic_and_boundary() {

--- a/src/ui/slash/cmd/cd.rs
+++ b/src/ui/slash/cmd/cd.rs
@@ -21,7 +21,7 @@ pub(crate) async fn cmd_cd(ctx: &mut SlashCtx<'_>, text: &str) -> anyhow::Result
     };
     match std::env::set_current_dir(&path) {
         Ok(()) => {
-            let canonical = std::fs::canonicalize(&path).unwrap_or(path);
+            let canonical = dunce::canonicalize(&path).unwrap_or(path);
             ctx.session.working_dir = CompactString::new(canonical.to_string_lossy().as_ref());
             if let Some(perm) = ctx.permission
                 && let Ok(mut guard) = perm.lock()


### PR DESCRIPTION
Ran into a few more file path problems while running on windows. Claude generated the following fix and explanation:

# Problem
On Windows, std::fs::canonicalize returns an extended-length "verbatim" path (\\?\C:\..., or \\?\UNC\server\share). permission::path::resolve_absolute returned that string directly, and normalize_for_prefix only stripped the prefix for the internal path_is_within comparison — not for the value handed back to callers. So the \\?\ form leaked into every path-resolving tool:

- apply_patch/edit resolved_paths (reported as apply_patch resolving to \\?\C:\...\SeqFunctions.dfy),
- the read-before-edit cache key, the modified-files set, and /rewind snapshot keys,
- the path text shown to the model.

Mixing verbatim and non-verbatim forms also causes key mismatches (recorded one way, looked up another) and breaks naive starts_with checks.

Why dunce

Options considered:

1. Hand-strip the prefix — brittle; must handle \\?\, \\?\UNC\, drive-letter variants, and must not strip when verbatim is genuinely required (path > MAX_PATH/260, reserved names like CON, trailing dot/space). Easy to get subtly wrong.
2. Keep verbatim, normalize at every use site — what we had; it's how the bug arose (comparison normalized, the returned string didn't). Doesn't scale — every new consumer can re-leak.
3. dunce::canonicalize (chosen) — calls std::fs::canonicalize then simplifies to the non-verbatim form only when it's still valid, otherwise keeps verbatim. That's option (1) done correctly → no long-path/reserved-name regression.

How it fits: drop-in signature (io::Result<PathBuf>, one-word swaps); no-op off Windows (alias for std there); no new build cost (dunce 1.0.5 was already transitive — just promoted to a direct dep; tiny crate, no transitive deps); security-preserving — resolve_absolute resolves symlinks for permission checks, and dunce wraps std canonicalize, so symlink resolution is unchanged; only the textual prefix is simplified. normalize_for_prefix stays as defense-in-depth.

Changes

Fixed at the source + the sites that re-canonicalized clean paths: permission::path (resolve_absolute both branches, canonical_or_self, canonicalize_for_cache), agent::tools::{modified, snapshots}, ui::slash::cmd::cd (working_dir), permission::checker (bash path perms). Out of scope: LSP URIs, semantic index, git-worktree, sandbox image refs, dirge config dir.

Tests

New resolve_absolute_has_no_verbatim_prefix (existing + new-file branches); fixed the two symlink tests' Windows gaps (missing #[cfg(windows)] arm, per-component tail join, graceful skip without symlink privilege). cargo test --no-default-features --features windows-default permission::path → 14 passed, 0 failed.