### PR TITLE
Add OpenCode provider

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,7 @@ Accepted top-level keys:
 
 | Key                       | Type    | Description                                                                                                                                                                 |
 | ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider`                | string  | Active provider alias. Built-ins are `openrouter`, `openai`, `anthropic`, `gemini`/`google`, `deepseek`, `glm`/`zhipu`, and `ollama`; any alias declared in `providers` is also accepted. Default: `openrouter`. See [Providers and roles](#providers-and-roles). |
+| `provider`                | string  | Active provider alias. Built-ins are `openrouter`, `openai`, `anthropic`, `gemini`/`google`, `deepseek`, `glm`/`zhipu`, `opencode`, and `ollama`; any alias declared in `providers` is also accepted. Default: `openrouter`. See [Providers and roles](#providers-and-roles). |
 | `auth`                    | string  | Default authentication source for providers that don't set their own `providers.<name>.auth`: `api-key` (the implicit default), `chatgpt` (Codex/OpenAI login tokens), or `anthropic` / `claude-code` (Anthropic Claude Code OAuth). See [Providers and roles](#providers-and-roles). |
 | `providers`               | object  | Map of provider alias → entry. The active model lives in `providers.<active-provider>.model`. Each role key below points at one of these aliases. See [Providers and roles](#providers-and-roles). |
 | `review_provider`         | string  | Provider alias for the background session-review pass. Falls back to `provider`. |

--- a/src/agent/agent_loop/h7_smoke.rs
+++ b/src/agent/agent_loop/h7_smoke.rs
@@ -101,6 +101,7 @@ fn build_stream_fn() -> Option<crate::agent::agent_loop::StreamFn> {
         AnyModel::Gemini(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::DeepSeek(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::Glm(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
+        AnyModel::OpenCode(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::Ollama(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
         AnyModel::Custom(m) => rig_stream_fn_from_model(m, vec![], chunk_timeout),
     };

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -243,6 +243,7 @@ pub async fn build_agent(
         AnyModel::Gemini(m) => build_inner!(m, Gemini),
         AnyModel::DeepSeek(m) => build_inner!(m, DeepSeek),
         AnyModel::Glm(m) => build_inner!(m, Glm),
+        AnyModel::OpenCode(m) => build_inner!(m, OpenCode),
         AnyModel::Ollama(m) => build_inner!(m, Ollama),
         AnyModel::Custom(m) => build_inner!(m, Custom),
     };

--- a/src/provider/client.rs
+++ b/src/provider/client.rs
@@ -376,6 +376,12 @@ where
             );
             Ok(AnyClient::Glm(b.build()?))
         }
+        ProviderKind::OpenCode => {
+            let b = openai::CompletionsClient::builder()
+                .api_key(&key)
+                .base_url(base_url.as_deref().unwrap_or("https://opencode.ai/zen/v1"));
+            Ok(AnyClient::OpenCode(b.build()?))
+        }
         ProviderKind::Ollama => {
             let key: ollama::OllamaApiKey = key.as_str().into();
             let mut b = ollama::Client::builder().api_key(key);

--- a/src/provider/dispatch.rs
+++ b/src/provider/dispatch.rs
@@ -31,6 +31,7 @@ pub enum AnyClient {
     Gemini(gemini::Client),
     DeepSeek(openai::CompletionsClient),
     Glm(openai::CompletionsClient),
+    OpenCode(openai::CompletionsClient),
     Ollama(ollama::Client),
     Custom(openai::CompletionsClient),
 }
@@ -61,6 +62,7 @@ impl AnyClient {
             AnyClient::Gemini(c) => AnyModel::Gemini(c.completion_model(name)),
             AnyClient::DeepSeek(c) => AnyModel::DeepSeek(c.completion_model(name)),
             AnyClient::Glm(c) => AnyModel::Glm(c.completion_model(name)),
+            AnyClient::OpenCode(c) => AnyModel::OpenCode(c.completion_model(name)),
             AnyClient::Ollama(c) => AnyModel::Ollama(c.completion_model(name)),
             AnyClient::Custom(c) => AnyModel::Custom(c.completion_model(name)),
         }
@@ -318,6 +320,7 @@ pub enum AnyModel {
     Gemini(gemini::completion::CompletionModel),
     DeepSeek(openai::completion::CompletionModel),
     Glm(openai::completion::CompletionModel),
+    OpenCode(openai::completion::CompletionModel),
     Ollama(ollama::CompletionModel),
     Custom(openai::completion::CompletionModel),
 }
@@ -373,6 +376,7 @@ impl AnyModel {
             AnyModel::Gemini(m) => one_shot!(m),
             AnyModel::DeepSeek(m) => one_shot!(m),
             AnyModel::Glm(m) => one_shot!(m),
+            AnyModel::OpenCode(m) => one_shot!(m),
             AnyModel::Ollama(m) => one_shot!(m),
             AnyModel::Custom(m) => one_shot!(m),
         }
@@ -435,6 +439,7 @@ impl AnyModel {
             AnyModel::Gemini(m) => m.model.clone(),
             AnyModel::DeepSeek(m) => m.model.clone(),
             AnyModel::Glm(m) => m.model.clone(),
+            AnyModel::OpenCode(m) => m.model.clone(),
             AnyModel::Ollama(m) => m.model.clone(),
             AnyModel::Custom(m) => m.model.clone(),
         }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -172,6 +172,7 @@ pub(crate) enum AnyAgentInner {
     Gemini(Agent<gemini::completion::CompletionModel>),
     DeepSeek(Agent<openai::completion::CompletionModel>),
     Glm(Agent<openai::completion::CompletionModel>),
+    OpenCode(Agent<openai::completion::CompletionModel>),
     Ollama(Agent<ollama::CompletionModel>),
     Custom(Agent<openai::completion::CompletionModel>),
 }
@@ -450,6 +451,7 @@ impl AnyAgent {
             AnyAgentInner::Gemini(_) => "gemini",
             AnyAgentInner::DeepSeek(_) => "deepseek",
             AnyAgentInner::Glm(_) => "glm",
+            AnyAgentInner::OpenCode(_) => "opencode",
             AnyAgentInner::Ollama(_) => "ollama",
             AnyAgentInner::Custom(_) => "custom",
         }

--- a/src/provider/resolve.rs
+++ b/src/provider/resolve.rs
@@ -21,6 +21,7 @@ pub enum ProviderKind {
     DeepSeek,
     Glm,
     Ollama,
+    OpenCode,
     Custom,
 }
 
@@ -37,6 +38,7 @@ pub fn default_model_for(provider_name: &str) -> &'static str {
         Some(ProviderKind::Gemini) => "gemini-2.0-flash",
         Some(ProviderKind::DeepSeek) => "deepseek-v4-pro",
         Some(ProviderKind::Glm) => "glm-5.2",
+        Some(ProviderKind::OpenCode) => "deepseek-v4-flash",
         Some(ProviderKind::Ollama) => "llama3",
         // OpenRouter + Custom + unknown — keep the historical default
         // since OpenRouter wants the `vendor/model` form.
@@ -78,6 +80,7 @@ pub fn parse_provider(name: &str) -> Option<ProviderKind> {
         "gemini" | "google" => Some(ProviderKind::Gemini),
         "deepseek" => Some(ProviderKind::DeepSeek),
         "glm" | "zhipu" => Some(ProviderKind::Glm),
+        "opencode" => Some(ProviderKind::OpenCode),
         "ollama" => Some(ProviderKind::Ollama),
         "custom" => Some(ProviderKind::Custom),
         _ => None,
@@ -368,6 +371,7 @@ fn provider_env_var(kind: ProviderKind) -> &'static str {
         ProviderKind::Gemini => "GEMINI_API_KEY",
         ProviderKind::DeepSeek => "DEEPSEEK_API_KEY",
         ProviderKind::Glm => "GLM_API_KEY",
+        ProviderKind::OpenCode => "OPENCODE_API_KEY",
         ProviderKind::Ollama => "OLLAMA_API_KEY",
         ProviderKind::OpenRouter => "OPENROUTER_API_KEY",
         ProviderKind::Custom => "CUSTOM_API_KEY",
@@ -401,6 +405,7 @@ pub(crate) const PROVIDER_AUTODETECT_ORDER: &[(&str, &str)] = &[
     // after GLM_API_KEY so users with both set get the dirge-
     // primary one; users with only ZHIPU_API_KEY still get glm.
     ("ZHIPU_API_KEY", "glm"),
+    ("OPENCODE_API_KEY", "opencode"),
     ("OLLAMA_API_KEY", "ollama"),
     ("OPENROUTER_API_KEY", "openrouter"),
 ];

--- a/src/provider/stream_dispatch.rs
+++ b/src/provider/stream_dispatch.rs
@@ -66,6 +66,7 @@ macro_rules! dispatch_stream_fn {
             $enum::Gemini($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::DeepSeek($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::Glm($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
+            $enum::OpenCode($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::Ollama($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
             $enum::Custom($bind) => __stream_fn($model, $tools, $timeout, $provider, $filter),
         }

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -114,6 +114,7 @@ pub(crate) async fn oneshot_with_model(
         super::AnyModel::Gemini(m) => run_oneshot(m, label, preamble, prompt, disable).await,
         super::AnyModel::DeepSeek(m) => run_oneshot(m, label, preamble, prompt, disable).await,
         super::AnyModel::Glm(m) => run_oneshot(m, label, preamble, prompt, disable).await,
+        super::AnyModel::OpenCode(m) => run_oneshot(m, label, preamble, prompt, disable).await,
         super::AnyModel::Ollama(m) => run_oneshot(m, label, preamble, prompt, disable).await,
         super::AnyModel::Custom(m) => run_oneshot(m, label, preamble, prompt, disable).await,
     }
@@ -131,6 +132,7 @@ fn oneshot_provider_kind(model: &super::AnyModel) -> &'static str {
         M::Gemini(_) => "gemini",
         M::DeepSeek(_) => "deepseek",
         M::Glm(_) => "glm",
+        M::OpenCode(_) => "opencode",
         M::Ollama(_) => "ollama",
         M::Custom(_) => "custom",
     }
@@ -148,7 +150,7 @@ fn reasoning_disable_for_kind(kind: &str) -> Option<serde_json::Value> {
     match kind {
         // vLLM / SGLang / DeepSeek-V3.1 convention for the hybrid models these
         // OpenAI-compatible endpoints serve.
-        "deepseek" | "glm" | "custom" | "openrouter" => {
+        "deepseek" | "glm" | "opencode" | "custom" | "openrouter" => {
             Some(serde_json::json!({ "chat_template_kwargs": { "thinking": false } }))
         }
         // Ollama's native per-request toggle.


### PR DESCRIPTION
Rebased #570 (by @gretel) onto current main and resolved the conflict.

Adds `ProviderKind::OpenCode` and the corresponding `AnyClient`/`AnyModel`/`AnyAgentInner` variants + match arms across the provider dispatch, plus the client builder (base URL `https://opencode.ai/zen/v1`, default model `deepseek-v4-flash`). Purely additive.

The only conflict was in `resolve.rs` — main had bumped the GLM default to `glm-5.2`; kept that and added the OpenCode default arm beside it. Also listed `opencode` in the built-in providers doc.

Supersedes #570 (couldn't push the rebase to the fork branch). Credit: @gretel.