### PR TITLE
Make the permission prompt scroll long commands (#587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   width (and clipped) after narrowing. The whole chamber — top border, body,
   colorized diffs, LSP-tail rows, and bottom border — reflows together, so the
   box never ends up with a mismatched header (dirge-ghpf).
+- Permission prompt no longer hides part of a long or multi-line command. The
+  alert box now scrolls: the command detail can be paged with ↑/↓, PgUp/PgDn,
+  or Ctrl+O while the `[y]/[a]/[n]/[ESC]` action row stays pinned, and a status
+  line shows how much is off-screen. Previously a tall command was cut with a
+  bare `…` and the modal swallowed scroll keys, so you had to approve a `bash`
+  command you couldn't fully read (#587).
 
 ## [0.18.1] - 2026-07-04
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1046,6 +1046,44 @@ pub async fn run_interactive(
                         }
                     }
                     state::ModalKind::Permission => {
+                        // dirge-coy3 (#587): when the command preview is taller
+                        // than the box, the arrow / paging keys — and Ctrl+O,
+                        // which users reach for — scroll the command instead of
+                        // deciding, so the WHOLE command is readable before
+                        // y/a/n. Only intercept when actually scrollable, so on a
+                        // short prompt these keys don't silently eat a keypress.
+                        if renderer.alert_is_scrollable() {
+                            const ALERT_SCROLL_PAGE: usize = 5;
+                            let is_ctrl_o = key.code == KeyCode::Char('o')
+                                && key.modifiers.contains(KeyModifiers::CONTROL);
+                            let scroll_key = match key.code {
+                                KeyCode::Up => {
+                                    renderer.alert_scroll_up(1);
+                                    true
+                                }
+                                KeyCode::Down => {
+                                    renderer.alert_scroll_down(1);
+                                    true
+                                }
+                                KeyCode::PageUp => {
+                                    renderer.alert_scroll_up(ALERT_SCROLL_PAGE);
+                                    true
+                                }
+                                KeyCode::PageDown => {
+                                    renderer.alert_scroll_down(ALERT_SCROLL_PAGE);
+                                    true
+                                }
+                                _ if is_ctrl_o => {
+                                    renderer.alert_scroll_down(ALERT_SCROLL_PAGE);
+                                    true
+                                }
+                                _ => false,
+                            };
+                            if scroll_key {
+                                renderer.request_repaint();
+                                continue;
+                            }
+                        }
                         // Phase 1: map the keystroke to a decision. Ctrl+C /
                         // Ctrl+D = "I want out" → Deny. The `a` branch also
                         // prints the will-allow line (or downgrades to allow-

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -543,6 +543,16 @@ pub struct Renderer {
     /// (text, color); painter centers text horizontally within the
     /// frame's inner band.
     alert_overlay: Option<Vec<(String, Color)>>,
+    /// Wrapped-row scroll offset into the alert overlay body when the
+    /// command (or other detail) is too tall for the box. The action-keys
+    /// row stays pinned; this scrolls only the head so a long/multi-line
+    /// command can be read in full before deciding (dirge-coy3). Reset to 0
+    /// whenever a new overlay is set.
+    alert_scroll: usize,
+    /// Max valid `alert_scroll` for the current overlay + box geometry,
+    /// recomputed each paint. Lets the scroll handlers clamp and lets
+    /// PageDown jump straight to the bottom of a long command.
+    alert_max_scroll: usize,
     /// Live PTY output for an active `!cmd`/`!!cmd` shell session, shown in the
     /// input-box frame as an overlay titled `[shell]` while the session runs.
     shell_overlay: Option<Vec<(String, Color)>>,
@@ -675,6 +685,8 @@ impl Renderer {
             #[cfg(feature = "dap")]
             debug_panel_data: None,
             alert_overlay: None,
+            alert_scroll: 0,
+            alert_max_scroll: 0,
             picker_overlay: None,
             rewind_overlay: None,
             alert_title: String::new(),
@@ -787,6 +799,8 @@ impl Renderer {
             left_panel_info,
             subagent_status,
             alert_overlay,
+            alert_scroll,
+            alert_max_scroll,
             picker_overlay,
             alert_title,
             avatar_state,
@@ -835,11 +849,13 @@ impl Renderer {
             BottomBody::Overlay {
                 title: alert_title.as_str(),
                 lines: lines.as_slice(),
+                scroll: *alert_scroll,
             }
         } else if let Some(lines) = self.shell_overlay.as_ref() {
             BottomBody::Overlay {
                 title: "[shell]",
                 lines: lines.as_slice(),
+                scroll: 0,
             }
         } else {
             // dirge-5w9v: scroll the editor so the cursor's wrapped row
@@ -894,7 +910,23 @@ impl Renderer {
             // Leave at least 4 rows for the chat (+ 5 fixed rows
             // of frames/status), so input_rows ≤ rows - 9.
             let ceiling = (rows_q as i32 - 9).max(1) as u16;
-            (wrapped as u16).clamp(1, ceiling)
+            let rows = (wrapped as u16).clamp(1, ceiling);
+            // Mirror the painter's head/tail split so the scroll handlers
+            // (dirge-coy3) know how far a too-tall command can scroll. When
+            // the head overflows, the painter reserves one row for the
+            // scroll-status line, so content rows = head_budget - 1.
+            let (head, tail) =
+                crate::ui::tui::bottom::overlay_head_tail_wrapped(lines, probe.input_box.width);
+            let inner_h = rows as usize;
+            let head_budget = inner_h.saturating_sub(tail);
+            let content_rows = if head > head_budget {
+                head_budget.saturating_sub(1)
+            } else {
+                head_budget
+            };
+            *alert_max_scroll = head.saturating_sub(content_rows);
+            *alert_scroll = (*alert_scroll).min(*alert_max_scroll);
+            rows
         } else if let Some(lines) = self.shell_overlay.as_ref() {
             let probe = crate::ui::tui::layout::Layout::with_panels(
                 cols_q,
@@ -1302,6 +1334,10 @@ impl Renderer {
     /// within `MAX_INPUT_VISIBLE_LINES` — taller overlays clip.
     pub fn set_alert_overlay(&mut self, rows: Vec<(String, Color)>) {
         self.alert_overlay = Some(rows);
+        // A fresh prompt always opens showing the TOP of the detail (the
+        // command's first line), so reset any scroll left from a prior one.
+        self.alert_scroll = 0;
+        self.alert_max_scroll = 0;
         if self.alert_title.is_empty() {
             self.alert_title = "[ALERT]".to_string();
         }
@@ -1311,9 +1347,49 @@ impl Renderer {
 
     pub fn clear_alert_overlay(&mut self) {
         self.alert_overlay = None;
+        self.alert_scroll = 0;
+        self.alert_max_scroll = 0;
         self.alert_title.clear();
         self.last_paint = None;
         self.needs_paint = true;
+    }
+
+    /// Scroll the alert overlay body down by `n` wrapped rows, clamped to
+    /// the last computed maximum (dirge-coy3). Used by the permission modal
+    /// so a command taller than the box can be read in full before deciding.
+    /// Returns true if the offset changed (caller repaints).
+    pub fn alert_scroll_down(&mut self, n: usize) -> bool {
+        let next = self
+            .alert_scroll
+            .saturating_add(n)
+            .min(self.alert_max_scroll);
+        if next != self.alert_scroll {
+            self.alert_scroll = next;
+            self.last_paint = None;
+            self.needs_paint = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Scroll the alert overlay body up by `n` wrapped rows (toward the top).
+    pub fn alert_scroll_up(&mut self, n: usize) -> bool {
+        let next = self.alert_scroll.saturating_sub(n);
+        if next != self.alert_scroll {
+            self.alert_scroll = next;
+            self.last_paint = None;
+            self.needs_paint = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the current alert overlay overflows its box (i.e. scrolling
+    /// is meaningful). Lets the modal decide whether to consume scroll keys.
+    pub fn alert_is_scrollable(&self) -> bool {
+        self.alert_max_scroll > 0
     }
 
     /// Set the live shell-session overlay (bottom box showing PTY output while

--- a/src/ui/tui/bottom.rs
+++ b/src/ui/tui/bottom.rs
@@ -45,10 +45,13 @@ pub enum BottomBody<'a> {
     /// frame's top border (e.g. `[ALERT]`); `lines` paint inside
     /// the inner band, one per row. Colors are crossterm-flavored
     /// (matches the rest of the renderer state) — converted to
-    /// ratatui at paint time.
+    /// ratatui at paint time. `scroll` is the wrapped-row offset into
+    /// the body when it overflows the box (the last line — action keys
+    /// — stays pinned to the bottom); 0 shows the top.
     Overlay {
         title: &'a str,
         lines: &'a [(String, crossterm::style::Color)],
+        scroll: usize,
     },
 }
 
@@ -120,9 +123,11 @@ impl<'a> Widget for BottomStrip<'a> {
                 ghost,
                 self.border_style,
             ),
-            Some(BottomBody::Overlay { title, lines }) => {
-                paint_overlay_box(buf, l.input_box, title, lines, self.border_style)
-            }
+            Some(BottomBody::Overlay {
+                title,
+                lines,
+                scroll,
+            }) => paint_overlay_box(buf, l.input_box, title, lines, *scroll, self.border_style),
             None => paint_empty_box(buf, l.input_box, self.border_style),
         }
         // right_margin: blank — explicitly clear so stale right
@@ -366,6 +371,7 @@ fn paint_overlay_box(
     area: Rect,
     title: &str,
     lines: &[(String, crossterm::style::Color)],
+    scroll: usize,
     _style: Style,
 ) {
     // Alert box border is yellow regardless of the supplied frame
@@ -409,21 +415,31 @@ fn paint_overlay_box(
         }
     }
 
-    // Layout: head visual rows fill from the top. If the combined
-    // head + sticky doesn't fit `inner_h`, truncate the END of head
-    // with a "…" indicator so the sticky (action keys) row is
-    // always shown.
+    // Layout: head visual rows fill from the top; the sticky tail
+    // (action keys) always anchors to the bottom. When the head
+    // overflows the available rows we DON'T silently drop the tail of
+    // the command — the user must be able to read the whole thing
+    // before approving it (dirge-coy3 / #587). Instead we reserve one
+    // row for a scroll-status line and window the head by `scroll`, so
+    // the full command is reachable with the keyboard.
     let sticky_len = sticky_last.len();
     let head_budget = inner_h.saturating_sub(sticky_len);
 
-    let need_ellipsis = head_visual.len() > head_budget;
-    let head_keep = if need_ellipsis {
+    let overflow = head_visual.len() > head_budget;
+    // With overflow, one row goes to the scroll-status line.
+    let content_rows = if overflow {
         head_budget.saturating_sub(1)
     } else {
         head_budget
     };
-    let head_to_show: Vec<&(String, crossterm::style::Color)> =
-        head_visual.iter().take(head_keep).collect();
+    let max_scroll = head_visual.len().saturating_sub(content_rows);
+    let scroll = scroll.min(max_scroll);
+    let end = (scroll + content_rows).min(head_visual.len());
+    let head_to_show: &[(String, crossterm::style::Color)] = if head_visual.is_empty() {
+        &[]
+    } else {
+        &head_visual[scroll..end]
+    };
 
     // Paint head rows LEFT-aligned with 1 leading space of padding.
     let mut row_idx = 0usize;
@@ -433,10 +449,19 @@ fn paint_overlay_box(
         buf.set_stringn(area.x + 2, y, text, inner_w.saturating_sub(2), st);
         row_idx += 1;
     }
-    if need_ellipsis && row_idx < inner_h {
+    // Scroll-status line: tells the user there's more and how to reach
+    // it, so a long command is never presented as if it were complete.
+    if overflow && row_idx < inner_h {
+        let above = scroll;
+        let below = max_scroll.saturating_sub(scroll);
+        let hint = if below > 0 {
+            format!("↓ {below} more line(s) — ↑/↓ PgUp/PgDn · Ctrl+O to scroll")
+        } else {
+            format!("↑ {above} line(s) above — ↑/↓ PgUp/PgDn to scroll")
+        };
         let y = area.y + 1 + row_idx as u16;
         let dim = Style::default().fg(RColor::DarkGray);
-        buf.set_stringn(area.x + 2, y, "…", inner_w.saturating_sub(2), dim);
+        buf.set_stringn(area.x + 2, y, &hint, inner_w.saturating_sub(2), dim);
         row_idx += 1;
     }
     // Paint the sticky tail rows (action keys) at the BOTTOM of the
@@ -471,6 +496,34 @@ pub fn overlay_wrapped_row_count(
         total += soft_wrap(text, wrap_w, "  ").len();
     }
     total
+}
+
+/// Wrapped-row counts for the overlay body, split as `(head, tail)`:
+/// every line except the last (the head — e.g. the command detail) and
+/// the last line alone (the sticky action-keys row). Mirrors the wrap
+/// width + per-line hanging indent used by [`paint_overlay_box`], so the
+/// renderer can compute an accurate maximum scroll offset for a body that
+/// overflows the box. Used by [`crate::ui::renderer`] to clamp the alert
+/// scroll (dirge-coy3).
+pub fn overlay_head_tail_wrapped(
+    lines: &[(String, crossterm::style::Color)],
+    outer_width: u16,
+) -> (usize, usize) {
+    let inner_w = (outer_width as usize).saturating_sub(2);
+    let wrap_w = inner_w.saturating_sub(2).max(1);
+    use crate::ui::wrap::soft_wrap;
+    let last_idx = lines.len().saturating_sub(1);
+    let (mut head, mut tail) = (0usize, 0usize);
+    for (i, (text, _)) in lines.iter().enumerate() {
+        let cont_indent = " ".repeat(label_prefix_width(text));
+        let n = soft_wrap(text, wrap_w, &cont_indent).len();
+        if i == last_idx {
+            tail += n;
+        } else {
+            head += n;
+        }
+    }
+    (head, tail)
 }
 
 fn paint_status(buf: &mut Buffer, area: Rect, status: &str) {
@@ -626,6 +679,7 @@ mod tests {
                 let widget = BottomStrip::new(&layout).body(BottomBody::Overlay {
                     title: "[ALERT]",
                     lines: &lines,
+                    scroll: 0,
                 });
                 f.render_widget(widget, area);
             })
@@ -646,6 +700,89 @@ mod tests {
             body0.contains("PERMISSION REQUIRED"),
             "got body0 {:?}",
             body0
+        );
+    }
+
+    /// dirge-coy3 (#587): a command taller than the box must stay fully
+    /// readable — the action-keys row is pinned to the bottom, a scroll
+    /// hint shows there's more, and scrolling reveals the hidden tail
+    /// (rather than silently dropping it under a bare "…").
+    #[test]
+    fn overlay_scrolls_long_command_and_pins_action_keys() {
+        use crossterm::style::Color as CC;
+        // 6 head lines + the action-keys row into a 4-row inner box:
+        // it overflows, so the body must scroll.
+        let mut lines: Vec<(String, CC)> = vec![("command: cd /a/b/c".to_string(), CC::Yellow)];
+        for i in 0..5 {
+            lines.push((format!("cmd-line-{i}"), CC::Yellow));
+        }
+        lines.push((
+            "[y] allow once  [a] allow always  [n] deny  [ESC] abort".to_string(),
+            CC::Yellow,
+        ));
+
+        let render_at = |scroll: usize| -> Vec<String> {
+            let layout = Layout::new(160, 30, 4);
+            let mut backend = TestBackend::new(160, 30);
+            let mut terminal = Terminal::new(backend.clone()).unwrap();
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    let widget = BottomStrip::new(&layout).body(BottomBody::Overlay {
+                        title: "[ALERT]",
+                        lines: &lines,
+                        scroll,
+                    });
+                    f.render_widget(widget, area);
+                })
+                .unwrap();
+            backend = terminal.backend().clone();
+            let area = layout.input_box;
+            (0..area.height)
+                .map(|dy| {
+                    row_chars(&backend, area.y + dy, area.x, area.width)
+                        .into_iter()
+                        .collect::<String>()
+                })
+                .collect()
+        };
+
+        // At the top: the command's first line shows, the LAST head line
+        // (cmd-line-4) is hidden, the action keys are pinned at the bottom,
+        // and a scroll hint tells the user there's more.
+        let top = render_at(0);
+        let joined_top = top.join("\n");
+        assert!(
+            joined_top.contains("command: cd /a/b/c"),
+            "top view must show the command start: {joined_top:?}"
+        );
+        assert!(
+            !joined_top.contains("cmd-line-4"),
+            "the tail must be hidden at scroll=0, not silently dropped: {joined_top:?}"
+        );
+        assert!(
+            joined_top.contains("more line(s)") || joined_top.contains("scroll"),
+            "a scroll hint must indicate hidden content: {joined_top:?}"
+        );
+        // Action keys pinned to the bottom inner row regardless of scroll.
+        let bottom_inner = &top[top.len() - 2];
+        assert!(
+            bottom_inner.contains("[y] allow once"),
+            "action keys must be pinned at the bottom: {bottom_inner:?}"
+        );
+
+        // Scrolled down: the previously-hidden tail line becomes visible,
+        // and the action keys are STILL pinned.
+        let scrolled = render_at(999); // clamps to max internally
+        let joined_scrolled = scrolled.join("\n");
+        assert!(
+            joined_scrolled.contains("cmd-line-4"),
+            "scrolling must reveal the command tail: {joined_scrolled:?}"
+        );
+        let bottom_inner_s = &scrolled[scrolled.len() - 2];
+        assert!(
+            bottom_inner_s.contains("[y] allow once"),
+            "action keys stay pinned after scrolling: {bottom_inner_s:?}"
         );
     }
 

--- a/src/ui/tui/scene.rs
+++ b/src/ui/tui/scene.rs
@@ -512,6 +512,7 @@ mod tests {
             body: BottomBody::Overlay {
                 title: "[ALERT]",
                 lines: &overlay_lines,
+                scroll: 0,
             },
             status: "permission required",
             show_left_panel: true,


### PR DESCRIPTION
Fixes #587.

## Problem

The `bash` permission alert renders `command: <cmd>` but a long or multi-line command is cut off with a bare `…`, and the modal swallows every non-decision key — so you have to approve a command you can't fully read. Ctrl+O (which the reporter reached for) does nothing. The in-scrollback ALERT chamber was removed a while back on purpose (the overlay is the single source of truth), so there's no other place to read the command — the overlay itself has to show all of it.

## Fix

Make the alert overlay body scrollable:

- The painter windows the head (command detail) by a wrapped-row offset and **pins the `[y]/[a]/[n]/[ESC]` action row to the bottom** regardless of scroll. When the body overflows it paints a dim scroll-status line (`↓ N more line(s) — ↑/↓ PgUp/PgDn · Ctrl+O to scroll`) so the command is never presented as if it were complete.
- The Permission modal routes **Up/Down, PgUp/PgDn, and Ctrl+O** to scroll instead of deciding — but only while the body actually overflows, so short prompts don't eat those keys. Only `y/a/n/Esc/Ctrl+C/Ctrl+D` decide.
- The renderer clamps the scroll offset against a per-frame maximum computed from the same wrap width + hanging-indent the painter uses (`overlay_head_tail_wrapped`), and resets it to the top whenever a new prompt opens.

## Tests

New `overlay_scrolls_long_command_and_pins_action_keys` asserts: at the top the command start shows, the tail is hidden (not dropped) with a scroll hint, action keys are pinned; after scrolling the tail becomes visible and the action keys stay pinned. Full UI suite (607) + clippy pass.