### PR TITLE
Keep focus reporting armed in the periodic mode reassert

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4723,16 +4723,19 @@ pub async fn run_interactive(
                     // past the throttle window and let the loop-top `render_frame!` flush
                     // it (no body needed — needs_paint is already set).
                     _ = tokio::time::sleep(tokio::time::Duration::from_millis(16)), if renderer.needs_paint() => {}
-                    // Self-heal terminal modes (SGR mouse capture + bracketed paste)
-                    // while idle. `tui_redraw` re-asserts them on every paint, but an
-                    // idle agent stops painting — and a mouse-capture leak (a bash-tool
-                    // child that opened /dev/tty and emitted `?1000l` on exit) can't
-                    // self-heal via a paint, because the lost wheel/drag events are the
-                    // very ones that would trigger one. So the wheel scrolls the whole
-                    // terminal and click-drag selection dies until a keystroke happens
-                    // to repaint. Poll on the reassert interval while idle to close
-                    // that window; the method throttles internally so this is cheap.
-                    // Gated on `!ui.is_running` since the active path already re-asserts.
+                    // Self-heal terminal modes (SGR mouse capture, bracketed
+                    // paste, focus reporting) while idle. `tui_redraw`
+                    // re-asserts them on every paint, but an idle agent stops
+                    // painting — and a reset (terminal reset, multiplexer
+                    // detach) that lands while idle can't self-heal via a
+                    // paint. The focus-reporting re-arm is what matters most
+                    // here: it keeps the `FocusGained → force_terminal_reassert`
+                    // reactive chain alive, so an alt-screen drop still
+                    // recovers on the next focus change instead of needing a
+                    // manual Ctrl+L. Poll on the reassert interval while idle
+                    // to close that window; the method throttles internally so
+                    // this is cheap. Gated on `!ui.is_running` since the
+                    // active path already re-asserts.
                     _ = tokio::time::sleep(tokio::time::Duration::from_secs(1)), if !ui.is_running => {
                         renderer.reassert_terminal_modes();
                     }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -198,15 +198,29 @@ const SHELL_BOX_MAX_ROWS: u16 = 12;
 
 /// Global terminal modes dirge owns and must keep asserted for its whole
 /// session: SGR mouse capture (`?1000`/`?1002`/`?1003`/`?1006`) so wheel +
-/// click reach the app, and bracketed paste (`?2004`). These are set once
-/// at startup ([`crate::ui::terminal::TerminalGuard::new`]); this is the
-/// exact same set, re-emitted periodically so a mid-session reset can't
-/// leave them off permanently. Both are idempotent with no visual effect
-/// when already enabled, so re-emitting on a throttle is safe. Notably this
-/// does NOT include the alternate screen (`?1049h`) — re-entering it can
+/// click reach the app, bracketed paste (`?2004`), and focus reporting
+/// (`?1004`). These are set once at startup
+/// ([`crate::ui::terminal::TerminalGuard::new`]); this is the exact same
+/// set, re-emitted periodically so a mid-session reset can't leave them off
+/// permanently. All are idempotent with no visual effect when already
+/// enabled, so re-emitting on a throttle is safe. Notably this does NOT
+/// include the alternate screen (`?1049h`) — re-entering it can
 /// clear/flicker on some terminals — nor cursor visibility (managed per
 /// frame by `draw_bottom`).
-const TERMINAL_MODE_REASSERT: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h";
+///
+/// `?1004h` is included specifically to keep the event-driven recovery
+/// alive: the primary heal path is `FocusGained → force_terminal_reassert`,
+/// but that event only fires while focus reporting is armed. An external
+/// reset (terminal "reset", tmux detach/reattach, a multiplexer that
+/// drops private modes) can turn `?1004` off, and once it's off no
+/// `FocusGained` ever arrives — so the whole reactive chain goes dark
+/// and only a manual Ctrl+L recovers. Periodically re-arming `?1004h`
+/// means the loss self-heals within one interval and `FocusGained` starts
+/// firing again. (dirge's own children can't be the clobberer: bash-tool
+/// and shell-session children are detached via `setsid()` with no
+/// controlling terminal, so a `/dev/tty` open fails with ENXIO — see
+/// `bash::exec::detach_session` and the `dirge-tc2q` test.)
+const TERMINAL_MODE_REASSERT: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h\x1b[?1004h";
 
 /// Full terminal re-assert (dirge-ph60, dirge-173j). Unlike
 /// [`TERMINAL_MODE_REASSERT`] this DOES re-enter the alternate screen
@@ -448,14 +462,15 @@ pub struct Renderer {
     /// 8ms repaint throttle to prevent /dev/tty write contention between
     /// keystroke-driven repaints — the root cause of typing stutter.
     last_paint: Option<std::time::Instant>,
-    /// Timestamp of the last terminal-mode re-assertion (SGR mouse capture +
-    /// bracketed paste). Those modes are enabled once at startup, but a
-    /// child program run via the bash tool (a pager / TUI) can reset them
-    /// mid-session by emitting `?1000l`/`?2004l` on exit — and there's no
-    /// other path that turns them back on, so the loss is permanent (wheel
-    /// scroll falls through to the terminal, selection stops reaching the
-    /// app). `tui_redraw` re-emits them on a throttle so dirge self-heals
-    /// within one interval of any such leak. `None` until the first paint.
+    /// Timestamp of the last terminal-mode re-assertion (SGR mouse capture,
+    /// bracketed paste, focus reporting). Those modes are enabled once at
+    /// startup, but an external reset (terminal reset, tmux/screen detach)
+    /// can turn them off mid-session — and with focus reporting off there's
+    /// no other path that turns them back on (the `FocusGained` recovery
+    /// can't fire), so the loss is permanent (wheel scroll falls through to
+    /// the terminal, selection stops reaching the app). `tui_redraw`
+    /// re-emits them on a throttle so dirge self-heals within one interval
+    /// of any such reset. `None` until the first paint.
     last_mode_reassert: Option<std::time::Instant>,
     /// Bumped each time scrollback eviction drains lines from the FRONT of
     /// `buffer`, which shifts every absolute line index down. Consumers
@@ -748,17 +763,20 @@ impl Renderer {
         use crate::ui::tui::bottom::{AvatarSpec, BottomBody};
         use crate::ui::tui::scene::{Scene, render_frame};
 
-        // Self-heal the global terminal modes (SGR mouse capture + bracketed
-        // paste). They're enabled once at startup, but a child program run
-        // through the bash tool — a pager or TUI (`git log` → `less`, `fzf`,
-        // `vim`, …) — opens /dev/tty and on exit emits `?1000l`/`?2004l` to
-        // restore ITS state, silently turning dirge's off. With no other
-        // re-enable path the loss is permanent: wheel scroll falls through to
-        // the terminal (the whole UI scrolls) and click/drag selection stops
-        // reaching the app. Re-emitting on a throttle (writing to a fresh
-        // /dev/tty, the same sink the guard's setup uses) heals it within one
-        // interval. Done before the 8ms paint throttle below so it keeps
-        // firing even while paints are coalesced.
+        // Self-heal the global terminal modes (SGR mouse capture, bracketed
+        // paste, focus reporting). They're enabled once at startup, but an
+        // external reset — a terminal "reset", a tmux/screen detach+reattach,
+        // a multiplexer that drops private modes — can turn them off
+        // mid-session. With no re-enable path the loss is permanent: wheel
+        // scroll falls through to the terminal (the whole UI scrolls) and
+        // click/drag selection stops reaching the app. The focus-reporting
+        // mode (`?1004h`) matters most: the primary recovery is
+        // `FocusGained → force_terminal_reassert`, but that event can't fire
+        // while focus reporting is off — so re-arming it here keeps the
+        // reactive chain alive. Re-emitting on a throttle (writing to a fresh
+        // /dev/tty, the same sink the guard's setup uses) heals any loss
+        // within one interval. Done before the 8ms paint throttle below so it
+        // keeps firing even while paints are coalesced.
         self.reassert_terminal_modes();
 
         // Re-clamp the scroll offset to the CURRENT geometry every frame. The
@@ -2695,20 +2713,28 @@ impl Renderer {
         }
     }
 
-    /// Re-assert the global terminal modes dirge owns (SGR mouse capture +
-    /// bracketed paste) if the throttle interval has elapsed, writing directly
-    /// to `/dev/tty`. Throttled and idempotent — safe to call as often as the
-    /// caller likes; only the first call per [`MODE_REASSERT_INTERVAL`] emits.
+    /// Re-assert the global terminal modes dirge owns (SGR mouse capture,
+    /// bracketed paste, focus reporting) if the throttle interval has
+    /// elapsed, writing directly to `/dev/tty`. Throttled and idempotent —
+    /// safe to call as often as the caller likes; only the first call per
+    /// [`MODE_REASSERT_INTERVAL`] emits.
     ///
-    /// `tui_redraw` calls this every paint, which heals a mid-session leak
-    /// (a bash-tool child that opened `/dev/tty` and emitted `?1000l`/`?2004l`
-    /// on exit) within one interval — but *only while frames are painting*.
-    /// When the agent is idle the event loop stops painting, so the loop also
-    /// calls this on an idle timer: otherwise a leak that lands while idle
-    /// can't self-heal, since the lost wheel/drag events are exactly what
-    /// would trigger a paint. Keyboard scroll (PageUp/Down) still dirties a
-    /// frame and heals it — which is why, in the broken state, the keyboard
-    /// keeps working while the mouse stays dead.
+    /// The primary recovery for a dropped alt screen is event-driven
+    /// (`FocusGained → force_terminal_reassert`); this periodic re-assert's
+    /// main job is to keep that chain alive by re-arming focus reporting
+    /// (`?1004h`), which an external reset (terminal reset, multiplexer
+    /// detach) can turn off. Once focus reporting is off, no `FocusGained`
+    /// ever arrives — so without this the reactive path goes dark and only
+    /// a manual Ctrl+L recovers. It also re-arms mouse capture + paste as a
+    /// safety net for terminals that don't report focus at all.
+    ///
+    /// `tui_redraw` calls this every paint, which heals a reset within one
+    /// interval — but *only while frames are painting*. When the agent is
+    /// idle the event loop stops painting, so the loop also calls this on an
+    /// idle timer: otherwise a reset that lands while idle can't self-heal.
+    /// Keyboard scroll (PageUp/Down) still dirties a frame and heals it —
+    /// which is why, in the broken state, the keyboard keeps working while
+    /// the mouse stays dead.
     pub fn reassert_terminal_modes(&mut self) {
         let now = std::time::Instant::now();
         if let Some(bytes) = mode_reassert_payload(self.last_mode_reassert, now) {

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -220,7 +220,8 @@ const SHELL_BOX_MAX_ROWS: u16 = 12;
 /// and shell-session children are detached via `setsid()` with no
 /// controlling terminal, so a `/dev/tty` open fails with ENXIO — see
 /// `bash::exec::detach_session` and the `dirge-tc2q` test.)
-const TERMINAL_MODE_REASSERT: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h\x1b[?1004h";
+const TERMINAL_MODE_REASSERT: &[u8] =
+    b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h\x1b[?1004h";
 
 /// Full terminal re-assert (dirge-ph60, dirge-173j). Unlike
 /// [`TERMINAL_MODE_REASSERT`] this DOES re-enter the alternate screen

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1038,12 +1038,12 @@ fn footer_shows_both_directions_when_scrolled() {
 
 // ── terminal-mode self-healing (fix/mouse-capture-self-heal) ──────────
 
-/// The re-assert payload re-enables exactly the modes dirge owns and that a
-/// child program can clobber: SGR mouse capture (so wheel + click reach the
-/// app) and bracketed paste. This is what heals "the whole UI scrolls off"
-/// — a leaked `?1000l` is undone by the next due paint re-emitting `?1000h`.
+/// The re-assert payload re-enables exactly the modes dirge owns and that an
+/// external reset can clobber: SGR mouse capture (so wheel + click reach the
+/// app), bracketed paste, AND focus reporting. This is what heals "the whole
+/// UI scrolls off" and — critically — keeps the event-driven recovery alive.
 #[test]
-fn mode_reassert_payload_re_enables_mouse_and_paste() {
+fn mode_reassert_payload_re_enables_mouse_paste_and_focus() {
     let now = std::time::Instant::now();
     let bytes = super::mode_reassert_payload(None, now).expect("first paint always re-asserts");
     let s = std::str::from_utf8(bytes).unwrap();
@@ -1056,6 +1056,16 @@ fn mode_reassert_payload_re_enables_mouse_and_paste() {
         "must re-enable SGR mouse encoding"
     );
     assert!(s.contains("\x1b[?2004h"), "must re-enable bracketed paste");
+    // The genuine fix (dirge-tc2q follow-up): focus reporting MUST be in the
+    // periodic payload. The primary recovery is FocusGained →
+    // force_terminal_reassert, but that event can't fire while focus
+    // reporting is off. An external reset that turns ?1004 off would
+    // otherwise strand the app until a manual Ctrl+L — re-arming it here
+    // means FocusGained starts firing again within one interval.
+    assert!(
+        s.contains("\x1b[?1004h"),
+        "must re-enable focus reporting so the FocusGained recovery stays armed"
+    );
     // Must NOT re-enter the alternate screen (would risk a per-second
     // clear/flicker) or toggle cursor visibility (managed per frame).
     assert!(!s.contains("\x1b[?1049h"), "must not re-enter alt screen");


### PR DESCRIPTION
The periodic terminal-mode reassert re-armed mouse capture and bracketed paste but **not** focus reporting (`?1004`). The primary mouse/selection recovery is event-driven — `FocusGained → force_terminal_reassert` — and that event only fires while `?1004` is armed. So once an external reset (terminal `reset`, tmux detach/reattach, a multiplexer that drops private modes) turned `?1004` off, no `FocusGained` ever arrived again, the reactive chain went dark, and only a manual **Ctrl+L** recovered — matching the persists-until-Ctrl+L symptom.

## Fix
Add `?1004h` to `TERMINAL_MODE_REASSERT` (the event-driven `TERMINAL_FULL_REASSERT` already carried it) so a clobbered focus-reporting mode self-heals within one interval and `FocusGained` starts firing again. The periodic poll isn't competing with the reactive path — it's the foundation that keeps it self-healing. It still re-arms mouse+paste as a safety net for terminals that don't report focus at all.

## Comment correction
The old doc narrative claimed a bash-tool child clobbered the modes by opening `/dev/tty` and emitting `?1000l` on exit. That's false: `bash::exec::detach_session` calls `setsid()`, so the child has no controlling terminal and a `/dev/tty` open fails with `ENXIO` (proven by `dirge-tc2q`). Replaced the narrative at all five sites (constant doc, `tui_redraw` block, `reassert_terminal_modes` doc, `last_mode_reassert` field doc, idle-timer block) with the accurate external-reset rationale, and renamed the test to assert `?1004h`.

One-line functional change; `?1004h` is idempotent and emits no event. build + clippy clean; reassert/focus tests pass.