### PR TITLE
fix: throttle force_terminal_reassert to break FocusGained feedback loop

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -230,6 +230,13 @@ const TERMINAL_FULL_REASSERT: &[u8] = b"\x1b[?2026h\x1b[?1049h\x1b[2J\x1b[?1000h
 /// enough that a leaked reset self-heals before it's annoying.
 const MODE_REASSERT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// How soon after a full re-assert (FocusGained / Ctrl+L) we may fire another.
+/// The tightest feedback loop is `?1004h` (focus-reporting enable) in
+/// [`TERMINAL_FULL_REASSERT`] → terminal replies with `ESC[I]` (FocusGained)
+/// → handler calls [`force_terminal_reassert`](Renderer::force_terminal_reassert)
+/// again. 500ms is well below human perception but breaks that microsecond loop.
+const FULL_REASSERT_THROTTLE: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Decide whether the terminal modes are due for re-assertion, returning
 /// the bytes to emit (or `None` when the throttle hasn't elapsed). Pure so
 /// the throttle + payload are unit-testable without a live terminal: a
@@ -457,6 +464,9 @@ pub struct Renderer {
     /// app). `tui_redraw` re-emits them on a throttle so dirge self-heals
     /// within one interval of any such leak. `None` until the first paint.
     last_mode_reassert: Option<std::time::Instant>,
+    /// Timestamp of the most recent [`force_terminal_reassert`] — throttles
+    /// the FocusGained → full-reassert → `?1004h` → FocusGained feedback loop.
+    last_full_reassert: Option<std::time::Instant>,
     /// Bumped each time scrollback eviction drains lines from the FRONT of
     /// `buffer`, which shifts every absolute line index down. Consumers
     /// holding an absolute index across appends (the Ctrl+O expansion
@@ -655,6 +665,7 @@ impl Renderer {
             needs_paint: false,
             last_paint: None,
             last_mode_reassert: None,
+            last_full_reassert: None,
             eviction_generation: 0,
             #[cfg(test)]
             test_cols: None,
@@ -2728,6 +2739,12 @@ impl Renderer {
     /// leaked the reset. Bound to Ctrl+L; never fires on the periodic
     /// self-heal, so the alt-screen re-entry can't flicker during normal use.
     pub fn force_terminal_reassert(&mut self) {
+        let now = std::time::Instant::now();
+        if let Some(last) = self.last_full_reassert
+            && now.saturating_duration_since(last) < FULL_REASSERT_THROTTLE
+        {
+            return;
+        }
         if let Some(mut tty) = crate::ui::terminal::open_tty_for_write() {
             let _ = tty.write_all(TERMINAL_FULL_REASSERT);
             let _ = tty.flush();
@@ -2736,6 +2753,7 @@ impl Renderer {
         // repaints against the freshly-cleared alt buffer (no stale diff).
         self.tui_terminal = build_tui_terminal();
         self.needs_paint = true;
+        self.last_full_reassert = Some(std::time::Instant::now());
         self.last_mode_reassert = Some(std::time::Instant::now());
     }
 

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1093,6 +1093,32 @@ fn full_reassert_re_enters_alt_screen_synchronized() {
     );
 }
 
+/// The full re-assert (FocusGained / Ctrl+L) must be throttled to break the
+/// `?1004h` → terminal `ESC[I]` → `FocusGained` → `force_terminal_reassert`
+/// → `?1004h` feedback loop. A second call within [`FULL_REASSERT_THROTTLE`]
+/// skips the write and backend rebuild entirely.
+#[test]
+fn force_terminal_reassert_is_throttled_against_feedback_loop() {
+    let mut r = Renderer::new().expect("renderer");
+
+    // First call: proceeds — the throttle is fresh (None).
+    r.force_terminal_reassert();
+    assert!(
+        r.needs_paint,
+        "first re-assert must dirty the frame for repaint"
+    );
+
+    // Simulate a FocusGained event arriving in the same tick (the
+    // feedback loop): reset the dirty flag and call again.
+    r.needs_paint = false;
+    r.force_terminal_reassert();
+    assert!(
+        !r.needs_paint,
+        "back-to-back force_terminal_reassert must be throttled — \
+         the ?1004h → FocusGained → re-assert loop must break here"
+    );
+}
+
 /// The throttle: re-assert on the first paint, then suppress until the
 /// interval elapses, then re-assert again. A leak that lands between paints
 /// is healed within one interval.


### PR DESCRIPTION
## What happened

The terminal was thrashing the CPU and flooding `/dev/tty` with escape sequences because of a tight feedback loop in the FocusGained recovery path.

## Root cause

`force_terminal_reassert` emits `TERMINAL_FULL_REASSERT`, which includes `?1004h` (focus-reporting enable). On terminals that honor `?1004h`, the terminal replies immediately with `ESC[I]` (FocusGained). The FocusGained handler — added in dirge-ph60 — calls `force_terminal_reassert` unconditionally, without any throttle.

This creates a self-sustaining microsecond loop:

```
?1004h → terminal ESC[I] → FocusGained → force_terminal_reassert → ?1004h → …
```

Every iteration:
- Writes the full re-assert escape sequence to `/dev/tty`
- Rebuilds the ratatui backend (creating a new `CrosstermBackend`)
- Dirties the frame for a full repaint

On my system this was spinning the event loop continuously, causing visible rendering jank and CPU churn.

## Fix

A 500ms throttle (`FULL_REASSERT_THROTTLE`) on `force_terminal_reassert` via a new `last_full_reassert` timestamp. A second call within the throttle window returns immediately — no `/dev/tty` write, no backend rebuild, no frame dirtied.

The throttle also covers the Ctrl+L manual hatch (same function), which is fine — you can't meaningfully Ctrl+L faster than 500ms apart anyway.

## Changes

- `src/ui/renderer.rs`: Added `FULL_REASSERT_THROTTLE` constant, `last_full_reassert` field, throttle guard in `force_terminal_reassert`
- `src/ui/renderer_tests.rs`: Added `force_terminal_reassert_is_throttled_against_feedback_loop` test

## CI

- `cargo fmt --all --check`: ✅
- `cargo clippy --all-targets --all-features`: ✅ (0 new warnings)
- `cargo test --bin dirge --all-features`: ✅ (all pass)