### PR TITLE
Recover FocusGained with a mode-only reassert (fix gnome-terminal/VTE strobe)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1553,17 +1553,18 @@ pub async fn run_interactive(
                             }
                             UserEvent::FocusGained => {
                                 // dirge-ph60: switching away from and back to
-                                // the terminal window is the common trigger
-                                // for the alt screen being dropped (dead
-                                // mouse, wheel scrolls native scrollback). On
-                                // focus-in, run the full re-assert — re-enter
-                                // the alt screen + mouse capture + paste +
-                                // focus reporting, wrapped in synchronized
-                                // output so it's invisible on a ?2026 terminal.
-                                // Idempotent when nothing broke, so it's safe
-                                // to fire on every focus-in. Replaces the
-                                // manual Ctrl+L hatch as the primary recovery.
-                                renderer.force_terminal_reassert();
+                                // the terminal window can leave a mode dropped
+                                // (dead mouse, wheel scrolls native scrollback).
+                                // dirge-1f2a: recover with a MODE-ONLY re-assert
+                                // — re-arm mouse capture + paste + focus
+                                // reporting, then repaint. Do NOT re-enter the
+                                // alt screen: `?1049h` re-enters+clears it,
+                                // which on VTE 0.76 (gnome-terminal) both
+                                // flashes and emits a synthetic FocusGained,
+                                // strobing on every alt-tab. We never leave the
+                                // alt screen on a focus change, so re-entry was
+                                // never needed. Ctrl+L keeps the full hatch.
+                                renderer.reassert_modes_light();
                                 renderer.request_repaint();
                                 continue;
                             }

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -2758,13 +2758,18 @@ impl Renderer {
         }
     }
 
-    /// Escape hatch (dirge-173j): force a FULL terminal re-assert —
-    /// re-enter the alternate screen, re-enable mouse capture + bracketed
-    /// paste — then rebuild the backend so the next frame fully repaints.
-    /// Recovers a session stranded in the main screen (dead mouse, wheel
-    /// scrolls native scrollback, selection uncaptured) regardless of what
-    /// leaked the reset. Bound to Ctrl+L; never fires on the periodic
-    /// self-heal, so the alt-screen re-entry can't flicker during normal use.
+    /// Manual escape hatch (dirge-173j): force a FULL terminal re-assert —
+    /// re-enter *and clear* the alternate screen (`?1049h`), re-enable mouse
+    /// capture + bracketed paste — then rebuild the backend so the next frame
+    /// fully repaints. Recovers a session stranded in the main screen (dead
+    /// mouse, wheel scrolls native scrollback, selection uncaptured) regardless
+    /// of what leaked the reset.
+    ///
+    /// Bound to Ctrl+L ONLY. The automatic `FocusGained` recovery uses
+    /// [`reassert_modes_light`](Renderer::reassert_modes_light) instead —
+    /// `?1049h`'s clear + synthetic-focus side effect made this flicker/strobe
+    /// on VTE when fired on every alt-tab (dirge-1f2a). Never fires on the
+    /// periodic self-heal.
     pub fn force_terminal_reassert(&mut self) {
         let now = std::time::Instant::now();
         if let Some(last) = self.last_full_reassert
@@ -2781,6 +2786,31 @@ impl Renderer {
         self.tui_terminal = build_tui_terminal();
         self.needs_paint = true;
         self.last_full_reassert = Some(std::time::Instant::now());
+        self.last_mode_reassert = Some(std::time::Instant::now());
+    }
+
+    /// Lightweight recovery for the automatic `FocusGained` path: re-arm SGR
+    /// mouse capture, bracketed paste, and focus reporting via
+    /// [`TERMINAL_MODE_REASSERT`] — WITHOUT re-entering the alternate screen
+    /// (`?1049h`) or clearing it (`2J`), and without rebuilding the backend.
+    ///
+    /// This is the fix for the gnome-terminal / VTE 0.76 strobe (dirge-1f2a).
+    /// The full re-assert's `?1049h` re-enters *and clears* the alt screen; on
+    /// VTE that both flashes and makes the terminal emit a *synthetic*
+    /// `FocusGained` as a side effect of processing `?1049h` — and since
+    /// focus-in fires on every window switch, that fed a self-reinforcing loop
+    /// (the #606 throttle bounded it, but the visible flash on each real
+    /// alt-tab remained). dirge never *leaves* the alt screen on a focus
+    /// change, so re-entering it was never needed: re-arming the modes and
+    /// letting the caller repaint fully recovers a dead mouse / dropped paste.
+    /// No `?1049h` means this can't trigger the synthetic-focus loop, so it is
+    /// deliberately un-throttled. The manual Ctrl+L hatch still uses
+    /// [`force_terminal_reassert`] for a genuine full recovery + clear.
+    pub fn reassert_modes_light(&mut self) {
+        if let Some(mut tty) = crate::ui::terminal::open_tty_for_write() {
+            let _ = tty.write_all(TERMINAL_MODE_REASSERT);
+            let _ = tty.flush();
+        }
         self.last_mode_reassert = Some(std::time::Instant::now());
     }
 

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1070,6 +1070,30 @@ fn mode_reassert_payload_re_enables_mouse_paste_and_focus() {
     // clear/flicker) or toggle cursor visibility (managed per frame).
     assert!(!s.contains("\x1b[?1049h"), "must not re-enter alt screen");
     assert!(!s.contains("\x1b[?25"), "must not touch cursor visibility");
+    // dirge-1f2a: this is also the FocusGained recovery payload — it must not
+    // clear the screen (the `2J` / `?1049h`-clear is the VTE flash + synthetic-
+    // focus loop source).
+    assert!(!s.contains("\x1b[2J"), "must not clear the screen");
+}
+
+/// dirge-1f2a: the automatic FocusGained recovery must be the LIGHT path — it
+/// re-arms modes and lets the caller repaint, but does NOT rebuild the backend
+/// or dirty a full frame the way the Ctrl+L `force_terminal_reassert` does.
+/// That, plus the mode-only payload (no `?1049h`), is what stops the
+/// gnome-terminal / VTE 0.76 strobe on every alt-tab.
+#[test]
+fn reassert_modes_light_does_not_churn_a_repaint() {
+    let mut r = Renderer::new().expect("renderer");
+    r.needs_paint = false;
+    r.reassert_modes_light();
+    assert!(
+        !r.needs_paint,
+        "light reassert must not force a full repaint/backend rebuild"
+    );
+    assert!(
+        r.last_mode_reassert.is_some(),
+        "light reassert records the mode re-arm timestamp"
+    );
 }
 
 /// The explicit redraw escape hatch (Ctrl+L, dirge-173j) DOES re-enter the


### PR DESCRIPTION
## Bug
Continuous TUI strobe on gnome-terminal 3.52 / VTE 0.76 (Ubuntu), v0.18.6+. Root cause (from the reporter's investigation): `EnableFocusChange` (`?1004h`, added in 0.18.6) makes the terminal send `FocusGained`; the handler ran `force_terminal_reassert`, whose `TERMINAL_FULL_REASSERT` emits **`?1049h`** — which re-enters *and clears* the alt screen. On VTE, processing `?1049h` while already in the alt screen emits a **synthetic** `FocusGained` (the `?2026` sync bracket defers *rendering* but not the event), so focus-in fed itself into a strobe.

## Why the earlier fixes weren't enough
- #605 kept `?1004` armed (correct, unrelated).
- #606's throttle bounded the *loop*, but a visible **flash on every real alt-tab** remained, because `?1049h` clears the screen before the repaint lands.

## Fix
dirge never *leaves* the alt screen on a focus change, so re-entering it was never needed. Recover with a **mode-only** reassert: new `reassert_modes_light` re-arms mouse capture + bracketed paste + focus reporting via the existing `TERMINAL_MODE_REASSERT` (**no `?1049h`, no `2J`**) and repaints. No `?1049h` → it can't trigger the synthetic-focus loop, so it's un-throttled and skips the backend rebuild. `force_terminal_reassert` (with the clear) stays as the manual **Ctrl+L** hatch for a genuine full recovery.

## Note on the reviewed branch
The branch's original approach dropped only the redundant `2J` but **kept `?1049h`** on the focus-in path — which, per the report, is itself the flash + synthetic-focus source (`?1049h` clears on its own). This replaces it with the mode-only recovery the report actually calls for.

Tests: the mode payload asserts no `?1049h`/`2J`; a new test pins that `reassert_modes_light` doesn't churn a full repaint/backend rebuild. fmt + clippy(`-D warnings`) clean; suite green (flaky h7 aside).

Reported against gnome-terminal 3.52 / VTE 0.76.