### PR TITLE
feat: Add optional macOS desktop notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,7 +647,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1173,6 +1182,7 @@ dependencies = [
  "libc",
  "libkrun-sys",
  "lsp-types",
+ "notify-rust",
  "nucleo-matcher",
  "pulldown-cmark",
  "ratatui",
@@ -1234,6 +1244,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2372,7 +2392,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2535,7 +2555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2626,6 +2646,20 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2772,6 +2806,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "tauri-winrt-notification",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +2950,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,7 +3085,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "windows 0.62.2",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3029,7 +3114,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4702,6 +4787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5661,14 +5757,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.3.2",
  "windows-core 0.62.2",
- "windows-future",
- "windows-numerics",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5694,15 +5812,39 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -5712,8 +5854,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link",
- "windows-threading",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5762,9 +5904,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -5773,7 +5931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5782,9 +5940,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5798,11 +5956,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5811,7 +5987,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5838,7 +6014,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5863,7 +6039,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5876,11 +6052,29 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,12 @@ experimental-graph-search = []
 # tree rather than orphaning bash's children.
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Native desktop notification backend for the opt-in OS notification feature.
+# Kept macOS-only while Linux/Windows support stays structured behind backend
+# modules for a later implementation.
+notify-rust = { version = "4", default-features = false }
+
 [dependencies]
 # CVE-2026 audit (2026-05-27): rig's default features pull a
 # sprawling transitive tree:

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,8 +124,9 @@ Accepted top-level keys:
 ### Desktop Notifications
 
 Desktop notifications are off unless `desktop_notifications.enabled` is set.
-On macOS, dirge uses `notify-rust` to show a system notification banner; Linux
-and Windows backend files are present but currently no-op.
+On macOS, dirge uses `notify-rust` to show a system notification banner through
+the Terminal notification sender; Linux and Windows backend files are present
+but currently no-op.
 
 ```json
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -108,6 +108,7 @@ Accepted top-level keys:
 | `show_tool_details`       | boolean | Show tool-result output in the TUI. Default: `true`.                                                                                                                         |
 | `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
 | `show_reasoning`          | boolean | Show the model's thinking/reasoning by default, instead of having to press `Ctrl+O` each turn. Default: `false`.                                                            |
+| `desktop_notifications`   | object  | Optional OS-level desktop notifications. Off when absent. Set `{ "enabled": true }` to notify on completed runs and prompts waiting for input. macOS is implemented first using the system notification banner; Linux/Windows backends are reserved by the same config shape. |
 | `max_sessions`            | integer | How many of the most-recent prior sessions in the same project (same working dir) to mine for Up-arrow / Ctrl+F command history, seeded ahead of the current session's prompts. Default: `3`. Set `0` to keep recall to the current session only. See [Command history](#command-history-cross-session-recall). |
 | `display`                 | string  | Preferred startup pane layout: a `\|`/`,`/space-separated subset of `left`, `main`, `right` (e.g. `"main\|right"`, `"main"`). The main pane is always shown; this picks which side panels appear. Override at runtime with `/display`. Default: automatic (side panels shown at ≥152 cols). |
 | `tool_result_max_chars`   | integer | Hard ceiling on characters per tool result. Default: `500`. Combined with `tool_result_max_lines` (lines applied first; chars trim what's left).                                |
@@ -119,6 +120,27 @@ Accepted top-level keys:
 | `mcp_servers`             | object  | MCP server map when compiled with the `mcp` feature. When omitted, defaults to a single Exa Web Search server; see below.                                                   |
 | `acp_servers`             | object  | ACP server config map when compiled with the `acp` feature. See the ACP section below.                                                                                       |
 | `editor_open_command`     | string  | Opt-in editor follow-along: a command template with `{path}` and `{line}` placeholders (e.g. `"zed {path}:{line}"`, `"code --goto {path}:{line}"`). When set, dirge opens files it reads or edits in this external GUI editor, detached and non-blocking — the editor "follows along" like Zed's AI panel. `None` (unset) disables the feature entirely. |
+
+### Desktop Notifications
+
+Desktop notifications are off unless `desktop_notifications.enabled` is set.
+On macOS, dirge uses the system notification banner via `osascript display
+notification`; Linux and Windows backend files are present but currently no-op.
+
+```json
+{
+  "desktop_notifications": {
+    "enabled": true,
+    "on_completion": true,
+    "on_input_required": true
+  }
+}
+```
+
+When enabled, omitted `on_completion` / `on_input_required` keys default to
+`true`. `on_completion` fires only when a run actually returns to idle, not when
+an automatic follow-up, reviewer pass, loop iteration, or queued interjection
+continues immediately.
 
 ### Context window & compaction
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,8 +124,8 @@ Accepted top-level keys:
 ### Desktop Notifications
 
 Desktop notifications are off unless `desktop_notifications.enabled` is set.
-On macOS, dirge uses the system notification banner via `osascript display
-notification`; Linux and Windows backend files are present but currently no-op.
+On macOS, dirge uses `notify-rust` to show a system notification banner; Linux
+and Windows backend files are present but currently no-op.
 
 ```json
 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -259,6 +259,17 @@ pub struct PluginSettings {
     pub auto_start: Option<bool>,
 }
 
+/// Optional desktop notification settings. The block is absent/off by default;
+/// when enabled, individual event classes default to on so a minimal
+/// `{ "enabled": true }` does the useful thing.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct DesktopNotificationConfig {
+    pub enabled: Option<bool>,
+    pub on_completion: Option<bool>,
+    pub on_input_required: Option<bool>,
+}
+
 /// `lsp = true`  → enable built-in servers with default commands.
 /// `lsp = false` → disable LSP entirely.
 /// `lsp = { server-id = { … } }` → enable defaults, overriding the named
@@ -485,6 +496,9 @@ pub struct Config {
     /// the `.janet` file stem under a plugin search dir). Absent entry =
     /// enabled, not auto-started (backward compatible).
     pub plugins: Option<HashMap<String, PluginSettings>>,
+    /// Optional OS-level desktop notifications for turn completion and
+    /// prompts waiting on human input. Absent/off by default.
+    pub desktop_notifications: Option<DesktopNotificationConfig>,
     pub permission: Option<serde_json::Value>,
     pub restrictive: Option<bool>,
     pub accept_all: Option<bool>,
@@ -1639,6 +1653,27 @@ mod tests {
         let empty: Config = serde_json::from_str("{}").unwrap();
         assert!(empty.plugin_enabled("anything"));
         assert!(!empty.plugin_auto_start("anything"));
+    }
+
+    #[test]
+    fn desktop_notifications_are_absent_by_default_and_parse() {
+        let cfg: Config = serde_json::from_str("{}").unwrap();
+        assert!(cfg.desktop_notifications.is_none());
+
+        let cfg: Config = serde_json::from_str(
+            r#"{
+                "desktop_notifications": {
+                    "enabled": true,
+                    "on_completion": false,
+                    "on_input_required": true
+                }
+            }"#,
+        )
+        .unwrap();
+        let desktop = cfg.desktop_notifications.expect("desktop notifications");
+        assert_eq!(desktop.enabled, Some(true));
+        assert_eq!(desktop.on_completion, Some(false));
+        assert_eq!(desktop.on_input_required, Some(true));
     }
 
     #[test]

--- a/src/ui/desktop_notify/linux.rs
+++ b/src/ui/desktop_notify/linux.rs
@@ -1,0 +1,8 @@
+use std::io;
+
+use super::NotificationSpec;
+
+pub(super) fn notify(_spec: &NotificationSpec<'_>) -> io::Result<()> {
+    // Backend reserved for a follow-up implementation, likely via notify-send.
+    Ok(())
+}

--- a/src/ui/desktop_notify/macos.rs
+++ b/src/ui/desktop_notify/macos.rs
@@ -6,6 +6,7 @@ use notify_rust::{Notification, set_application};
 use super::NotificationSpec;
 
 static SET_APPLICATION: Once = Once::new();
+const NOTIFICATION_SENDER_BUNDLE: &str = "com.apple.Terminal";
 
 pub(super) fn notify(spec: &NotificationSpec<'_>) -> io::Result<()> {
     prime_notification_sender();
@@ -21,7 +22,29 @@ pub(super) fn notify(spec: &NotificationSpec<'_>) -> io::Result<()> {
 fn prime_notification_sender() {
     SET_APPLICATION.call_once(|| {
         // The default mac-notification-sys app lookup can resolve to Finder and
-        // fail for CLI runs. Terminal is the backend's own fallback sender.
-        let _ = set_application("com.apple.Terminal");
+        // fail for CLI runs. Terminal is the backend's stable fallback sender.
+        tracing::debug!(
+            target: "dirge::ui::desktop_notify",
+            sender = NOTIFICATION_SENDER_BUNDLE,
+            "using macOS notification sender"
+        );
+        if let Err(err) = set_application(NOTIFICATION_SENDER_BUNDLE) {
+            tracing::debug!(
+                target: "dirge::ui::desktop_notify",
+                error = %err,
+                sender = NOTIFICATION_SENDER_BUNDLE,
+                "macOS notification sender setup failed; continuing with backend default"
+            );
+        }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_terminal_as_macos_sender() {
+        assert_eq!(NOTIFICATION_SENDER_BUNDLE, "com.apple.Terminal");
+    }
 }

--- a/src/ui/desktop_notify/macos.rs
+++ b/src/ui/desktop_notify/macos.rs
@@ -1,0 +1,63 @@
+use std::io;
+use std::process::{Command, Stdio};
+
+use super::NotificationSpec;
+
+pub(super) fn notify(spec: &NotificationSpec<'_>) -> io::Result<()> {
+    let script = notification_script(spec.title, spec.message);
+    Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+}
+
+fn notification_script(title: &str, message: &str) -> String {
+    format!(
+        "display notification {} with title {}",
+        applescript_string(message),
+        applescript_string(title),
+    )
+}
+
+fn applescript_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            c if c.is_control() => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applescript_strings_escape_quotes_and_backslashes() {
+        assert_eq!(
+            applescript_string(r#"say "hi" \ now"#),
+            r#""say \"hi\" \\ now""#,
+        );
+    }
+
+    #[test]
+    fn notification_script_uses_display_notification() {
+        let script = notification_script("Dirge", "Needs input");
+        assert_eq!(
+            script,
+            r#"display notification "Needs input" with title "Dirge""#,
+        );
+    }
+}

--- a/src/ui/desktop_notify/macos.rs
+++ b/src/ui/desktop_notify/macos.rs
@@ -23,19 +23,7 @@ fn prime_notification_sender() {
     SET_APPLICATION.call_once(|| {
         // The default mac-notification-sys app lookup can resolve to Finder and
         // fail for CLI runs. Terminal is the backend's stable fallback sender.
-        tracing::debug!(
-            target: "dirge::ui::desktop_notify",
-            sender = NOTIFICATION_SENDER_BUNDLE,
-            "using macOS notification sender"
-        );
-        if let Err(err) = set_application(NOTIFICATION_SENDER_BUNDLE) {
-            tracing::debug!(
-                target: "dirge::ui::desktop_notify",
-                error = %err,
-                sender = NOTIFICATION_SENDER_BUNDLE,
-                "macOS notification sender setup failed; continuing with backend default"
-            );
-        }
+        let _ = set_application(NOTIFICATION_SENDER_BUNDLE);
     });
 }
 

--- a/src/ui/desktop_notify/macos.rs
+++ b/src/ui/desktop_notify/macos.rs
@@ -1,63 +1,14 @@
 use std::io;
-use std::process::{Command, Stdio};
+
+use notify_rust::Notification;
 
 use super::NotificationSpec;
 
 pub(super) fn notify(spec: &NotificationSpec<'_>) -> io::Result<()> {
-    let script = notification_script(spec.title, spec.message);
-    Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
+    Notification::new()
+        .summary(spec.title)
+        .body(spec.message)
+        .show()
         .map(|_| ())
-}
-
-fn notification_script(title: &str, message: &str) -> String {
-    format!(
-        "display notification {} with title {}",
-        applescript_string(message),
-        applescript_string(title),
-    )
-}
-
-fn applescript_string(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('"');
-    for ch in value.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            c if c.is_control() => out.push(' '),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn applescript_strings_escape_quotes_and_backslashes() {
-        assert_eq!(
-            applescript_string(r#"say "hi" \ now"#),
-            r#""say \"hi\" \\ now""#,
-        );
-    }
-
-    #[test]
-    fn notification_script_uses_display_notification() {
-        let script = notification_script("Dirge", "Needs input");
-        assert_eq!(
-            script,
-            r#"display notification "Needs input" with title "Dirge""#,
-        );
-    }
+        .map_err(|err| io::Error::other(err.to_string()))
 }

--- a/src/ui/desktop_notify/macos.rs
+++ b/src/ui/desktop_notify/macos.rs
@@ -1,14 +1,27 @@
 use std::io;
+use std::sync::Once;
 
-use notify_rust::Notification;
+use notify_rust::{Notification, set_application};
 
 use super::NotificationSpec;
 
+static SET_APPLICATION: Once = Once::new();
+
 pub(super) fn notify(spec: &NotificationSpec<'_>) -> io::Result<()> {
+    prime_notification_sender();
+
     Notification::new()
         .summary(spec.title)
         .body(spec.message)
         .show()
         .map(|_| ())
         .map_err(|err| io::Error::other(err.to_string()))
+}
+
+fn prime_notification_sender() {
+    SET_APPLICATION.call_once(|| {
+        // The default mac-notification-sys app lookup can resolve to Finder and
+        // fail for CLI runs. Terminal is the backend's own fallback sender.
+        let _ = set_application("com.apple.Terminal");
+    });
 }

--- a/src/ui/desktop_notify/mod.rs
+++ b/src/ui/desktop_notify/mod.rs
@@ -1,0 +1,159 @@
+//! OS-level desktop notifications.
+//!
+//! This is deliberately separate from `ui::notifications`, which is the
+//! in-TUI chat notification channel. Call sites emit semantic events here and
+//! the platform module owns OS-specific mechanics. macOS is implemented first;
+//! other platforms are structured as no-ops until their backends are filled in.
+
+use crate::config::{Config, DesktopNotificationConfig};
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "linux")]
+use linux as platform;
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(target_os = "windows")]
+use windows as platform;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+mod platform {
+    use std::io;
+
+    use super::NotificationSpec;
+
+    pub(super) fn notify(_spec: &NotificationSpec<'_>) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DesktopNotifyEvent {
+    Completion,
+    InputRequired(InputRequiredKind),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputRequiredKind {
+    Permission,
+    Question,
+    PluginDialog,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct NotificationSpec<'a> {
+    pub(super) title: &'a str,
+    pub(super) message: &'a str,
+}
+
+pub(crate) fn notify(cfg: &Config, event: DesktopNotifyEvent) {
+    if !should_notify(cfg.desktop_notifications.as_ref(), event) {
+        return;
+    }
+
+    let spec = spec_for(event);
+    if let Err(err) = platform::notify(&spec) {
+        tracing::debug!(
+            target: "dirge::ui::desktop_notify",
+            error = %err,
+            "desktop notification skipped"
+        );
+    }
+}
+
+fn should_notify(settings: Option<&DesktopNotificationConfig>, event: DesktopNotifyEvent) -> bool {
+    let Some(settings) = settings else {
+        return false;
+    };
+    if !settings.enabled.unwrap_or(false) {
+        return false;
+    }
+    match event {
+        DesktopNotifyEvent::Completion => settings.on_completion.unwrap_or(true),
+        DesktopNotifyEvent::InputRequired(_) => settings.on_input_required.unwrap_or(true),
+    }
+}
+
+fn spec_for(event: DesktopNotifyEvent) -> NotificationSpec<'static> {
+    match event {
+        DesktopNotifyEvent::Completion => NotificationSpec {
+            title: "Dirge",
+            message: "Run completed.",
+        },
+        DesktopNotifyEvent::InputRequired(InputRequiredKind::Permission) => NotificationSpec {
+            title: "Dirge needs approval",
+            message: "A tool permission prompt is waiting for your input.",
+        },
+        DesktopNotifyEvent::InputRequired(InputRequiredKind::Question) => NotificationSpec {
+            title: "Dirge needs input",
+            message: "A question is waiting for your response.",
+        },
+        DesktopNotifyEvent::InputRequired(InputRequiredKind::PluginDialog) => NotificationSpec {
+            title: "Dirge needs input",
+            message: "A plugin dialog is waiting for your response.",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_cfg() -> DesktopNotificationConfig {
+        DesktopNotificationConfig {
+            enabled: Some(true),
+            on_completion: None,
+            on_input_required: None,
+        }
+    }
+
+    #[test]
+    fn notifications_are_off_when_config_absent_or_disabled() {
+        assert!(!should_notify(None, DesktopNotifyEvent::Completion));
+
+        let cfg = DesktopNotificationConfig {
+            enabled: Some(false),
+            on_completion: Some(true),
+            on_input_required: Some(true),
+        };
+        assert!(!should_notify(Some(&cfg), DesktopNotifyEvent::Completion));
+    }
+
+    #[test]
+    fn enabled_defaults_to_both_event_classes() {
+        let cfg = enabled_cfg();
+        assert!(should_notify(Some(&cfg), DesktopNotifyEvent::Completion));
+        assert!(should_notify(
+            Some(&cfg),
+            DesktopNotifyEvent::InputRequired(InputRequiredKind::Question),
+        ));
+    }
+
+    #[test]
+    fn per_event_toggles_are_honored() {
+        let cfg = DesktopNotificationConfig {
+            enabled: Some(true),
+            on_completion: Some(false),
+            on_input_required: Some(true),
+        };
+        assert!(!should_notify(Some(&cfg), DesktopNotifyEvent::Completion));
+        assert!(should_notify(
+            Some(&cfg),
+            DesktopNotifyEvent::InputRequired(InputRequiredKind::Permission),
+        ));
+    }
+
+    #[test]
+    fn event_specs_are_stable() {
+        let spec = spec_for(DesktopNotifyEvent::InputRequired(
+            InputRequiredKind::PluginDialog,
+        ));
+        assert_eq!(spec.title, "Dirge needs input");
+        assert!(spec.message.contains("plugin dialog"));
+    }
+}

--- a/src/ui/desktop_notify/windows.rs
+++ b/src/ui/desktop_notify/windows.rs
@@ -1,0 +1,8 @@
+use std::io;
+
+use super::NotificationSpec;
+
+pub(super) fn notify(_spec: &NotificationSpec<'_>) -> io::Result<()> {
+    // Backend reserved for a follow-up implementation, likely via PowerShell toast.
+    Ok(())
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod buffer;
 mod chat_state;
 pub(crate) mod colors;
 pub(crate) mod compaction;
+pub(crate) mod desktop_notify;
 pub(crate) mod done_phase;
 mod editor_follow;
 pub(crate) mod events;
@@ -4209,6 +4210,12 @@ pub async fn run_interactive(
                             req: ask_req,
                             pending_chamber_tool,
                         });
+                        crate::ui::desktop_notify::notify(
+                            cfg,
+                            crate::ui::desktop_notify::DesktopNotifyEvent::InputRequired(
+                                crate::ui::desktop_notify::InputRequiredKind::Permission,
+                            ),
+                        );
                         renderer.request_repaint();
                     }
                     Some(notif) = async {
@@ -4641,6 +4648,12 @@ pub async fn run_interactive(
                                 anchor,
                                 entry: None,
                             });
+                            crate::ui::desktop_notify::notify(
+                                cfg,
+                                crate::ui::desktop_notify::DesktopNotifyEvent::InputRequired(
+                                    crate::ui::desktop_notify::InputRequiredKind::Question,
+                                ),
+                            );
                         }
                         renderer.request_repaint();
                     }
@@ -4680,7 +4693,10 @@ pub async fn run_interactive(
                                     &format!("[plugin {}] {}", safe_title, safe_question),
                                     c_perm(),
                                 )?;
-                                renderer.write_line("  (y) yes  (n) no  (ESC) cancel = no", c_perm())?;
+                                renderer.write_line(
+                                    "  (y) yes  (n) no  (ESC) cancel = no",
+                                    c_perm(),
+                                )?;
                                 ui.input_mode = state::InputMode::DialogConfirm { reply };
                             }
                             DialogRequest::Select { title, options, reply } => {
@@ -4694,12 +4710,23 @@ pub async fn run_interactive(
                                     c_perm(),
                                 )?;
                                 for (i, opt) in options.iter().enumerate() {
-                                    renderer.write_line(&format!("  {}: {}", i + 1, opt), c_perm())?;
+                                    renderer
+                                        .write_line(&format!("  {}: {}", i + 1, opt), c_perm())?;
                                 }
-                                renderer.write_line("  (1-9) select  (ESC) cancel", c_perm())?;
-                                ui.input_mode = state::InputMode::DialogSelect { reply, options };
+                                renderer.write_line(
+                                    "  (1-9) select  (ESC) cancel",
+                                    c_perm(),
+                                )?;
+                                ui.input_mode =
+                                    state::InputMode::DialogSelect { reply, options };
                             }
                         }
+                        crate::ui::desktop_notify::notify(
+                            cfg,
+                            crate::ui::desktop_notify::DesktopNotifyEvent::InputRequired(
+                                crate::ui::desktop_notify::InputRequiredKind::PluginDialog,
+                            ),
+                        );
                         renderer.request_repaint();
                     }
                     Some(plan_req) = async {

--- a/src/ui/run_handlers/done.rs
+++ b/src/ui/run_handlers/done.rs
@@ -523,6 +523,12 @@ pub(crate) async fn finish_done(
             is_running,
             ctx.cfg.memory_graduation.unwrap_or(true),
         )?;
+        if !*is_running {
+            crate::ui::desktop_notify::notify(
+                ctx.cfg,
+                crate::ui::desktop_notify::DesktopNotifyEvent::Completion,
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add opt-in `desktop_notifications` config for completion and input-required events
- route notification events through platform backend modules
- use `notify-rust` for the macOS backend while keeping Linux/Windows stubs for future support
- document config and add focused tests

## Tests
- cargo fmt
- cargo fmt --check
- git diff --check
- cargo test desktop_notify
- cargo test desktop_notifications
- cargo check
- cargo check --no-default-features --features windows-default

Fixes #594