### PR TITLE
fix: guard periodic mode reassert against mid-drag selection

### DIFF
--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -2782,6 +2782,13 @@ impl Renderer {
     /// which is why, in the broken state, the keyboard keeps working while
     /// the mouse stays dead.
     pub fn reassert_terminal_modes(&mut self) {
+        // Don't write to /dev/tty while the user is mid-drag selecting
+        // text: re-sending mouse-tracking enable sequences (?1003h et al.)
+        // resets internal tracking state on some terminals, dropping the
+        // drag so MouseUp never fires and copy_to_clipboard is never called.
+        if self.selection_active {
+            return;
+        }
         let now = std::time::Instant::now();
         if let Some(bytes) = mode_reassert_payload(self.last_mode_reassert, now) {
             if let Some(mut tty) = crate::ui::terminal::open_tty_for_write() {
@@ -2841,6 +2848,11 @@ impl Renderer {
     /// deliberately un-throttled. The manual Ctrl+L hatch still uses
     /// [`force_terminal_reassert`] for a genuine full recovery + clear.
     pub fn reassert_modes_light(&mut self) {
+        // Same guard as reassert_terminal_modes: writing mode-enable
+        // sequences to /dev/tty mid-drag drops the selection.
+        if self.selection_active {
+            return;
+        }
         let now = std::time::Instant::now();
         // Throttle: a terminal that echoes `FocusGained` on the `?1004h` in
         // TERMINAL_MODE_REASSERT would otherwise drive an unbounded re-arm →

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1253,6 +1253,38 @@ fn reassert_terminal_modes_arms_and_respects_throttle() {
     );
 }
 
+/// When the user is mid-drag selecting text, `reassert_terminal_modes` must
+/// not write to /dev/tty: re-sending mouse-tracking enable sequences
+/// (?1003h et al.) resets internal tracking state on some terminals,
+/// dropping the drag so MouseUp never fires and copy_to_clipboard is never
+/// called.
+#[test]
+fn reassert_terminal_modes_suppressed_during_selection() {
+    let mut r = Renderer::new().expect("renderer");
+    r.selection_active = true;
+    // The method arms the throttle on write, so a no-write call leaves
+    // last_mode_reassert at None — a subsequent payload probe must still
+    // show a payload is due (we didn't arm the throttle).
+    r.reassert_terminal_modes();
+    assert!(
+        r.mode_reassert_due_in_test().is_some(),
+        "selection guard must skip the write entirely, leaving throttle unarmed"
+    );
+}
+
+/// Same guard for the FocusGained path: `reassert_modes_light` must not
+/// write to /dev/tty mid-drag.
+#[test]
+fn reassert_modes_light_suppressed_during_selection() {
+    let mut r = Renderer::new().expect("renderer");
+    r.selection_active = true;
+    r.reassert_modes_light();
+    assert!(
+        r.mode_reassert_due_in_test().is_some(),
+        "selection guard must skip the light reassert, leaving throttle unarmed"
+    );
+}
+
 /// Scrollback eviction (front drain past MAX_SCROLLBACK) bumps the
 /// eviction generation — the counter the Ctrl+O collapse guard relies on
 /// to know an absolute line anchor has been invalidated.


### PR DESCRIPTION
Writing mouse-tracking enable sequences (?1003h et al.) to /dev/tty while the user is mid-drag selecting text resets internal tracking state on some terminals (vte/GNOME Terminal), dropping the drag so MouseUp never fires and copy_to_clipboard is never called.

Guard both reassert_terminal_modes() and reassert_modes_light() with an early return when selection_active is true. The call sites (tui_redraw and the idle loop in mod.rs) route through these methods, so they're covered without changes to callers.