### PR TITLE
chore: upgrade rig from 0.37 to 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,7 +1114,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1649,6 +1658,10 @@ name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -1766,6 +1779,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2051,7 +2076,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3717,18 +3742,18 @@ dependencies = [
 
 [[package]]
 name = "rig"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d928cf3d6427216f3df8b1f4f6c38909d1d512d3ce5e1f503ac5dd869ab0540"
+checksum = "e98e2e8f01c4c5bc23f577983634fa4d5244ffb070ea14c23b1ea5bd406e5cac"
 dependencies = [
  "rig-core",
 ]
 
 [[package]]
 name = "rig-core"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bd308c89a90f89ce7cd6641a078c7d2a2c55fb5a4147fd48b5a0989c3430bd"
+checksum = "80a4bc7a93b329c4e1a66d5fd211d79990e7331e3c701f057c29f135f548686d"
 dependencies = [
  "as-any",
  "async-stream",
@@ -3740,6 +3765,7 @@ dependencies = [
  "futures-timer",
  "glob",
  "http",
+ "indexmap 2.14.0",
  "mime",
  "mime_guess",
  "nanoid",
@@ -3761,11 +3787,11 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.1.14"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9149c63403a49ddfd5d373860487e6feef0021bfe5329812d1c4e72ee207c"
+checksum = "5531bfa887b371eab658a92de7db35003370bbeee208ff5e68bbb81a5ae92d3d"
 dependencies = [
- "convert_case",
+ "convert_case 0.11.0",
  "deluxe",
  "indoc",
  "proc-macro-crate 3.5.0",
@@ -4183,6 +4209,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4869,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -5221,21 +5253,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,14 +185,14 @@ libc = "0.2"
 # cargo-audit findings. The `rustls` feature on rig-core ensures the
 # reqwest TLS backend stays on the modern rustls 0.23 → webpki 0.103
 # stack rather than the legacy 0.21 pathway.
-rig = { version = "0.37", default-features = false, features = ["rmcp"] }
+rig = { version = "0.39", default-features = false, features = ["rmcp"] }
 # Explicit dep to pin feature flags. Without this, rig (our only
 # dep on rig-core) enables `derive` and `reqwest` via its own
 # feature resolution, but we want `rustls` explicitly declared so
 # future readers understand the TLS backend choice is deliberate.
 # cargo-machete reports this as unused — the package.metadata
 # block at the top of this file suppresses that false positive.
-rig-core = { version = "0.37", default-features = false, features = ["reqwest", "derive", "rustls"] }
+rig-core = { version = "0.39", default-features = false, features = ["reqwest", "derive", "rustls"] }
 # Macros for emitting `Stream<Item = …>` from async generator-style
 # code blocks. Used by `agent_loop::rig_stream` to wrap rig's
 # `StreamingCompletionResponse` into our pi-style `StreamEvent`

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -853,6 +853,7 @@ mod tests {
             content: OneOrMany::many(vec![
                 UserContent::Text(Text {
                     text: "hi".to_string(),
+                    additional_params: None,
                 }),
                 UserContent::Image(Image {
                     data: DocumentSourceKind::Url("dirge-asset:abc".to_string()),

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -442,7 +442,8 @@ where
                     };
                 }
                 Ok(StreamedAssistantContent::Final(r)) => {
-                    token_usage = r.token_usage().map(|u| super::message::TokenUsage {
+                    let u = r.token_usage();
+                    token_usage = Some(super::message::TokenUsage {
                         input_tokens: u.input_tokens,
                         output_tokens: u.output_tokens,
                         cached_input_tokens: u.cached_input_tokens,

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -530,8 +530,8 @@ mod tests {
     struct TestResponse;
 
     impl GetTokenUsage for TestResponse {
-        fn token_usage(&self) -> Option<rig::completion::Usage> {
-            None
+        fn token_usage(&self) -> rig::completion::Usage {
+            rig::completion::Usage::default()
         }
     }
 
@@ -572,10 +572,12 @@ mod tests {
     async fn wraps_simple_text_response() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "Hello".to_string(),
+                text: "Hello".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " world".to_string(),
+                text: " world".to_string(),,
+                additional_params: None,
             })),
         ]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
@@ -1003,11 +1005,13 @@ mod tests {
     async fn wraps_error_emits_error_and_stops() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "partial".to_string(),
+                text: "partial".to_string(),,
+                additional_params: None,
             })),
             Err(CompletionError::ProviderError("bad upstream".to_string())),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " more text".to_string(),
+                text: " more text".to_string(),,
+                additional_params: None,
             })),
         ]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
@@ -1272,7 +1276,8 @@ mod tests {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Reasoning(r1)),
             Ok(StreamedAssistantContent::Text(Text {
-                text: "between".to_string(),
+                text: "between".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::Reasoning(r2)),
         ]);
@@ -1440,14 +1445,16 @@ mod tests {
     async fn wraps_mixed_content_resets_block_indices() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "hi ".to_string(),
+                text: "hi ".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::ReasoningDelta {
                 id: None,
                 reasoning: "thinking".to_string(),
             }),
             Ok(StreamedAssistantContent::Text(Text {
-                text: "done".to_string(),
+                text: "done".to_string(),,
+                additional_params: None,
             })),
         ]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
@@ -1496,7 +1503,8 @@ mod tests {
             if n == 0 {
                 Some((
                     Ok(StreamedAssistantContent::Text(Text {
-                        text: "first chunk".to_string(),
+                        text: "first chunk".to_string(),,
+                        additional_params: None,
                     })),
                     1,
                 ))
@@ -1544,7 +1552,8 @@ mod tests {
     #[tokio::test]
     async fn chunk_timeout_none_disables_timeout() {
         let raw = raw_stream(vec![Ok(StreamedAssistantContent::Text(Text {
-            text: "ok".to_string(),
+            text: "ok".to_string(),,
+            additional_params: None,
         }))]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
         // Normal completion — no Error.
@@ -1593,7 +1602,8 @@ mod tests {
                         tokio::time::sleep(Duration::from_secs(20)).await;
                         Some((
                             Ok(StreamedAssistantContent::Text(Text {
-                                text: "thinking…".to_string(),
+                                text: "thinking…".to_string(),,
+                                additional_params: None,
                             })),
                             2,
                         ))
@@ -1605,7 +1615,8 @@ mod tests {
                         tokio::time::sleep(Duration::from_secs(20)).await;
                         Some((
                             Ok(StreamedAssistantContent::Text(Text {
-                                text: "more thinking…".to_string(),
+                                text: "more thinking…".to_string(),,
+                                additional_params: None,
                             })),
                             3,
                         ))
@@ -1733,10 +1744,12 @@ mod tests {
         use crate::agent::agent_loop::tool::AbortSignal;
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "first".to_string(),
+                text: "first".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " second".to_string(),
+                text: " second".to_string(),,
+                additional_params: None,
             })),
         ]);
         let signal = AbortSignal::new();
@@ -1772,7 +1785,8 @@ mod tests {
     #[tokio::test]
     async fn signal_none_does_not_affect_stream() {
         let raw = raw_stream(vec![Ok(StreamedAssistantContent::Text(Text {
-            text: "ok".to_string(),
+            text: "ok".to_string(),,
+            additional_params: None,
         }))]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
         // Normal completion — no Error.
@@ -1792,10 +1806,12 @@ mod tests {
     async fn chunk_timeout_does_not_fire_on_fast_stream() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "fast 1".to_string(),
+                text: "fast 1".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " 2".to_string(),
+                text: " 2".to_string(),,
+                additional_params: None,
             })),
         ]);
         // Tight timeout (10ms) but all events fire
@@ -1823,13 +1839,13 @@ mod tests {
         #[derive(Clone, Debug)]
         struct UsageResponse;
         impl GetTokenUsage for UsageResponse {
-            fn token_usage(&self) -> Option<rig::completion::Usage> {
+            fn token_usage(&self) -> rig::completion::Usage {
                 let mut u = rig::completion::Usage::new();
                 u.input_tokens = 1000;
                 u.output_tokens = 50;
                 u.cached_input_tokens = 800;
                 u.cache_creation_input_tokens = 0;
-                Some(u)
+                u
             }
         }
 
@@ -1840,7 +1856,8 @@ mod tests {
             >,
         > = Box::pin(futures::stream::iter(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "hi".to_string(),
+                text: "hi".to_string(),,
+                additional_params: None,
             })),
             Ok(StreamedAssistantContent::Final(UsageResponse)),
         ]));

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -443,12 +443,25 @@ where
                 }
                 Ok(StreamedAssistantContent::Final(r)) => {
                     let u = r.token_usage();
-                    token_usage = Some(super::message::TokenUsage {
-                        input_tokens: u.input_tokens,
-                        output_tokens: u.output_tokens,
-                        cached_input_tokens: u.cached_input_tokens,
-                        cache_creation_input_tokens: u.cache_creation_input_tokens,
-                    });
+                    // rig 0.39 changed `token_usage()` from `Option<Usage>`
+                    // to `Usage`, using all-zeros as its "provider didn't
+                    // report" sentinel (the old `None`). Preserve that
+                    // distinction: an unreported turn must stay `None` so the
+                    // downstream guard in stream.rs doesn't emit a
+                    // `LoopEvent::Usage` for it and dilute the cache-hit ratio
+                    // with an empty turn.
+                    if u.input_tokens != 0
+                        || u.output_tokens != 0
+                        || u.cached_input_tokens != 0
+                        || u.cache_creation_input_tokens != 0
+                    {
+                        token_usage = Some(super::message::TokenUsage {
+                            input_tokens: u.input_tokens,
+                            output_tokens: u.output_tokens,
+                            cached_input_tokens: u.cached_input_tokens,
+                            cache_creation_input_tokens: u.cache_creation_input_tokens,
+                        });
+                    }
                 }
                 Err(err) => {
                     yield StreamEvent::Error {
@@ -1873,5 +1886,47 @@ mod tests {
         assert_eq!(usage.input_tokens, 1000);
         assert_eq!(usage.cached_input_tokens, 800);
         assert_eq!(usage.cache_creation_input_tokens, 0);
+    }
+
+    /// rig 0.39 returns an all-zeros `Usage` (not `None`) when a provider
+    /// doesn't report token usage. `Done.usage` must stay `None` in that
+    /// case so the loop's usage guard skips it — emitting a zero-usage
+    /// event would dilute the session cache-hit ratio with empty turns.
+    #[tokio::test]
+    async fn final_response_with_unreported_usage_stays_none() {
+        #[derive(Clone, Debug)]
+        struct NoUsageResponse;
+        impl GetTokenUsage for NoUsageResponse {
+            fn token_usage(&self) -> rig::completion::Usage {
+                rig::completion::Usage::default()
+            }
+        }
+
+        let raw: Pin<
+            Box<
+                dyn Stream<
+                        Item = Result<StreamedAssistantContent<NoUsageResponse>, CompletionError>,
+                    > + Send,
+            >,
+        > = Box::pin(futures::stream::iter(vec![
+            Ok(StreamedAssistantContent::Text(Text {
+                text: "hi".to_string(),
+                additional_params: None,
+            })),
+            Ok(StreamedAssistantContent::Final(NoUsageResponse)),
+        ]));
+
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        let usage = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Done { usage, .. } => Some(*usage),
+                _ => None,
+            })
+            .expect("a Done event");
+        assert!(
+            usage.is_none(),
+            "unreported (all-zeros) usage must map to None, got {usage:?}"
+        );
     }
 }

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -572,11 +572,11 @@ mod tests {
     async fn wraps_simple_text_response() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "Hello".to_string(),,
+                text: "Hello".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " world".to_string(),,
+                text: " world".to_string(),
                 additional_params: None,
             })),
         ]);
@@ -1005,12 +1005,12 @@ mod tests {
     async fn wraps_error_emits_error_and_stops() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "partial".to_string(),,
+                text: "partial".to_string(),
                 additional_params: None,
             })),
             Err(CompletionError::ProviderError("bad upstream".to_string())),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " more text".to_string(),,
+                text: " more text".to_string(),
                 additional_params: None,
             })),
         ]);
@@ -1276,7 +1276,7 @@ mod tests {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Reasoning(r1)),
             Ok(StreamedAssistantContent::Text(Text {
-                text: "between".to_string(),,
+                text: "between".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::Reasoning(r2)),
@@ -1445,7 +1445,7 @@ mod tests {
     async fn wraps_mixed_content_resets_block_indices() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "hi ".to_string(),,
+                text: "hi ".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::ReasoningDelta {
@@ -1453,7 +1453,7 @@ mod tests {
                 reasoning: "thinking".to_string(),
             }),
             Ok(StreamedAssistantContent::Text(Text {
-                text: "done".to_string(),,
+                text: "done".to_string(),
                 additional_params: None,
             })),
         ]);
@@ -1503,7 +1503,7 @@ mod tests {
             if n == 0 {
                 Some((
                     Ok(StreamedAssistantContent::Text(Text {
-                        text: "first chunk".to_string(),,
+                        text: "first chunk".to_string(),
                         additional_params: None,
                     })),
                     1,
@@ -1552,7 +1552,7 @@ mod tests {
     #[tokio::test]
     async fn chunk_timeout_none_disables_timeout() {
         let raw = raw_stream(vec![Ok(StreamedAssistantContent::Text(Text {
-            text: "ok".to_string(),,
+            text: "ok".to_string(),
             additional_params: None,
         }))]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
@@ -1602,7 +1602,7 @@ mod tests {
                         tokio::time::sleep(Duration::from_secs(20)).await;
                         Some((
                             Ok(StreamedAssistantContent::Text(Text {
-                                text: "thinking…".to_string(),,
+                                text: "thinking…".to_string(),
                                 additional_params: None,
                             })),
                             2,
@@ -1615,7 +1615,7 @@ mod tests {
                         tokio::time::sleep(Duration::from_secs(20)).await;
                         Some((
                             Ok(StreamedAssistantContent::Text(Text {
-                                text: "more thinking…".to_string(),,
+                                text: "more thinking…".to_string(),
                                 additional_params: None,
                             })),
                             3,
@@ -1744,11 +1744,11 @@ mod tests {
         use crate::agent::agent_loop::tool::AbortSignal;
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "first".to_string(),,
+                text: "first".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " second".to_string(),,
+                text: " second".to_string(),
                 additional_params: None,
             })),
         ]);
@@ -1785,7 +1785,7 @@ mod tests {
     #[tokio::test]
     async fn signal_none_does_not_affect_stream() {
         let raw = raw_stream(vec![Ok(StreamedAssistantContent::Text(Text {
-            text: "ok".to_string(),,
+            text: "ok".to_string(),
             additional_params: None,
         }))]);
         let events = drain(wrap_streamed_assistant(raw, None, None)).await;
@@ -1806,11 +1806,11 @@ mod tests {
     async fn chunk_timeout_does_not_fire_on_fast_stream() {
         let raw = raw_stream(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "fast 1".to_string(),,
+                text: "fast 1".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::Text(Text {
-                text: " 2".to_string(),,
+                text: " 2".to_string(),
                 additional_params: None,
             })),
         ]);
@@ -1856,7 +1856,7 @@ mod tests {
             >,
         > = Box::pin(futures::stream::iter(vec![
             Ok(StreamedAssistantContent::Text(Text {
-                text: "hi".to_string(),,
+                text: "hi".to_string(),
                 additional_params: None,
             })),
             Ok(StreamedAssistantContent::Final(UsageResponse)),

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -445,6 +445,7 @@ fn build_user_content(parts: &[Value], asset_dir: Option<&std::path::Path>) -> O
                 {
                     user_parts.push(UserContent::Text(Text {
                         text: t.to_string(),
+                        additional_params: None,
                     }));
                 }
             }
@@ -458,6 +459,7 @@ fn build_user_content(parts: &[Value], asset_dir: Option<&std::path::Path>) -> O
                     Some(img) => user_parts.push(UserContent::Image(img)),
                     None => user_parts.push(UserContent::Text(Text {
                         text: format!("[image unavailable: {asset_id}]"),
+                        additional_params: None,
                     })),
                 }
             }
@@ -1324,8 +1326,11 @@ mod tests {
     struct NopModel;
 
     impl GetTokenUsage for NopStreamResponse {
-        fn token_usage(&self) -> Option<rig::completion::Usage> {
-            None
+        // rig 0.39 changed the trait return type from Option<Usage> to
+        // Usage. All-zeros is the "provider didn't report" sentinel per
+        // rig's own docs — functionally unchanged from the pre-0.39 None.
+        fn token_usage(&self) -> rig::completion::Usage {
+            rig::completion::Usage::default()
         }
     }
 

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -125,6 +125,7 @@ pub fn convert_history(session: &Session) -> Vec<Message> {
                     if !msg.content.is_empty() {
                         parts.push(UserContent::Text(Text {
                             text: msg.content.to_string(),
+                            additional_params: None,
                         }));
                     }
                     for img in &msg.images {


### PR DESCRIPTION
Two small breaking changes in rig 0.39:

**`GetTokenUsage::token_usage()`** now returns `Usage` directly instead of `Option<Usage>`. All-zeros is rig's "provider didn't report" sentinel — the `NopStreamResponse` and two test mock impls switch from `None` to `Usage::default()`, functionally equivalent. The `token_usage().map(|u| ...)` call site in `rig_stream.rs` flattens to a direct let-binding.

**`Text` struct** (both `completion::message::Text` and `streaming::Text`) gained a required `additional_params: Option<serde_json::Value>` field. Passed as `None` everywhere — we don't use provider-specific text params.

- `cargo fmt` — clean
- `cargo clippy -- -D warnings` — clean
- 319 rig-related tests pass, full suite green aside from 7 pre-existing relay/sandbox flaky tests