### PR TITLE
Pin rig to an exact version (fixes #616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to dirge are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-07-08
+
+### Fixed
+- `cargo install dirge-agent` failed to compile against rig. rig ships
+  breaking API changes in patch releases (0.37.1 added a required
+  `Text.additional_params` field), and `cargo install` resolves without the
+  lockfile, so the caret dependency drifted onto an incompatible rig. rig and
+  rig-core are now pinned to an exact version so published installs build
+  against the rig dirge was tested with (dirge-omgq, GH #616).
+
 ## [0.19.1] - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "dirge-agent"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # taken on crates.io. The installed BINARY is still `dirge` (see [[bin]]),
 # so users run: `cargo install dirge-agent` then the `dirge` command.
 name = "dirge-agent"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2024"
 # MSRV: edition 2024 needs 1.85, but the dependency tree (time, serde_with,
 # darling, instability) requires 1.88 — pin there so older toolchains fail
@@ -185,14 +185,20 @@ libc = "0.2"
 # cargo-audit findings. The `rustls` feature on rig-core ensures the
 # reqwest TLS backend stays on the modern rustls 0.23 → webpki 0.103
 # stack rather than the legacy 0.21 pathway.
-rig = { version = "0.39", default-features = false, features = ["rmcp"] }
+# Pinned to an exact version, not a caret. rig ships breaking API
+# changes in patch/minor releases (0.37.0 -> 0.37.1 added a required
+# `Text.additional_params` field), and `cargo install dirge-agent`
+# resolves without our Cargo.lock, so a caret would let a published
+# dirge drift onto an incompatible rig and fail to build (GH #616).
+# Bump this deliberately when adopting a new rig.
+rig = { version = "=0.39.0", default-features = false, features = ["rmcp"] }
 # Explicit dep to pin feature flags. Without this, rig (our only
 # dep on rig-core) enables `derive` and `reqwest` via its own
 # feature resolution, but we want `rustls` explicitly declared so
 # future readers understand the TLS backend choice is deliberate.
 # cargo-machete reports this as unused — the package.metadata
 # block at the top of this file suppresses that false positive.
-rig-core = { version = "0.39", default-features = false, features = ["reqwest", "derive", "rustls"] }
+rig-core = { version = "=0.39.0", default-features = false, features = ["reqwest", "derive", "rustls"] }
 # Macros for emitting `Stream<Item = …>` from async generator-style
 # code blocks. Used by `agent_loop::rig_stream` to wrap rig's
 # `StreamingCompletionResponse` into our pi-style `StreamEvent`


### PR DESCRIPTION
`cargo install dirge-agent` was failing to compile against rig.

rig ships breaking API changes in patch releases — 0.37.1 added a required `Text.additional_params` field. `cargo install` resolves dependencies without our `Cargo.lock`, so the caret constraint (`rig = "0.37"`, and after #615 `rig = "0.39"`) let a published dirge drift onto an incompatible rig and fail with E0063. #615 adapted the code to 0.39 but kept the caret, so it would recur on the next rig patch.

Pin rig and rig-core to `=0.39.0` so published installs build against the rig dirge was tested with. Bump to 0.19.2 and publish to actually deliver the fix to `cargo install` users.

Fixes #616.