### PR TITLE
fix(agent-loop): recover from transient mid-stream errors

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -194,6 +194,21 @@ pub(crate) const RESUME_NUDGE_TAG: &str = "[resume]";
 /// repeatedly stops after broken tool calls can't loop forever.
 const MAX_RESUME_NUDGE: u8 = 3;
 
+/// Run-level recovery nudge reinjected (bounded by
+/// [`MAX_TRANSIENT_RECOVERIES`]) when a transient mid-stream error
+/// ("error decoding response body", network blip, rate-limit) kills an
+/// assistant turn AFTER content has already streamed. The streaming
+/// retry layer can't replay the turn (the partial is already on
+/// screen), so the run loop recovers instead: the preserved partial
+/// stays in the transcript and this nudge tells the model to continue
+/// rather than restart from scratch.
+const TRANSIENT_RECOVERY_NUDGE: &str = "Your previous response was cut off by a transient connection error before it finished. Continue from where you left off — do not repeat what you already said.";
+
+/// Upper bound on consecutive transient-error recoveries, so a
+/// genuinely dead network can't loop the run forever. Past this the
+/// error surfaces as terminal (the run ends, as it did before recovery).
+const MAX_TRANSIENT_RECOVERIES: u8 = 3;
+
 /// Stable prefix of the max-agent-turns truncation notice. The
 /// headless result path (`provider::run`) matches on this to mark the
 /// run truncated in its JSON envelope (dirge-18v2) — sharing the
@@ -1412,6 +1427,11 @@ pub async fn run_loop(
     // Deterministic resume-after-failure (bounded by MAX_RESUME_NUDGE).
     let mut resume_nudges: u8 = 0;
 
+    // Run-level recovery from a transient mid-stream error (bounded by
+    // MAX_TRANSIENT_RECOVERIES). Counts consecutive recoveries so a
+    // truly dead network still terminates.
+    let mut transient_recoveries: u8 = 0;
+
     // dirge-ksjl: open-issues gate counter (bounded by MAX_OPEN_ISSUES_NUDGES).
     let mut open_issues_nudges: u8 = 0;
 
@@ -1436,8 +1456,14 @@ pub async fn run_loop(
 
         let mut has_more_tool_calls = true;
 
-        // Pi line 174: INNER LOOP.
-        while has_more_tool_calls || !pending_messages.is_empty() {
+        // Pi line 174: INNER LOOP. `recovery_pending` forces one more
+        // iteration after a transient mid-stream error is recovered at
+        // the run level (see the error/aborted short-circuit below) —
+        // the nudge rides in context.messages, so the flag alone drives
+        // the next turn when no tool calls or steering are pending.
+        let mut recovery_pending = false;
+        while has_more_tool_calls || !pending_messages.is_empty() || recovery_pending {
+            recovery_pending = false;
             // Circuit-breaker bookkeeping is at-most-once per iteration:
             // a single iteration can run BOTH the turn-start fold and the
             // (ungated) post-usage ExitWithSummary pass, and counting two
@@ -1630,6 +1656,56 @@ pub async fn run_loop(
                 assistant_msg.stop_reason,
                 StopReason::Error | StopReason::Aborted
             ) {
+                // Run-level recovery: a transient mid-stream failure
+                // (network blip, "error decoding response body",
+                // rate-limit) that arrived AFTER the model had already
+                // streamed content can't be silently retried by the
+                // stream layer (the partial is already on screen), but
+                // it shouldn't kill the whole run either. The partial is
+                // already preserved in the transcript (stream.rs Error
+                // arm), so nudge the model to continue and take another
+                // turn — bounded by MAX_TRANSIENT_RECOVERIES so a truly
+                // dead network still terminates. Aborted (explicit
+                // cancel) and non-transient errors (auth, context-length)
+                // still terminate as before.
+                let transient = assistant_msg.stop_reason == StopReason::Error
+                    && transient_recoveries < MAX_TRANSIENT_RECOVERIES
+                    && assistant_msg
+                        .error_message
+                        .as_deref()
+                        .map(|e| {
+                            use crate::agent::recovery::{ErrorKind, classify_error};
+                            matches!(classify_error(e), ErrorKind::Network | ErrorKind::RateLimit)
+                        })
+                        .unwrap_or(false);
+                if transient {
+                    transient_recoveries += 1;
+                    // LLM-facing only: not routed through pending_messages
+                    // (which render as user turns) so it doesn't surface as
+                    // a `<you>` line. Mirrors the stall-recovery nudge in
+                    // retry.rs.
+                    current_context.messages.push(serde_json::json!({
+                        "role": "user",
+                        "content": TRANSIENT_RECOVERY_NUDGE,
+                    }));
+                    let _ = emit
+                        .send(LoopEvent::RetryNotice {
+                            attempt: transient_recoveries as u32,
+                            delay_ms: 0,
+                            error: assistant_msg
+                                .error_message
+                                .clone()
+                                .unwrap_or_else(|| "transient stream error".to_string()),
+                        })
+                        .await;
+                    // No tool calls ran (the stream errored before
+                    // dispatch). Force one more inner iteration so the
+                    // nudge drives the next assistant turn.
+                    has_more_tool_calls = false;
+                    recovery_pending = true;
+                    continue;
+                }
+
                 let _ = emit
                     .send(LoopEvent::TurnEnd {
                         message: assistant_msg.clone(),

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -153,6 +153,171 @@ fn empty_context() -> Context {
     }
 }
 
+/// Regression: a transient mid-stream error ("error decoding response
+/// body") arriving AFTER the model has streamed content must NOT kill
+/// the run. The streaming retry layer can't replay the turn (the
+/// partial is already on screen), but the run loop recovers: it keeps
+/// the preserved partial, nudges the model to continue, and the next
+/// turn proceeds — instead of tearing down to idle and dropping any
+/// queued steering.
+#[tokio::test]
+async fn transient_midstream_error_recovers_instead_of_terminating() {
+    use crate::agent::agent_loop::message::{DeltaPhase, LoopEvent};
+    let call = std::sync::Arc::new(AtomicUsize::new(0));
+    let factory: StreamFn = std::sync::Arc::new({
+        let call = call.clone();
+        move |_ctx, _opts| {
+            let n = call.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // First call: stream some text, then die mid-stream
+                // with a transient transport error.
+                let partial = AssistantMessage::new(
+                    vec![ContentBlock::Text {
+                        text: "working on it".to_string(),
+                    }],
+                    StopReason::Stop,
+                );
+                Box::pin(futures::stream::iter(vec![
+                    StreamEvent::Start {
+                        partial: AssistantMessage::new(Vec::new(), StopReason::Stop),
+                    },
+                    StreamEvent::Delta {
+                        partial,
+                        phase: DeltaPhase::TextDelta,
+                    },
+                    StreamEvent::Error {
+                        error: "error decoding response body".to_string(),
+                    },
+                ]))
+            } else {
+                // Recovery turn: complete normally.
+                let msg = AssistantMessage::new(
+                    vec![ContentBlock::Text {
+                        text: "all done now".to_string(),
+                    }],
+                    StopReason::Stop,
+                );
+                Box::pin(futures::stream::iter(vec![StreamEvent::Done {
+                    reason: StopReason::Stop,
+                    message: msg,
+                    usage: None,
+                }]))
+            }
+        }
+    });
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+    let messages = run_agent_loop(
+        vec![LoopMessage::User(UserMessage::text("start"))],
+        empty_context(),
+        build_config(),
+        AbortSignal::new(),
+        &tx,
+        &factory,
+        None,
+        None,
+    )
+    .await;
+
+    // The run recovered past the error: the final assistant turn
+    // completed instead of the run dying on the errored turn.
+    let last_text = messages.iter().rev().find_map(|m| match m {
+        LoopMessage::Assistant(a) => a.content.iter().find_map(|b| match b {
+            ContentBlock::Text { text } => Some(text.clone()),
+            _ => None,
+        }),
+        _ => None,
+    });
+    assert_eq!(
+        last_text.as_deref(),
+        Some("all done now"),
+        "run must continue past a transient error and complete the recovery turn"
+    );
+
+    // A retry/recovery banner was surfaced so the UI isn't silent.
+    let mut saw_retry = false;
+    while let Ok(evt) = rx.try_recv() {
+        if matches!(evt, LoopEvent::RetryNotice { .. }) {
+            saw_retry = true;
+        }
+    }
+    assert!(
+        saw_retry,
+        "recovery should surface a RetryNotice banner instead of dying silently"
+    );
+}
+
+/// A sustained outage (every call fails transiently) must still
+/// terminate — the recovery budget caps consecutive recoveries so a
+/// dead network can't loop the run forever. After the budget is spent
+/// the error surfaces as terminal, exactly as it did before recovery.
+#[tokio::test]
+async fn sustained_transient_error_terminates_after_budget() {
+    use crate::agent::agent_loop::message::DeltaPhase;
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let factory: StreamFn = std::sync::Arc::new({
+        let calls = calls.clone();
+        move |_ctx, _opts| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            let partial = AssistantMessage::new(
+                vec![ContentBlock::Text {
+                    text: "halfway".to_string(),
+                }],
+                StopReason::Stop,
+            );
+            Box::pin(futures::stream::iter(vec![
+                StreamEvent::Start {
+                    partial: AssistantMessage::new(Vec::new(), StopReason::Stop),
+                },
+                StreamEvent::Delta {
+                    partial,
+                    phase: DeltaPhase::TextDelta,
+                },
+                StreamEvent::Error {
+                    error: "error decoding response body".to_string(),
+                },
+            ]))
+        }
+    });
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(64);
+    let messages = run_agent_loop(
+        vec![LoopMessage::User(UserMessage::text("start"))],
+        empty_context(),
+        build_config(),
+        AbortSignal::new(),
+        &tx,
+        &factory,
+        None,
+        None,
+    )
+    .await;
+
+    // Recovered MAX_TRANSIENT_RECOVERIES times, then one final terminal
+    // error — not an unbounded loop.
+    let total_calls = calls.load(Ordering::SeqCst);
+    assert_eq!(
+        total_calls,
+        (MAX_TRANSIENT_RECOVERIES as usize) + 1,
+        "run must stop after the recovery budget is exhausted, not loop forever"
+    );
+
+    // The run terminated on a real error (not a clean Stop).
+    let last = messages
+        .iter()
+        .rev()
+        .find_map(|m| match m {
+            LoopMessage::Assistant(a) => Some(a),
+            _ => None,
+        })
+        .expect("an assistant message exists");
+    assert_eq!(
+        last.stop_reason,
+        StopReason::Error,
+        "after the budget the error must surface as terminal"
+    );
+}
+
 /// LOOP-9 integration: `run_compaction_pass` end-to-end. Feed
 /// a long conversation, a mock summarizer, and assert that
 /// (a) the older messages were dropped, (b) a SUMMARY_PREFIX

--- a/src/agent/agent_loop/stream.rs
+++ b/src/agent/agent_loop/stream.rs
@@ -35,7 +35,8 @@ use futures::stream::StreamExt;
 use tokio::sync::mpsc;
 
 use super::message::{
-    AssistantMessage, LoopEvent, LoopMessage, StopReason, StreamEvent, assistant_to_value,
+    AssistantMessage, ContentBlock, LoopEvent, LoopMessage, StopReason, StreamEvent,
+    assistant_to_value,
 };
 use super::tool::AbortSignal;
 use super::types::{Context, LoopConfig};
@@ -222,11 +223,16 @@ pub async fn stream_assistant_response(
 
     // 5. Iterate events.
     let mut added_partial = false;
+    // Latest partial snapshot — captured on Start/Delta so a
+    // mid-stream `Error` can preserve whatever streamed instead of
+    // finalizing an empty turn (see the Error arm).
+    let mut last_partial: Option<AssistantMessage> = None;
     let mut final_message: Option<(AssistantMessage, Option<super::message::TokenUsage>)> = None;
 
     while let Some(event) = stream.next().await {
         match event {
             StreamEvent::Start { partial } => {
+                last_partial = Some(partial.clone());
                 context.messages.push(assistant_to_value(&partial));
                 added_partial = true;
                 let _ = emit
@@ -236,6 +242,7 @@ pub async fn stream_assistant_response(
                     .await;
             }
             StreamEvent::Delta { partial, phase } => {
+                last_partial = Some(partial.clone());
                 if added_partial {
                     // Replace the last context message with the
                     // updated partial. Pi: `context.messages[
@@ -271,8 +278,23 @@ pub async fn stream_assistant_response(
                 break;
             }
             StreamEvent::Error { error } => {
+                // Preserve whatever streamed before the error rather
+                // than discarding it. A transient mid-stream failure
+                // ("error decoding response body") must not erase the
+                // model's in-progress work from the transcript — the
+                // run-level recovery in run.rs relies on the partial
+                // being here so the run can continue instead of dying
+                // on an empty turn.
+                let mut content = last_partial.take().map(|p| p.content).unwrap_or_default();
+                // The stream was cut mid-flight, so any tool-call
+                // block in the partial never executed (tool dispatch
+                // happens only after this fn returns). An unexecuted
+                // tool_use would orphan it (no matching tool_result)
+                // and break the next turn's API call, so strip
+                // tool-call blocks and keep text/thinking.
+                content.retain(|b| !matches!(b, ContentBlock::ToolCall { .. }));
                 let finalised = AssistantMessage {
-                    content: Vec::new(),
+                    content,
                     stop_reason: StopReason::Error,
                     error_message: Some(error),
                 };
@@ -931,5 +953,128 @@ mod tests {
             }
         }
         assert!(saw_escalation, "expected EscalationActivated event");
+    }
+
+    /// Regression: a mid-stream `Error` arriving AFTER the model has
+    /// streamed text must preserve the partial content in the returned
+    /// assistant message — not finalize an empty turn. Without this, a
+    /// transient transport blip ("error decoding response body")
+    /// silently erases the model's in-progress work from the transcript,
+    /// so the run can't recover and the user sees an empty turn.
+    #[tokio::test]
+    async fn error_after_streamed_text_preserves_partial() {
+        use crate::agent::agent_loop::message::DeltaPhase;
+        let stream_fn: StreamFn = Arc::new(|_ctx, _opts| {
+            let partial = AssistantMessage::new(
+                vec![ContentBlock::Text {
+                    text: "working on it".to_string(),
+                }],
+                StopReason::Stop,
+            );
+            Box::pin(futures::stream::iter(vec![
+                StreamEvent::Start {
+                    partial: AssistantMessage::new(Vec::new(), StopReason::Stop),
+                },
+                StreamEvent::Delta {
+                    partial,
+                    phase: DeltaPhase::TextDelta,
+                },
+                StreamEvent::Error {
+                    error: "error decoding response body".to_string(),
+                },
+            ]))
+        });
+        let mut ctx = Context::default();
+        let (tx, _rx) = mpsc::channel::<LoopEvent>(64);
+        let (msg, _usage) = stream_assistant_response(
+            &mut ctx,
+            &build_config(identity_converter()),
+            AbortSignal::new(),
+            &tx,
+            &stream_fn,
+        )
+        .await;
+
+        assert_eq!(msg.stop_reason, StopReason::Error);
+        let text: String = msg
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            text, "working on it",
+            "streamed partial must be preserved on a mid-stream Error"
+        );
+        assert_eq!(
+            msg.error_message.as_deref(),
+            Some("error decoding response body"),
+        );
+    }
+
+    /// A tool-call block in the streamed partial was never executed —
+    /// the stream errored before dispatch. Keeping it would orphan the
+    /// tool_use (no matching tool_result) and break the next turn's API
+    /// call. The preserved partial must strip tool-call blocks and keep
+    /// text/thinking.
+    #[tokio::test]
+    async fn error_after_streamed_content_strips_incomplete_tool_call() {
+        use crate::agent::agent_loop::message::DeltaPhase;
+        let stream_fn: StreamFn = Arc::new(|_ctx, _opts| {
+            let partial = AssistantMessage::new(
+                vec![
+                    ContentBlock::Text {
+                        text: "let me read the file".to_string(),
+                    },
+                    ContentBlock::ToolCall {
+                        id: "call-1".to_string(),
+                        name: "read".to_string(),
+                        arguments: serde_json::json!({"path": "x.rs"}),
+                    },
+                ],
+                StopReason::ToolUse,
+            );
+            Box::pin(futures::stream::iter(vec![
+                StreamEvent::Start {
+                    partial: AssistantMessage::new(Vec::new(), StopReason::Stop),
+                },
+                StreamEvent::Delta {
+                    partial,
+                    phase: DeltaPhase::ToolCallDelta,
+                },
+                StreamEvent::Error {
+                    error: "error decoding response body".to_string(),
+                },
+            ]))
+        });
+        let mut ctx = Context::default();
+        let (tx, _rx) = mpsc::channel::<LoopEvent>(64);
+        let (msg, _usage) = stream_assistant_response(
+            &mut ctx,
+            &build_config(identity_converter()),
+            AbortSignal::new(),
+            &tx,
+            &stream_fn,
+        )
+        .await;
+
+        assert_eq!(msg.stop_reason, StopReason::Error);
+        assert!(
+            msg.content
+                .iter()
+                .all(|b| !matches!(b, ContentBlock::ToolCall { .. })),
+            "unexecuted tool-call blocks must be stripped from the preserved partial"
+        );
+        let text: String = msg
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "let me read the file");
     }
 }


### PR DESCRIPTION
A transient transport error ("error decoding response body", network blip, rate-limit) arriving AFTER the model had streamed content hit three compounding problems:

- The streaming retry layer only retries before committed content, so a post-commit blip was not retried — correctly, since a replay would duplicate the already-rendered partial on screen.
- stream.rs then finalized the turn with content: Vec::new(), erasing the model's in-progress work from the transcript.
- run.rs treated StopReason::Error as terminal, so the run tore down to idle (^_^) and handle_error cleared the interjection queue — dropping any steering the user had queued mid-run.

This correlated with steering because a long active turn is exactly when the stream is most exposed to a body-decode blip AND when the user is most likely to steer.

Recovery is run-level, not a silent replay:

- stream.rs now preserves the last streamed partial (text + thinking) on Error instead of Vec::new(). Incomplete ToolCall blocks are stripped — they never dispatched, so keeping one would orphan the tool_use and break the next API call.
- run.rs treats a transient Error (Network/RateLimit per the existing classifier) as recoverable: the preserved partial stays in the transcript, a "you were cut off, continue" nudge drives the next turn, and a RetryNotice banner surfaces so the UI isn't silent. Any queued steering is delivered instead of dropped.

Bounded by MAX_TRANSIENT_RECOVERIES (3) so a genuinely dead network still terminates; Aborted (explicit cancel) and non-transient errors (auth, context-length) still terminate exactly as before.

Verification: 4 new tests (partial preservation + tool-call stripping at the stream layer; recovery-continues + budget-exhaustion at the run layer); run/stream/retry/bridge/integration suites green; fmt clean; no new clippy in changed files.