### PR TITLE
P3 edit tooling: fuzzy-match delta/diff, atomic /rewind, shared size cap (r6v6, nmbs, ygzn)

### DIFF
--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -7,8 +7,8 @@ use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path_resolve};
 
 /// Max content size for a single create op (1 MiB). Audit L5 noted
-/// the dual cap with `MAX_APPLY_PATCH_BYTES` (100 MiB) — both apply
-/// to creates and the tighter wins. Intentional: creating a 50 MB
+/// the dual cap with the shared `text_io::MAX_EDIT_BYTES` (100 MiB) — both
+/// apply to creates and the tighter wins. Intentional: creating a 50 MB
 /// file from inside an LLM tool call is almost always a bug; the
 /// large cap exists for update / read paths on legitimately large
 /// files. The tight create cap protects the LLM from accidentally
@@ -66,10 +66,7 @@ pub struct ApplyPatchArgs {
     pub operations: Vec<PatchOp>,
 }
 
-/// Cap apply_patch read/write at 100 MiB. The tool isn't meant for
-/// binary blobs or generated artifacts; an LLM pointing it at a
-/// gigabyte file should fail fast rather than OOM the process.
-const MAX_APPLY_PATCH_BYTES: u64 = 100 * 1024 * 1024;
+use crate::agent::tools::text_io::{MAX_EDIT_BYTES, check_edit_size};
 
 async fn apply_create(path: &str, content: &str) -> Result<String, String> {
     let p = Path::new(path);
@@ -83,11 +80,11 @@ async fn apply_create(path: &str, content: &str) -> Result<String, String> {
             .await
             .map_err(|e| format!("failed to create parent dir: {}", e))?;
     }
-    if content.len() as u64 > MAX_APPLY_PATCH_BYTES {
+    if content.len() as u64 > MAX_EDIT_BYTES {
         return Err(format!(
             "create content too large: {} bytes (cap {} bytes)",
             content.len(),
-            MAX_APPLY_PATCH_BYTES,
+            MAX_EDIT_BYTES,
         ));
     }
     // Phase-2 tree-sitter validation: refuse to create
@@ -109,14 +106,8 @@ async fn apply_update(path: &str, old_text: &str, new_text: &str) -> Result<Stri
     // Pre-check size before reading the file into memory. The
     // metadata call is cheap (single stat); rejecting here avoids
     // a multi-GB allocation in `read_to_string`.
-    if let Ok(meta) = tokio::fs::metadata(path).await
-        && meta.len() > MAX_APPLY_PATCH_BYTES
-    {
-        return Err(format!(
-            "file too large for apply_patch: {} bytes (cap {} bytes); use bash + sed/awk for huge files",
-            meta.len(),
-            MAX_APPLY_PATCH_BYTES,
-        ));
+    if let Ok(meta) = tokio::fs::metadata(path).await {
+        check_edit_size("apply_patch", meta.len())?;
     }
     let original_bytes = tokio::fs::read(path)
         .await

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -161,19 +161,12 @@ impl Tool for EditTool {
             )));
         }
 
-        // Pre-check size before reading. The edit tool isn't meant
-        // for huge generated artifacts; cap at 100 MiB so an LLM
-        // pointing it at a gigabyte log file fails fast rather
-        // than OOM-ing the process. Matches the apply_patch cap.
-        const MAX_EDIT_BYTES: u64 = 100 * 1024 * 1024;
-        if let Ok(meta) = tokio::fs::metadata(&resolved_path).await
-            && meta.len() > MAX_EDIT_BYTES
-        {
-            return Err(ToolError::Msg(format!(
-                "file too large for edit: {} bytes (cap {} bytes); use bash with sed/awk for huge files",
-                meta.len(),
-                MAX_EDIT_BYTES,
-            )));
+        // Pre-check size before reading (shared cap; dirge-ygzn). The edit
+        // tool isn't meant for huge generated artifacts — fail fast rather
+        // than OOM the process.
+        if let Ok(meta) = tokio::fs::metadata(&resolved_path).await {
+            crate::agent::tools::text_io::check_edit_size("edit", meta.len())
+                .map_err(ToolError::Msg)?;
         }
         let bytes = tokio::fs::read(&resolved_path).await?;
         // Shared decode seam: refuses non-UTF-8 (dirge-yga0), strips a leading
@@ -384,19 +377,22 @@ impl Tool for EditTool {
             result.push('\n');
             result.push_str(&note);
         }
-        // Mention the line delta when adding/removing lines so the
-        // LLM can confirm the size of change without re-reading
-        // the diff block. For replace_all the per-replacement
-        // delta multiplies by the number of replacements — the
-        // user wants the FILE delta, not the per-instance delta.
-        let old_lines = args.old_text.lines().count();
+        // Mention the line delta when adding/removing lines so the LLM can
+        // confirm the size of change without re-reading the diff block.
+        //
+        // dirge-r6v6: charge the delta (and, below, the diff) against the
+        // bytes ACTUALLY replaced — the matched range(s) — not args.old_text.
+        // When a fuzzy fallback fires, the whitespace-normalized matcher tries
+        // blocks up to +5 lines, so the matched block can be a different size
+        // than old_text; charging old_text would report the wrong delta and
+        // show `-` lines that were never in the file. For replace_all the
+        // blocks can individually differ in size, so the total is summed per
+        // range rather than multiplied by the match count.
         let new_lines = args.new_text.lines().count();
-        let per_replacement_delta = new_lines as i64 - old_lines as i64;
-        let total_delta = if do_replace_all {
-            per_replacement_delta * (match_positions.len() as i64)
-        } else {
-            per_replacement_delta
-        };
+        let (first_start, first_end) = match_ranges[0];
+        let matched_block = &content[first_start..first_end];
+        let total_delta =
+            replacement_line_delta(&content, &match_ranges, &args.new_text, do_replace_all);
         if total_delta != 0 {
             result.push_str(&format!(" ({:+} lines)", total_delta));
         }
@@ -406,15 +402,14 @@ impl Tool for EditTool {
         // useful diffs for any non-trivial edit. Bump to 200 lines
         // per side which covers the vast majority of real edits;
         // edits larger than that are likely refactors where the
-        // "edit + diff" pattern isn't the right tool anyway.
-        // `old_lines` / `new_lines` already computed above for the
-        // delta summary.
-        if old_lines <= 200 && new_lines <= 200 {
+        // "edit + diff" pattern isn't the right tool anyway. Gate on the
+        // matched block (the real removed text), not old_text.
+        if matched_block.lines().count() <= 200 && new_lines <= 200 {
             result.push_str(&Self::show_diff(
                 &args.path,
                 &content,
                 byte_pos,
-                &args.old_text,
+                matched_block,
                 &args.new_text,
             ));
         }
@@ -466,6 +461,30 @@ impl Tool for EditTool {
 // end_byte) byte ranges in `content` that match `find` under the
 // helper's normalization. Empty Vec = no matches. The cascade
 // tries each in priority order in the call site above.
+
+/// dirge-r6v6: line delta of an edit, charged against the bytes actually
+/// replaced (the matched `ranges`) rather than args.old_text. A fuzzy
+/// fallback can match a block of a different size than old_text, so charging
+/// old_text drifts the model's picture of the change. For replace_all each
+/// range can be a different size (the whitespace-normalized matcher tries
+/// blocks up to +5 lines), so the total is summed per range.
+fn replacement_line_delta(
+    content: &str,
+    ranges: &[(usize, usize)],
+    new_text: &str,
+    replace_all: bool,
+) -> i64 {
+    let new_lines = new_text.lines().count() as i64;
+    if replace_all {
+        ranges
+            .iter()
+            .map(|&(s, e)| new_lines - content[s..e].lines().count() as i64)
+            .sum()
+    } else {
+        let (s, e) = ranges[0];
+        new_lines - content[s..e].lines().count() as i64
+    }
+}
 
 /// dirge-nj6d: reduce a set of (start, end) byte ranges to a disjoint
 /// subset. Sorts by start and greedily keeps a range only if it begins
@@ -678,6 +697,48 @@ fn find_indentation_flexible_matches(content: &str, find: &str) -> Option<Vec<(u
 #[cfg(test)]
 mod fuzzy_tests {
     use super::*;
+
+    // dirge-r6v6: the delta is charged against the matched block, not the
+    // old_text the caller sent. A fuzzy fallback can match a larger block.
+    #[test]
+    fn replacement_delta_uses_matched_block_line_count() {
+        let content = "keep\nalpha\nbeta\ngamma\nkeep\n";
+        // The block actually replaced is the 3 middle lines.
+        assert_eq!(&content[5..22], "alpha\nbeta\ngamma\n");
+        let ranges = vec![(5usize, 22usize)];
+        // Replacing a 3-line block with 1 line ⇒ -2, no matter what
+        // 1-line old_text the model approximated it with.
+        assert_eq!(replacement_line_delta(content, &ranges, "one\n", false), -2);
+    }
+
+    #[test]
+    fn replacement_delta_sums_per_range_for_replace_all() {
+        // Two matched blocks of different sizes (2 and 3 lines), each
+        // replaced by a single line ⇒ (1-2) + (1-3) = -3. A multiply-by-count
+        // would be wrong when the blocks differ in size.
+        let content = "a\nb\nX\nc\nd\ne\nX\n";
+        assert_eq!(&content[0..4], "a\nb\n");
+        assert_eq!(&content[6..12], "c\nd\ne\n");
+        let ranges = vec![(0usize, 4usize), (6usize, 12usize)];
+        assert_eq!(replacement_line_delta(content, &ranges, "z", true), -3);
+    }
+
+    // dirge-r6v6: the diff's `-` lines and the following context come from the
+    // matched block, so a fuzzy match doesn't print removed lines never in the
+    // file or misplace the trailing context.
+    #[test]
+    fn show_diff_removes_matched_block_lines() {
+        let content = "ctx0\nalpha\nbeta\ngamma\ntail\n";
+        let byte_pos = content.find("alpha").unwrap();
+        let matched_block = "alpha\nbeta\ngamma";
+        let diff = EditTool::show_diff("f.rs", content, byte_pos, matched_block, "one");
+        assert!(diff.contains("-alpha\n"), "diff: {diff}");
+        assert!(diff.contains("-beta\n"), "diff: {diff}");
+        assert!(diff.contains("-gamma\n"), "diff: {diff}");
+        assert!(diff.contains("+one\n"), "diff: {diff}");
+        // Trailing context is the line AFTER the 3-line block, not after 1.
+        assert!(diff.contains(" tail\n"), "diff: {diff}");
+    }
 
     #[test]
     fn line_trimmed_matches_indent_drift() {

--- a/src/agent/tools/edit_lines.rs
+++ b/src/agent/tools/edit_lines.rs
@@ -208,15 +208,10 @@ impl Tool for EditLinesTool {
             )));
         }
 
-        const MAX_EDIT_BYTES: u64 = 100 * 1024 * 1024;
-        if let Ok(meta) = tokio::fs::metadata(&resolved_path).await
-            && meta.len() > MAX_EDIT_BYTES
-        {
-            return Err(ToolError::Msg(format!(
-                "file too large for edit_lines: {} bytes (cap {} bytes)",
-                meta.len(),
-                MAX_EDIT_BYTES,
-            )));
+        // Shared size cap (dirge-ygzn).
+        if let Ok(meta) = tokio::fs::metadata(&resolved_path).await {
+            crate::agent::tools::text_io::check_edit_size("edit_lines", meta.len())
+                .map_err(ToolError::Msg)?;
         }
 
         let bytes = tokio::fs::read(&resolved_path).await?;

--- a/src/agent/tools/edit_minified.rs
+++ b/src/agent/tools/edit_minified.rs
@@ -21,9 +21,6 @@ use crate::agent::tools::{AskSender, EditArgs, PermCheck, ToolError, require_and
 use crate::lsp::manager::LspManager;
 use crate::semantic::minify::{MinifiedEditError, apply_minified_edit};
 
-/// Cap on the file size we'll read+minify for an edit (mirrors `edit`).
-const MAX_EDIT_BYTES: u64 = 100 * 1024 * 1024;
-
 pub struct EditMinifiedTool {
     permission: Option<PermCheck>,
     ask_tx: Option<AskSender>,
@@ -112,14 +109,10 @@ impl Tool for EditMinifiedTool {
             )));
         }
 
-        if let Ok(meta) = tokio::fs::metadata(&resolved).await
-            && meta.len() > MAX_EDIT_BYTES
-        {
-            return Err(ToolError::Msg(format!(
-                "file too large for edit_minified: {} bytes (cap {})",
-                meta.len(),
-                MAX_EDIT_BYTES
-            )));
+        // Shared size cap (dirge-ygzn).
+        if let Ok(meta) = tokio::fs::metadata(&resolved).await {
+            crate::agent::tools::text_io::check_edit_size("edit_minified", meta.len())
+                .map_err(ToolError::Msg)?;
         }
 
         let source = tokio::fs::read_to_string(&resolved).await.map_err(|e| {

--- a/src/agent/tools/snapshots.rs
+++ b/src/agent/tools/snapshots.rs
@@ -232,7 +232,14 @@ pub fn restore_from(turn_id: &str) -> Vec<PathBuf> {
     let mut restored = Vec::new();
     for (path, cap) in &targets {
         let ok = match cap {
-            Capture::Content(bytes) => std::fs::write(path, bytes.as_slice()).is_ok(),
+            // dirge-nmbs: restore through the same atomic write-temp-then-rename
+            // path every mutating tool uses, so a crash mid-/rewind of a large
+            // file can't leave it truncated and an existing file's mode (+x) is
+            // preserved across the swap. Project semantics (umask perms), not
+            // the owner-only 0600 the session/memory state uses.
+            Capture::Content(bytes) => {
+                crate::fs_atomic::atomic_write_sync_project(path, bytes.as_slice()).is_ok()
+            }
             Capture::Absent => match std::fs::remove_file(path) {
                 Ok(_) => true,
                 // Already gone is a successful "restore to absent".
@@ -303,6 +310,30 @@ mod tests {
             let restored = restore_from("u1");
             assert_eq!(restored.len(), 1);
             assert_eq!(std::fs::read_to_string(&p).unwrap(), "original");
+        });
+    }
+
+    // dirge-nmbs: restore goes through the atomic project write, which
+    // preserves an existing file's mode across the swap (a truncating
+    // std::fs::write would keep the mode too, but the atomic path is what
+    // guards against a crash leaving the file half-written).
+    #[cfg(unix)]
+    #[test]
+    fn restore_preserves_executable_bit() {
+        use std::os::unix::fs::PermissionsExt;
+        isolated(|dir| {
+            let p = dir.join("hook.sh");
+            std::fs::write(&p, "#!/bin/sh\necho pre").unwrap();
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+            begin_turn("u1");
+            capture(&p); // pre-state
+            std::fs::write(&p, "#!/bin/sh\necho mutated").unwrap();
+
+            restore_from("u1");
+            assert_eq!(std::fs::read_to_string(&p).unwrap(), "#!/bin/sh\necho pre");
+            let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o755, "restore dropped the +x bit");
         });
     }
 

--- a/src/agent/tools/text_io.rs
+++ b/src/agent/tools/text_io.rs
@@ -14,6 +14,29 @@
 //! then calls [`SourceText::reencode`] — it can't skip BOM handling or pick a
 //! different line-ending policy by accident.
 
+/// Largest on-disk file the in-place editors will read into memory.
+///
+/// These tools operate on source files, not generated blobs or logs; a model
+/// pointing one at a gigabyte file should fail fast with a clear message rather
+/// than OOM the process. Consolidated here (dirge-ygzn) so `edit`,
+/// `edit_lines`, `edit_minified`, and `apply_patch` share one limit and one
+/// message shape instead of four hand-rolled copies that drift.
+pub(crate) const MAX_EDIT_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Reject a file that exceeds [`MAX_EDIT_BYTES`] with a model-facing message.
+/// `tool` names the caller ("edit", "apply_patch", …) so the error points at
+/// the tool the model actually invoked.
+pub(crate) fn check_edit_size(tool: &str, len: u64) -> Result<(), String> {
+    if len > MAX_EDIT_BYTES {
+        Err(format!(
+            "file too large for {tool}: {len} bytes (cap {MAX_EDIT_BYTES} bytes); \
+             use bash with sed/awk for huge files"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// The line-ending shape of a file, detected at decode time so write-back can
 /// restore it instead of blanket-normalizing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -143,6 +166,17 @@ impl SourceText {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // dirge-ygzn: the shared size guard replaces four copy-pasted
+    // meta.len()>CAP stanzas; one limit, one message shape.
+    #[test]
+    fn edit_size_guard_allows_under_cap_and_names_the_tool() {
+        assert!(check_edit_size("edit", MAX_EDIT_BYTES).is_ok());
+        assert!(check_edit_size("edit", 0).is_ok());
+        let err = check_edit_size("apply_patch", MAX_EDIT_BYTES + 1).unwrap_err();
+        assert!(err.contains("apply_patch"), "got: {err}");
+        assert!(err.contains("too large"), "got: {err}");
+    }
 
     #[test]
     fn lf_file_round_trips_unchanged() {

--- a/src/fs_atomic.rs
+++ b/src/fs_atomic.rs
@@ -80,6 +80,16 @@ pub fn atomic_write_sync(target: &Path, content: &[u8]) -> io::Result<()> {
     atomic_write_inner(target, content, /* private */ true)
 }
 
+/// Synchronous atomic write for PROJECT files: new files inherit the umask
+/// (≈0644) rather than being forced owner-only, matching the async
+/// [`atomic_write`] used by `write`/`edit`/`apply_patch`. For sync callers
+/// that restore project files under a lock — the `/rewind` restore path
+/// (dirge-nmbs) — so a crash mid-restore can't leave a truncated file and an
+/// existing file's mode (e.g. +x) is preserved across the swap.
+pub fn atomic_write_sync_project(target: &Path, content: &[u8]) -> io::Result<()> {
+    atomic_write_inner(target, content, /* private */ false)
+}
+
 /// dirge-i5pu: shared impl. `private` controls the new-file mode — `true`
 /// forces owner-only 0600 (session/memory state); `false` lets new files
 /// inherit the umask (≈0644), which is correct for agent-created PROJECT


### PR DESCRIPTION
Three P3 fixes in the in-place edit path, from the 2026-07-10 review backlog.

**r6v6** — Edit fuzzy-fallback reported the line delta and the diff's `-` lines from `old_text`, not the block actually matched. When a fuzzy fallback fires (the whitespace-normalized matcher tries blocks up to +5 lines), a 1-line `old_text` matching a 3-line block reported the wrong `(±N lines)` and printed removed lines never in the file. Now charged against `content[start..end]` of the matched range; `replace_all` sums the per-range delta since blocks can differ in size.

**nmbs** — `/rewind` restored content with plain `std::fs::write` (in-place O_TRUNC), so a crash mid-restore of a large file left it truncated. Routed through the atomic write-temp-then-rename path via a new sync project-file variant (`atomic_write_sync_project`), so restore is crash-safe and preserves an existing file's mode.

**ygzn** — the 100MiB pre-read cap was re-declared in `edit`, `edit_lines`, `edit_minified`, and `apply_patch` with three different message shapes. Consolidated to one `MAX_EDIT_BYTES` const + `check_edit_size` helper next to `decode_for_edit`.

Tests: `replacement_line_delta` (matched-block delta, per-range sum), `show_diff` matched-block rendering, `check_edit_size`, restore preserves +x. Clippy `--all-targets` clean.