### PR TITLE
session_db: unify session lineage on origin_id — single source of truth (m7ja follow-up)

### DIFF
--- a/src/extras/session_db.rs
+++ b/src/extras/session_db.rs
@@ -274,9 +274,12 @@ impl SessionDb {
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .map_err(|e| format!("Failed to read schema version: {e}"))?;
 
-        if current >= SCHEMA_VERSION {
-            return Ok(());
-        }
+        // No early-return on an up-to-date DB: each migration below is guarded
+        // by `current < N`, so an already-migrated DB skips them all, but the
+        // feature-independent `ensure_*` steps must still run every open. Unlike
+        // `ensure_skills_tables` (which creates its own table before the
+        // ladder), `ensure_session_origin` ALTERs `sessions`, so it runs AFTER
+        // v1 has guaranteed that table exists (dirge-m7ja).
 
         if current < 1 {
             self.run_migration_v1()?;
@@ -340,9 +343,15 @@ impl SessionDb {
             self.run_migration_v15()?;
         }
 
-        self.conn
-            .pragma_update(None, "user_version", SCHEMA_VERSION)
-            .map_err(|e| format!("Failed to set schema version: {e}"))?;
+        if current < SCHEMA_VERSION {
+            self.conn
+                .pragma_update(None, "user_version", SCHEMA_VERSION)
+                .map_err(|e| format!("Failed to set schema version: {e}"))?;
+        }
+
+        // Feature-independent, idempotent, runs every open. Must follow v1
+        // (which creates `sessions`). dirge-m7ja.
+        self.ensure_session_origin()?;
 
         Ok(())
     }
@@ -1444,10 +1453,26 @@ impl SessionDb {
 
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn set_parent_session(&self, session_id: &str, parent_id: &str) -> Result<(), String> {
+        // dirge-m7ja: also propagate the origin (the parent's origin, or the
+        // parent id when the parent is itself the conversation's original), so
+        // lineage resolves through `origin_id` exactly as `link_fold`
+        // establishes it. Keeps this a faithful lineage-setup helper under the
+        // unified model.
+        let origin: String = self
+            .conn
+            .query_row(
+                "SELECT origin_id FROM sessions WHERE id = ?1",
+                params![parent_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .ok()
+            .flatten()
+            .filter(|o| !o.is_empty())
+            .unwrap_or_else(|| parent_id.to_string());
         self.conn
             .execute(
-                "UPDATE sessions SET parent_session_id = ?1 WHERE id = ?2",
-                params![parent_id, session_id],
+                "UPDATE sessions SET parent_session_id = ?1, origin_id = ?2 WHERE id = ?3",
+                params![parent_id, origin, session_id],
             )
             .map_err(|e| format!("Failed to set parent session: {e}"))?;
         Ok(())
@@ -1489,11 +1514,27 @@ impl SessionDb {
             params![new_sid, source, model, provider, now],
         )
         .map_err(|e| format!("Failed to insert rotated session: {e}"))?;
+        // dirge-m7ja: the rotation shares the OLD session's origin (or, when the
+        // old session is itself the conversation's original, the old id). This
+        // is the authoritative lineage key `resolve_parent` reads, so every
+        // rotation groups under one root via a single lookup — no dependence on
+        // the parent chain staying intact. parent_session_id is kept too, as
+        // non-load-bearing provenance (the immediate predecessor).
+        let origin: String = tx
+            .query_row(
+                "SELECT origin_id FROM sessions WHERE id = ?1",
+                params![old_sid],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .ok()
+            .flatten()
+            .filter(|o| !o.is_empty())
+            .unwrap_or_else(|| old_sid.to_string());
         tx.execute(
-            "UPDATE sessions SET parent_session_id = ?1 WHERE id = ?2",
-            params![old_sid, new_sid],
+            "UPDATE sessions SET parent_session_id = ?1, origin_id = ?2 WHERE id = ?3",
+            params![old_sid, origin, new_sid],
         )
-        .map_err(|e| format!("Failed to link fold parent: {e}"))?;
+        .map_err(|e| format!("Failed to link fold lineage: {e}"))?;
         tx.commit()
             .map_err(|e| format!("Failed to commit fold link: {e}"))?;
         Ok(())
@@ -1520,10 +1561,94 @@ impl SessionDb {
         Ok(())
     }
 
-    pub fn resolve_parent(&self, session_id: &str) -> Result<String, String> {
+    /// dirge-m7ja: bring the SQLite sessions table onto the same lineage key
+    /// the JSON side already uses (`Session::effective_origin`). `origin_id` is
+    /// the id of the conversation's ORIGINAL session, shared by every fold
+    /// rotation; NULL means the row IS its own origin (a fresh, unfolded
+    /// session). This is the single source of truth `resolve_parent` reads —
+    /// replacing the fragile `parent_session_id` chain walk, where one lost
+    /// intermediate link split a conversation into two roots.
+    ///
+    /// Feature-independent + idempotent (the `ensure_skills_tables` pattern),
+    /// so it applies in every build regardless of the feature-gated
+    /// `SCHEMA_VERSION`, and re-running only touches rows still missing origin.
+    fn ensure_session_origin(&self) -> Result<(), String> {
+        // A partial/legacy schema (some migration tests, a DB mid-build before
+        // v1) may not have the sessions table yet — nothing to do until it
+        // exists. A real fresh DB always has it by this point (v1 ran above).
+        let has_sessions: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !has_sessions {
+            return Ok(());
+        }
+
+        // Add the column if it isn't there yet (guarded like the v4 ADD COLUMNs).
+        if let Err(e) = self
+            .conn
+            .execute("ALTER TABLE sessions ADD COLUMN origin_id TEXT", [])
+            && !e.to_string().contains("duplicate column name")
+        {
+            return Err(format!("Failed to add sessions.origin_id: {e}"));
+        }
+
+        // Backfill needs the parent chain; a schema predating parent_session_id
+        // has nothing to derive from (roots stay NULL, which is correct).
+        let has_parent: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM pragma_table_info('sessions') WHERE name='parent_session_id'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !has_parent {
+            return Ok(());
+        }
+
+        // Backfill legacy rows from the existing parent chain, once. Roots
+        // (no parent) keep NULL — `resolve_parent` treats NULL as "own id is
+        // the root", matching the JSON side. Only NULL-origin children are
+        // touched, so this is safe to re-run and safe under the exclusive
+        // migration lock.
+        let pending: Vec<String> = {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT id FROM sessions \
+                     WHERE origin_id IS NULL AND parent_session_id IS NOT NULL",
+                )
+                .map_err(|e| format!("Failed to scan for origin backfill: {e}"))?;
+            stmt.query_map([], |row| row.get(0))
+                .map_err(|e| format!("Failed to read origin backfill rows: {e}"))?
+                .filter_map(|r| r.ok())
+                .collect()
+        };
+        for id in pending {
+            let root = self.chain_root(&id)?;
+            if root != id {
+                self.conn
+                    .execute(
+                        "UPDATE sessions SET origin_id = ?1 WHERE id = ?2 AND origin_id IS NULL",
+                        params![root, id],
+                    )
+                    .map_err(|e| format!("Failed to backfill origin for {id}: {e}"))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Root of `session_id`'s `parent_session_id` chain (the pre-origin walk).
+    /// Used ONLY to backfill legacy rows in [`ensure_session_origin`]; live
+    /// lineage resolution goes through `origin_id` via [`resolve_parent`].
+    fn chain_root(&self, session_id: &str) -> Result<String, String> {
         let mut current = session_id.to_string();
-        // Walk the parent chain up to root (max 100 hops to prevent
-        // infinite loops on corrupted data).
+        // Bounded walk (max 100 hops) so corrupted/cyclic legacy data can't spin.
         for _ in 0..100 {
             let parent: Option<String> = self
                 .conn
@@ -1540,6 +1665,30 @@ impl SessionDb {
             }
         }
         Ok(current)
+    }
+
+    /// The lineage ROOT of `session_id` — the id of the conversation's original
+    /// session, shared by every fold rotation. A single indexed lookup of the
+    /// authoritative `origin_id`: NULL/empty (or an unknown session) means the
+    /// session is its own root, matching `Session::effective_origin` on the
+    /// JSON side. dirge-m7ja replaced the `parent_session_id` chain walk with
+    /// this, so a rotation whose intermediate link was lost still groups
+    /// correctly as long as its origin is set — and there's no walk, hop cap,
+    /// or cycle risk.
+    pub fn resolve_parent(&self, session_id: &str) -> Result<String, String> {
+        let origin: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT origin_id FROM sessions WHERE id = ?1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .ok()
+            .and_then(|o: Option<String>| o);
+        Ok(match origin {
+            Some(o) if !o.is_empty() => o,
+            _ => session_id.to_string(),
+        })
     }
 }
 

--- a/src/extras/session_db_tests.rs
+++ b/src/extras/session_db_tests.rs
@@ -1527,3 +1527,116 @@ fn link_fold_chains_multiple_folds_to_original_root() {
     assert_eq!(db.resolve_parent("s2").unwrap(), "s0");
     assert_eq!(db.resolve_parent("s1").unwrap(), "s0");
 }
+
+/// dirge-m7ja: the robustness win of the unified model — `resolve_parent` reads
+/// the authoritative `origin_id`, so a rotation whose intermediate
+/// `parent_session_id` link was lost (the exact drift the old chain walk
+/// couldn't survive — it would report the child as its own root) still groups
+/// under the conversation root.
+#[test]
+fn resolve_parent_uses_origin_not_broken_chain() {
+    let (db, _dir) = temp_db();
+    db.insert_session("root", "cli", "m", "p", "2026-01-01T10:00:00Z")
+        .unwrap();
+    db.insert_session("child", "cli", "m", "p", "2026-01-01T10:05:00Z")
+        .unwrap();
+    // Origin set; parent_session_id deliberately absent.
+    db.conn
+        .execute(
+            "UPDATE sessions SET origin_id = 'root' WHERE id = 'child'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(db.resolve_parent("child").unwrap(), "root");
+}
+
+/// dirge-m7ja: legacy DBs (parent chain, no origin) are backfilled from the
+/// existing chain on open, so every rotation gains the root as its origin and
+/// resolves through a single lookup afterward. Roots keep NULL.
+#[test]
+fn ensure_session_origin_backfills_legacy_chain() {
+    let (db, _dir) = temp_db();
+    for (id, t) in [
+        ("s0", "2026-01-01T10:00:00Z"),
+        ("s1", "2026-01-01T10:05:00Z"),
+        ("s2", "2026-01-01T10:10:00Z"),
+    ] {
+        db.insert_session(id, "cli", "m", "p", t).unwrap();
+    }
+    // Legacy shape: raw parent links, NO origin (bypass set_parent_session,
+    // which now also sets origin).
+    db.conn
+        .execute(
+            "UPDATE sessions SET parent_session_id='s0', origin_id=NULL WHERE id='s1'",
+            [],
+        )
+        .unwrap();
+    db.conn
+        .execute(
+            "UPDATE sessions SET parent_session_id='s1', origin_id=NULL WHERE id='s2'",
+            [],
+        )
+        .unwrap();
+
+    db.ensure_session_origin().unwrap();
+
+    let origin = |id: &str| -> Option<String> {
+        db.conn
+            .query_row(
+                "SELECT origin_id FROM sessions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(origin("s2").as_deref(), Some("s0"));
+    assert_eq!(origin("s1").as_deref(), Some("s0"));
+    assert_eq!(origin("s0"), None, "root keeps a NULL origin");
+    assert_eq!(db.resolve_parent("s2").unwrap(), "s0");
+}
+
+/// dirge-m7ja: a fold writes the authoritative `origin_id` directly (single
+/// lookup, no chain walk), propagating the conversation root across rotations.
+#[test]
+fn link_fold_sets_authoritative_origin_id() {
+    let (db, _dir) = temp_db();
+    db.insert_session("s0", "cli", "m", "p", "2026-01-01T10:00:00Z")
+        .unwrap();
+    db.link_fold("s0", "s1", "cli", "m", "p", "2026-01-01T10:05:00Z")
+        .unwrap();
+    db.link_fold("s1", "s2", "cli", "m", "p", "2026-01-01T10:10:00Z")
+        .unwrap();
+    let o2: Option<String> = db
+        .conn
+        .query_row("SELECT origin_id FROM sessions WHERE id = 's2'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        o2.as_deref(),
+        Some("s0"),
+        "origin points straight at the root"
+    );
+    assert_eq!(db.resolve_parent("s2").unwrap(), "s0");
+}
+
+/// dirge-m7ja: the origin backfill is idempotent — re-running never re-touches
+/// an already-set origin and roots stay NULL.
+#[test]
+fn ensure_session_origin_is_idempotent() {
+    let (db, _dir) = temp_db();
+    db.insert_session("s0", "cli", "m", "p", "2026-01-01T10:00:00Z")
+        .unwrap();
+    db.link_fold("s0", "s1", "cli", "m", "p", "2026-01-01T10:05:00Z")
+        .unwrap();
+    db.ensure_session_origin().unwrap();
+    db.ensure_session_origin().unwrap();
+    assert_eq!(db.resolve_parent("s1").unwrap(), "s0");
+    let o0: Option<String> = db
+        .conn
+        .query_row("SELECT origin_id FROM sessions WHERE id = 's0'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(o0, None, "root origin stays NULL across re-runs");
+}


### PR DESCRIPTION
Follow-up to #655. Collapses the two lineage models into one.

**Before:** SQLite answered "same conversation?" by walking a `parent_session_id` chain; the JSON side used a flat origin (`Session::effective_origin`). The two could diverge and *contradict* — the same conversation showing once in the session list and twice in search — and a single lost intermediate link split a lineage into two roots that `resolve_parent` could never rejoin.

**After:** SQLite adopts the JSON model.

- `sessions.origin_id` = the original session's id, shared by every fold rotation; NULL means the row is its own root (matches `effective_origin`'s `origin_id ?? id`).
- `ensure_session_origin` adds the column and backfills legacy rows from the existing chain — idempotent, run before the version gate (the `ensure_skills_tables` pattern, so it's feature-independent across the 13/15 `SCHEMA_VERSION` split), and guarded for partial schemas missing the table/column.
- `resolve_parent` is now a single indexed lookup of `origin_id` (falling back to own id) instead of a 100-hop chain walk — no hop cap, no cycle risk, and a rotation whose intermediate link was lost still groups correctly.
- `link_fold` / `set_parent_session` write `origin_id` atomically, propagating the root. `parent_session_id` stays as non-load-bearing provenance.

**Scope:** a DB whose chain broke *before* this fix can't be healed from SQLite alone (would need reading JSON files on every open — a layering + perf cost); going forward drift is structurally prevented since origin is written atomically at fold time. Non-destructive (no column drop).

Tests: origin-based resolve survives a broken chain; legacy chain backfill; fold sets authoritative origin; idempotent re-run; all existing lineage + `session_search` grouping tests pass (26) via `set_parent_session` origin propagation. Full suite green (the one `h7_glm` smoke failure is the known real-API flake, passes in isolation). Clippy `--all-targets` clean.