### PR TITLE
feat: add animations_enabled config toggle

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -37,6 +37,7 @@ Example:
   "default_permission_mode": "standard",
   "show_tool_details": true,
   "show_edit_diff": true,
+  "animations_enabled": true,
   "show_reasoning": false,
   "display": "left|main|right",
   "tool_result_max_chars": 500,
@@ -107,6 +108,7 @@ Accepted top-level keys:
 | `default_permission_mode` | string  | Permission mode when no mode boolean/CLI flag is set. Use `standard`, `restrictive`, `accept`, or `yolo`.                                                                   |
 | `show_tool_details`       | boolean | Show tool-result output in the TUI. Default: `true`.                                                                                                                         |
 | `show_edit_diff`          | boolean | Show colorized diff output for `edit` tool results (`-` red, `+` green, `@@` cyan). Default: `true`.                                                                        |
+| `animations_enabled`      | boolean | Enable TUI animations (avatar face toggling, spinner repaint timer). Default: `true`. Set to `false` to reduce terminal flicker and CPU usage; the avatar freezes to a static face. |
 | `show_reasoning`          | boolean | Show the model's thinking/reasoning by default, instead of having to press `Ctrl+O` each turn. Default: `false`.                                                            |
 | `desktop_notifications`   | object  | Optional OS-level desktop notifications. Off when absent. Set `{ "enabled": true }` to notify on completed runs and prompts waiting for input. Backed by `notify-rust` on macOS, Linux, and Windows. |
 | `max_sessions`            | integer | How many of the most-recent prior sessions in the same project (same working dir) to mine for Up-arrow / Ctrl+F command history, seeded ahead of the current session's prompts. Default: `3`. Set `0` to keep recall to the current session only. See [Command history](#command-history-cross-session-recall). |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -74,7 +74,9 @@ kill-subagent) are **rebindable** via the `keybindings` config — see
 
 A 5-cell face lives in the left margin of the input row and reflects what the
 agent is currently doing. Single-tick animation alternates between two poses
-where applicable.
+where applicable. Set `animations_enabled: false` in config to freeze the
+avatar to a static face and bypass the 200ms repaint timer (reduces terminal
+flicker and CPU usage).
 
 | State | Frames | Meaning |
 |-------|--------|---------|

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -689,6 +689,10 @@ pub struct Config {
     pub default_permission_mode: Option<String>,
     pub show_tool_details: Option<bool>,
     pub show_edit_diff: Option<bool>,
+    /// TUI animations (avatar face toggling, spinner repaint timer).
+    /// Default true. Set to false to reduce terminal flicker and CPU
+    /// usage; the avatar freezes to a static face.
+    pub animations_enabled: Option<bool>,
     /// Make the model's thinking/reasoning burst visible by default,
     /// without having to press Ctrl+O each turn (GH #461). Absent or
     /// `false` keeps today's behavior (reasoning hidden until toggled).

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -286,6 +286,7 @@ pub async fn run_interactive(
     let _guard = TerminalGuard::new()?;
 
     let mut renderer = Renderer::new()?;
+    renderer.set_animations_enabled(cfg.animations_enabled.unwrap_or(true));
     // Apply the preferred pane layout from config (`display`). An invalid
     // spec is surfaced as a warning and ignored (panels keep their
     // automatic width-based default); the `/display` command overrides
@@ -4880,7 +4881,7 @@ pub async fn run_interactive(
                         };
                         renderer.request_repaint();
                     }
-                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(200)), if ui.is_running => {
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(200)), if ui.is_running && renderer.animations_enabled() => {
                         // #387: drive the spinner/avatar animation. Force a repaint so
                         // the loop-top render effect advances the spinner (whose tick
                         // changes in cache_bottom but wouldn't trip dirty-on-change by

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -631,6 +631,8 @@ pub struct Renderer {
     /// Animation flip; toggled by `tick_avatar()` so the avatar's
     /// eyes / mouth alternate between two poses per state.
     avatar_tick: bool,
+    /// Whether TUI animations are enabled (set at construction from config).
+    animations_enabled: bool,
 
     // ── ratatui migration (Phase 6) ────────────────────────────────
     /// The ratatui Terminal driving the new paint pipeline. `Option`
@@ -747,6 +749,7 @@ impl Renderer {
             alert_title: String::new(),
             avatar_state: crate::ui::avatar::AvatarState::Idle,
             avatar_tick: false,
+            animations_enabled: true,
             // ratatui's backend writes to /dev/tty (a fresh fd
             // pointing at the controlling terminal) rather than the
             // process's stdout. With stdout/stderr redirected to
@@ -779,6 +782,16 @@ impl Renderer {
     /// tooltip appears on the next redraw.
     pub fn notify_copied(&mut self) {
         self.copied_at = Some(std::time::Instant::now());
+    }
+
+    /// Configure whether TUI animations are enabled (set from config at startup).
+    pub fn set_animations_enabled(&mut self, enabled: bool) {
+        self.animations_enabled = enabled;
+    }
+
+    /// Check whether TUI animations are enabled.
+    pub fn animations_enabled(&self) -> bool {
+        self.animations_enabled
     }
 
     /// If text was copied within the last 2 seconds, returns the
@@ -2732,7 +2745,7 @@ impl Renderer {
         };
         self.input_rows = (total_rows + completion_extra).clamp(1, MAX_INPUT_VISIBLE_LINES as u16);
 
-        if is_running {
+        if is_running && self.animations_enabled {
             self.spinner_tick = !self.spinner_tick;
             self.avatar_tick = !self.avatar_tick;
         }


### PR DESCRIPTION
## Summary

Add `animations_enabled` config option to disable TUI animations (avatar face toggling and the 200 ms repaint timer).

**Default: `true`** — preserves existing behavior.

### What it does when set to `false`

- Avatar freezes to a static face (tick no longer flips)
- 200 ms repaint timer is bypassed while the agent is running
- Reduces terminal flicker, CPU usage, and mouse-selection interference

### Changes

- **`src/config/mod.rs`** — new `animations_enabled: Option<bool>` field
- **`src/ui/renderer.rs`** — `Renderer` stores the flag; gates the tick flip in `cache_bottom()`
- **`src/ui/mod.rs`** — gates the 200 ms `request_repaint()` call
- **`docs/config.md`** — example config + reference table entry
- **`docs/tui.md`** — mentions the toggle in the avatar section

### Commits

- `26a9cee` feat: add animations_enabled config toggle
- `d282656` docs: document animations_enabled config option