### PR TITLE
Fix three P1 audit bugs: double-run, chat history loss, fold snapshot index

### DIFF
--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -942,7 +942,7 @@ async fn run_compaction_pass_with_focus(
             .filter(|cp| cp.generation == *generation);
         let mut reused = false;
         if let Some(cp) = reusable
-            && let Some((new_msgs, first_kept)) = compression::apply_checkpoint_summary(
+            && let Some((new_msgs, _first_kept)) = compression::apply_checkpoint_summary(
                 &current_context.messages,
                 &cp.summary,
                 cp.boundary,
@@ -953,8 +953,15 @@ async fn run_compaction_pass_with_focus(
                 current_context.messages = new_msgs;
                 after_summary = projected;
                 applied_summary = cp.summary;
-                applied_first_kept = first_kept;
-                outcome = SummaryOutcome::Succeeded(first_kept);
+                // dirge-vpma.3: apply_checkpoint_summary yields `[summary] +
+                // messages[cut..]`, so the summary marker sits at NEW-list index 0.
+                // `Succeeded(idx)` / `first_kept_index` are the NEW-list summary
+                // index (restore_working_files splices file snapshots at idx+1), so
+                // report 0 — the returned `_first_kept` is the OLD-list cut and
+                // feeding it splices snapshots at the wrong position (mid-tail →
+                // orphaned tool_use/result → provider 400, or past the end).
+                applied_first_kept = 0;
+                outcome = SummaryOutcome::Succeeded(0);
                 reused = true;
                 tracing::info!(
                     target: "dirge::agent_loop",

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -1647,10 +1647,18 @@ mod tests {
         let (out, cut) = apply_checkpoint_summary(&msgs, "## Goal\nx", 4).unwrap();
         // Returned index is an OLD-list index (the tail cut).
         assert_eq!(cut, 4);
-        assert_ne!(cut, 0, "cut is old-list; must not be used as the new-list summary index");
+        assert_ne!(
+            cut, 0,
+            "cut is old-list; must not be used as the new-list summary index"
+        );
         // The summary marker — restore_working_files' anchor — is at new index 0.
         assert_eq!(out[0]["role"].as_str().unwrap(), "system");
-        assert!(out[0]["content"].as_str().unwrap().starts_with(SUMMARY_PREFIX));
+        assert!(
+            out[0]["content"]
+                .as_str()
+                .unwrap()
+                .starts_with(SUMMARY_PREFIX)
+        );
     }
 
     #[test]

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -1628,6 +1628,31 @@ mod tests {
         assert_eq!(out[2]["content"].as_str().unwrap(), "a2");
     }
 
+    /// dirge-vpma.3: apply_checkpoint_summary returns the OLD-list cut (the
+    /// first kept message in the pre-fold list), NOT the new-list position of
+    /// the summary marker. The fold produces `[summary] + tail`, so the marker
+    /// is always at NEW-list index 0 — that 0, not the returned cut, is what
+    /// the checkpoint-reuse path must report as the summary index to
+    /// restore_working_files. Pins the distinction the reuse path got wrong.
+    #[test]
+    fn checkpoint_reuse_summary_marker_sits_at_new_index_zero() {
+        let msgs = vec![
+            serde_json::json!({"role": "user", "content": "u0"}),
+            serde_json::json!({"role": "assistant", "content": "a0"}),
+            serde_json::json!({"role": "user", "content": "u1"}),
+            serde_json::json!({"role": "assistant", "content": "a1"}),
+            serde_json::json!({"role": "user", "content": "u2"}),
+            serde_json::json!({"role": "assistant", "content": "a2"}),
+        ];
+        let (out, cut) = apply_checkpoint_summary(&msgs, "## Goal\nx", 4).unwrap();
+        // Returned index is an OLD-list index (the tail cut).
+        assert_eq!(cut, 4);
+        assert_ne!(cut, 0, "cut is old-list; must not be used as the new-list summary index");
+        // The summary marker — restore_working_files' anchor — is at new index 0.
+        assert_eq!(out[0]["role"].as_str().unwrap(), "system");
+        assert!(out[0]["content"].as_str().unwrap().starts_with(SUMMARY_PREFIX));
+    }
+
     #[test]
     fn checkpoint_reuse_snaps_cut_back_to_user_boundary() {
         // boundary lands mid-turn (on an assistant/tool message); the cut

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -467,6 +467,38 @@ mod plugin_hook_tests {
         assert!(is_running);
     }
 
+    /// Regression test: `install_into` sets `is_running = true`.  Callers
+    /// that redundantly set it back to `false` after a drain break the
+    /// invariant — the UI then thinks no run is active (Ctrl+C cancel
+    /// breaks, next prompt spawns a duplicate concurrent agent).
+    #[tokio::test]
+    async fn install_into_is_running_must_not_be_overwritten_by_caller() {
+        let (_tx, event_rx) = mpsc::channel(1);
+        let (interject_tx, _) = mpsc::channel(1);
+        let (cancel_tx, _) = mpsc::channel(1);
+        let runner = AgentRunner {
+            event_rx,
+            task: tokio::spawn(async {}),
+            interject_tx,
+            cancel_tx,
+        };
+        let (mut rx, mut abort, mut interject, mut cancel) = (None, None, None, None);
+        let mut is_running = false;
+        runner.install_into(
+            &mut rx,
+            &mut abort,
+            &mut interject,
+            &mut cancel,
+            &mut is_running,
+        );
+        // The macro manages is_running; a caller must not overwrite it.
+        assert!(is_running, "install_into sets is_running; caller must not set false");
+        // Simulate the bug: if a call site did `is_running = false` here it
+        // would clobber the live drain.  That line was removed — verify the
+        // flag stays true without it.
+        assert!(is_running, "is_running must still be true; no overwrite allowed");
+    }
+
     #[test]
     fn summarize_actions_dedups_preserving_first_occurrence_order() {
         let actions = [

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -492,11 +492,17 @@ mod plugin_hook_tests {
             &mut is_running,
         );
         // The macro manages is_running; a caller must not overwrite it.
-        assert!(is_running, "install_into sets is_running; caller must not set false");
+        assert!(
+            is_running,
+            "install_into sets is_running; caller must not set false"
+        );
         // Simulate the bug: if a call site did `is_running = false` here it
         // would clobber the live drain.  That line was removed — verify the
         // flag stays true without it.
-        assert!(is_running, "is_running must still be true; no overwrite allowed");
+        assert!(
+            is_running,
+            "is_running must still be true; no overwrite allowed"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3110,7 +3110,6 @@ pub async fn run_interactive(
                                     // output + "› interrupted" were logged above; `!!`
                                     // leaves no trace at all.
                                     drain_interjections!();
-                                    ui.is_running = false;
                                     renderer.set_avatar_state(avatar::AvatarState::Idle);
                                 }
                                 renderer.request_repaint();

--- a/src/ui/renderer.rs
+++ b/src/ui/renderer.rs
@@ -1201,11 +1201,22 @@ impl Renderer {
         if self.chats.len() <= 1 || idx >= self.chats.len() {
             return;
         }
+        let removing_active = idx == self.active_chat;
         self.chats.remove(idx);
         if idx < self.active_chat {
             self.active_chat -= 1;
         } else if idx == self.active_chat && self.active_chat >= self.chats.len() {
             self.active_chat = 0;
+        }
+        // dirge-vpma.2: the removed chat's content is still in the hot
+        // fields. When the ACTIVE chat was removed, active_chat now points
+        // at a survivor whose snapshot must be loaded — otherwise the next
+        // switch_chat's save_active() overwrites the survivor's history
+        // with the dead chat's content. Only on the active-removal path:
+        // otherwise the hot fields already hold the (unchanged) active chat
+        // and load_active() would clobber them from its emptied slot.
+        if removing_active {
+            self.load_active();
         }
         self.needs_paint = true;
     }

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1677,3 +1677,62 @@ fn terminal_size_uses_cached_tty_size() {
         "test_cols override must take precedence over cache"
     );
 }
+
+/// dirge-vpma.2: closing the ACTIVE chat must load a survivor's
+/// snapshot into the hot fields, or the next switch_chat's
+/// save_active() overwrites the survivor's history with the dead
+/// chat's content.
+#[test]
+fn remove_active_chat_does_not_clobber_survivor_history() {
+    let mut r = Renderer::new().expect("renderer");
+    r.add_chat("A"); // index 1
+    r.add_chat("B"); // index 2
+    r.buffer.push(LineEntry { text: CompactString::new("main-content"), color: Color::White });
+    r.switch_chat(1);
+    r.buffer.push(LineEntry { text: CompactString::new("A-content"), color: Color::White });
+    r.switch_chat(2);
+    r.buffer.push(LineEntry { text: CompactString::new("B-content"), color: Color::White });
+    // A active, hot = "A-content"; B's content safely in its slot.
+    r.switch_chat(1);
+    assert_eq!(r.buffer[0].text.as_str(), "A-content");
+    // Close the ACTIVE chat A. active_chat (1) now points at B.
+    r.remove_chat(1);
+    assert_eq!(r.chat_count(), 2);
+    assert_ne!(
+        r.buffer.first().map(|l| l.text.as_str()),
+        Some("A-content"),
+        "closed chat's content must not linger in the hot fields"
+    );
+    // Round-trip: switching away and back must preserve B's history.
+    let survivor = r.active_chat();
+    r.switch_chat(0);
+    r.switch_chat(survivor);
+    assert_eq!(r.buffer.len(), 1);
+    assert_eq!(
+        r.buffer[0].text.as_str(),
+        "B-content",
+        "surviving chat's history must survive closing the active chat"
+    );
+}
+
+/// dirge-vpma.2 guard: removing a NON-active chat must NOT disturb the
+/// active chat's live hot fields (load_active() there would clobber
+/// them from the emptied slot).
+#[test]
+fn remove_inactive_chat_preserves_active_hot_fields() {
+    let mut r = Renderer::new().expect("renderer");
+    r.add_chat("A"); // 1
+    r.add_chat("B"); // 2
+    r.switch_chat(2); // B active
+    r.buffer.push(LineEntry { text: CompactString::new("B-live"), color: Color::White });
+    // Remove an EARLIER inactive chat; active shifts 2 -> 1 but B's
+    // live buffer must be untouched.
+    r.remove_chat(0);
+    assert_eq!(r.active_chat(), 1);
+    assert_eq!(r.buffer.len(), 1);
+    assert_eq!(
+        r.buffer[0].text.as_str(),
+        "B-live",
+        "removing an inactive chat must not disturb the active buffer"
+    );
+}

--- a/src/ui/renderer_tests.rs
+++ b/src/ui/renderer_tests.rs
@@ -1687,11 +1687,20 @@ fn remove_active_chat_does_not_clobber_survivor_history() {
     let mut r = Renderer::new().expect("renderer");
     r.add_chat("A"); // index 1
     r.add_chat("B"); // index 2
-    r.buffer.push(LineEntry { text: CompactString::new("main-content"), color: Color::White });
+    r.buffer.push(LineEntry {
+        text: CompactString::new("main-content"),
+        color: Color::White,
+    });
     r.switch_chat(1);
-    r.buffer.push(LineEntry { text: CompactString::new("A-content"), color: Color::White });
+    r.buffer.push(LineEntry {
+        text: CompactString::new("A-content"),
+        color: Color::White,
+    });
     r.switch_chat(2);
-    r.buffer.push(LineEntry { text: CompactString::new("B-content"), color: Color::White });
+    r.buffer.push(LineEntry {
+        text: CompactString::new("B-content"),
+        color: Color::White,
+    });
     // A active, hot = "A-content"; B's content safely in its slot.
     r.switch_chat(1);
     assert_eq!(r.buffer[0].text.as_str(), "A-content");
@@ -1724,7 +1733,10 @@ fn remove_inactive_chat_preserves_active_hot_fields() {
     r.add_chat("A"); // 1
     r.add_chat("B"); // 2
     r.switch_chat(2); // B active
-    r.buffer.push(LineEntry { text: CompactString::new("B-live"), color: Color::White });
+    r.buffer.push(LineEntry {
+        text: CompactString::new("B-live"),
+        color: Color::White,
+    });
     // Remove an EARLIER inactive chat; active shifts 2 -> 1 but B's
     // live buffer must be untouched.
     r.remove_chat(0);


### PR DESCRIPTION
Clears the three P1 bugs from the Wavescope entropy audit (`dirge-vpma` epic). Each was verified still-live against current code, fixed via TDD where a seam exists, and delegated to dirge for implementation with review + independent verification.

## dirge-vpma.1 — double concurrent agent run (`src/ui/mod.rs`)
The shell `ShellEvent::Exited` else-branch (the `!!`/interrupted-`!` path) set `ui.is_running = false` right after `drain_interjections!()`, which already owns the flag — true when the drain spawns a runner for a queued interjection, false when the queue is empty. The stray assignment marked a live drained run idle: Ctrl+C couldn't cancel it (the abort path requires `is_running`), and the next prompt took the not-running submit path, so `install_into` overwrote the runner slots and two agents ran concurrently. Dropped the line to match the `Next::Finish { clear_queue: false }` drain site. Adds an invariant test on `install_into`.

## dirge-vpma.2 — closing a chat destroys a survivor's history (`src/ui/renderer.rs`)
`remove_chat` adjusted `active_chat` but never called `load_active()`, so closing the active chat (Ctrl+X) left the closed chat's content in the hot fields while `active_chat` pointed at a survivor. The next `switch_chat`'s `save_active()` then wrote that stale content into the survivor's snapshot slot, permanently destroying its history. Load the survivor's snapshot after removing the active chat — guarded on `removing_active` so closing an *inactive* chat still leaves the live hot fields untouched. Adds a reproducer plus that guard as tests.

## dirge-vpma.3 — checkpoint-reuse fold splices file snapshots at the wrong index (`src/agent/agent_loop/run.rs`)
The checkpoint-reuse fold returned `SummaryOutcome::Succeeded(cut)` where `cut` is an old-list index, but `Succeeded(idx)` is the new-list index of the inserted summary — `restore_working_files` splices post-compaction file snapshots at `idx+1`. `apply_checkpoint_summary` produces `[summary] + messages[cut..]`, so the summary marker always sits at new-list index 0. Feeding `cut` inserted the snapshots at the wrong position: clamped past the end for a large cut, or mid-tail between an assistant `tool_use` and its `tool_result` for a small one — an orphaned pair that 400s the next request. Incremental checkpointing is default-on, so this is the common fold path. Report 0. The event's `first_kept_index` is inert (the consumer recomputes the cut in session space per dirge-4kgk); set to match for coherence. Adds a regression test pinning the summary-at-index-0 invariant.

## Verification
Full suite: 3790 passed, 0 failed (the live GLM smoke test skips without a key). `clippy -- -D warnings` clean.