### PR TITLE
fix: opencode reasoning profile matches DeepSeek API shape

### DIFF
--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -82,8 +82,8 @@ pub fn reasoning_profile(provider: Option<&str>) -> ReasoningProfile {
             disable: DisableWire::ChatTemplateKwargs,
         },
         Some("opencode") => ReasoningProfile {
-            effort: EffortWire::GenericLevel,
-            disable: DisableWire::ChatTemplateKwargs,
+            effort: EffortWire::TopLevelEffort,
+            disable: DisableWire::ThinkingToggle,
         },
         Some("gemini") => ReasoningProfile {
             effort: EffortWire::GeminiBudget,
@@ -238,8 +238,8 @@ mod tests {
             ),
             (
                 "opencode",
-                EffortWire::GenericLevel,
-                DisableWire::ChatTemplateKwargs,
+                EffortWire::TopLevelEffort,
+                DisableWire::ThinkingToggle,
             ),
             (
                 "gemini",

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -254,8 +254,8 @@ mod tests {
 
     #[test]
     fn reasoning_disable_shapes_per_provider() {
-        // Hosted DeepSeek / GLM: thinking:{type:"disabled"} toggle.
-        for kind in ["deepseek", "glm"] {
+        // Hosted DeepSeek / GLM / OpenCode: thinking:{type:"disabled"} toggle.
+        for kind in ["deepseek", "glm", "opencode"] {
             assert_eq!(
                 reasoning_disable_for_kind(kind),
                 Some(serde_json::json!({ "thinking": { "type": "disabled" } })),
@@ -263,7 +263,7 @@ mod tests {
             );
         }
         // Self-hosted vLLM / SGLang backends: chat_template_kwargs convention.
-        for kind in ["opencode", "custom", "openrouter"] {
+        for kind in ["custom", "openrouter"] {
             assert_eq!(
                 reasoning_disable_for_kind(kind),
                 Some(serde_json::json!({ "chat_template_kwargs": { "thinking": false } })),


### PR DESCRIPTION
OpenCode at https://opencode.ai/zen/v1 proxies to DeepSeek models, but its reasoning profile used `GenericLevel` (`reasoning_level`) and `ChatTemplateKwargs` (`chat_template_kwargs`) — the vLLM/SGLang self-hosted keys that DeepSeek's hosted API ignores.

Switch to `TopLevelEffort` (`reasoning_effort`) + `ThinkingToggle` (`thinking: {type: disabled}`), matching the built-in DeepSeek provider. This enables both deep thinking mode and correct one-shot disable.