### PR TITLE
fix(subagent): defer critic, ignore blank retry task ids

### DIFF
--- a/src/agent/agent_loop/hooks.rs
+++ b/src/agent/agent_loop/hooks.rs
@@ -170,6 +170,8 @@ pub type GetSteeringMessagesFn =
 pub type GetFollowupMessagesFn =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Vec<LoopMessage>> + Send>> + Send + Sync>;
 
+pub type ShouldDeferFinalizationFn = Arc<dyn Fn() -> bool + Send + Sync>;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/agent/agent_loop/hooks.rs
+++ b/src/agent/agent_loop/hooks.rs
@@ -170,6 +170,10 @@ pub type GetSteeringMessagesFn =
 pub type GetFollowupMessagesFn =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Vec<LoopMessage>> + Send>> + Send + Sync>;
 
+/// Polled at the finalization boundary. Returns `true` when the run should
+/// defer finalization — e.g. coordinated subagent work is still running, so the
+/// parent turn should end WITHOUT the critic (and lower gates) firing and be
+/// re-woken when the batch becomes deliverable.
 pub type ShouldDeferFinalizationFn = Arc<dyn Fn() -> bool + Send + Sync>;
 
 #[cfg(test)]

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -571,6 +571,10 @@ pub fn spawn_loop_runner(cfg: LoopSpawnConfig) -> LoopRunner {
             .bg_store
             .clone()
             .map(|store| crate::agent::tools::background::followup_from_background_store(store)),
+        should_defer_finalization: cfg.bg_store.clone().map(|store| {
+            std::sync::Arc::new(move || store.coordinator_generation_running())
+                as crate::agent::agent_loop::hooks::ShouldDeferFinalizationFn
+        }),
         reasoning: None,
         thinking_budgets: None,
         headers: std::collections::HashMap::new(),

--- a/src/agent/agent_loop/integration_tests.rs
+++ b/src/agent/agent_loop/integration_tests.rs
@@ -59,6 +59,7 @@ fn build_config() -> LoopConfig {
         should_stop_after_turn: None,
         get_steering_messages: None,
         get_followup_messages: None,
+        should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
         headers: std::collections::HashMap::new(),

--- a/src/agent/agent_loop/plugin_hooks_tests.rs
+++ b/src/agent/agent_loop/plugin_hooks_tests.rs
@@ -77,6 +77,7 @@ fn build_config() -> LoopConfig {
         should_stop_after_turn: None,
         get_steering_messages: None,
         get_followup_messages: None,
+        should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
         headers: std::collections::HashMap::new(),

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -326,6 +326,21 @@ async fn poll_finalization_follow_up(
             return (msgs, FollowUpSource::Hook);
         }
     }
+
+    // Coordinator work may intentionally outlive this parent turn. The
+    // completion hook above gets first chance to deliver a batch that became
+    // terminal at the boundary; only a still-running generation defers the
+    // critic and every lower "are we done?" gate. The UI wakes the parent when
+    // the batch becomes deliverable, so returning no follow-up here suspends
+    // cleanly without polling or consuming one-shot gate budgets.
+    if config
+        .should_defer_finalization
+        .as_ref()
+        .is_some_and(|should_defer| should_defer())
+    {
+        return (Vec::new(), FollowUpSource::None);
+    }
+
     // 1.5 Deterministic resume-after-failure: fires when the model's last
     //     action was a failed tool call and it stopped without retrying.
     //     Cheap, no LLM call, always-on. Bounded by MAX_RESUME_NUDGE.

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -109,6 +109,7 @@ fn build_config() -> LoopConfig {
         should_stop_after_turn: None,
         get_steering_messages: None,
         get_followup_messages: None,
+        should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
         headers: std::collections::HashMap::new(),
@@ -3944,6 +3945,63 @@ fn run_delta_to_review_engages_when_capped_identical_but_fingerprint_differs() {
     );
 }
 
+/// A nonterminal coordinator generation is an intentional suspension, not a
+/// completion candidate. The finalization poll must return before invoking the
+/// critic, and must leave its one-shot budget untouched for reconciliation.
+#[tokio::test]
+async fn finalization_defers_critic_while_external_work_is_pending() {
+    use crate::agent::agent_loop::critic::CriticFn;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = build_config();
+    config.should_defer_finalization = Some(Arc::new(|| true));
+    let judge: CriticFn = Arc::new({
+        let calls = calls.clone();
+        move |_prompt| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok("VERDICT: COMPLETE\nFINDINGS: none".to_string()) })
+        }
+    });
+    config.critic_fn = Some(judge);
+    let new_messages = vec![LoopMessage::ToolResult(
+        crate::agent::agent_loop::message::ToolResultMessage {
+            tool_call_id: "call_1".into(),
+            tool_name: "task".into(),
+            content: vec![crate::agent::agent_loop::message::ContentBlock::Text {
+                text: "background task started".into(),
+            }],
+            details: serde_json::Value::Null,
+            is_error: false,
+        },
+    )];
+    let mut critic_done = false;
+    let (emit, _emit_rx) = tokio::sync::mpsc::channel(8);
+    let (msgs, source) = poll_finalization_follow_up(
+        &config,
+        "sys",
+        &new_messages,
+        &mut critic_done,
+        &mut 0u8,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
+    )
+    .await;
+
+    assert!(msgs.is_empty());
+    assert_eq!(source, FollowUpSource::None);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(!critic_done);
+}
+
 /// Highest-priority gate (the caller hook) short-circuits the lower gates:
 /// when it yields a follow-up, the critic is never consulted (`critic_done`
 /// stays false) and the todo gate isn't reached. This locks the precedence.
@@ -3957,7 +4015,9 @@ async fn finalization_hook_short_circuits_lower_gates() {
             )]
         })
     }));
-
+    // A batch can become terminal at this exact boundary. Delivery must win
+    // over a stale/overlapping deferral signal.
+    config.should_defer_finalization = Some(Arc::new(|| true));
     let mut critic_done = false;
     let mut goal_reacts = 0u8;
     let mut todo_nudges = 0u8;

--- a/src/agent/agent_loop/steering.rs
+++ b/src/agent/agent_loop/steering.rs
@@ -359,6 +359,7 @@ mod tests {
             should_stop_after_turn: None,
             get_steering_messages: None,
             get_followup_messages: None,
+            should_defer_finalization: None,
             reasoning: None,
             thinking_budgets: None,
             headers: std::collections::HashMap::new(),

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -209,6 +209,7 @@ fn build_config() -> LoopConfig {
         should_stop_after_turn: None,
         get_steering_messages: None,
         get_followup_messages: None,
+        should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
         headers: std::collections::HashMap::new(),

--- a/src/agent/agent_loop/types.rs
+++ b/src/agent/agent_loop/types.rs
@@ -327,6 +327,12 @@ pub struct LoopConfig {
     /// (types.ts:243).
     pub get_followup_messages: Option<super::hooks::GetFollowupMessagesFn>,
 
+    /// Polled at the finalization boundary: when set and it returns `true`,
+    /// the run ends cleanly WITHOUT invoking the critic or any lower "are we
+    /// done?" gate, so a parent turn waiting on still-running coordinated
+    /// subagents isn't judged prematurely. Wired to
+    /// `BackgroundStore::coordinator_generation_running`; the UI re-wakes the
+    /// parent once the batch is deliverable.
     pub should_defer_finalization: Option<super::hooks::ShouldDeferFinalizationFn>,
 
     // ============================================================

--- a/src/agent/agent_loop/types.rs
+++ b/src/agent/agent_loop/types.rs
@@ -327,6 +327,8 @@ pub struct LoopConfig {
     /// (types.ts:243).
     pub get_followup_messages: Option<super::hooks::GetFollowupMessagesFn>,
 
+    pub should_defer_finalization: Option<super::hooks::ShouldDeferFinalizationFn>,
+
     // ============================================================
     // Phase 4.6 — provider stream options (pi parity)
     // ============================================================
@@ -707,6 +709,7 @@ impl Clone for LoopConfig {
             should_stop_after_turn: self.should_stop_after_turn.clone(),
             get_steering_messages: self.get_steering_messages.clone(),
             get_followup_messages: self.get_followup_messages.clone(),
+            should_defer_finalization: self.should_defer_finalization.clone(),
             reasoning: self.reasoning,
             thinking_budgets: self.thinking_budgets.clone(),
             headers: self.headers.clone(),
@@ -761,6 +764,7 @@ impl LoopConfig {
             should_stop_after_turn: None,
             get_steering_messages: None,
             get_followup_messages: None,
+            should_defer_finalization: None,
             reasoning: None,
             thinking_budgets: None,
             headers: std::collections::HashMap::new(),

--- a/src/agent/tools/background.rs
+++ b/src/agent/tools/background.rs
@@ -759,6 +759,20 @@ impl BackgroundStore {
                 .any(|n| !tracked.contains(n.id.as_str()))
     }
 
+    pub fn coordinator_generation_running(&self) -> bool {
+        let inner = self.lock();
+        let Some(coordinator) = &inner.coordinator else {
+            return false;
+        };
+        !coordinator.active_task_ids.is_empty()
+            && coordinator.active_task_ids.iter().any(|id| {
+                matches!(
+                    inner.tasks.get(id).map(|task| &task.state),
+                    Some(TaskState::Running)
+                )
+            })
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
         self.inner.lock_ignore_poison()
     }
@@ -971,6 +985,20 @@ fn truncate_state(state: TaskState) -> TaskState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn coordinator_reports_nonterminal_generation_until_batch_finishes() {
+        let store = BackgroundStore::new();
+        store.enable_coordinator(crate::config::SubagentDispatchStrategy::Full);
+        store
+            .insert_coordinator_dispatch("task".into(), "research".into(), false, false, None)
+            .unwrap();
+
+        assert!(store.coordinator_generation_running());
+
+        store.notify("task", TaskState::Completed("done".into()));
+        assert!(!store.coordinator_generation_running());
+    }
 
     #[test]
     fn coordinator_allows_one_retry_for_a_failed_dispatch() {

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -1267,6 +1267,12 @@ pub struct Args {
     pub retry_of: Option<String>,
 }
 
+fn normalize_retry_of(retry_of: Option<String>) -> Option<String> {
+    retry_of
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+}
+
 impl Tool for TaskTool {
     const NAME: &'static str = "task";
 
@@ -1406,11 +1412,12 @@ impl Tool for TaskTool {
         };
 
         let background = args.background.unwrap_or(false);
+        let retry_of = normalize_retry_of(args.retry_of);
         let is_writer = matches!(
             tier,
             crate::context::agent_defs::SubagentToolTier::ReadWrite
         );
-        if args.retry_of.is_some() && !background {
+        if retry_of.is_some() && !background {
             return Err(ToolError::Msg("retry_of requires background=true".into()));
         }
         if self.bg_store.coordinator_strategy().is_some() && !background && is_writer {
@@ -1443,7 +1450,7 @@ impl Tool for TaskTool {
                     timeout,
                     background,
                     is_writer,
-                    args.retry_of,
+                    retry_of,
                     args.prompt,
                     args.agent,
                 )
@@ -1476,7 +1483,7 @@ impl Tool for TaskTool {
                         args.prompt.clone(),
                         is_writer,
                         false,
-                        args.retry_of.as_deref(),
+                        retry_of.as_deref(),
                     )
                     .map_err(ToolError::Msg)?;
             } else {
@@ -1707,6 +1714,16 @@ mod tests {
     use crate::provider::AnyModel;
     use rig::client::CompletionClient;
     use rig::providers::openrouter;
+
+    #[test]
+    fn blank_retry_id_is_treated_as_absent() {
+        assert_eq!(normalize_retry_of(Some("".to_string())), None);
+        assert_eq!(normalize_retry_of(Some("   ".to_string())), None);
+        assert_eq!(
+            normalize_retry_of(Some(" task-id ".to_string())),
+            Some("task-id".to_string())
+        );
+    }
 
     fn mock_tool() -> TaskTool {
         // The model is never invoked in these tests — they exercise the


### PR DESCRIPTION
Normalize optional retry identifiers at the task-tool boundary so empty or whitespace-only values behave like omitted fields. This keeps generated tool calls from entering coordinator retry validation for a nonexistent task while preserving the existing one-retry policy for real IDs.

Deliberately keep strict validation for nonblank IDs and trim surrounding whitespace rather than weakening coordinator admission rules.

Verified: regression and coordinator retry tests pass; fmt and clippy clean; full binary suite passes excluding live h7_glm; binary builds.

---

Normalize optional retry identifiers at the task-tool boundary so empty or whitespace-only values behave like omitted fields. This keeps generated tool calls from entering coordinator retry validation for a nonexistent task while preserving the existing one-retry policy for real IDs.

Deliberately keep strict validation for nonblank IDs and trim surrounding whitespace rather than weakening coordinator admission rules.

Verified: regression and coordinator retry tests pass; fmt and clippy clean; full binary suite passes excluding live h7_glm; binary builds.