### PR TITLE
feat(lsp): add cmake-language-server and filename-based ServerInfo matching

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -876,19 +876,24 @@ CLI flag: `--no-lsp` (overrides the config; same effect as `lsp: false`).
 
 ### Built-in server commands
 
-| Server id     | Default command                              |
-| ------------- | -------------------------------------------- |
-| `rust`        | `rust-analyzer`                              |
-| `typescript`  | `typescript-language-server --stdio`         |
-| `pyright`     | `pyright-langserver --stdio`                 |
-| `clojure-lsp` | `clojure-lsp`                                |
+| Server id            | Default command                              |
+| -------------------- | -------------------------------------------- |
+| `rust`               | `rust-analyzer`                              |
+| `typescript`         | `typescript-language-server --stdio`         |
+| `pyright`            | `pyright-langserver --stdio`                 |
+| `clojure-lsp`        | `clojure-lsp`                                |
+| `gopls`              | `gopls`                                      |
+| `jdtls`              | `jdtls`                                      |
+| `clangd`             | `clangd`                                     |
+| `ruby-lsp`           | `ruby-lsp`                                   |
+| `bash-language-server` | `bash-language-server start`               |
+| `cmake`              | `cmake-language-server`                      |
 
 Servers are spawned lazily on first file touch and cached per `(workspace_root, server_id)` pair. Concurrent agent tool calls for the same file deduplicate so dirge never races two `rust-analyzer` processes against one workspace.
 
 ### Known limitations
 
 - The `extensions` override is currently ignored. The claimed-extensions list lives in the static `builtin_servers()` registry at `src/lsp/server.rs`. Adding new extensions today requires editing that file. Follow-up.
-- v1 has four built-in servers. Additional servers can be added by extending `builtin_servers()` + `ProcessSpawner::default_commands()` in source.
 
 ## ACP (Agent Communication Protocol) configuration
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -28,6 +28,7 @@ discovering it later via `cargo check`.
 | `clangd` | `clangd` | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hh`, `.hpp`, `.hxx`, `.m`, `.mm` |
 | `ruby-lsp` | `ruby-lsp` | `.rb`, `.rake`, `.gemspec` |
 | `bash-language-server` | `bash-language-server start` | `.sh`, `.bash` |
+| `cmake` | `cmake-language-server` | `.cmake` (+ `CMakeLists.txt` by name) |
 
 Missing binaries trip the broken-server backoff (1s → 2s → … capped at 10 min)
 rather than failing dirge — the rest of the session keeps working. Override the
@@ -42,7 +43,9 @@ pyright looks for `pyproject.toml`/`setup.py`/etc.; clojure-lsp looks for
 `deps.edn`/`project.clj`/`shadow-cljs.edn`/`bb.edn`/`.clj-kondo`; gopls follows
 `go.mod`/`go.work`; jdtls looks for `pom.xml`/`build.gradle`; clangd uses
 `compile_commands.json`/`CMakeLists.txt`/`Makefile`/`meson.build`; ruby-lsp
-follows `Gemfile`/`Rakefile`; bash-language-server uses the file's parent.
+follows `Gemfile`/`Rakefile`; bash-language-server uses the file's parent. Cmake
+uses the same root markers as clangd (`compile_commands.json`, `CMakeLists.txt`,
+`Makefile`, `meson.build`).
 
 Disable: `--no-lsp` flag or `{ "lsp": false }` in the config. Per-server
 overrides (custom command, env, init options) live in the config — see

--- a/src/lsp/language.rs
+++ b/src/lsp/language.rs
@@ -75,9 +75,14 @@ const LANGUAGES: &[(&str, &str)] = &[
     ("nix", "nix"),
     ("zig", "zig"),
     ("dfy", "dafny"),
+    ("cmake", "cmake"),
 ];
 
-const FILENAMES: &[(&str, &str)] = &[("makefile", "makefile"), ("dockerfile", "dockerfile")];
+const FILENAMES: &[(&str, &str)] = &[
+    ("makefile", "makefile"),
+    ("dockerfile", "dockerfile"),
+    ("cmakelists.txt", "cmake"),
+];
 
 #[cfg(test)]
 mod tests {
@@ -151,6 +156,10 @@ mod tests {
         // Case insensitive.
         assert_eq!(lang("makefile"), "makefile");
         assert_eq!(lang("path/to/Makefile"), "makefile");
+        // CMakeLists.txt has a generic .txt extension; it must match by filename.
+        assert_eq!(lang("CMakeLists.txt"), "cmake");
+        assert_eq!(lang("cmakelists.txt"), "cmake");
+        assert_eq!(lang("path/to/CMakeLists.txt"), "cmake");
     }
 
     #[test]

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -225,14 +225,25 @@ impl LspManager {
             .unwrap_or("")
             .to_lowercase();
 
+        let file_name = file
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
         let mut out = Vec::new();
 
         for server in self.servers.iter() {
-            if !server
+            let ext_match = server
                 .extensions
                 .iter()
-                .any(|e| e.eq_ignore_ascii_case(&ext))
-            {
+                .any(|e| e.eq_ignore_ascii_case(&ext));
+            let name_match = server
+                .filenames
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&file_name));
+
+            if !ext_match && !name_match {
                 continue;
             }
             let Some(root) = (server.root)(file, &self.worktree) else {

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -16,6 +16,10 @@ pub struct ServerInfo {
     /// override the builtin list — see
     /// `apply_extension_overrides`.
     pub extensions: Vec<String>,
+    /// Filenames (including extension) that this server claims. Used for
+    /// files like `CMakeLists.txt` whose extension (`.txt`) would otherwise
+    /// never trigger a match. Compared case-insensitively in `get_clients`.
+    pub filenames: Vec<String>,
     /// Walks up from `file` (bounded by `stop_at`) to locate the workspace
     /// root. Returns `None` when no plausible root exists (signals "don't
     /// attach this server to this file").
@@ -237,21 +241,25 @@ pub fn builtin_servers() -> Vec<ServerInfo> {
         ServerInfo {
             id: "rust",
             extensions: owned(&["rs"]),
+            filenames: owned(&[]),
             root: rust_workspace_root,
         },
         ServerInfo {
             id: "typescript",
             extensions: owned(&["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]),
+            filenames: owned(&[]),
             root: typescript_root,
         },
         ServerInfo {
             id: "pyright",
             extensions: owned(&["py", "pyi"]),
+            filenames: owned(&[]),
             root: pyright_root,
         },
         ServerInfo {
             id: "clojure-lsp",
             extensions: owned(&["clj", "cljs", "cljc", "edn", "bb"]),
+            filenames: owned(&[]),
             root: clojure_root,
         },
         // Audit M5: semantic adapters cover 10 languages but only 4
@@ -264,26 +272,31 @@ pub fn builtin_servers() -> Vec<ServerInfo> {
         ServerInfo {
             id: "gopls",
             extensions: owned(&["go"]),
+            filenames: owned(&[]),
             root: go_root,
         },
         ServerInfo {
             id: "jdtls",
             extensions: owned(&["java"]),
+            filenames: owned(&[]),
             root: java_root,
         },
         ServerInfo {
             id: "clangd",
             extensions: owned(&["c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx", "m", "mm"]),
+            filenames: owned(&[]),
             root: cfamily_root,
         },
         ServerInfo {
             id: "ruby-lsp",
             extensions: owned(&["rb", "rake", "gemspec"]),
+            filenames: owned(&[]),
             root: ruby_root,
         },
         ServerInfo {
             id: "bash-language-server",
             extensions: owned(&["sh", "bash"]),
+            filenames: owned(&[]),
             root: bash_root,
         },
         // Dafny: `dafny server` speaks LSP over stdio. Best-effort like
@@ -292,7 +305,20 @@ pub fn builtin_servers() -> Vec<ServerInfo> {
         ServerInfo {
             id: "dafny",
             extensions: owned(&["dfy"]),
+            filenames: owned(&[]),
             root: dafny_root,
+        },
+        // CMake: cmake-language-server speaks LSP over stdio.
+        // Best-effort like the others — if `cmake-language-server`
+        // isn't on PATH the spawn errors and broken-server backoff
+        // takes over. Uses cfamily_root because CMake projects
+        // share the same markers (compile_commands.json, Makefile,
+        // CMakeLists.txt).
+        ServerInfo {
+            id: "cmake",
+            extensions: owned(&["cmake"]),
+            filenames: owned(&["cmakelists.txt"]),
+            root: cfamily_root,
         },
     ]
 }

--- a/src/lsp/spawn.rs
+++ b/src/lsp/spawn.rs
@@ -174,6 +174,15 @@ impl ProcessSpawner {
                 init_options: Value::Null,
             },
         );
+        m.insert(
+            "cmake".to_string(),
+            ProcessCommand {
+                program: PathBuf::from("cmake-language-server"),
+                args: vec![],
+                env: vec![],
+                init_options: Value::Null,
+            },
+        );
         m
     }
 }


### PR DESCRIPTION
Adds `cmake-language-server` with filename-based matching, needed for `CMakeLists.txt` (generic .txt extension would never match by extension alone). The new `filenames` field on `ServerInfo` allows matching files by exact filename case-insensitively.

Also syncs `docs/config.md` table with the full built-in server list (`gopls, jdtls, clangd, ruby-lsp, bash-language-server` were already registered in source but missing from the table) and removes the stale "v1 has four built-in servers" note.