### PR TITLE
fix(agent-loop): stop Blocking critic re-raising unchanged-diff findings

### DIFF
--- a/src/agent/agent_loop/critic.rs
+++ b/src/agent/agent_loop/critic.rs
@@ -273,9 +273,11 @@ pub fn build_unified_prompt(
     transcript: &str,
     diff: Option<&str>,
     verification: Option<VerificationStatus>,
-    // dirge-9b2k R2: findings a prior Blocking reaction raised that the model
-    // addressed or declined, so the judge re-raises one only if the decline was
-    // wrong rather than blindly re-emitting it. `None`/blank = no section.
+    // dirge-9b2k R2: findings a prior Blocking reaction raised. The judge is told
+    // to re-raise one only if it's still present AND the model neither fixed nor
+    // justified it (blindly re-emitting a declined finding is the duplicate bug;
+    // silently dropping an unaddressed one is the opposite failure). `None`/blank
+    // = no section.
     prior_findings: Option<&str>,
 ) -> String {
     let rules = strip_compaction_summary(rules).trim();
@@ -293,11 +295,12 @@ pub fn build_unified_prompt(
     };
     let prior_findings_block = match prior_findings {
         Some(p) if !p.trim().is_empty() => format!(
-            "\n\n--- findings raised on an earlier review (the assistant addressed or \
-             declined them; its reasoning is in the transcript above) ---\n{}\n--- end prior \
-             findings ---\n\
-             Do NOT re-raise any of these unless the assistant's reasoning for declining is \
-             factually wrong — in that case, explain why the reasoning fails.",
+            "\n\n--- findings raised on an earlier review (the assistant's response is in the \
+             transcript above) ---\n{}\n--- end prior findings ---\n\
+             For each: if the assistant fixed it, or gave a sound reason for leaving it, do NOT \
+             re-raise it. If it is still present and the assistant neither fixed nor justified \
+             it, DO re-raise it. Only re-raise a justified finding when the justification is \
+             factually wrong — then explain why it fails.",
             p.trim()
         ),
         _ => String::new(),
@@ -833,7 +836,13 @@ mod tests {
 
     #[test]
     fn unified_prompt_includes_diff_only_when_present() {
-        let with = build_unified_prompt("rules", "did stuff", Some("@@ -1 +1 @@\n-a\n+b"), None, None);
+        let with = build_unified_prompt(
+            "rules",
+            "did stuff",
+            Some("@@ -1 +1 @@\n-a\n+b"),
+            None,
+            None,
+        );
         assert!(with.contains("diff under review"));
         assert!(with.contains("+b"));
         let without = build_unified_prompt("rules", "did stuff", None, None, None);
@@ -847,7 +856,13 @@ mod tests {
     fn unified_prompt_omits_prior_findings_section_when_none() {
         // dirge-9b2k R2: no prior findings → no new section (identical to the
         // pre-R2 prompt).
-        let p = build_unified_prompt("rules", "did stuff", Some("@@ -1 +1 @@\n-a\n+b"), None, None);
+        let p = build_unified_prompt(
+            "rules",
+            "did stuff",
+            Some("@@ -1 +1 @@\n-a\n+b"),
+            None,
+            None,
+        );
         assert!(!p.contains("earlier review"));
         assert!(p.contains("diff under review"));
     }
@@ -868,14 +883,21 @@ mod tests {
             None,
             Some("- High — sql injection"),
         );
-        assert!(p.contains("earlier review"), "prior-findings section must appear");
+        assert!(
+            p.contains("earlier review"),
+            "prior-findings section must appear"
+        );
         assert!(
             p.contains("- High — sql injection"),
             "the prior findings must be inlined"
         );
         assert!(
-            p.contains("Do NOT re-raise"),
-            "the decline-rebuttal instruction must be present"
+            p.contains("do NOT re-raise"),
+            "the suppress-if-addressed instruction must be present"
+        );
+        assert!(
+            p.contains("neither fixed nor justified"),
+            "the re-raise-if-unaddressed instruction must be present"
         );
     }
 

--- a/src/agent/agent_loop/critic.rs
+++ b/src/agent/agent_loop/critic.rs
@@ -273,6 +273,10 @@ pub fn build_unified_prompt(
     transcript: &str,
     diff: Option<&str>,
     verification: Option<VerificationStatus>,
+    // dirge-9b2k R2: findings a prior Blocking reaction raised that the model
+    // addressed or declined, so the judge re-raises one only if the decline was
+    // wrong rather than blindly re-emitting it. `None`/blank = no section.
+    prior_findings: Option<&str>,
 ) -> String {
     let rules = strip_compaction_summary(rules).trim();
     let rules_block = if rules.is_empty() {
@@ -287,11 +291,22 @@ pub fn build_unified_prompt(
         ),
         _ => String::new(),
     };
+    let prior_findings_block = match prior_findings {
+        Some(p) if !p.trim().is_empty() => format!(
+            "\n\n--- findings raised on an earlier review (the assistant addressed or \
+             declined them; its reasoning is in the transcript above) ---\n{}\n--- end prior \
+             findings ---\n\
+             Do NOT re-raise any of these unless the assistant's reasoning for declining is \
+             factually wrong — in that case, explain why the reasoning fails.",
+            p.trim()
+        ),
+        _ => String::new(),
+    };
     format!(
         "{UNIFIED_FORMAT}\n\n\
          --- assistant instructions & constraints (judge within these; never demand a \
          forbidden/out-of-scope action) ---\n{rules_block}\n--- end instructions ---\n\n\
-         --- transcript ---\n{transcript}\n--- end transcript ---{diff_block}{}",
+         --- transcript ---\n{transcript}\n--- end transcript ---{diff_block}{prior_findings_block}{}",
         verification_block(verification)
     )
 }
@@ -380,19 +395,28 @@ pub async fn run_unified_review(
     transcript: &str,
     diff: Option<&str>,
     verification: Option<VerificationStatus>,
-) -> Vec<LoopMessage> {
-    let prompt = build_unified_prompt(rules, transcript, diff, verification);
+    prior_findings: Option<&str>,
+) -> (Vec<LoopMessage>, Option<String>) {
+    let prompt = build_unified_prompt(rules, transcript, diff, verification, prior_findings);
     let response = run_judge!(
         judge,
         prompt,
         "dirge::critic",
         "unified review call failed; finalizing without it",
-        Vec::new()
+        (Vec::new(), None)
     );
     let (verdict, findings) = parse_unified(&response);
-    build_unified_followup(verdict, findings)
+    // dirge-9b2k R2: surface the rendered findings so the caller can hand them
+    // to the next reaction's judge prompt (Blocking path in run.rs).
+    let raised = if findings.is_empty() {
+        None
+    } else {
+        Some(render_findings(&findings))
+    };
+    let msgs = build_unified_followup(verdict, findings)
         .into_iter()
-        .collect()
+        .collect();
+    (msgs, raised)
 }
 
 #[cfg(test)]
@@ -408,7 +432,7 @@ mod tests {
         transcript: &str,
         verification: Option<VerificationStatus>,
     ) -> String {
-        build_unified_prompt(rules, transcript, None, verification)
+        build_unified_prompt(rules, transcript, None, verification, None)
     }
 
     #[test]
@@ -689,6 +713,7 @@ mod tests {
             "edited foo.rs",
             None,
             Some(VerificationStatus::Unverified),
+            None,
         )
         .await;
         let prompt = seen.lock().unwrap().clone();
@@ -707,8 +732,9 @@ mod tests {
         let judge: CriticFn =
             Arc::new(|_p| Box::pin(async { Ok("VERDICT: COMPLETE\nFINDINGS: none".to_string()) }));
         assert!(
-            run_unified_review(&judge, "rules", "did stuff", None, None)
+            run_unified_review(&judge, "rules", "did stuff", None, None, None)
                 .await
+                .0
                 .is_empty()
         );
     }
@@ -807,22 +833,59 @@ mod tests {
 
     #[test]
     fn unified_prompt_includes_diff_only_when_present() {
-        let with = build_unified_prompt("rules", "did stuff", Some("@@ -1 +1 @@\n-a\n+b"), None);
+        let with = build_unified_prompt("rules", "did stuff", Some("@@ -1 +1 @@\n-a\n+b"), None, None);
         assert!(with.contains("diff under review"));
         assert!(with.contains("+b"));
-        let without = build_unified_prompt("rules", "did stuff", None, None);
+        let without = build_unified_prompt("rules", "did stuff", None, None, None);
         assert!(!without.contains("diff under review"));
         // Both carry the combined verdict+findings format contract.
         assert!(with.contains("FINDINGS:"));
         assert!(without.contains("FINDINGS:"));
     }
 
+    #[test]
+    fn unified_prompt_omits_prior_findings_section_when_none() {
+        // dirge-9b2k R2: no prior findings → no new section (identical to the
+        // pre-R2 prompt).
+        let p = build_unified_prompt("rules", "did stuff", Some("@@ -1 +1 @@\n-a\n+b"), None, None);
+        assert!(!p.contains("earlier review"));
+        assert!(p.contains("diff under review"));
+    }
+
+    #[test]
+    fn unified_prompt_omits_prior_findings_section_when_blank() {
+        // A whitespace-only string carries no real findings — still no section.
+        let p = build_unified_prompt("rules", "did stuff", Some("diff"), None, Some("  \n "));
+        assert!(!p.contains("earlier review"));
+    }
+
+    #[test]
+    fn unified_prompt_includes_prior_findings_section_when_present() {
+        let p = build_unified_prompt(
+            "rules",
+            "did stuff",
+            Some("diff"),
+            None,
+            Some("- High — sql injection"),
+        );
+        assert!(p.contains("earlier review"), "prior-findings section must appear");
+        assert!(
+            p.contains("- High — sql injection"),
+            "the prior findings must be inlined"
+        );
+        assert!(
+            p.contains("Do NOT re-raise"),
+            "the decline-rebuttal instruction must be present"
+        );
+    }
+
     #[tokio::test]
     async fn run_unified_review_fails_open_on_error() {
         let judge: CriticFn = Arc::new(|_p| Box::pin(async { anyhow::bail!("provider down") }));
         assert!(
-            run_unified_review(&judge, "rules", "did stuff", Some("diff"), None)
+            run_unified_review(&judge, "rules", "did stuff", Some("diff"), None, None)
                 .await
+                .0
                 .is_empty(),
             "a judge error must not block finalization"
         );

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -306,6 +306,12 @@ async fn poll_finalization_follow_up(
     // persistent Blocking path uses `code_review_reacts` instead.
     critic_done: &mut bool,
     code_review_reacts: &mut u8,
+    // dirge-<tag>: fingerprint of the diff the Blocking judge last reviewed, so
+    // an unchanged diff (the model declined/rebutted) isn't re-reviewed.
+    last_reviewed_fingerprint: &mut Option<u64>,
+    // dirge-9b2k R2: the last reaction's rendered findings, handed to the next
+    // judge prompt so it doesn't blindly re-raise one the model rebutted.
+    last_review_findings: &mut Option<String>,
     code_review_baseline: Option<&super::code_review::RunDiff>,
     goal_reacts: &mut u8,
     todo_nudges: &mut u8,
@@ -396,43 +402,81 @@ async fn poll_finalization_follow_up(
         if may_fire && let Some(judge) = &config.critic_fn {
             // Capture the run's diff only when diff-review is on AND the working
             // tree changed since run start; otherwise review completeness alone.
-            let diff_owned: Option<String> = if mode != CodeReviewMode::Off {
-                let repo =
-                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-                // Diff capture shells out to git — do it off the async runtime.
-                let captured = tokio::task::spawn_blocking(move || {
-                    super::code_review::capture_run_diff(&repo)
-                })
-                .await
-                .ok()
-                .flatten();
-                run_delta_to_review(captured.as_ref(), code_review_baseline).map(str::to_string)
-            } else {
-                None
-            };
-            let transcript = build_critic_transcript(new_messages);
-            // dirge-6q3w: thread the run's compile/lint/test signal so the judge
-            // can be pickier about unverified changes. dirge-bedj: judge within
-            // the agent's own system prompt so it never demands a forbidden
-            // action.
-            let verification = config.verifier.as_ref().map(|v| v.status());
-            let msgs = super::critic::run_unified_review(
-                judge,
-                system_prompt,
-                &transcript,
-                diff_owned.as_deref(),
-                verification,
-            )
-            .await;
-            // One-shot modes fire at most once (flip regardless of verdict);
-            // blocking spends its budget only when it actually re-enters.
-            if one_shot {
-                *critic_done = true;
-            } else if !msgs.is_empty() {
-                *code_review_reacts += 1;
-            }
-            if !msgs.is_empty() {
-                return (msgs, FollowUpSource::Critic);
+            // dirge-9b2k: keep the UNcapped fingerprint too (dirge-8gdv) so the
+            // Blocking path can tell when the model changed nothing between two
+            // reviews of the same diff and skip a redundant stateless judge call.
+            let (diff_owned, current_fingerprint): (Option<String>, Option<u64>) =
+                if mode != CodeReviewMode::Off {
+                    let repo =
+                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+                    // Diff capture shells out to git — do it off the async runtime.
+                    let captured = tokio::task::spawn_blocking(move || {
+                        super::code_review::capture_run_diff(&repo)
+                    })
+                    .await
+                    .ok()
+                    .flatten();
+                    let fp = captured.as_ref().map(|d| d.fingerprint);
+                    let diff =
+                        run_delta_to_review(captured.as_ref(), code_review_baseline)
+                            .map(str::to_string);
+                    (diff, fp)
+                } else {
+                    (None, None)
+                };
+            // dirge-9b2k: Blocking dedupe. The judge is stateless, so when the
+            // model declined a finding and changed nothing on disk, the next
+            // reaction re-reviews the identical diff, re-raises the same finding,
+            // and elicits the same rebuttal — a duplicate message. When this exact
+            // diff (by uncapped fingerprint) was reviewed last reaction, skip the
+            // judge call; the model's rebuttal stands. Off/Advisory are one-shot
+            // via `critic_done`, so the guard is Blocking-only.
+            //
+            // Falling through (NOT early-returning) is load-bearing: a skip is
+            // semantically "the critic found nothing this reaction", and the
+            // existing empty-findings path falls through to the goal / todo /
+            // open-issues gates. An early `return` here would silently drop those
+            // nudges — so `skip` only gates the judge block below, leaving the
+            // downstream gates in play on a skipped reaction.
+            let skip = mode == CodeReviewMode::Blocking
+                && diff_owned.is_some()
+                && current_fingerprint == *last_reviewed_fingerprint;
+            if !skip {
+                let transcript = build_critic_transcript(new_messages);
+                // dirge-6q3w: thread the run's compile/lint/test signal so the
+                // judge can be pickier about unverified changes. dirge-bedj: judge
+                // within the agent's own system prompt so it never demands a
+                // forbidden action.
+                let verification = config.verifier.as_ref().map(|v| v.status());
+                let (msgs, raised_findings) = super::critic::run_unified_review(
+                    judge,
+                    system_prompt,
+                    &transcript,
+                    diff_owned.as_deref(),
+                    verification,
+                    last_review_findings.as_deref(),
+                )
+                .await;
+                // dirge-9b2k: remember the diff we just reviewed so the next
+                // Blocking reaction can skip it when the model changed nothing.
+                if mode == CodeReviewMode::Blocking && diff_owned.is_some() {
+                    *last_reviewed_fingerprint = current_fingerprint;
+                }
+                // dirge-9b2k R2: hand the last reaction's findings to the next
+                // judge so it re-raises one only if the model's decline was wrong.
+                if mode == CodeReviewMode::Blocking {
+                    *last_review_findings = raised_findings;
+                }
+                // One-shot modes fire at most once (flip regardless of verdict);
+                // blocking spends its budget only when it actually re-enters.
+                if one_shot {
+                    *critic_done = true;
+                } else if !msgs.is_empty() {
+                    *code_review_reacts += 1;
+                }
+                if !msgs.is_empty() {
+                    return (msgs, FollowUpSource::Critic);
+                }
             }
         }
     }
@@ -1425,6 +1469,12 @@ pub async fn run_loop(
     // (fix-then-re-review) bounded by MAX_REVIEW_REACT.
     let mut critic_done = false;
     let mut code_review_reacts: u8 = 0;
+    // dirge-<tag>: see poll_finalization_follow_up — the last-reviewed diff
+    // fingerprint drives the Blocking dedupe.
+    let mut last_reviewed_fingerprint: Option<u64> = None;
+    // dirge-9b2k R2: the last judge reaction's findings, threaded into the next
+    // judge prompt so a rebutted finding isn't blindly re-raised.
+    let mut last_review_findings: Option<String> = None;
 
     // dirge-1g3v: snapshot the working-tree diff at run start so the reviewer
     // can tell what THIS run changed. Without a baseline it diffed the whole
@@ -2379,6 +2429,8 @@ pub async fn run_loop(
             &new_messages,
             &mut critic_done,
             &mut code_review_reacts,
+            &mut last_reviewed_fingerprint,
+            &mut last_review_findings,
             code_review_baseline.as_ref(),
             &mut goal_reacts,
             &mut todo_nudges,

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -306,7 +306,7 @@ async fn poll_finalization_follow_up(
     // persistent Blocking path uses `code_review_reacts` instead.
     critic_done: &mut bool,
     code_review_reacts: &mut u8,
-    // dirge-<tag>: fingerprint of the diff the Blocking judge last reviewed, so
+    // dirge-9b2k: fingerprint of the diff the Blocking judge last reviewed, so
     // an unchanged diff (the model declined/rebutted) isn't re-reviewed.
     last_reviewed_fingerprint: &mut Option<u64>,
     // dirge-9b2k R2: the last reaction's rendered findings, handed to the next
@@ -417,9 +417,8 @@ async fn poll_finalization_follow_up(
                     .ok()
                     .flatten();
                     let fp = captured.as_ref().map(|d| d.fingerprint);
-                    let diff =
-                        run_delta_to_review(captured.as_ref(), code_review_baseline)
-                            .map(str::to_string);
+                    let diff = run_delta_to_review(captured.as_ref(), code_review_baseline)
+                        .map(str::to_string);
                     (diff, fp)
                 } else {
                     (None, None)
@@ -457,14 +456,15 @@ async fn poll_finalization_follow_up(
                     last_review_findings.as_deref(),
                 )
                 .await;
-                // dirge-9b2k: remember the diff we just reviewed so the next
-                // Blocking reaction can skip it when the model changed nothing.
-                if mode == CodeReviewMode::Blocking && diff_owned.is_some() {
-                    *last_reviewed_fingerprint = current_fingerprint;
-                }
-                // dirge-9b2k R2: hand the last reaction's findings to the next
-                // judge so it re-raises one only if the model's decline was wrong.
+                // dirge-9b2k: carry per-reaction state forward for the next
+                // Blocking finalization. The fingerprint (only when a diff was
+                // actually reviewed) lets the next reaction skip an unchanged
+                // diff; the findings feed its judge prompt so it re-raises one
+                // only if still-present-and-unaddressed.
                 if mode == CodeReviewMode::Blocking {
+                    if diff_owned.is_some() {
+                        *last_reviewed_fingerprint = current_fingerprint;
+                    }
                     *last_review_findings = raised_findings;
                 }
                 // One-shot modes fire at most once (flip regardless of verdict);
@@ -1469,7 +1469,7 @@ pub async fn run_loop(
     // (fix-then-re-review) bounded by MAX_REVIEW_REACT.
     let mut critic_done = false;
     let mut code_review_reacts: u8 = 0;
-    // dirge-<tag>: see poll_finalization_follow_up — the last-reviewed diff
+    // dirge-9b2k: see poll_finalization_follow_up — the last-reviewed diff
     // fingerprint drives the Blocking dedupe.
     let mut last_reviewed_fingerprint: Option<u64> = None;
     // dirge-9b2k R2: the last judge reaction's findings, threaded into the next

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -3983,6 +3983,8 @@ async fn finalization_defers_critic_while_external_work_is_pending() {
         &new_messages,
         &mut critic_done,
         &mut 0u8,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut 0u8,
         &mut 0u8,
@@ -4030,6 +4032,8 @@ async fn finalization_hook_short_circuits_lower_gates() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4074,6 +4078,8 @@ async fn finalization_all_gates_silent_yields_none() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4115,6 +4121,8 @@ async fn finalization_goal_unmet_reenters_and_counts() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4177,6 +4185,8 @@ async fn finalization_unified_judge_reenters_on_finding() {
         &new_messages,
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4227,6 +4237,8 @@ async fn finalization_goal_met_finalizes() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4267,6 +4279,8 @@ async fn finalization_goal_bound_stops_reentry() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4304,6 +4318,8 @@ async fn finalization_goal_without_judge_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None, // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4349,6 +4365,8 @@ async fn open_issues_gate_off_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4399,6 +4417,8 @@ async fn open_issues_gate_blocking_with_session_open_issues_nudges() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4455,6 +4475,8 @@ async fn open_issues_gate_blocking_has_bound() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4498,6 +4520,8 @@ async fn open_issues_gate_zero_open_session_issues_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4535,6 +4559,8 @@ async fn open_issues_gate_missing_db_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4579,6 +4605,8 @@ async fn open_issues_gate_advisory_emits_notice_but_does_not_reenter() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
+        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
         &mut todo_nudges,
@@ -4609,6 +4637,302 @@ async fn open_issues_gate_advisory_emits_notice_but_does_not_reenter() {
     }
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── Blocking review dedupe (dirge-9b2k): skip re-reviewing an unchanged diff ─
+//
+// The unified finalization judge is stateless, so a Blocking run that persists
+// across finalizations can loop: when the model declines a finding and changes
+// nothing on disk, a naive re-review re-raises the identical finding and the
+// model re-emits the identical rebuttal — a duplicate. The fix skips the judge
+// when this exact diff (by uncapped fingerprint) was reviewed last reaction.
+
+/// Serialize tests that flip the process-global CWD, since git diff capture
+/// reads `current_dir()`. Without this, two such tests race under parallel
+/// execution and each captures the other's tree.
+static REVIEW_CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Restore the CWD on drop — even if the test panics mid-assertion after
+/// `set_current_dir`, so a failed Blocking test can't strand the suite in a
+/// temp dir that gets removed.
+struct CwdGuard {
+    orig: std::path::PathBuf,
+}
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.orig);
+    }
+}
+
+/// A temp git repo with one committed file and one uncommitted edit, so
+/// `capture_run_diff` yields a stable, non-empty diff. Caller must hold
+/// [`REVIEW_CWD_TEST_LOCK`] and have moved the CWD nowhere else.
+fn temp_review_repo(suffix: &str) -> std::path::PathBuf {
+    let dir = temp_dir(&format!("blocking-review-{suffix}"));
+    let git = |args: &[&str]| {
+        let _ = std::process::Command::new("git")
+            .current_dir(&dir)
+            .args(args)
+            .output();
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "test@test.test"]);
+    git(&["config", "user.name", "test"]);
+    std::fs::write(dir.join("a.rs"), "fn main() {}\n").unwrap();
+    git(&["add", "."]);
+    git(&["commit", "-q", "-m", "base"]);
+    // dirty edit — the diff capture reviews this.
+    std::fs::write(dir.join("a.rs"), "fn main() { let x = 1; }\n").unwrap();
+    dir
+}
+
+/// A run that made a tool call, so `run_made_tool_calls` is true and the
+/// unified judge gate is eligible.
+fn run_with_tool_result() -> Vec<LoopMessage> {
+    vec![LoopMessage::ToolResult(
+        crate::agent::agent_loop::message::ToolResultMessage {
+            tool_call_id: "call_1".into(),
+            tool_name: "task".into(),
+            content: vec![crate::agent::agent_loop::message::ContentBlock::Text {
+                text: "done".into(),
+            }],
+            details: serde_json::Value::Null,
+            is_error: false,
+        },
+    )]
+}
+
+/// A stateless judge stub that always raises one high finding, recording how
+/// many times it was invoked.
+fn counting_judge(calls: &Arc<AtomicUsize>) -> crate::agent::agent_loop::critic::CriticFn {
+    let calls = calls.clone();
+    Arc::new(move |_p: String| {
+        calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok("VERDICT: INCOMPLETE\nFINDINGS:\n- High — bug".to_string()) })
+    })
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)] // current-thread runtime; lock only serializes CWD
+async fn blocking_review_skips_judge_when_diff_unchanged_across_reactions() {
+    use crate::agent::agent_loop::types::CodeReviewMode;
+
+    let _lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
+    let repo = temp_review_repo("skip");
+    let guard = CwdGuard {
+        orig: std::env::current_dir().unwrap(),
+    };
+    std::env::set_current_dir(&repo).unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = build_config();
+    config.critic_fn = Some(counting_judge(&calls));
+    config.code_review_mode = CodeReviewMode::Blocking;
+
+    let msgs_run = run_with_tool_result();
+    let mut critic_done = false;
+    let mut reacts = 0u8;
+    let mut last_fp: Option<u64> = None;
+    let mut last_findings: Option<String> = None;
+    let (emit, _rx) = tokio::sync::mpsc::channel(8);
+
+    // Reaction 1: the judge reviews the diff and raises a finding.
+    let (msgs1, src1) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
+        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "first reaction calls the judge");
+    assert!(!msgs1.is_empty(), "first reaction returns the finding");
+    assert_eq!(src1, FollowUpSource::Critic);
+    assert_eq!(reacts, 1, "first reaction spends a budget");
+    assert!(!critic_done, "Blocking never sets the one-shot flag");
+    assert!(last_fp.is_some(), "the reviewed diff fingerprint is recorded");
+
+    // Reaction 2: the diff on disk is UNCHANGED → the judge must be skipped.
+    let (msgs2, src2) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
+        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "judge NOT called again on an unchanged diff"
+    );
+    assert!(msgs2.is_empty(), "no follow-up — the model's rebuttal stands");
+    assert_eq!(src2, FollowUpSource::None);
+    assert_eq!(reacts, 1, "budget not spent on the skipped reaction");
+
+    drop(guard);
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// dirge-9b2k regression: the Blocking dedupe skip must NOT early-return out of
+/// `poll_finalization_follow_up` — it must fall through to the downstream gates.
+/// Here reaction 2 skips the judge (unchanged diff), but an unfinished todo is
+/// present, so the TODO gate fires instead of finalizing with `None`. An earlier
+/// version of the guard `return`ed on skip, silently dropping the todo nudge.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)] // current-thread runtime; locks only serialize CWD + TODO_LIST
+async fn blocking_review_skip_falls_through_to_downstream_gate() {
+    use crate::agent::agent_loop::types::CodeReviewMode;
+    use crate::agent::tools::todo::{TODO_LIST, TodoItem};
+
+    let _cwd_lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
+    let repo = temp_review_repo("fallthrough");
+    let guard = CwdGuard {
+        orig: std::env::current_dir().unwrap(),
+    };
+    std::env::set_current_dir(&repo).unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = build_config();
+    config.critic_fn = Some(counting_judge(&calls));
+    config.code_review_mode = CodeReviewMode::Blocking;
+
+    let msgs_run = run_with_tool_result();
+    let mut critic_done = false;
+    let mut reacts = 0u8;
+    let mut last_fp: Option<u64> = None;
+    let mut last_findings: Option<String> = None;
+    let (emit, _emit_rx) = tokio::sync::mpsc::channel(8);
+
+    // Reaction 1: the judge reviews the diff and raises a finding.
+    let (msgs1, src1) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None,
+        &mut 0u8, &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1, "first reaction calls the judge");
+    assert_eq!(src1, FollowUpSource::Critic);
+    assert!(!msgs1.is_empty());
+
+    // Plant an unfinished todo so the TODO gate is armed for reaction 2.
+    // Set it WITHOUT holding the lock across the poll — `unfinished_count()`
+    // inside the poll re-locks TODO_LIST, and std Mutex isn't reentrant.
+    *TODO_LIST.lock().unwrap() = vec![TodoItem {
+        content: "still open".into(),
+        status: "open".into(),
+        priority: "normal".into(),
+    }];
+
+    // Reaction 2: the diff on disk is UNCHANGED → the judge is skipped, BUT the
+    // fall-through must reach the TODO gate (unfinished todo present).
+    let mut todo_nudges = 0u8;
+    let (msgs2, src2) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None,
+        &mut todo_nudges, &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "judge NOT called again on an unchanged diff"
+    );
+    assert!(
+        !msgs2.is_empty(),
+        "the skipped reaction must fall through to the todo gate"
+    );
+    assert_eq!(
+        src2,
+        FollowUpSource::Todo,
+        "the TODO gate fires, not Critic and not None"
+    );
+    assert_eq!(reacts, 1, "budget not spent on the skipped reaction");
+
+    // Restore the global so no other test sees our planted todo.
+    TODO_LIST.lock().unwrap().clear();
+    drop(guard);
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)] // current-thread runtime; lock only serializes CWD
+async fn blocking_review_re_fires_judge_when_diff_changes_between_reactions() {
+    use crate::agent::agent_loop::types::CodeReviewMode;
+
+    let _lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
+    let repo = temp_review_repo("changed");
+    let guard = CwdGuard {
+        orig: std::env::current_dir().unwrap(),
+    };
+    std::env::set_current_dir(&repo).unwrap();
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = build_config();
+    config.critic_fn = Some(counting_judge(&calls));
+    config.code_review_mode = CodeReviewMode::Blocking;
+
+    let msgs_run = run_with_tool_result();
+    let mut critic_done = false;
+    let mut reacts = 0u8;
+    let mut last_fp: Option<u64> = None;
+    let mut last_findings: Option<String> = None;
+    let (emit, _rx) = tokio::sync::mpsc::channel(8);
+
+    // Reaction 1.
+    let (msgs1, _src1) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
+        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(!msgs1.is_empty());
+
+    // The model changes the code on disk → the diff fingerprint changes.
+    std::fs::write(repo.join("a.rs"), "fn main() { let x = 2; let y = 3; }\n").unwrap();
+
+    // Reaction 2: the diff CHANGED → the judge fires again.
+    let (msgs2, src2) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
+        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "judge re-fires when the diff changed"
+    );
+    assert!(!msgs2.is_empty());
+    assert_eq!(src2, FollowUpSource::Critic);
+
+    drop(guard);
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+#[tokio::test]
+async fn advisory_review_unaffected_by_last_reviewed_fingerprint() {
+    use crate::agent::agent_loop::types::CodeReviewMode;
+
+    // Advisory is one-shot via critic_done; the Blocking-only dedupe (last_fp)
+    // must never suppress it. A set fingerprint cannot block the Advisory judge.
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = build_config();
+    config.critic_fn = Some(counting_judge(&calls));
+    // default code_review_mode is Advisory; assert it explicitly.
+    assert_eq!(config.code_review_mode, CodeReviewMode::Advisory);
+
+    let msgs_run = run_with_tool_result();
+    let mut critic_done = false;
+    let mut reacts = 0u8;
+    let mut last_fp: Option<u64> = Some(999); // must NOT suppress Advisory
+    let mut last_findings: Option<String> = None;
+    let (emit, _rx) = tokio::sync::mpsc::channel(8);
+
+    let (msgs1, src1) = poll_finalization_follow_up(
+        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
+        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+    )
+    .await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "Advisory judge fires despite a set last_fp"
+    );
+    assert!(!msgs1.is_empty());
+    assert_eq!(src1, FollowUpSource::Critic);
+    assert!(critic_done, "Advisory flips the one-shot flag");
 }
 
 // ── track-work advisory (R3): edited files but no active todo ──────────────

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -3983,7 +3983,7 @@ async fn finalization_defers_critic_while_external_work_is_pending() {
         &new_messages,
         &mut critic_done,
         &mut 0u8,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut 0u8,
@@ -4032,9 +4032,9 @@ async fn finalization_hook_short_circuits_lower_gates() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4078,9 +4078,9 @@ async fn finalization_all_gates_silent_yields_none() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4121,9 +4121,9 @@ async fn finalization_goal_unmet_reenters_and_counts() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4185,9 +4185,9 @@ async fn finalization_unified_judge_reenters_on_finding() {
         &new_messages,
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4237,9 +4237,9 @@ async fn finalization_goal_met_finalizes() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4279,9 +4279,9 @@ async fn finalization_goal_bound_stops_reentry() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4318,9 +4318,9 @@ async fn finalization_goal_without_judge_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
-        None, // code_review_baseline
+        None,                // code_review_baseline
         &mut goal_reacts,
         &mut todo_nudges,
         &mut resume_nudges,
@@ -4365,7 +4365,7 @@ async fn open_issues_gate_off_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4417,7 +4417,7 @@ async fn open_issues_gate_blocking_with_session_open_issues_nudges() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4475,7 +4475,7 @@ async fn open_issues_gate_blocking_has_bound() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4520,7 +4520,7 @@ async fn open_issues_gate_zero_open_session_issues_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4559,7 +4559,7 @@ async fn open_issues_gate_missing_db_is_inert() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4605,7 +4605,7 @@ async fn open_issues_gate_advisory_emits_notice_but_does_not_reenter() {
         &[],
         &mut critic_done,
         &mut code_review_reacts,
-        &mut None::<u64>, // last_reviewed_fingerprint
+        &mut None::<u64>,    // last_reviewed_fingerprint
         &mut None::<String>, // last_review_findings
         None,
         &mut goal_reacts,
@@ -4738,21 +4738,58 @@ async fn blocking_review_skips_judge_when_diff_unchanged_across_reactions() {
 
     // Reaction 1: the judge reviews the diff and raises a finding.
     let (msgs1, src1) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
-        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
-    assert_eq!(calls.load(Ordering::SeqCst), 1, "first reaction calls the judge");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "first reaction calls the judge"
+    );
     assert!(!msgs1.is_empty(), "first reaction returns the finding");
     assert_eq!(src1, FollowUpSource::Critic);
     assert_eq!(reacts, 1, "first reaction spends a budget");
     assert!(!critic_done, "Blocking never sets the one-shot flag");
-    assert!(last_fp.is_some(), "the reviewed diff fingerprint is recorded");
+    assert!(
+        last_fp.is_some(),
+        "the reviewed diff fingerprint is recorded"
+    );
 
     // Reaction 2: the diff on disk is UNCHANGED → the judge must be skipped.
     let (msgs2, src2) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
-        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
     assert_eq!(
@@ -4760,7 +4797,10 @@ async fn blocking_review_skips_judge_when_diff_unchanged_across_reactions() {
         1,
         "judge NOT called again on an unchanged diff"
     );
-    assert!(msgs2.is_empty(), "no follow-up — the model's rebuttal stands");
+    assert!(
+        msgs2.is_empty(),
+        "no follow-up — the model's rebuttal stands"
+    );
     assert_eq!(src2, FollowUpSource::None);
     assert_eq!(reacts, 1, "budget not spent on the skipped reaction");
 
@@ -4800,11 +4840,30 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
 
     // Reaction 1: the judge reviews the diff and raises a finding.
     let (msgs1, src1) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None,
-        &mut 0u8, &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
-    assert_eq!(calls.load(Ordering::SeqCst), 1, "first reaction calls the judge");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "first reaction calls the judge"
+    );
     assert_eq!(src1, FollowUpSource::Critic);
     assert!(!msgs1.is_empty());
 
@@ -4821,8 +4880,23 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
     // fall-through must reach the TODO gate (unfinished todo present).
     let mut todo_nudges = 0u8;
     let (msgs2, src2) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None,
-        &mut todo_nudges, &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut todo_nudges,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
     assert_eq!(
@@ -4873,8 +4947,23 @@ async fn blocking_review_re_fires_judge_when_diff_changes_between_reactions() {
 
     // Reaction 1.
     let (msgs1, _src1) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
-        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
     assert_eq!(calls.load(Ordering::SeqCst), 1);
@@ -4885,8 +4974,23 @@ async fn blocking_review_re_fires_judge_when_diff_changes_between_reactions() {
 
     // Reaction 2: the diff CHANGED → the judge fires again.
     let (msgs2, src2) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
-        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
     assert_eq!(
@@ -4921,8 +5025,23 @@ async fn advisory_review_unaffected_by_last_reviewed_fingerprint() {
     let (emit, _rx) = tokio::sync::mpsc::channel(8);
 
     let (msgs1, src1) = poll_finalization_follow_up(
-        &config, "sys", &msgs_run, &mut critic_done, &mut reacts, &mut last_fp, &mut last_findings, None, &mut 0u8,
-        &mut 0u8, &mut 0u8, GateMode::Off, None, None, &mut 0u8, &mut 0u8, &emit,
+        &config,
+        "sys",
+        &msgs_run,
+        &mut critic_done,
+        &mut reacts,
+        &mut last_fp,
+        &mut last_findings,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &mut 0u8,
+        GateMode::Off,
+        None,
+        None,
+        &mut 0u8,
+        &mut 0u8,
+        &emit,
     )
     .await;
     assert_eq!(


### PR DESCRIPTION
## Problem

In Blocking code-review mode, the agent emits the same message 2–3 times — e.g. the model pushing back on a review finding, then repeating the identical rebuttal.

The unified finalization critic (`run_unified_review`) is a stateless judge call that re-reviews the run diff on every finalization, up to `MAX_REVIEW_REACT`. The only guard, `run_delta_to_review`, compares the current diff against the **run-start baseline** — never against the **previously-reviewed** diff. So when the model declines a finding and changes nothing on disk, the same diff is re-reviewed, the same finding is re-raised, and the model re-emits an identical rebuttal.

(The `⊕ repaired 0 input(s): ; 5 invalid` telemetry line that shows up nearby is unrelated — it's the per-run cumulative repair counter, not the duplicate driver.)

## Fix

- **Skip an unchanged re-review.** Track the last-reviewed diff fingerprint (uncapped `RunDiff::fingerprint`, per dirge-8gdv) and skip the judge when it matches. The skip **falls through** to the goal/todo/open-issues gates rather than short-circuiting finalization — an early return there would silently drop those nudges.
- **Prior findings on a changed diff.** When the diff did change, thread the prior reaction's findings into the next judge prompt with an instruction to re-raise only if the model's decline was factually wrong. `None`/blank prior findings produce a byte-identical prompt to before.

Blocking-only. Off/Advisory remain one-shot via `critic_done`.

## Tests

New tests in `run_tests.rs` and `critic.rs`:
- unchanged diff across reactions → judge skipped, no follow-up, budget preserved
- changed diff → judge re-fires (guard doesn't over-suppress)
- skipped reaction still falls through to the todo gate (regression test for the early-return bug)
- Advisory unaffected by the fingerprint state
- prompt omits/includes the prior-findings section for none/blank/present

`cargo test --bin dirge agent_loop` → 662 passed, 0 failed.
