### PR TITLE
fix(agent-loop): make Blocking-review tests parallel-safe

### DIFF
--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -605,6 +605,7 @@ pub fn spawn_loop_runner(cfg: LoopSpawnConfig) -> LoopRunner {
         critic_fn: cfg.critic_fn.clone(),
         code_review_fn: cfg.code_review_fn.clone(),
         code_review_mode: cfg.code_review_mode,
+        code_review_repo: None,
         open_issues_gate_mode: cfg.open_issues_gate_mode,
         session_id: cfg.session_id.clone(),
         goal_fn: cfg.goal_fn.clone(),

--- a/src/agent/agent_loop/integration_tests.rs
+++ b/src/agent/agent_loop/integration_tests.rs
@@ -88,6 +88,7 @@ fn build_config() -> LoopConfig {
         critic_fn: None,
         code_review_fn: None,
         code_review_mode: crate::agent::agent_loop::types::CodeReviewMode::default(),
+        code_review_repo: None,
         open_issues_gate_mode: crate::agent::agent_loop::types::GateMode::Off,
         session_id: None,
         goal_fn: None,

--- a/src/agent/agent_loop/plugin_hooks_tests.rs
+++ b/src/agent/agent_loop/plugin_hooks_tests.rs
@@ -102,6 +102,7 @@ fn build_config() -> LoopConfig {
         critic_fn: None,
         code_review_fn: None,
         code_review_mode: crate::agent::agent_loop::types::CodeReviewMode::default(),
+        code_review_repo: None,
         open_issues_gate_mode: crate::agent::agent_loop::types::GateMode::Off,
         session_id: None,
         goal_fn: None,

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -407,8 +407,11 @@ async fn poll_finalization_follow_up(
             // reviews of the same diff and skip a redundant stateless judge call.
             let (diff_owned, current_fingerprint): (Option<String>, Option<u64>) =
                 if mode != CodeReviewMode::Off {
-                    let repo =
-                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+                    // dirge-9b2k: honor an explicit repo override (tests inject a
+                    // temp tree); production leaves it None → process CWD.
+                    let repo = config.code_review_repo.clone().unwrap_or_else(|| {
+                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+                    });
                     // Diff capture shells out to git — do it off the async runtime.
                     let captured = tokio::task::spawn_blocking(move || {
                         super::code_review::capture_run_diff(&repo)
@@ -1482,7 +1485,10 @@ pub async fn run_loop(
     // and could block the loop. Only needed when the reviewer is armed.
     let code_review_baseline: Option<super::code_review::RunDiff> =
         if config.code_review_fn.is_some() {
-            let repo = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            // dirge-9b2k: same repo-override seam as the finalization poll.
+            let repo = config.code_review_repo.clone().unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+            });
             tokio::task::spawn_blocking(move || super::code_review::capture_run_diff(&repo))
                 .await
                 .ok()

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -138,6 +138,7 @@ fn build_config() -> LoopConfig {
         critic_fn: None,
         code_review_fn: None,
         code_review_mode: crate::agent::agent_loop::types::CodeReviewMode::default(),
+        code_review_repo: None,
         open_issues_gate_mode: crate::agent::agent_loop::types::GateMode::Off,
         session_id: None,
         goal_fn: None,
@@ -4647,26 +4648,10 @@ async fn open_issues_gate_advisory_emits_notice_but_does_not_reenter() {
 // model re-emits the identical rebuttal — a duplicate. The fix skips the judge
 // when this exact diff (by uncapped fingerprint) was reviewed last reaction.
 
-/// Serialize tests that flip the process-global CWD, since git diff capture
-/// reads `current_dir()`. Without this, two such tests race under parallel
-/// execution and each captures the other's tree.
-static REVIEW_CWD_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Restore the CWD on drop — even if the test panics mid-assertion after
-/// `set_current_dir`, so a failed Blocking test can't strand the suite in a
-/// temp dir that gets removed.
-struct CwdGuard {
-    orig: std::path::PathBuf,
-}
-impl Drop for CwdGuard {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.orig);
-    }
-}
-
 /// A temp git repo with one committed file and one uncommitted edit, so
-/// `capture_run_diff` yields a stable, non-empty diff. Caller must hold
-/// [`REVIEW_CWD_TEST_LOCK`] and have moved the CWD nowhere else.
+/// `capture_run_diff` yields a stable, non-empty diff. The caller points the
+/// reviewer at it via `config.code_review_repo`, so these tests never touch the
+/// process-global CWD and can run in parallel with any other test.
 fn temp_review_repo(suffix: &str) -> std::path::PathBuf {
     let dir = temp_dir(&format!("blocking-review-{suffix}"));
     let git = |args: &[&str]| {
@@ -4713,21 +4698,16 @@ fn counting_judge(calls: &Arc<AtomicUsize>) -> crate::agent::agent_loop::critic:
 }
 
 #[tokio::test]
-#[allow(clippy::await_holding_lock)] // current-thread runtime; lock only serializes CWD
 async fn blocking_review_skips_judge_when_diff_unchanged_across_reactions() {
     use crate::agent::agent_loop::types::CodeReviewMode;
 
-    let _lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
     let repo = temp_review_repo("skip");
-    let guard = CwdGuard {
-        orig: std::env::current_dir().unwrap(),
-    };
-    std::env::set_current_dir(&repo).unwrap();
 
     let calls = Arc::new(AtomicUsize::new(0));
     let mut config = build_config();
     config.critic_fn = Some(counting_judge(&calls));
     config.code_review_mode = CodeReviewMode::Blocking;
+    config.code_review_repo = Some(repo.clone());
 
     let msgs_run = run_with_tool_result();
     let mut critic_done = false;
@@ -4804,41 +4784,43 @@ async fn blocking_review_skips_judge_when_diff_unchanged_across_reactions() {
     assert_eq!(src2, FollowUpSource::None);
     assert_eq!(reacts, 1, "budget not spent on the skipped reaction");
 
-    drop(guard);
     let _ = std::fs::remove_dir_all(&repo);
 }
 
 /// dirge-9b2k regression: the Blocking dedupe skip must NOT early-return out of
 /// `poll_finalization_follow_up` — it must fall through to the downstream gates.
-/// Here reaction 2 skips the judge (unchanged diff), but an unfinished todo is
-/// present, so the TODO gate fires instead of finalizing with `None`. An earlier
-/// version of the guard `return`ed on skip, silently dropping the todo nudge.
+/// Here reaction 2 skips the critic (unchanged diff), and the GOAL gate fires
+/// instead of finalizing with `None`. An earlier version of the guard `return`ed
+/// on skip, silently dropping that follow-up. The goal gate is config-injected,
+/// so this test carries no process-global state and is parallel-safe.
 #[tokio::test]
-#[allow(clippy::await_holding_lock)] // current-thread runtime; locks only serialize CWD + TODO_LIST
 async fn blocking_review_skip_falls_through_to_downstream_gate() {
     use crate::agent::agent_loop::types::CodeReviewMode;
-    use crate::agent::tools::todo::{TODO_LIST, TodoItem};
 
-    let _cwd_lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
     let repo = temp_review_repo("fallthrough");
-    let guard = CwdGuard {
-        orig: std::env::current_dir().unwrap(),
-    };
-    std::env::set_current_dir(&repo).unwrap();
 
     let calls = Arc::new(AtomicUsize::new(0));
     let mut config = build_config();
     config.critic_fn = Some(counting_judge(&calls));
     config.code_review_mode = CodeReviewMode::Blocking;
+    config.code_review_repo = Some(repo.clone());
+    // A downstream goal gate whose stop condition is never met — an unmet goal
+    // re-enters the loop, so its firing proves the skip fell through the critic.
+    config.goal = Some("ship it".to_string());
+    config.goal_fn = Some(Arc::new(|_p: String| {
+        Box::pin(async { Ok("GOAL: UNMET\n- keep going".to_string()) })
+    }));
 
     let msgs_run = run_with_tool_result();
     let mut critic_done = false;
     let mut reacts = 0u8;
     let mut last_fp: Option<u64> = None;
     let mut last_findings: Option<String> = None;
+    let mut goal_reacts = 0u8;
     let (emit, _emit_rx) = tokio::sync::mpsc::channel(8);
 
-    // Reaction 1: the judge reviews the diff and raises a finding.
+    // Reaction 1: the critic reviews the diff and raises a finding, returning
+    // before the goal gate is reached.
     let (msgs1, src1) = poll_finalization_follow_up(
         &config,
         "sys",
@@ -4848,7 +4830,7 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
         &mut last_fp,
         &mut last_findings,
         None,
-        &mut 0u8,
+        &mut goal_reacts,
         &mut 0u8,
         &mut 0u8,
         GateMode::Off,
@@ -4862,23 +4844,17 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
     assert_eq!(
         calls.load(Ordering::SeqCst),
         1,
-        "first reaction calls the judge"
+        "first reaction calls the critic"
     );
     assert_eq!(src1, FollowUpSource::Critic);
     assert!(!msgs1.is_empty());
+    assert_eq!(
+        goal_reacts, 0,
+        "goal gate not reached while the critic fires"
+    );
 
-    // Plant an unfinished todo so the TODO gate is armed for reaction 2.
-    // Set it WITHOUT holding the lock across the poll — `unfinished_count()`
-    // inside the poll re-locks TODO_LIST, and std Mutex isn't reentrant.
-    *TODO_LIST.lock().unwrap() = vec![TodoItem {
-        content: "still open".into(),
-        status: "open".into(),
-        priority: "normal".into(),
-    }];
-
-    // Reaction 2: the diff on disk is UNCHANGED → the judge is skipped, BUT the
-    // fall-through must reach the TODO gate (unfinished todo present).
-    let mut todo_nudges = 0u8;
+    // Reaction 2: the diff on disk is UNCHANGED → the critic is skipped, BUT the
+    // fall-through must reach the goal gate.
     let (msgs2, src2) = poll_finalization_follow_up(
         &config,
         "sys",
@@ -4888,7 +4864,7 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
         &mut last_fp,
         &mut last_findings,
         None,
-        &mut todo_nudges,
+        &mut goal_reacts,
         &mut 0u8,
         &mut 0u8,
         GateMode::Off,
@@ -4902,41 +4878,34 @@ async fn blocking_review_skip_falls_through_to_downstream_gate() {
     assert_eq!(
         calls.load(Ordering::SeqCst),
         1,
-        "judge NOT called again on an unchanged diff"
+        "critic NOT called again on an unchanged diff"
     );
     assert!(
         !msgs2.is_empty(),
-        "the skipped reaction must fall through to the todo gate"
+        "the skipped reaction must fall through to the goal gate"
     );
     assert_eq!(
         src2,
-        FollowUpSource::Todo,
-        "the TODO gate fires, not Critic and not None"
+        FollowUpSource::Goal,
+        "the goal gate fires, not Critic and not None"
     );
-    assert_eq!(reacts, 1, "budget not spent on the skipped reaction");
+    assert_eq!(reacts, 1, "critic budget not spent on the skipped reaction");
+    assert_eq!(goal_reacts, 1, "the goal gate fired on the fall-through");
 
-    // Restore the global so no other test sees our planted todo.
-    TODO_LIST.lock().unwrap().clear();
-    drop(guard);
     let _ = std::fs::remove_dir_all(&repo);
 }
 
 #[tokio::test]
-#[allow(clippy::await_holding_lock)] // current-thread runtime; lock only serializes CWD
 async fn blocking_review_re_fires_judge_when_diff_changes_between_reactions() {
     use crate::agent::agent_loop::types::CodeReviewMode;
 
-    let _lock = REVIEW_CWD_TEST_LOCK.lock().unwrap();
     let repo = temp_review_repo("changed");
-    let guard = CwdGuard {
-        orig: std::env::current_dir().unwrap(),
-    };
-    std::env::set_current_dir(&repo).unwrap();
 
     let calls = Arc::new(AtomicUsize::new(0));
     let mut config = build_config();
     config.critic_fn = Some(counting_judge(&calls));
     config.code_review_mode = CodeReviewMode::Blocking;
+    config.code_review_repo = Some(repo.clone());
 
     let msgs_run = run_with_tool_result();
     let mut critic_done = false;
@@ -5001,7 +4970,6 @@ async fn blocking_review_re_fires_judge_when_diff_changes_between_reactions() {
     assert!(!msgs2.is_empty());
     assert_eq!(src2, FollowUpSource::Critic);
 
-    drop(guard);
     let _ = std::fs::remove_dir_all(&repo);
 }
 

--- a/src/agent/agent_loop/steering.rs
+++ b/src/agent/agent_loop/steering.rs
@@ -388,6 +388,7 @@ mod tests {
             critic_fn: None,
             code_review_fn: None,
             code_review_mode: crate::agent::agent_loop::types::CodeReviewMode::default(),
+            code_review_repo: None,
             open_issues_gate_mode: crate::agent::agent_loop::types::GateMode::Off,
             session_id: None,
             goal_fn: None,

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -238,6 +238,7 @@ fn build_config() -> LoopConfig {
         critic_fn: None,
         code_review_fn: None,
         code_review_mode: crate::agent::agent_loop::types::CodeReviewMode::default(),
+        code_review_repo: None,
         open_issues_gate_mode: crate::agent::agent_loop::types::GateMode::Off,
         session_id: None,
         goal_fn: None,

--- a/src/agent/agent_loop/types.rs
+++ b/src/agent/agent_loop/types.rs
@@ -510,6 +510,13 @@ pub struct LoopConfig {
     /// default is [`CodeReviewMode::Advisory`].
     pub code_review_mode: CodeReviewMode,
 
+    /// Repository root for the finalization reviewer's diff capture. `None`
+    /// (production default) falls back to the process working directory. Set
+    /// explicitly so a caller — or a test — can capture the diff of a specific
+    /// tree without depending on the process-global CWD (which parallel tests
+    /// race).
+    pub code_review_repo: Option<std::path::PathBuf>,
+
     /// How the open-issues finalization gate engages. Default `Off`
     /// (opt-in). Resolved at `build_agent` time from
     /// `Config::resolve_open_issues_gate_mode`.
@@ -740,6 +747,7 @@ impl Clone for LoopConfig {
             critic_fn: self.critic_fn.clone(),
             code_review_fn: self.code_review_fn.clone(),
             code_review_mode: self.code_review_mode,
+            code_review_repo: self.code_review_repo.clone(),
             open_issues_gate_mode: self.open_issues_gate_mode,
             session_id: self.session_id.clone(),
             goal_fn: self.goal_fn.clone(),
@@ -797,6 +805,7 @@ impl LoopConfig {
             critic_fn: None,
             code_review_fn: None,
             code_review_mode: CodeReviewMode::Advisory,
+            code_review_repo: None,
             open_issues_gate_mode: GateMode::Off,
             session_id: None,
             goal_fn: None,


### PR DESCRIPTION
## Problem

CI [run 29619940422](https://github.com/dirge-code/dirge/actions/runs/29619940422) failed on `build (dap)` at `blocking_review_skips_judge_when_diff_unchanged_across_reactions` — "judge NOT called again on an unchanged diff." Green in every other job; the `dap,plugin` feature set compiles a different test binary, so its parallel schedule exposed two races that the default build happened to dodge.

Both are test-only races on process-global state (the finalization-review tests added in #681):

1. **Process CWD.** The reviewer captures its diff from `current_dir()`. These tests `set_current_dir` into a temp git repo, but any *other* parallel test that flips CWD corrupts the second reaction's fingerprint → the dedupe skip doesn't fire → the judge is called twice → assertion fails. A `REVIEW_CWD_TEST_LOCK` only serialized these tests against each other, not against the rest of the suite.
2. **Global `TODO_LIST`.** `blocking_review_skip_falls_through` planted an unfinished todo in the process-global `TODO_LIST` to arm a downstream gate. While planted, concurrent full-loop `run()` tests read it at finalization and flaked (`test_emits_full_agent_loop_event_sequence`, `h7_scenario_2`, …).

## Fix

- Add `LoopConfig.code_review_repo: Option<PathBuf>`. `None` (production) → process CWD, behavior unchanged; tests set it to the temp repo, so the reviewer's two capture sites (finalization poll + run-start baseline) never read the process CWD. The three Blocking tests drop `set_current_dir` / `CwdGuard` / the CWD lock entirely — they're now CWD-independent.
- Rewrite `blocking_review_skip_falls_through` to prove fall-through via the **goal gate** (config-injected `goal` + `goal_fn`) instead of the global `TODO_LIST`. No process-global state.

## Verification

- Exact CI command `cargo test --bin dirge --features dap,plugin`: **4454 passed, 0 failed**.
- `agent_loop` suite under `dap,plugin` hammered **10× consecutively, all green**.
- Default features + `clippy` clean; `rustfmt` clean.
