### PR TITLE
docs: Cerebras base_url example + 0.19.14 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to dirge are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.14] - 2026-07-18
+
+### Added
+- Cerebras as a first-class provider. Set `CEREBRAS_API_KEY` and select it with
+  `--provider cerebras` (or a `providers.cerebras` entry); defaults to
+  `gemma-4-31b` against `https://api.cerebras.ai/v1`. Reasoning effort is clamped
+  to `low`/`medium`/`high`, and image input is model-specific (`gemma-4-31b`
+  only). `CEREBRAS_API_KEY` is isolated from other providers (#683).
+
 ## [0.19.13] - 2026-07-17
 
 ### Fixed

--- a/docs/config.md
+++ b/docs/config.md
@@ -308,7 +308,19 @@ model override; keep the secret in `CEREBRAS_API_KEY`:
 ```
 
 Set `providers.cerebras.base_url` to an HTTPS proxy or custom Cerebras
-endpoint. Dirge does not read a separate `CEREBRAS_BASE_URL` variable.
+endpoint. Dirge does not read a separate `CEREBRAS_BASE_URL` variable:
+
+```json
+{
+  "provider": "cerebras",
+  "providers": {
+    "cerebras": {
+      "model": "gemma-4-31b",
+      "base_url": "https://cerebras-proxy.example.com/v1"
+    }
+  }
+}
+```
 
 Reasoning and image support depend on the model. For `gemma-4-31b`, Dirge
 sends top-level `reasoning_effort` values (`low`, `medium`, or `high`) and


### PR DESCRIPTION
Follow-ups to #683 (tracked in `dirge-asly`).

- **docs/config.md** — add a config example for the `providers.cerebras.base_url` override (the section had the prose note but no example; GLM reviewer's suggestion).
- **CHANGELOG.md** — add the `0.19.14` entry for the Cerebras provider, which merged in #683 without one.

Deliberately left the other review nits: the README provider lists already include `cerebras` consistently (the `provider_type` list is alphabetical with it), and `client.rs`'s module doc going generic is better than the stale "8-backend" count it replaced.

Docs/changelog only — no code change.