### PR TITLE
test(config): cover provider header ${ENV_VAR} interpolation + 0.19.15 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to dirge are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.15] - 2026-07-18
+
+### Added
+- Custom per-provider HTTP headers via `providers.<name>.headers` (a
+  name → value map). A value that is exactly `${ENV_VAR}` is resolved from the
+  environment; header names and values are validated before the client is built
+  (#686).
+- `--verbose` now logs HTTP request method/URI/status and classifies stream and
+  retry errors (abort, timeout, network, auth, rate-limit), making API failures
+  easier to diagnose. The logged URI has its query string stripped so a
+  credential embedded there (e.g. Gemini's `?key=`) never reaches the logs
+  (#685).
+
 ## [0.19.14] - 2026-07-18
 
 ### Added

--- a/docs/config.md
+++ b/docs/config.md
@@ -278,7 +278,7 @@ Each `providers` entry accepts:
 | `allow_insecure` | Allow `http://` URLs (plaintext). Default `false`; only enable for local-only proxies. |
 | `stream_chunk_timeout_secs` | Per-provider streaming chunk timeout override. |
 | `multimodal` | Override for whether this provider/model accepts image input (gates the Ctrl+V image-paste UX). `true`/`false` forces it either way; omit to auto-detect from the model name and provider type. Set `true` to enable pasting into a local vision model (e.g. Ollama `llama3.2-vision`) behind a generic provider type. |
-| `headers` | Extra HTTP request headers. Values may be literal strings or `${ENV_VAR}` references. |
+| `headers` | Extra HTTP request headers. A value that is exactly `${ENV_VAR}` is replaced by that environment variable (an unset variable is a hard error); any other value, including one with `${…}` embedded in surrounding text, is sent literally. |
 | `options` | Free-form per-provider model options; currently honors `temperature`. |
 
 The aliases on the left of the map become the values you write in

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -142,6 +142,19 @@ impl ProviderEntry {
 mod provider_entry_tests {
     use super::ProviderEntry;
 
+    /// Serializes the env-mutating test. `std::env::set_var` is `unsafe`
+    /// because environment mutation is process-global; concurrent tests racing
+    /// on env would flake.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Removes the test env var on drop so a panic mid-test can't leak it.
+    struct EnvGuard(&'static str);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(self.0) };
+        }
+    }
+
     #[test]
     fn resolves_literal_headers() {
         let entry: ProviderEntry = serde_json::from_value(serde_json::json!({
@@ -156,6 +169,31 @@ mod provider_entry_tests {
     fn rejects_invalid_header_values() {
         let entry: ProviderEntry = serde_json::from_value(serde_json::json!({
             "headers": {"X-Title": "bad\nvalue"}
+        }))
+        .unwrap();
+        assert!(entry.resolved_headers().is_err());
+    }
+
+    #[test]
+    fn resolves_env_var_headers() {
+        const VAR: &str = "DIRGE_TEST_HEADER_TOKEN";
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var(VAR, "s3cr3t") };
+        let _guard = EnvGuard(VAR);
+        let entry: ProviderEntry = serde_json::from_value(serde_json::json!({
+            "headers": {"Authorization": format!("${{{VAR}}}")}
+        }))
+        .unwrap();
+        let headers = entry.resolved_headers().unwrap();
+        assert_eq!(headers.get("authorization").unwrap(), "s3cr3t");
+    }
+
+    #[test]
+    fn rejects_unset_env_var_headers() {
+        // A whole-value `${VAR}` that points at an unset variable is a hard
+        // error, not a silent empty header.
+        let entry: ProviderEntry = serde_json::from_value(serde_json::json!({
+            "headers": {"Authorization": "${DIRGE_DEFINITELY_UNSET_HEADER_VAR}"}
         }))
         .unwrap();
         assert!(entry.resolved_headers().is_err());


### PR DESCRIPTION
Follow-up to #686 (`dirge-t77v`).

- **Tests** for the `${ENV_VAR}` branch of `ProviderEntry::resolved_headers` — a set var resolves, an unset var errors — which the merged PR's two tests didn't cover. Uses the `ENV_LOCK` + `unsafe set_var` + RAII-cleanup pattern the codebase's other env tests use, so it's parallel-safe.
- **Docs:** clarify that `${ENV_VAR}` interpolation is whole-value only (`Bearer ${TOKEN}` is sent literally).
- **CHANGELOG:** add the `0.19.15` entry for #685 (verbose logging) and #686 (custom headers), which shipped without changelog entries.

Tests + docs only.