### PR TITLE
Treat provider usage-cap 429s as non-retryable

### DIFF
--- a/src/agent/recovery.rs
+++ b/src/agent/recovery.rs
@@ -45,10 +45,26 @@ static STATUS_5XX_RE: LazyLock<Regex> = LazyLock::new(|| {
 pub enum ErrorKind {
     ContextLength,
     RateLimit,
+    /// A rate-limit-shaped 429 whose quota won't reset within a window
+    /// we're willing to wait out — a provider usage cap (e.g. Zhipu/GLM's
+    /// "5-hour usage limit", error code 1308), or any 429 whose
+    /// `Retry-After` exceeds [`MAX_IN_RUN_RETRY_WAIT`]. Split from
+    /// [`RateLimit`] because retrying with the capped backoff just
+    /// re-hits the cap (burning the retry budget and stalling the run for
+    /// minutes before dying mid-task); the run should stop cleanly and
+    /// resume after the quota resets instead. Non-retryable, like Auth.
+    UsageCap,
     Network,
     Auth,
     Other,
 }
+
+/// A rate-limit whose server-requested wait is longer than this is
+/// treated as an [`ErrorKind::UsageCap`] rather than a retryable
+/// [`ErrorKind::RateLimit`]: our backoff caps at the same 5 minutes
+/// (`backoff_duration_for_msg`), so retrying sooner than the server asked
+/// just earns another 429. Matches that ceiling.
+pub(crate) const MAX_IN_RUN_RETRY_WAIT: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Clone)]
 pub struct RecoveryPolicy {
@@ -264,6 +280,30 @@ pub(crate) fn retry_after_from_error_msg(msg: &str) -> Option<Duration> {
     None
 }
 
+/// Best-effort human-readable reset time for a usage-cap error, for
+/// surfacing "resets at …" to the user. Recognizes an ISO-ish
+/// `YYYY-MM-DD HH:MM[:SS]` timestamp anywhere in the message — the form
+/// Zhipu/GLM emits ("您的限额将在 2026-07-18 07:41:55 重置" / "resets at …");
+/// failing that, derives a relative hint from a `Retry-After` header.
+/// `None` when neither is present.
+pub fn usage_cap_reset_hint(msg: &str) -> Option<String> {
+    static RESET_TS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2})?").expect("static regex compiles")
+    });
+    if let Some(m) = RESET_TS_RE.find(msg) {
+        return Some(m.as_str().to_string());
+    }
+    let wait = retry_after_from_error_msg(msg)?;
+    let secs = wait.as_secs();
+    Some(if secs >= 3600 {
+        format!("~{}h from now", secs / 3600)
+    } else if secs >= 60 {
+        format!("~{}m from now", secs / 60)
+    } else {
+        format!("~{secs}s from now")
+    })
+}
+
 /// Scan `msg` for a `Retry-After:` header whose value parses as an
 /// RFC 7231 HTTP-date (IMF-fixdate, RFC 850, or asctime form). Returns
 /// the time from now until that date, clamped to 0 if in the past.
@@ -383,29 +423,49 @@ pub fn classify_error(msg: &str) -> ErrorKind {
         return ErrorKind::Auth;
     }
 
-    if lower.contains("rate limit") || lower.contains("too many requests") {
-        return ErrorKind::RateLimit;
+    // Usage caps: rate-limit-shaped responses whose quota won't reset
+    // within a retryable window. Zhipu/GLM returns HTTP 429 code 1308 with
+    // a multi-hour reset ("已达到 5 小时的使用上限" — reached the 5-hour usage
+    // limit); it contains "too many requests", so it MUST be caught before
+    // the generic rate-limit arm below or it'd be retried futilely (the
+    // reset is hours out; our backoff caps at 5 min — the run stalls
+    // through its budget, then dies mid-task). Match the unambiguous cap
+    // wording, not the 429 shell, so a momentary throttle stays retryable.
+    if lower.contains("使用上限")            // Zhipu: "usage limit / ceiling"
+        || lower.contains("usage limit")
+        || lower.contains("usage cap")
+        || lower.contains("daily limit")
+        || lower.contains("quota exceeded")
+        || lower.contains("code\":\"1308")   // Zhipu usage-cap error code
+        || lower.contains("code\": \"1308")
+    {
+        return ErrorKind::UsageCap;
     }
 
-    if lower.contains(" 429 ") || lower.contains("error 429") || lower.starts_with("429 ") {
-        return ErrorKind::RateLimit;
-    }
-
-    // PROV-7: Gemini emits 429s with body
-    // `{"error":{"status":"RESOURCE_EXHAUSTED",…}}` that often
-    // arrive stringified without the literal " 429 " or "rate
-    // limit" wording. Treat as transient so the backoff loop runs.
-    if lower.contains("resource_exhausted") || lower.contains("resource has been exhausted") {
-        return ErrorKind::RateLimit;
-    }
-
-    // Anthropic's `overloaded_error` is a transient capacity signal —
-    // structurally a rate-limit response without the "rate limit" /
-    // "too many" wording. Classify as RateLimit so the retry-with-
-    // backoff policy applies; previously it fell through to `Other`
-    // and the user saw a one-shot failure on transient backend
-    // pressure.
-    if lower.contains("overloaded") {
+    // Rate-limit-shaped 429s. PROV-7: Gemini emits `RESOURCE_EXHAUSTED`
+    // bodies without the literal " 429 " / "rate limit" wording;
+    // Anthropic's `overloaded_error` is a transient capacity signal
+    // shaped like a rate-limit without that wording. All are transient —
+    // retry with backoff — UNLESS the server's `Retry-After` is longer
+    // than we'll wait (a usage cap in disguise; see below).
+    let rate_limited = lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains(" 429 ")
+        || lower.contains("error 429")
+        || lower.starts_with("429 ")
+        || lower.contains("resource_exhausted")
+        || lower.contains("resource has been exhausted")
+        || lower.contains("overloaded");
+    if rate_limited {
+        // A rate-limit whose requested wait exceeds our backoff ceiling
+        // is effectively a usage cap: retrying at the capped delay just
+        // re-hits it. Stop cleanly (UsageCap) rather than burning the
+        // budget on retries that can't succeed.
+        if let Some(wait) = retry_after_from_error_msg(msg)
+            && wait > MAX_IN_RUN_RETRY_WAIT
+        {
+            return ErrorKind::UsageCap;
+        }
         return ErrorKind::RateLimit;
     }
 
@@ -527,6 +587,10 @@ pub fn user_facing_error(msg: &str, attempts: usize) -> String {
         ErrorKind::RateLimit => (
             "provider rate-limited the request",
             "wait a moment and retry, or switch to a different model via /model",
+        ),
+        ErrorKind::UsageCap => (
+            "provider usage cap reached — the quota won't reset within a retryable window",
+            "wait for the quota to reset (see the reset time in the cause), then re-run to resume; or switch providers via /model",
         ),
         ErrorKind::ContextLength => (
             "conversation exceeds the model's context window",
@@ -826,6 +890,84 @@ mod tests {
             classify_error("received http 502 from upstream"),
             ErrorKind::Network
         );
+    }
+
+    /// dirge-u6zc: Zhipu/GLM's 5-hour usage cap (HTTP 429, code 1308) is
+    /// a UsageCap, not a retryable RateLimit — retrying just re-hits it.
+    #[test]
+    fn zhipu_usage_cap_1308_is_usage_cap_not_ratelimit() {
+        let msg = r#"ProviderError: Invalid status code 429 Too Many Requests with message: {"error":{"code":"1308","message":"已达到 5 小时的使用上限。您的限额将在 2026-07-18 07:41:55 重置。"}}"#;
+        assert_eq!(classify_error(msg), ErrorKind::UsageCap);
+    }
+
+    /// A rate-limit whose Retry-After exceeds our backoff ceiling is a
+    /// usage cap in disguise — retrying at the capped delay can't succeed.
+    #[test]
+    fn long_retry_after_promotes_ratelimit_to_usage_cap() {
+        assert_eq!(
+            classify_error("429 Too Many Requests; Retry-After: 18000"),
+            ErrorKind::UsageCap
+        );
+    }
+
+    /// A short Retry-After stays a retryable RateLimit — a momentary
+    /// throttle, not a cap.
+    #[test]
+    fn short_retry_after_stays_ratelimit() {
+        assert_eq!(
+            classify_error("429 Too Many Requests; Retry-After: 30"),
+            ErrorKind::RateLimit
+        );
+    }
+
+    /// A plain 429 with no cap signal and no long Retry-After stays a
+    /// retryable RateLimit (regression guard for the common case).
+    #[test]
+    fn plain_429_without_cap_signal_stays_ratelimit() {
+        assert_eq!(
+            classify_error("HTTP 429 Too Many Requests"),
+            ErrorKind::RateLimit
+        );
+        assert_eq!(classify_error("rate limit exceeded"), ErrorKind::RateLimit);
+        assert_eq!(classify_error("overloaded_error"), ErrorKind::RateLimit);
+    }
+
+    /// UsageCap is non-retryable — the retry policy must not burn the
+    /// budget on it.
+    #[test]
+    fn usage_cap_is_not_retryable() {
+        let p = RecoveryPolicy::default();
+        assert!(!p.should_retry(0, ErrorKind::UsageCap));
+    }
+
+    /// The reset hint pulls the Zhipu timestamp so the user knows when
+    /// to resume; a Retry-After yields a relative hint.
+    #[test]
+    fn usage_cap_reset_hint_extracts_reset_time() {
+        let zhipu = r#"{"code":"1308","message":"已达到 5 小时的使用上限。您的限额将在 2026-07-18 07:41:55 重置。"}"#;
+        assert_eq!(
+            usage_cap_reset_hint(zhipu).as_deref(),
+            Some("2026-07-18 07:41:55")
+        );
+        assert_eq!(
+            usage_cap_reset_hint("429; Retry-After: 18000").as_deref(),
+            Some("~5h from now")
+        );
+        assert_eq!(
+            usage_cap_reset_hint("plain error, no reset").as_deref(),
+            None
+        );
+    }
+
+    /// UsageCap gets its own user-facing headline distinct from RateLimit.
+    #[test]
+    fn user_facing_error_classifies_usage_cap() {
+        let pretty = user_facing_error(
+            r#"429 Too Many Requests {"code":"1308","message":"使用上限"}"#,
+            2,
+        );
+        assert!(pretty.to_lowercase().contains("usage cap"));
+        assert!(pretty.contains("cause:"));
     }
 
     /// `user_facing_error` produces a multi-line message with headline,

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -24,6 +24,11 @@ pub(crate) enum RunEnd {
     /// The event channel closed without a `Done` — the runner died
     /// (panic/abort) and `full_response` is whatever streamed first.
     Incomplete,
+    /// A provider usage cap (dirge-u6zc) stopped the run: the quota won't
+    /// reset within a retryable window (e.g. Zhipu/GLM's 5-hour limit).
+    /// Distinct from `Incomplete` so a consumer can tell "pause and resume
+    /// after the quota resets" from a genuine runner failure.
+    UsageCapped,
 }
 
 /// Build the machine-readable result envelope for the headless modes.
@@ -41,6 +46,9 @@ pub(crate) fn headless_result_json(
         // Matches the Claude Code stream-json convention dirge mimics.
         RunEnd::Truncated => ("error_max_turns", true),
         RunEnd::Incomplete => ("error", true),
+        // dirge-u6zc: a quota pause, not a task failure — a resuming
+        // wrapper keys on this subtype to re-run after the reset.
+        RunEnd::UsageCapped => ("error_usage_cap", true),
     };
     serde_json::json!({
         "type": "result",
@@ -191,6 +199,10 @@ impl AnyAgent {
         // can't claim success for a truncated or runner-died run.
         let mut completed = false;
         let mut truncated = false;
+        // dirge-u6zc: a provider usage cap stopped the run (quota reset is
+        // hours out — not retryable). Flagged from the Error arm so the
+        // envelope reports a distinct, resumable outcome.
+        let mut usage_capped = false;
         // Accumulate the turn's tool calls so the headless save is
         // full-fidelity (matching the interactive path). Without this the
         // saved assistant message carried only its final text, so a resumed
@@ -276,6 +288,30 @@ impl AnyAgent {
                 AgentEvent::Error(err) => {
                     if had_output {
                         println!();
+                    }
+                    // dirge-u6zc: a provider usage cap isn't a failure to
+                    // retry — the quota resets hours out, so retrying just
+                    // re-hits it. Stop cleanly with a distinct, resumable
+                    // outcome (the session is saved below) and tell the user
+                    // when the quota resets, rather than dumping a raw
+                    // ProviderError and exiting like a hard failure.
+                    if matches!(
+                        crate::agent::recovery::classify_error(&err),
+                        crate::agent::recovery::ErrorKind::UsageCap
+                    ) {
+                        usage_capped = true;
+                        let resume = format!(
+                            "Session {session_id} saved; re-run (e.g. `dirge --continue`) once the quota resets to resume."
+                        );
+                        match crate::agent::recovery::usage_cap_reset_hint(&err) {
+                            Some(reset) => eprintln!(
+                                "Provider usage cap reached — quota resets at {reset}. {resume}\n  ↳ cause: {err}"
+                            ),
+                            None => eprintln!(
+                                "Provider usage cap reached — quota won't reset within a retryable window. {resume}\n  ↳ cause: {err}"
+                            ),
+                        }
+                        break;
                     }
                     eprintln!("Error: {}", err);
                     let _ = task.await;
@@ -365,7 +401,9 @@ impl AnyAgent {
         // dirge-18v2: classify how the stream ended. A truncated run
         // or one whose runner died without a Done must not produce a
         // success envelope.
-        let end = if !completed {
+        let end = if usage_capped {
+            RunEnd::UsageCapped
+        } else if !completed {
             RunEnd::Incomplete
         } else if truncated {
             RunEnd::Truncated
@@ -437,6 +475,14 @@ impl AnyAgent {
                 "run ended without completing — the agent runner stopped before producing a result"
             ));
         }
+        // dirge-u6zc: exit non-zero on a usage cap so a non-JSON script
+        // consumer notices the run paused; the envelope's `error_usage_cap`
+        // subtype and the stderr reset hint distinguish it from a failure.
+        if end == RunEnd::UsageCapped {
+            return Err(anyhow::anyhow!(
+                "provider usage cap reached — run paused before completion; resume after the quota resets"
+            ));
+        }
         Ok((full_response, tool_calls))
     }
 }
@@ -462,6 +508,14 @@ mod tests {
         let died = headless_result_json(RunEnd::Incomplete, 10, 1, "fragment", "sid");
         assert_eq!(died["subtype"], "error");
         assert_eq!(died["is_error"], true);
+
+        // dirge-u6zc: a usage-cap pause is a distinct, resumable outcome —
+        // its own subtype so a wrapper can re-run after the reset, not the
+        // generic "error" it'd share with a runner death.
+        let capped = headless_result_json(RunEnd::UsageCapped, 10, 5, "partial", "sid");
+        assert_eq!(capped["subtype"], "error_usage_cap");
+        assert_eq!(capped["is_error"], true);
+        assert_eq!(capped["result"], "partial", "partial work still delivered");
     }
 
     /// dirge-kuqp: a turn's assistant event carries its streamed text


### PR DESCRIPTION
## Problem

A headless multi-stage run in a real project died at stage 6/6 with:

```
Error: ProviderError: Invalid status code 429 Too Many Requests with message:
  {"error":{"code":"1308","message":"已达到 5 小时的使用上限。您的限额将在 2026-07-18 07:41:55 重置。"}}
```

GLM/Zhipu's 5-hour usage cap (HTTP 429, code 1308) is shaped like a rate-limit, so `classify_error` tagged it `RateLimit` → retryable. But the quota resets *hours* out while backoff caps at 5 min, so every retry re-hit the cap, burned the retry budget (looking like a stall), then the run terminated mid-task. In headless there's no human to resume, and it exited looking like a generic failure.

## Fix

**Classification (`recovery.rs`)** — new `ErrorKind::UsageCap`:
- `classify_error` routes to it, *before* the generic rate-limit arm, for the Zhipu `1308` / `使用上限` and English `usage limit` / `usage cap` / `daily limit` / `quota exceeded` wording, **and** any rate-limit-shaped 429 whose `Retry-After` exceeds the 5-min backoff ceiling (`MAX_IN_RUN_RETRY_WAIT`).
- `UsageCap` is non-retryable: `should_retry` excludes it and `run.rs`'s transient-recovery arm (`matches!(… Network | RateLimit)`) excludes it — so the run stops cleanly instead of stalling through the budget.
- `usage_cap_reset_hint()` extracts the reset timestamp; `user_facing_error` gets a matching arm.

**Headless surfacing (`provider/run.rs`)** — resumable outcome:
- New `RunEnd::UsageCapped` → envelope subtype `error_usage_cap`, `is_error: true` (distinct from the generic `error` a runner-death gets, so a wrapper can tell "resume after reset" from "failed").
- `run_print` prints `Provider usage cap reached — quota resets at <time>. Session <id> saved; re-run (e.g. \`dirge --continue\`) …` and exits non-zero distinctly. The session is already persisted, so re-running resumes.

Complementary to `provider::billing_fallback` (OpenAI-subscription-specific, own matcher — no conflict).

## Tests

7 new in `recovery.rs` (Zhipu 1308 → UsageCap; long Retry-After → UsageCap; short Retry-After / plain 429 stay retryable — regression guards; not-retryable; reset-hint; user-facing arm), 1 in `run.rs` (envelope subtype). `fmt` + `clippy` clean; `provider` (263) and `recovery` (40) suites pass; builds under `--features loop,plugin`.

Fixes dirge-u6zc. Follow-ups filed as dirge-2m68 (completeness backstop for no-critic / one-shot-fail-open critic).