### PR TITLE
Add SBOM generation, attestation, and OSV scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Audit dependencies
         uses: pirafrank/audit-check-action@v1
 
+      - name: OSV vulnerability scan
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        with:
+          scan-args: "--lockfile=Cargo.lock --config=.osv-scanner.toml"
+
   # The `validate_all_plugins_compile` Rust test (mod_tests.rs) loads every
   # plugin against the full dirge harness surface.  It runs in the
   # --all-features test variant below.  That's the canonical gate; there is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,32 @@ on:
     tags:
       - "v*"
 
-permissions: write-all
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
 
 jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: psastras/sbom-rs/actions/install-cargo-sbom@cargo-sbom-latest
+      - name: Generate SPDX SBOM
+        run: cargo sbom --output-format spdx_2_3 -o sbom.spdx.json
+      - name: Upload SBOM as release asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: sbom.spdx.json
+          tag: ${{ github.ref }}
+          overwrite: true
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json
   build:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -73,6 +96,23 @@ jobs:
           $archive = "dirge-${{ matrix.target }}.zip"
           Compress-Archive -Path "target/${{ matrix.target }}/release/dirge.exe" -DestinationPath $archive
           (Get-FileHash $archive -Algorithm SHA256).Hash | Out-File -Encoding ascii "$archive.sha256"
+
+      - name: Download SBOM
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom
+      - name: Attest binary (Unix)
+        if: matrix.os != 'windows-latest'
+        uses: actions/attest@v4
+        with:
+          subject-path: dirge-${{ matrix.target }}.tar.gz
+          sbom-path: sbom.spdx.json
+      - name: Attest binary (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/attest@v4
+        with:
+          subject-path: dirge-${{ matrix.target }}.zip
+          sbom-path: sbom.spdx.json
 
       - name: Upload release assets
         uses: svenstaro/upload-release-action@v2
@@ -147,7 +187,7 @@ jobs:
       # PR route (peter-evans/create-pull-request) failed on every release
       # with "GitHub Actions is not permitted to create or approve pull
       # requests" — a repo Actions toggle that's off. `main` is unprotected
-      # and this job has `contents: write` (permissions: write-all), so a
+      # and this job has contents: write (explicit permissions), so a
       # direct push works and needs no extra setting or PAT. A GITHUB_TOKEN
       # push doesn't re-trigger workflows, so this can't loop.
       - name: Commit nix/bin.nix bump

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0057"
+reason = "fxhash is a transitive dep of bm25; no maintained fork exists that preserves the required hash32/hash64 API"


### PR DESCRIPTION
[GitHub Doc](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)

- Generate an SPDX SBOM via `cargo-sbom` during release, upload it as both a release asset and a workflow artifact.
- Each binary artifact is attested against the SBOM using `actions/attest@v4`, establishing build provenance with a dependency predicate.
- In CI, add `osv-scanner` to the existing audit job to catch vulnerable dependencies on every push/PR.
- `osv-scanner` ignores unmaintained `fxhash` so job will not fail on this issue.