### PR TITLE
config: add configurable shell path

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -788,6 +788,9 @@ pub struct Config {
     /// Default authentication source for providers that do not set
     /// `providers.<name>.auth`. `ApiKey` remains the implicit default.
     pub auth: Option<ProviderAuth>,
+    /// Shell binary path for non-sandboxed bash execution.
+    /// Default: `"bash"` (looked up via $PATH by the OS spawn mechanism).
+    pub shell: Option<String>,
     pub max_tokens: Option<u64>,
     pub temperature: Option<f64>,
     pub no_tools: Option<bool>,


### PR DESCRIPTION
- Add shell config option so users can set the shell binary.
- Defaults to "bash" when unset. Set i.e. `shell = "/opt/homebrew/bin/bash"` in config file.