### PR TITLE
config: add configurable shell path

### DIFF
--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -607,7 +607,8 @@ pub async fn build_loop_tools(
                 sandbox.clone(),
                 cache.clone(),
             )
-            .with_shell_store(Some(tools::bg_shell::global())),
+            .with_shell_store(Some(tools::bg_shell::global()))
+            .with_shell_path_option(cfg.shell.clone()),
             Some(ToolExecutionMode::Sequential),
         )
         .await,

--- a/src/agent/tools/bash/mod.rs
+++ b/src/agent/tools/bash/mod.rs
@@ -27,6 +27,9 @@ pub struct BashTool {
     /// (`kill_shell`). When absent (e.g. some headless paths) `background`
     /// degrades gracefully to synchronous execution.
     shell_store: Option<crate::agent::tools::bg_shell::BackgroundShellStore>,
+    /// Custom shell binary path. When set, commands are wrapped as `{shell} -c '{cmd}'`
+    /// before reaching the sandbox wrapper. Default: unset (sandbox's hardcoded "bash").
+    shell_path: Option<String>,
 }
 
 impl BashTool {
@@ -39,7 +42,15 @@ impl BashTool {
             execution_root: None,
             cache: None,
             shell_store: None,
+            shell_path: None,
         }
+    }
+
+    /// Set a custom shell binary path. Commands are wrapped as `{shell} -c '{cmd}'`.
+    /// Accepts `Option<String>` — no-op when None.
+    pub fn with_shell_path_option(mut self, path: Option<String>) -> Self {
+        self.shell_path = path;
+        self
     }
 
     pub fn with_cache(
@@ -55,6 +66,7 @@ impl BashTool {
             execution_root: None,
             cache: Some(cache),
             shell_store: None,
+            shell_path: None,
         }
     }
 
@@ -113,6 +125,15 @@ impl Tool for BashTool {
         let command =
             crate::ui::ansi::strip_escapes(&args.command, crate::ui::ansi::StripPolicy::KEEP_BOTH);
         check::check_bash_segments(&self.permission, &self.ask_tx, &command).await?;
+
+        // Wrap with the configured shell if set, so the command runs under the
+        // user's chosen shell binary instead of the default PATH-resolved "bash".
+        let command = if let Some(shell) = &self.shell_path {
+            let escaped = command.replace('\'', "'\\''");
+            format!("{shell} -c '{escaped}'")
+        } else {
+            command
+        };
 
         // F6: spawn into its own process group so a timeout can
         // SIGKILL the entire subprocess tree, not just the

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -788,6 +788,9 @@ pub struct Config {
     /// Default authentication source for providers that do not set
     /// `providers.<name>.auth`. `ApiKey` remains the implicit default.
     pub auth: Option<ProviderAuth>,
+    /// Shell binary path for non-sandboxed bash execution.
+    /// Default: `"bash"` (looked up via $PATH by the OS spawn mechanism).
+    pub shell: Option<String>,
     pub max_tokens: Option<u64>,
     pub temperature: Option<f64>,
     pub no_tools: Option<bool>,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2565,6 +2565,7 @@ pub async fn run_interactive(
                                             kind,
                                             cols,
                                             rows,
+                                            cfg.shell.as_deref(),
                                         ) {
                                             Ok(session) => {
                                                 // `$ cmd` marks the start in the chat log;

--- a/src/ui/shell_session.rs
+++ b/src/ui/shell_session.rs
@@ -81,6 +81,7 @@ pub(crate) fn spawn(
     kind: ShellKind,
     cols: u16,
     rows: u16,
+    shell_path: Option<&str>,
 ) -> io::Result<ShellSession> {
     let (primary, secondary) = open_pty_pair()?;
     let secondary_fd = secondary.as_raw_fd();
@@ -91,7 +92,14 @@ pub(crate) fn spawn(
     set_winsize(secondary_fd, cols, rows);
 
     // Build the command with the PTY slave as stdin/stdout/stderr.
-    let mut cmd = sandbox.command_for_interactive(command);
+    let effective_cmd = match shell_path {
+        Some(shell) => {
+            let escaped = command.replace('\'', "'\\''");
+            format!("{shell} -c '{escaped}'")
+        }
+        None => command.to_string(),
+    };
+    let mut cmd = sandbox.command_for_interactive(&effective_cmd);
     let din = secondary.try_clone()?;
     let dout = secondary.try_clone()?;
     let derr = secondary.try_clone()?;
@@ -291,6 +299,7 @@ pub(crate) fn spawn(
     kind: ShellKind,
     _cols: u16,
     _rows: u16,
+    _shell_path: Option<&str>,
 ) -> io::Result<ShellSession> {
     use std::process::Stdio;
 
@@ -472,6 +481,7 @@ mod tests {
             ShellKind::Visible,
             80,
             24,
+            None,
         )
         .unwrap();
         let ShellSession {
@@ -495,6 +505,7 @@ mod tests {
             ShellKind::Visible,
             80,
             24,
+            None,
         )
         .unwrap();
         let ShellSession {
@@ -513,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn forwards_stdin_to_child() {
-        let s = spawn("cat", &sb(), ShellKind::Visible, 80, 24).unwrap();
+        let s = spawn("cat", &sb(), ShellKind::Visible, 80, 24, None).unwrap();
         let ShellSession {
             input_tx,
             mut events_rx,
@@ -540,6 +551,7 @@ mod tests {
             ShellKind::Visible,
             80,
             24,
+            None,
         )
         .unwrap();
         let ShellSession {
@@ -561,7 +573,7 @@ mod tests {
 
     #[tokio::test]
     async fn propagates_nonzero_exit_code() {
-        let s = spawn("exit 7", &sb(), ShellKind::Visible, 80, 24).unwrap();
+        let s = spawn("exit 7", &sb(), ShellKind::Visible, 80, 24, None).unwrap();
         let ShellSession {
             input_tx,
             mut events_rx,
@@ -580,6 +592,7 @@ mod tests {
             ShellKind::Visible,
             80,
             24,
+            None,
         )
         .unwrap();
         let ShellSession {
@@ -601,6 +614,7 @@ mod tests {
             ShellKind::Visible,
             80,
             24,
+            None,
         )
         .unwrap();
         let ShellSession {
@@ -626,7 +640,7 @@ mod tests {
 
     #[tokio::test]
     async fn interrupt_kills_long_running_process() {
-        let s = spawn("sleep 30", &sb(), ShellKind::Visible, 80, 24).unwrap();
+        let s = spawn("sleep 30", &sb(), ShellKind::Visible, 80, 24, None).unwrap();
         let mut session = s;
         tokio::time::sleep(Duration::from_millis(200)).await;
         if let Some(tx) = session.interrupt.take() {


### PR DESCRIPTION
- Add config option so users can set the shell binary path (e.g. `/opt/homebrew/bin/bash`) for execution via `BashTool` and interactive shell (`!cmd`).
- Configuration: `shell = "/path/to/shell"` - defaults to unset (`bash` via `PATH`).