### PR TITLE
fix(release): repair SBOM job so releases don't break

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: psastras/sbom-rs/actions/install-cargo-sbom@cargo-sbom-latest
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      # Install from crates.io rather than psastras/sbom-rs/actions/…@cargo-sbom-latest:
+      # that tag is stale (2023, no actions/ dir) so the action ref fails to resolve.
+      - name: Install cargo-sbom
+        run: cargo install cargo-sbom --locked
+      # cargo-sbom writes to stdout (no -o flag) and the SPDX value is
+      # spdx_json_2_3 (not spdx_2_3).
       - name: Generate SPDX SBOM
-        run: cargo sbom --output-format spdx_2_3 -o sbom.spdx.json
+        run: cargo sbom --output-format spdx_json_2_3 > sbom.spdx.json
       - name: Upload SBOM as release asset
         uses: svenstaro/upload-release-action@v2
         with:
@@ -33,6 +42,11 @@ jobs:
           path: sbom.spdx.json
   build:
     name: ${{ matrix.target }}
+    # Wait for the SBOM: the "Download SBOM" step below pulls the `sbom`
+    # artifact, and attestation needs it. Without this the jobs race and
+    # build can hit Download SBOM before sbom uploads (or after it fails),
+    # dying before it uploads the binaries.
+    needs: sbom
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fast-follow to #693. Its SBOM job has three bugs that would break the next release, plus a job-ordering race. None were caught by CI because `release.yml` only runs on tag pushes — the PR's green checks never exercised it. I verified each by installing cargo-sbom 0.10.0 locally and running the exact commands.

## Bugs fixed

1. **Install action doesn't resolve.** `psastras/sbom-rs/actions/install-cargo-sbom@cargo-sbom-latest` — that git tag is stale at a 2023 v0.1.0 commit with no `actions/` directory (the action only exists on the repo's `main`). GitHub can't find `action.yaml` at that ref → the job fails immediately. Replaced with `cargo install cargo-sbom --locked` from crates.io (also better provenance for a supply-chain job).
2. **Invalid format value.** `--output-format spdx_2_3` isn't accepted; cargo-sbom 0.10 wants `spdx_json_2_3` (`error: invalid value`).
3. **Nonexistent flag.** `-o sbom.spdx.json` → `error: unexpected argument '-o' found`. cargo-sbom writes to stdout; redirect with `> sbom.spdx.json`.

Because the `build` job had no `needs: sbom`, a failing sbom job wouldn't stop `build` — it would compile for minutes then die at "Download SBOM" **before uploading the binaries**, so the whole release would ship with no assets.

## Also

- **`needs: sbom` on `build`** — the download/attest steps require the SBOM artifact. This also makes `build` skip cleanly if sbom fails, and ensures the release exists (sbom creates it) before binaries upload.

## Verified locally

```
cargo install cargo-sbom --locked        # cargo-sbom v0.10.0
cargo sbom --output-format spdx_json_2_3 > sbom.spdx.json   # 690KB valid SPDX 2.3 JSON
cargo sbom --output-format spdx_2_3 -o sbom.spdx.json       # errors (the merged command)
```

Known limitation (not fixed here): the sbom job generates one project-level SBOM, but the x86-mac/windows targets build `--no-default-features --features windows-default`, so the attested SBOM slightly over-represents deps for those two. Per-target SBOMs would be a larger change.

Note: `release.yml` is tag-only, so this PR's CI can't exercise it either — the validation above is manual.