### PR TITLE
fix(mcp): delegate always returned empty files_changed

### DIFF
--- a/src/extras/mcp_server.rs
+++ b/src/extras/mcp_server.rs
@@ -160,10 +160,11 @@ impl DirgeMcp {
         )
         .await;
         let after = git_status_set(&project_dir);
-        let files_changed = changed_paths(&before, &after);
+        let git_changed = changed_paths(&before, &after);
 
         match run {
             Ok(env) => {
+                let files_changed = merge_changed(git_changed, &env.files_changed);
                 let result = json!({
                     "session_id": session_id,
                     "status": env.status,
@@ -248,6 +249,11 @@ struct Envelope {
     summary: String,
     turns: u64,
     duration_ms: u64,
+    /// Files dirge's own edit/write/patch/bash tools recorded touching this
+    /// run — read straight from the child's result JSON. Authoritative and
+    /// git-independent (issue #704); the git-status diff is only a
+    /// supplement for anything the tools didn't record.
+    files_changed: Vec<String>,
 }
 
 /// SIGKILL a whole process group on drop. Mirrors
@@ -433,7 +439,30 @@ async fn run_delegation(
             .get("duration_ms")
             .and_then(|v| v.as_u64())
             .unwrap_or(0),
+        files_changed: env_val
+            .get("files_changed")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|s| s.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
     })
+}
+
+/// Union of the git-status diff and dirge's own modified-files record,
+/// sorted and deduped. dirge's record (from the result envelope) is
+/// authoritative and works even when the project isn't a git repo, git is
+/// off PATH, or the edits were committed mid-run — the exact cases where
+/// the git diff alone came back empty (issue #704). git still contributes
+/// as a supplement, catching anything the tools didn't record.
+fn merge_changed(git: Vec<String>, reported: &[String]) -> Vec<String> {
+    let mut v = git;
+    v.extend(reported.iter().cloned());
+    v.sort();
+    v.dedup();
+    v
 }
 
 /// `git status --porcelain` as a set of `"XY path"` lines. Empty (not an
@@ -602,6 +631,34 @@ mod tests {
         .into();
         let changed = changed_paths(&before, &after);
         assert_eq!(changed, vec!["c.rs".to_string(), "src/b.rs".to_string()]);
+    }
+
+    /// issue #704: `files_changed` unions the git diff with dirge's own
+    /// record so it's never empty just because git saw nothing (non-repo,
+    /// git off PATH, committed edits). Result is sorted + deduped across
+    /// both sources.
+    #[test]
+    fn merge_changed_unions_git_and_reported() {
+        // git blind (not a repo) but dirge recorded its edits → reported wins.
+        assert_eq!(
+            merge_changed(vec![], &["src/a.rs".into(), "src/b.rs".into()]),
+            vec!["src/a.rs".to_string(), "src/b.rs".to_string()]
+        );
+        // Overlap dedupes; a git-only path (e.g. a bash edit the tools
+        // didn't record) is still carried.
+        assert_eq!(
+            merge_changed(
+                vec!["src/a.rs".into(), "gen/x.rs".into()],
+                &["src/a.rs".into(), "src/b.rs".into()]
+            ),
+            vec![
+                "gen/x.rs".to_string(),
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string()
+            ]
+        );
+        // Both empty → empty (a genuine no-op run).
+        assert!(merge_changed(vec![], &[]).is_empty());
     }
 
     #[test]

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -40,6 +40,7 @@ pub(crate) fn headless_result_json(
     num_turns: u32,
     result: &str,
     session_id: &str,
+    files_changed: &[String],
 ) -> serde_json::Value {
     let (subtype, is_error) = match end {
         RunEnd::Completed => ("success", false),
@@ -58,8 +59,42 @@ pub(crate) fn headless_result_json(
         "num_turns": num_turns,
         "result": result,
         "session_id": session_id,
+        // Files the run's edit/write/patch/bash tools touched, from the
+        // modified-files tracker. Reported here (not inferred from git by
+        // the consumer) so `files_changed` is accurate even when the
+        // project isn't a git repo, git isn't on PATH, or the edits were
+        // committed mid-run — see dirge MCP `delegate` (issue #704).
+        "files_changed": files_changed,
         "total_cost_usd": 0.0,
     })
+}
+
+/// Files the run modified — snapshot the process-global modified-files
+/// tracker (write/edit/edit_lines/edit_minified/apply_patch/bash all mark
+/// it) and project each to a `cwd`-relative string when it lives under the
+/// working dir, else its absolute path. Sorted + deduped. Empty when
+/// nothing was touched. The tracker is authoritative and git-independent,
+/// which is the point: a git-status diff silently reports nothing when the
+/// project isn't a repo (issue #704).
+fn headless_files_changed() -> Vec<String> {
+    // Canonicalize cwd to match the tracker, which stores canonical paths;
+    // a raw cwd wouldn't strip on symlinked dirs (e.g. macOS /tmp).
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|c| crate::permission::path::canonical_or_self(&c));
+    let mut v: Vec<String> = crate::agent::tools::modified::recent(usize::MAX)
+        .into_iter()
+        .map(|p| {
+            cwd.as_ref()
+                .and_then(|c| p.strip_prefix(c).ok())
+                .unwrap_or(p.as_path())
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    v.sort();
+    v.dedup();
+    v
 }
 
 /// Build a stream-json `assistant` event for one turn (dirge-kuqp).
@@ -444,6 +479,7 @@ impl AnyAgent {
             num_turns,
             &full_response,
             &session_id,
+            &headless_files_changed(),
         );
 
         match output_format {
@@ -523,27 +559,44 @@ mod tests {
     /// — `--print` consumers parse this JSON, not stderr.
     #[test]
     fn result_envelope_reflects_run_end() {
-        let ok = headless_result_json(RunEnd::Completed, 10, 2, "answer", "sid");
+        let ok = headless_result_json(RunEnd::Completed, 10, 2, "answer", "sid", &[]);
         assert_eq!(ok["subtype"], "success");
         assert_eq!(ok["is_error"], false);
         assert_eq!(ok["result"], "answer");
 
-        let capped = headless_result_json(RunEnd::Truncated, 10, 100, "partial", "sid");
+        let capped = headless_result_json(RunEnd::Truncated, 10, 100, "partial", "sid", &[]);
         assert_eq!(capped["subtype"], "error_max_turns");
         assert_eq!(capped["is_error"], true);
         assert_eq!(capped["result"], "partial", "partial text still delivered");
 
-        let died = headless_result_json(RunEnd::Incomplete, 10, 1, "fragment", "sid");
+        let died = headless_result_json(RunEnd::Incomplete, 10, 1, "fragment", "sid", &[]);
         assert_eq!(died["subtype"], "error");
         assert_eq!(died["is_error"], true);
 
         // dirge-u6zc: a usage-cap pause is a distinct, resumable outcome —
         // its own subtype so a wrapper can re-run after the reset, not the
         // generic "error" it'd share with a runner death.
-        let capped = headless_result_json(RunEnd::UsageCapped, 10, 5, "partial", "sid");
+        let capped = headless_result_json(RunEnd::UsageCapped, 10, 5, "partial", "sid", &[]);
         assert_eq!(capped["subtype"], "error_usage_cap");
         assert_eq!(capped["is_error"], true);
         assert_eq!(capped["result"], "partial", "partial work still delivered");
+    }
+
+    /// issue #704: the envelope carries `files_changed` verbatim (a JSON
+    /// array) so the MCP `delegate` consumer reads dirge's own record of
+    /// edited files instead of guessing from `git status`. Empty when the
+    /// run touched nothing; never absent.
+    #[test]
+    fn result_envelope_carries_files_changed() {
+        let none = headless_result_json(RunEnd::Completed, 1, 1, "ok", "sid", &[]);
+        assert_eq!(none["files_changed"], serde_json::json!([]));
+
+        let files = ["src/a.rs".to_string(), "tests/b.rs".to_string()];
+        let env = headless_result_json(RunEnd::Completed, 1, 1, "ok", "sid", &files);
+        assert_eq!(
+            env["files_changed"],
+            serde_json::json!(["src/a.rs", "tests/b.rs"])
+        );
     }
 
     /// dirge-kuqp: a turn's assistant event carries its streamed text


### PR DESCRIPTION
Fixes #704.

## Problem

`delegate` derived `files_changed` purely from a `git status --porcelain` diff taken before and after the child run. That silently returns `[]` whenever git can't observe the edits:

- the project isn't a git repo (the reporter's Windows case),
- `git` isn't on `PATH`,
- the run committed its work mid-delegation.

In all of these the file edits are real and on disk, but `files_changed` comes back empty on every call — breaking the review workflow that depends on it.

## Fix

dirge already records every file its `write`/`edit`/`edit_lines`/`edit_minified`/`apply_patch`/`bash` tools touch, in the process-global modified-files tracker (`agent::tools::modified`). Each `delegate` spawns a fresh child process, so that tracker holds exactly the current delegation's edits.

- `run.rs`: the headless JSON result envelope now carries `files_changed`, snapshotted from the tracker and made cwd-relative where possible. Git-independent, so it's accurate in a non-repo / no-git / committed-mid-run project.
- `mcp_server.rs`: `delegate` reads `files_changed` from the envelope and unions it with the existing git diff. The tracker is authoritative; git stays as a supplement for anything the tools didn't record (e.g. a bash edit the mark heuristic missed).

The response shape is unchanged.

## Tests

- `result_envelope_carries_files_changed` — envelope includes the array, empty vs populated.
- `merge_changed_unions_git_and_reported` — union dedupes/sorts across both sources; git-blind still yields the reported paths; both-empty stays empty.
- Existing envelope/`changed_paths` tests updated and green.

Verified end-to-end: running `dirge --print --output-format json` in a **non-git** dir on a task that edits a file now returns `"files_changed":["parse_svg.py"]` (previously `[]`).