### PR TITLE
fix(mcp): MCP tools skipped when name collides with a disabled built-in

### DIFF
--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -33,14 +33,20 @@ use super::build_session_search_tool;
 /// server or plugin may not shadow `read`/`bash`/etc. — rig's builder and the
 /// LoopTool registry would otherwise prefer the last-added tool, letting an
 /// arbitrary external tool replace a core dirge tool. Returns `true` when
-/// `name` collides with a built-in (emitting a warning that names `source`,
-/// e.g. `"MCP server 'foo'"` or `"plugin"`) so the caller can skip it.
+/// `name` collides with a built-in that is actually present in this build
+/// (emitting a warning that names `source`, e.g. `"MCP server 'foo'"` or
+/// `"plugin"`) so the caller can skip it.
+///
+/// Only reserves built-ins compiled into the current build: a feature-gated
+/// tool that isn't registered (e.g. `search_graph` without
+/// `experimental-graph-search`) leaves its name free for an external tool,
+/// so it isn't skipped into nonexistence (issue #702).
 ///
 /// Single source of truth for the collision policy, previously inlined
 /// verbatim at three sites (MCP eager + MCP background + plugin) [dirge-p99h].
 #[cfg(any(feature = "mcp", feature = "plugin"))]
 fn shadows_builtin(name: &str, source: &str) -> bool {
-    if tools::BUILTIN_TOOL_NAMES.contains(&name) {
+    if tools::reserves_builtin_name(name) {
         eprintln!(
             "warning: {source} exports tool '{name}' which collides with a dirge built-in; skipping it",
         );
@@ -996,5 +1002,31 @@ mod tests {
         // A name no built-in uses → accepted.
         assert!(!shadows_builtin("totally_custom_tool", "plugin"));
         assert!(!shadows_builtin("acme_search", "MCP server 'acme'"));
+    }
+
+    /// issue #702: `search_graph` is a built-in only behind
+    /// `experimental-graph-search`. When that feature is off (default
+    /// builds) the built-in isn't registered, so an MCP server exporting
+    /// `search_graph` must NOT be shadowed — otherwise the name resolves to
+    /// no tool at all. Guarded by cfg so it only asserts when the feature is
+    /// actually off.
+    #[cfg(not(feature = "experimental-graph-search"))]
+    #[test]
+    fn disabled_feature_builtin_does_not_shadow_mcp_tool() {
+        assert!(!shadows_builtin(
+            "search_graph",
+            "MCP server 'codebase-memory-mcp'"
+        ));
+    }
+
+    /// The mirror: when the feature IS on, the built-in exists and the name
+    /// stays reserved.
+    #[cfg(feature = "experimental-graph-search")]
+    #[test]
+    fn enabled_feature_builtin_still_shadows_mcp_tool() {
+        assert!(shadows_builtin(
+            "search_graph",
+            "MCP server 'codebase-memory-mcp'"
+        ));
     }
 }

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -252,6 +252,82 @@ pub const BUILTIN_TOOL_NAMES: &[&str] = &[
     "plugin_tool",
 ];
 
+/// Whether the built-in named `name` is actually compiled into THIS build.
+/// Most built-ins are unconditional; a handful are registered only behind a
+/// cargo feature (see the `#[cfg(...)]` gates in
+/// `agent/builder/loop_tools.rs`) and are absent when it's off. Names that
+/// aren't feature-gated — including anything not a built-in at all — return
+/// `true`; callers gate on `BUILTIN_TOOL_NAMES` membership separately (see
+/// [`reserves_builtin_name`]).
+///
+/// Keep this mapping in sync with those registration gates.
+// Only reached via `reserves_builtin_name`, whose sole non-test caller is
+// the mcp/plugin collision gate; unused in a build with neither feature.
+#[cfg_attr(not(any(feature = "mcp", feature = "plugin")), allow(dead_code))]
+fn builtin_compiled_in(name: &str) -> bool {
+    match name {
+        // src/agent/builder/loop_tools.rs: build_graph_tool, cfg experimental-graph-search
+        "search_graph" => cfg!(feature = "experimental-graph-search"),
+        // semantic_manager.tools(), cfg semantic
+        "list_symbols" | "get_symbol_body" | "find_definition" | "find_callers"
+        | "find_callees" => cfg!(feature = "semantic"),
+        // LspTool, cfg lsp
+        "lsp" => cfg!(feature = "lsp"),
+        // DebugTool, cfg dap
+        "debug" => cfg!(feature = "dap"),
+        _ => true,
+    }
+}
+
+/// Whether `name` is reserved by a built-in tool that is ACTUALLY present in
+/// this build. A feature-gated built-in that isn't compiled in does NOT
+/// reserve its name — so an MCP server or plugin may export a tool by that
+/// name and have it registered instead of silently skipped (issue #702:
+/// `search_graph` was reserved even in default builds, where it lives behind
+/// `experimental-graph-search` and isn't registered, leaving no such tool
+/// available at all).
+///
+/// This is the collision gate for externally-sourced tools. It stays
+/// narrower than [`BUILTIN_TOOL_NAMES`], which remains the full known set
+/// for deny/allow-list validation — a config may legitimately name a tool
+/// that some build ships even if the current one doesn't.
+#[cfg_attr(not(any(feature = "mcp", feature = "plugin")), allow(dead_code))]
+pub fn reserves_builtin_name(name: &str) -> bool {
+    BUILTIN_TOOL_NAMES.contains(&name) && builtin_compiled_in(name)
+}
+
+#[cfg(test)]
+mod builtin_reservation_tests {
+    use super::*;
+
+    /// issue #702: a feature-gated built-in reserves its name only when its
+    /// feature is compiled in. Asserted against the build's own cfg so the
+    /// invariant holds under any feature set (default or `--no-default-features`).
+    #[test]
+    fn feature_gated_builtins_reserve_only_when_compiled_in() {
+        assert_eq!(
+            reserves_builtin_name("search_graph"),
+            cfg!(feature = "experimental-graph-search"),
+        );
+        assert_eq!(reserves_builtin_name("debug"), cfg!(feature = "dap"));
+        assert_eq!(reserves_builtin_name("lsp"), cfg!(feature = "lsp"));
+        assert_eq!(
+            reserves_builtin_name("list_symbols"),
+            cfg!(feature = "semantic"),
+        );
+    }
+
+    /// Unconditional built-ins always reserve; non-built-ins never do.
+    #[test]
+    fn unconditional_builtins_reserve_and_customs_do_not() {
+        assert!(reserves_builtin_name("read"));
+        assert!(reserves_builtin_name("bash"));
+        assert!(reserves_builtin_name("write"));
+        assert!(!reserves_builtin_name("acme_search"));
+        assert!(!reserves_builtin_name("totally_custom_tool"));
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {
     #[error("{0}")]


### PR DESCRIPTION
Fixes #702.

## Problem

The MCP/plugin collision filter (`shadows_builtin`) rejected any external tool whose name appears in `BUILTIN_TOOL_NAMES`. But that list includes tools that are only registered behind a cargo feature:

| name | feature | in default build? |
|---|---|---|
| `search_graph` | `experimental-graph-search` | no |
| `list_symbols`, `get_symbol_body`, `find_definition`, `find_callers`, `find_callees` | `semantic` | yes |
| `lsp` | `lsp` | yes |
| `debug` | `dap` | no |

In a default build, `experimental-graph-search` and `dap` are off, so those built-ins aren't registered — yet an MCP server exporting `search_graph` was still skipped with:

```
warning: MCP server 'codebase-memory-mcp' exports tool 'search_graph' which collides with a dirge built-in; skipping it
```

The result: no `search_graph` tool available at all, built-in or MCP.

## Fix

`reserves_builtin_name(name)` returns true only when the name is a built-in that is *actually compiled into this build* — membership in `BUILTIN_TOOL_NAMES` **and** its gating feature (if any) enabled. The collision gate now uses it, so a feature-gated built-in that isn't present leaves its name free for an external tool.

`BUILTIN_TOOL_NAMES` is unchanged and stays the full known set for the other consumers (deny/allow-list validation in `context/prompts.rs`, `agent_defs::to_deny_list`), where a config may legitimately name a tool that some build ships even if the current one doesn't.

Core built-ins (`read`, `bash`, …) and the runtime-toggled `websearch`/`webfetch` still reserve unconditionally — the change is scoped to compile-time feature gating.

## Tests

- `feature_gated_builtins_reserve_only_when_compiled_in` — asserts each gated name against the build's own `cfg!`, so it holds under any feature set.
- `unconditional_builtins_reserve_and_customs_do_not`.
- `disabled_feature_builtin_does_not_shadow_mcp_tool` (cfg: feature off) — the exact reporter scenario: MCP `search_graph` is allowed through in a default build.
- `enabled_feature_builtin_still_shadows_mcp_tool` (cfg: feature on) — the mirror: reserved when the built-in exists.