### PR TITLE
feat(provider): add openai-responses provider_type for the Responses API (#703)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -270,7 +270,7 @@ Each `providers` entry accepts:
 
 | Field | Description |
 |-------|-------------|
-| `provider_type` | Built-in backend to use: `openrouter`, `openai`, `anthropic`, `gemini`, `deepseek`, `glm`, `cerebras`, `opencode`, `ollama`, or `custom`. Optional — defaults to the entry's alias when that alias matches a built-in name. |
+| `provider_type` | Built-in backend to use: `openrouter`, `openai`, `openai-responses`, `anthropic`, `gemini`, `deepseek`, `glm`, `cerebras`, `opencode`, `ollama`, or `custom`. Optional — defaults to the entry's alias when that alias matches a built-in name. `openai` speaks the Chat Completions API (`/v1/chat/completions`); `openai-responses` speaks the Responses API (`/v1/responses`) — see below. |
 | `base_url` | Endpoint base URL (for custom / self-hosted endpoints). |
 | `model` | Model name for this provider. |
 | `api_key` | Literal key or `${ENV_VAR}` interpolation. Takes precedence over `api_key_env`. |
@@ -284,6 +284,34 @@ Each `providers` entry accepts:
 
 The aliases on the left of the map become the values you write in
 role-assignment keys.
+
+### OpenAI Chat Completions vs Responses API
+
+`provider_type: "openai"` sends requests to the Chat Completions endpoint
+(`/v1/chat/completions`). Some OpenAI-compatible endpoints only expose the
+newer Responses API (`/v1/responses`) — e.g. an OAuth proxy that mirrors what
+OpenAI itself serves for GPT-5+. Set `provider_type: "openai-responses"` to
+target that endpoint instead:
+
+```json
+{
+  "providers": {
+    "gpt5-proxy": {
+      "provider_type": "openai-responses",
+      "model": "gpt-5.6",
+      "base_url": "http://127.0.0.1:8639/v1",
+      "api_key": "${MY_PROXY_KEY}",
+      "allow_insecure": true
+    }
+  }
+}
+```
+
+It behaves like `openai` in every other respect (default model, API-key auth,
+`base_url` handling) — only the request shape and endpoint differ. The api key
+is sent as a bearer token; unlike `auth: chatgpt` this uses no OAuth/Codex
+login, so it works against any plain `/v1/responses` server. (`allow_insecure`
+is honored here since no OAuth bearer is involved.)
 
 ### Cerebras
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1677,8 +1677,9 @@ pub fn load() -> Config {
                 eprintln!(
                     "error: provider {:?} has invalid provider_type {:?}.\n\
                      Either the alias must match a built-in (openrouter, openai,\n\
-                     anthropic, gemini, deepseek, glm, cerebras, opencode, ollama,\n\
-                     custom) or set `provider_type` explicitly to one of those.",
+                     openai-responses, anthropic, gemini, deepseek, glm, cerebras,\n\
+                     opencode, ollama, custom) or set `provider_type` explicitly\n\
+                     to one of those.",
                     name, ptype,
                 );
                 std::process::exit(1);

--- a/src/provider/client.rs
+++ b/src/provider/client.rs
@@ -414,6 +414,33 @@ where
             b = b.http_headers(headers);
             Ok(AnyClient::ChatGptOpenAI(b.build()?))
         }
+        ProviderKind::OpenAI if info.openai_responses => {
+            // #703: a custom/self-hosted OpenAI provider that speaks the
+            // Responses API (`/v1/responses`) rather than chat/completions
+            // (e.g. an OAuth proxy that only exposes /responses). Reuse the
+            // ChatGptOpenAI client (`openai::Client` → Responses adapter) but
+            // with a NON-token `CodexHttpClient`: no OAuth refresh — just the
+            // plain api-key bearer rig sets, against the configured base_url.
+            // The codex http layer still normalizes the outgoing Responses
+            // body (rig 0.37 emits `instructions: null` + a system item in
+            // `input`), which is the correct shape for ANY /v1/responses
+            // endpoint, not just chatgpt.com's.
+            let mut b = openai::Client::builder().api_key(&key).http_client(
+                crate::provider::compressing_http::CompressingHttpClient::new(
+                    CodexHttpClient::default(),
+                    crate::llmtrim::ir::ProviderKind::OpenAi,
+                    std::sync::Arc::new(crate::compression::config_for_preset(
+                        &resolve_compression_preset(),
+                    )),
+                    resolve_compression_enabled(),
+                ),
+            );
+            if let Some(base_url) = &base_url {
+                b = b.base_url(base_url);
+            }
+            b = b.http_headers(headers);
+            Ok(AnyClient::ChatGptOpenAI(b.build()?))
+        }
         ProviderKind::OpenAI => {
             let mut b = openai::CompletionsClient::builder()
                 .http_client(
@@ -1322,6 +1349,52 @@ mod tests {
         assert!(
             !loaded.get(),
             "configured OpenAI base_url must not read the Dirge OAuth store"
+        );
+    }
+
+    #[test]
+    fn openai_responses_provider_type_builds_responses_client() {
+        // #703: `provider_type: "openai-responses"` with a plain api-key +
+        // custom base_url builds the Responses client (ChatGptOpenAI), not the
+        // chat/completions client — and never touches the OAuth store.
+        let providers = HashMap::from([(
+            "gpt5-proxy".to_string(),
+            ProviderEntry {
+                provider_type: Some("openai-responses".to_string()),
+                base_url: Some("https://proxy.invalid/v1".to_string()),
+                api_key: Some("sk-test".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let loaded = Cell::new(false);
+        let client = create_client_with("gpt5-proxy", None, &providers, no_env, || {
+            loaded.set(true);
+            Ok(None)
+        })
+        .unwrap();
+        assert!(
+            matches!(client, AnyClient::ChatGptOpenAI(_)),
+            "openai-responses must build the Responses (ChatGptOpenAI) client"
+        );
+        assert!(
+            !loaded.get(),
+            "a custom api-key Responses provider must not read the OAuth store"
+        );
+
+        // Control: plain `openai` with the same shape stays chat/completions.
+        let providers = HashMap::from([(
+            "vanilla".to_string(),
+            ProviderEntry {
+                provider_type: Some("openai".to_string()),
+                base_url: Some("https://proxy.invalid/v1".to_string()),
+                api_key: Some("sk-test".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let client = create_client_with("vanilla", None, &providers, no_env, || Ok(None)).unwrap();
+        assert!(
+            matches!(client, AnyClient::OpenAI(_)),
+            "plain openai must build the chat/completions client"
         );
     }
 

--- a/src/provider/resolve.rs
+++ b/src/provider/resolve.rs
@@ -74,10 +74,25 @@ pub fn default_model_for_alias(
     }
 }
 
+/// True when a `provider_type` string selects the OpenAI **Responses** API
+/// (`/v1/responses`) rather than chat/completions (#703). Both separators are
+/// accepted so a config typo (`openai_responses`) still works. The kind stays
+/// `ProviderKind::OpenAI`; only the client dialect differs (see
+/// [`ProviderInfo::openai_responses`]).
+pub fn is_openai_responses_type(provider_type: &str) -> bool {
+    matches!(
+        provider_type.trim().to_ascii_lowercase().as_str(),
+        "openai-responses" | "openai_responses"
+    )
+}
+
 pub fn parse_provider(name: &str) -> Option<ProviderKind> {
     match name.to_lowercase().as_str() {
         "openrouter" => Some(ProviderKind::OpenRouter),
         "openai" => Some(ProviderKind::OpenAI),
+        // #703: the Responses-API dialect resolves to the OpenAI kind — it
+        // differs only in which endpoint/client is built (ChatGptOpenAI).
+        "openai-responses" | "openai_responses" => Some(ProviderKind::OpenAI),
         "anthropic" => Some(ProviderKind::Anthropic),
         "gemini" | "google" => Some(ProviderKind::Gemini),
         "deepseek" => Some(ProviderKind::DeepSeek),
@@ -263,6 +278,12 @@ pub struct ProviderInfo {
     /// already expanded). When present, takes precedence over both
     /// `api_key_env` and the standard env-var fallback chain.
     pub api_key_literal: Option<String>,
+    /// #703: the provider_type selected the OpenAI **Responses** API
+    /// (`provider_type: "openai-responses"`). `kind` is still `OpenAI`; this
+    /// flag forks the client build to `ChatGptOpenAI` (the `/v1/responses`
+    /// client) with the configured `base_url` + api key. Never set for OAuth /
+    /// ChatGPT-auth paths, which already force the Responses endpoint.
+    pub openai_responses: bool,
 }
 
 pub fn resolve_provider_info(
@@ -325,6 +346,7 @@ pub fn resolve_provider_info(
             api_key_env: entry.api_key_env.clone(),
             auth: entry.auth,
             api_key_literal,
+            openai_responses: is_openai_responses_type(&ptype),
         });
     }
     // Then plugin-registered providers from `harness/register-provider`.
@@ -371,6 +393,7 @@ pub fn resolve_provider_info(
             api_key_env: entry.api_key_env,
             auth: entry.auth,
             api_key_literal,
+            openai_responses: is_openai_responses_type(&ptype),
         });
     }
     let kind = parse_provider(name)?;
@@ -380,6 +403,7 @@ pub fn resolve_provider_info(
         api_key_env: None,
         auth: None,
         api_key_literal: None,
+        openai_responses: is_openai_responses_type(name),
     })
 }
 
@@ -826,6 +850,54 @@ mod resolve_model_switch_tests {
             model: model.map(str::to_string),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn openai_responses_type_parses_as_openai_kind() {
+        // #703: the Responses dialect resolves to the OpenAI kind, both
+        // separators, case-insensitively.
+        assert_eq!(
+            parse_provider("openai-responses"),
+            Some(ProviderKind::OpenAI)
+        );
+        assert_eq!(
+            parse_provider("openai_responses"),
+            Some(ProviderKind::OpenAI)
+        );
+        assert!(is_openai_responses_type("openai-responses"));
+        assert!(is_openai_responses_type("  OpenAI-Responses "));
+        assert!(!is_openai_responses_type("openai"));
+        assert!(!is_openai_responses_type("anthropic"));
+    }
+
+    #[test]
+    fn resolve_provider_info_flags_openai_responses() {
+        let providers = HashMap::from([
+            (
+                "gpt5".to_string(),
+                ProviderEntry {
+                    provider_type: Some("openai-responses".to_string()),
+                    base_url: Some("https://proxy.invalid/v1".to_string()),
+                    api_key: Some("sk-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+            (
+                "vanilla".to_string(),
+                ProviderEntry {
+                    provider_type: Some("openai".to_string()),
+                    base_url: Some("https://proxy.invalid/v1".to_string()),
+                    api_key: Some("sk-test".to_string()),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let r = resolve_provider_info("gpt5", &providers).unwrap();
+        assert_eq!(r.kind, ProviderKind::OpenAI);
+        assert!(r.openai_responses, "openai-responses must set the flag");
+        let v = resolve_provider_info("vanilla", &providers).unwrap();
+        assert_eq!(v.kind, ProviderKind::OpenAI);
+        assert!(!v.openai_responses, "plain openai must not set the flag");
     }
 
     /// The user's real shape: deepseek default + a pinned glm + local ollama.


### PR DESCRIPTION
Closes #703.

A custom provider with `provider_type: "openai"` always targets `/v1/chat/completions`. Some OpenAI-compatible endpoints only expose the Responses API (`/v1/responses`) — e.g. the OAuth proxy in the issue that mirrors what OpenAI itself serves for GPT-5+ — and there was no way to select it.

## What

Add a new `provider_type: "openai-responses"`:

```json
"providers": {
  "gpt5-proxy": {
    "provider_type": "openai-responses",
    "model": "gpt-5.6",
    "base_url": "http://127.0.0.1:8639/v1",
    "api_key": "${MY_PROXY_KEY}",
    "allow_insecure": true
  }
}
```

- Resolves to the **OpenAI kind**, so every other behavior (default model, env-var fallbacks, `base_url`/`allow_insecure` handling, model-family routing) is reused — no `ProviderKind` explosion.
- Forks only the final client build to the existing `ChatGptOpenAI` client (`openai::Client`'s Responses adapter) with a **non-token** `CodexHttpClient`: a plain api-key bearer against the configured `base_url`, no OAuth/Codex login. The codex http layer still normalizes the outgoing Responses body (rig 0.37 emits `instructions: null` + a system item in `input`), which is the correct shape for any `/v1/responses` endpoint.
- `allow_insecure` is honored (the https-only guard only applies to OAuth bearers), so the reporter's `http://127.0.0.1` proxy works.
- `provider_type: "openai"` is unchanged (chat/completions).

## Note

Pin a `model` on the entry. An unset model falls back to the OpenAI default (`gpt-4o`), which the Codex-default remap (`resolve_codex_default`, only fires when the model is *not* explicitly set) would then rewrite — harmless but not what you want against a proxy.

## Tests

- `parse_provider("openai-responses")` → OpenAI kind (both separators, case-insensitive); `resolve_provider_info` sets the `openai_responses` flag for it and not for plain `openai`.
- `create_client` builds `AnyClient::ChatGptOpenAI` for `openai-responses` (and doesn't read the OAuth store), while plain `openai` still builds `AnyClient::OpenAI`.
- `cargo fmt` + `cargo clippy --tests` clean; provider suite green locally.

Docs: `docs/config.md` (provider_type table + a "Chat Completions vs Responses API" subsection).