### PR TITLE
test: fix two timing-flaky tests that failed all-features CI

### DIFF
--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -1640,15 +1640,21 @@ where
     F: FnOnce(mpsc::Sender<DialogReply>) -> DialogRequest,
 {
     let (reply_tx, reply_rx) = mpsc::channel();
-    let req = build(reply_tx);
-    tx.send(req).ok()?;
 
     // Mark a dialog in flight so the host's eval loop keeps waiting for the
     // human answer instead of timing out at the tight per-hook budget and
     // running the gated tool while the confirm is still on screen
     // (dirge-hwzs). Cleared when this scope exits (answer, timeout, or
     // shutdown), so a hook stuck for a NON-dialog reason still times out.
+    //
+    // Entered BEFORE the request is published: once the responder can see
+    // the request it can also answer it, and anything observing "is a
+    // dialog in flight?" in that window must not see zero. Sending first
+    // left a gap where the dialog was visible but not yet counted.
     let _pending = DialogPendingGuard::enter();
+
+    let req = build(reply_tx);
+    tx.send(req).ok()?;
 
     // Poll for the reply. Wake every `DIALOG_POLL` to check the
     // worker-shutdown flag so a UI exit or `Worker::Drop` doesn't pin
@@ -2641,31 +2647,56 @@ mod tests {
     /// (`dispatch_tool_hook`) sees no block and runs the gated tool while
     /// the confirm is still on screen. Here the answer arrives well after
     /// the 100 ms base timeout; the in-flight dialog must extend the wait.
+    /// The base budget must comfortably exceed the time the worker needs to
+    /// go from `Cmd::Eval` to entering `harness/confirm`, because the
+    /// extension only engages if `dialog_pending` is already set when the
+    /// budget expires. The original 100 ms raced a cold Janet VM and failed
+    /// on loaded CI with "did not reply within 0s"; the warm-up eval below
+    /// removes VM init from that path, and this leaves generous headroom for
+    /// scheduling jitter on top.
+    const CONFIRM_BASE_BUDGET: Duration = Duration::from_millis(750);
+    /// Must exceed [`CONFIRM_BASE_BUDGET`] — that gap is the whole point of
+    /// the test, so the answer cannot arrive before the base budget lapses.
+    const CONFIRM_ANSWER_DELAY: Duration = Duration::from_millis(1500);
+
     #[test]
     fn eval_waits_for_an_in_flight_confirm_past_the_base_timeout() {
         let (mut worker, mut dialog_rx, _lsp_rx) = Worker::try_spawn().unwrap();
 
-        // Answer only after a delay far longer than the base timeout below.
+        // Warm up so the timed eval below doesn't pay Janet VM init. Without
+        // this the worker could still be starting when the base budget
+        // expires, `dialog_pending` would read 0, and the eval would time
+        // out — the extension never getting a chance to engage.
+        worker.eval("(+ 1 1)").expect("warm-up eval");
+
+        // Answer only after a delay longer than the base budget.
         let helper = std::thread::spawn(move || match dialog_rx.blocking_recv() {
             Some(DialogRequest::Confirm { reply, .. }) => {
-                std::thread::sleep(Duration::from_millis(400));
+                std::thread::sleep(CONFIRM_ANSWER_DELAY);
                 let _ = reply.send(DialogReply::Confirm(true));
             }
             other => panic!("unexpected dialog request: {other:?}"),
         });
 
-        // Base timeout (100 ms) ≪ the 400 ms answer delay. Pre-fix this
-        // returned a timeout Err; the in-flight-dialog extension makes it
-        // wait for the real answer.
-        let r = worker.eval_with_timeout(
-            r#"(harness/confirm "warn" "really?")"#,
-            Duration::from_millis(100),
-        );
+        // Pre-fix this returned a timeout Err; the in-flight-dialog
+        // extension makes it wait for the real answer.
+        let started = std::time::Instant::now();
+        let r =
+            worker.eval_with_timeout(r#"(harness/confirm "warn" "really?")"#, CONFIRM_BASE_BUDGET);
+        let waited = started.elapsed();
         helper.join().unwrap();
         assert_eq!(
             r.as_deref(),
             Ok("true"),
             "eval must wait for the confirm answer instead of timing out, got {r:?}"
+        );
+        // Guards against the assertion above passing for the wrong reason: if
+        // the answer somehow arrived before the base budget lapsed, the
+        // extension was never exercised and this test proves nothing.
+        assert!(
+            waited >= CONFIRM_BASE_BUDGET,
+            "the answer must arrive AFTER the base budget lapses, else the \
+             extension path is untested (waited {waited:?})",
         );
     }
 

--- a/src/ui/relay_tests/crossterm_suite.rs
+++ b/src/ui/relay_tests/crossterm_suite.rs
@@ -139,6 +139,8 @@ mod tests {
             let injector_bytes2 = Arc::clone(&injector_bytes);
             let shutdown_active = Arc::new(AtomicBool::new(false));
             let shutdown_active2 = Arc::clone(&shutdown_active);
+            let injector_paused = Arc::new(AtomicBool::new(false));
+            let injector_paused2 = Arc::clone(&injector_paused);
             let charset: Vec<u8> = (b'a'..=b'z')
                 .chain(b'A'..=b'Z')
                 .chain(b'0'..=b'9')
@@ -148,6 +150,10 @@ mod tests {
                 for i in 0u64.. {
                     if !injector_running2.load(Ordering::Relaxed) {
                         break;
+                    }
+                    if injector_paused2.load(Ordering::Relaxed) {
+                        std::thread::sleep(Duration::from_millis(1));
+                        continue;
                     }
                     let b = charset[i as usize % charset.len()];
                     let _ = pri.write_all(&[b]);
@@ -160,20 +166,58 @@ mod tests {
             });
 
             std::thread::sleep(Duration::from_millis(100));
+
+            // Pause the flood and let the bridge catch up before sampling the
+            // baseline. `event_count` is incremented by the BRIDGE thread,
+            // which trails the reader under load — sampling while it lags
+            // credits pre-shutdown events to the post-shutdown window and
+            // inflates `new_events`. That is a measurement artifact, not a
+            // reader that ignored the flag: on a loaded machine this reported
+            // 8 "new" events from a 2-byte shutdown window. With the flood
+            // paused the bridge drains to a fixed point, so the baseline is
+            // exact.
+            injector_paused.store(true, Ordering::Relaxed);
+            let settle_deadline = Instant::now() + Duration::from_secs(2);
+            let mut last_seen = event_count.load(Ordering::Relaxed);
+            loop {
+                std::thread::sleep(Duration::from_millis(10));
+                let current = event_count.load(Ordering::Relaxed);
+                if current == last_seen || Instant::now() >= settle_deadline {
+                    break;
+                }
+                last_seen = current;
+            }
             let events_before = event_count.load(Ordering::Relaxed);
 
+            // Resume so bytes are genuinely in flight as shutdown lands —
+            // that in-flight byte is the race this section exists to check.
+            injector_paused.store(false, Ordering::Relaxed);
             shutdown_active.store(true, Ordering::Relaxed);
             crate::ui::terminal::EVENT_READER_SHUTDOWN.store(true, Ordering::Relaxed);
             crate::ui::terminal::join_reader(Duration::from_millis(50));
 
-            // The reader is now joined (consuming nothing). The earlier
-            // version drained whatever the free-running injector happened
-            // to have buffered at this instant — racy, so the drain came
-            // back empty intermittently. Instead write a DETERMINISTIC
-            // sentinel (a byte outside the injector's alnum charset) now
-            // that nothing will consume it, and drain until it appears.
-            // This still exercises the drain-capture path (the real
-            // invariant) without depending on injector timing.
+            // Quiesce the injector BEFORE the sentinel. The shutdown-race
+            // window this section measures is already closed — the flood ran
+            // continuously through `EVENT_READER_SHUTDOWN` and the join above,
+            // which is what puts bytes in flight at the moment of shutdown —
+            // so stopping here costs the test nothing.
+            //
+            // Leaving it running made the drain below chase a live producer:
+            // the sentinel lands behind whatever the injector has already
+            // queued, and at ~1 byte/ms the drain consumes at roughly the
+            // production rate without ever clearing that backlog. On loaded
+            // CI the deadline expired with the sentinel still buffered
+            // (observed: drained=187, shutdown_window_bytes=191, no sentinel).
+            // With the producer stopped the backlog is finite, so the drain
+            // reaches the sentinel in bounded time.
+            injector_running.store(false, Ordering::Relaxed);
+            let _ = injector.join();
+
+            // The reader is joined and the flood is stopped, so nothing will
+            // consume this. Write a DETERMINISTIC sentinel (a byte outside
+            // the injector's alnum charset) and drain until it appears — the
+            // earlier version drained whatever happened to be buffered at
+            // this instant, which came back empty intermittently.
             const SENTINEL: u8 = b'~';
             {
                 let mut sentinel_pri = primary.try_clone().expect("clone primary for sentinel");
@@ -181,7 +225,11 @@ mod tests {
                 let _ = sentinel_pri.flush();
             }
             let mut drained: Vec<u8> = Vec::new();
-            let drain_deadline = Instant::now() + Duration::from_millis(200);
+            // Generous, but the loop exits the moment the sentinel appears —
+            // this only bounds the pathological case. With the producer
+            // stopped the backlog is finite, so a slow runner needs headroom
+            // to chew through it, not a tighter deadline.
+            let drain_deadline = Instant::now() + Duration::from_secs(2);
             while Instant::now() < drain_deadline {
                 drained.extend_from_slice(&crate::ui::terminal::drain_stdin_nonblocking());
                 if drained.contains(&SENTINEL) {
@@ -205,8 +253,6 @@ mod tests {
             }
             let events_after = event_count.load(Ordering::Relaxed);
 
-            injector_running.store(false, Ordering::Relaxed);
-            let _ = injector.join();
             bridge_done.store(true, Ordering::Relaxed);
             let _ = bridge.join();
 


### PR DESCRIPTION
Both of these failed intermittently on `build (all-features)` during #719 while passing locally. Neither was guarding a regression — they were racing wall-clock deadlines against work whose latency isn't bounded.

## `plugin::worker::eval_waits_for_an_in_flight_confirm_past_the_base_timeout`

`eval_with_timeout` only extends past the base budget if `dialog_pending` is set when that budget expires. A 100 ms budget raced a cold Janet VM reaching `harness/confirm`; when it lost, the eval timed out and reported `did not reply within 0s` (100 ms truncating to 0 in `as_secs`).

Warm up the worker so the timed eval doesn't pay VM init, and give the budget real headroom (750 ms base / 1500 ms answer). Also assert the answer arrived *after* the base budget lapsed — otherwise the test can pass without ever exercising the extension it exists to guard.

While here: `send_dialog` published the request *before* entering `DialogPendingGuard`, leaving a window where a responder could see a dialog that wasn't yet counted as in flight. The guard now enters first.

## `ui::relay_tests::crossterm_suite` (section 3.2)

Two separate problems.

**The drain chased a live producer.** The sentinel lands behind whatever the injector already queued, and at ~1 byte/ms the drain consumes at roughly the production rate without ever clearing the backlog — the deadline expired with the sentinel still buffered (`drained=187, shutdown_bytes=191`). The injector is now quiesced before the sentinel is written; the shutdown window this section measures is already closed by `join_reader`, so nothing is lost.

**The baseline lagged.** This one only surfaced under stress testing. `event_count` is incremented by the *bridge* thread, which trails the reader under load, so sampling `events_before` while it lagged credited pre-shutdown events to the post-shutdown window — 8 "new" events from a 2-byte shutdown window. That's a measurement artifact, not a reader ignoring the shutdown flag. The injector now pauses, the bridge drains to a fixed point, the baseline is sampled, then the flood resumes so bytes are still genuinely in flight when shutdown lands.

`MAX_SHUTDOWN_RACE_EVENTS` deliberately stays at 3. It had already been raised from 0 once for this same symptom; raising it again would have hidden the lagging-baseline bug rather than fixed it.

## Verification

Each test passes 12/12 with all 10 cores saturated — that stress load is what surfaced the second crossterm defect, which a single clean run sails past. clippy and rustfmt are clean. Leaving the full suite to CI.