### PR TITLE
test(microvm): skip host-key tests when ssh-keygen is absent

### DIFF
--- a/src/sandbox/microvm/ssh.rs
+++ b/src/sandbox/microvm/ssh.rs
@@ -421,6 +421,20 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    // `HostKeys::generate` shells out to `ssh-keygen`; when that binary isn't
+    // installed (e.g. a minimal CI runner) the host-key tests would panic on
+    // process spawn instead of exercising anything. Skip loudly in that case —
+    // the assertions below still run in full wherever ssh-keygen exists.
+    fn ssh_keygen_on_path() -> bool {
+        // `is_file`, not `exists`: a *directory* named `ssh-keygen` on PATH
+        // would satisfy the guard and then panic on spawn — the very failure
+        // this check exists to prevent. Fails safe in the other direction too
+        // (an unreadable PATH entry skips rather than panics).
+        std::env::var_os("PATH")
+            .map(|p| std::env::split_paths(&p).any(|dir| dir.join("ssh-keygen").is_file()))
+            .unwrap_or(false)
+    }
+
     #[test]
     fn ssh_exec_connection_refused() {
         // Pick a port where nothing is listening.
@@ -534,6 +548,12 @@ mod tests {
 
     #[test]
     fn host_keys_public_key_bytes_roundtrip() {
+        if !ssh_keygen_on_path() {
+            eprintln!(
+                "skipping: ssh-keygen not on PATH; install it to exercise host-key generation"
+            );
+            return;
+        }
         let hk = HostKeys::generate().expect("generate host keys");
         let raw = hk.public_key_bytes().expect("decode public key");
         assert_eq!(raw.len(), 32, "ed25519 raw key must be 32 bytes");
@@ -543,6 +563,12 @@ mod tests {
 
     #[test]
     fn host_keys_generated_key_is_ed25519() {
+        if !ssh_keygen_on_path() {
+            eprintln!(
+                "skipping: ssh-keygen not on PATH; install it to exercise host-key generation"
+            );
+            return;
+        }
         let hk = HostKeys::generate().unwrap();
         assert!(
             hk.public_key.starts_with("ssh-ed25519 "),


### PR DESCRIPTION
Closes dirge-04q0.

`host_keys_generated_key_is_ed25519` and `host_keys_public_key_bytes_roundtrip` call `HostKeys::generate()`, which shells out to `ssh-keygen`. On a runner without that binary they panic on spawn (`No such file or directory (os error 2)`) and fail the all-features job. Environment-dependent, not a regression — it passed on runs where the binary happened to be present.

Both tests now check `ssh-keygen` is on PATH and skip with a message when it isn't.

**Skip rather than generate in-process**: the production path genuinely shells out to `ssh-keygen`, so generating a key in-process would test something other than what ships. The assertions are untouched, so wherever the binary exists these cover exactly what they did before — no silent weakening.

The guard uses `is_file` rather than `exists`: a *directory* named `ssh-keygen` on PATH would otherwise satisfy it and then panic on spawn, which is the failure this is meant to prevent.

## Verification

- 9/9 pass locally with `ssh-keygen` installed — the assertions run in full, so the guard doesn't skip when it shouldn't.
- Under `PATH=/nonexistent` the two tests skip cleanly and pass instead of panicking, with the reason printed.

Leaving the full suite to CI.