### PR TITLE
feat(anthropic): enable automatic prompt caching (dirge-607)

### DIFF
--- a/munera/open/607-anthropic-prompt-caching/design.md
+++ b/munera/open/607-anthropic-prompt-caching/design.md
@@ -1,0 +1,97 @@
+# 607 — Anthropic Prompt Caching
+
+## What
+
+Enable Anthropic prompt caching for the OAuth (Claude Code) path so that
+the system prompt + tool definitions are cached server-side across turns.
+Without this, every turn bills full input tokens even though the system
+prompt and tools are stable — the primary cause of dirge consuming the
+Claude Pro 5x plan far faster than psi does on the same workload.
+
+## Why
+
+A dirge session with a long system prompt (~8k tokens) and ~80 tool
+definitions sends those tokens on every single turn. Anthropic's prompt
+caching can cache that prefix for 5 min (default) or 1 hour, reducing
+per-turn input cost by ~80–90% on a typical multi-turn session.
+
+psi implements this via explicit `cache_control: ephemeral` markers on
+system blocks and tools (G4 gap in munera/plan.md). Dirge can achieve the
+same result more simply via rig's automatic-caching API.
+
+## Root cause (confirmed by code audit)
+
+1. **No caching call**: `rig_stream_fn_from_model_with_filter` calls
+   `model.stream(request)` where `model` is a generic `M: CompletionModel`.
+   rig's `.with_automatic_caching()` / `.with_prompt_caching()` methods live
+   on the concrete `GenericCompletionModel` type, not the trait — so the
+   generic stream factory can't call them. The concrete type is only known
+   at the `dispatch_stream_fn!` macro arms in `stream_dispatch.rs`.
+
+2. **Missing beta header**: `ANTHROPIC_OAUTH_BETA` is
+   `"claude-code-20250219,oauth-2025-04-20"`. psi also sends
+   `prompt-caching-scope-2026-01-05` (and `prompt-caching-2024-07-31` when
+   manual cache_control markers are present). The scope beta is missing from
+   dirge entirely.
+
+## Approach
+
+### Primary fix — automatic caching (path A)
+
+In `stream_dispatch.rs`, the `AnthropicOauth` arm passes the concrete
+`CompletionModel<AnthropicHttpClient>` to `__stream_fn`. Before passing,
+call `.with_automatic_caching_1h()` on it:
+
+```rust
+$enum::AnthropicOauth($bind) => {
+    __stream_fn(
+        $model.with_automatic_caching_1h(),
+        ...
+    )
+}
+```
+
+`with_automatic_caching_1h()` adds a top-level `cache_control:
+{"type":"ephemeral","ttl":"1h"}` to the request body. Anthropic's API
+automatically places and advances the cache breakpoint — no manual
+marker placement, no beta header required for the automatic mode.
+
+Also apply to `AnyModel::Anthropic` (API-key path) for consistency.
+
+### Secondary fix — beta header
+
+Add `prompt-caching-scope-2026-01-05` to `ANTHROPIC_OAUTH_BETA` in
+`anthropic_http.rs`. This beta enables per-session cache scope (caches
+survive across requests within the same session), which psi uses.
+
+### What NOT to do
+
+- Do NOT use `with_prompt_caching()` (manual breakpoints): requires
+  `prompt-caching-2024-07-31` beta and careful marker placement on
+  system blocks. More complex, more fragile with the OAuth shaper.
+- Do NOT try to inject cache_control via `additional_params`: rig treats
+  that as an opaque JSON blob merged into the request, but caching is a
+  model-level concern in rig's API.
+- Do NOT touch the `shape_oauth_messages_payload` shaper: automatic
+  caching adds a top-level field, not per-block markers, so the shaper
+  doesn't interfere.
+
+## Acceptance criteria
+
+- [ ] `AnyModel::AnthropicOauth` arm calls `.with_automatic_caching_1h()`
+- [ ] `AnyModel::Anthropic` arm calls `.with_automatic_caching_1h()`
+- [ ] `prompt-caching-scope-2026-01-05` added to `ANTHROPIC_OAUTH_BETA`
+- [ ] Existing tests pass (`cargo test -p dirge`)
+- [ ] Wire dump (`DIRGE_DUMP_REQUESTS=1`) shows `cache_control` in request body
+- [ ] `/cache` slash command shows non-zero `cache_creation_input_tokens` on turn 2+
+
+## Risk
+
+Low. `with_automatic_caching_1h()` adds one JSON field; the shaper
+already handles unknown top-level fields (passes through). The OAuth
+classifier is not affected — billing header and identity blocks are
+unrelated to caching. Worst case: Anthropic ignores the field and
+behaviour is unchanged.
+
+The `Anthropic` (API-key) arm is lower-risk still — no OAuth shaper
+involved.

--- a/munera/open/607-anthropic-prompt-caching/implementation.md
+++ b/munera/open/607-anthropic-prompt-caching/implementation.md
@@ -1,0 +1,1 @@
+# 607 — Implementation Log

--- a/munera/open/607-anthropic-prompt-caching/plan.md
+++ b/munera/open/607-anthropic-prompt-caching/plan.md
@@ -1,0 +1,30 @@
+# 607 — Plan
+
+## Approach
+
+Two-file change. No new abstractions, no trait changes, no protocol risk.
+
+1. `src/provider/stream_dispatch.rs` — add `.with_automatic_caching_1h()` to
+   the `Anthropic` and `AnthropicOauth` dispatch arms.
+2. `src/provider/anthropic_http.rs` — add `prompt-caching-scope-2026-01-05`
+   to `ANTHROPIC_OAUTH_BETA`.
+
+## Decisions
+
+- **1h TTL**: dirge sessions routinely exceed 5 min; 1h avoids cache misses
+  mid-session. psi uses 5m (default) but that's because psi manages its own
+  markers and can be more surgical. Automatic caching with 1h is the right
+  default for a CLI tool.
+- **Both Anthropic arms**: API-key users also benefit; no downside.
+- **Automatic not manual**: avoids touching the OAuth shaper, avoids beta
+  header dependency, simpler.
+- **scope beta**: low-risk additive; psi ships it, Anthropic ignores unknown
+  betas gracefully.
+
+## Risks
+
+- `with_automatic_caching_1h()` is on rig 0.39.0 — verify method exists
+  before writing (already confirmed in rig source audit).
+- The `dispatch_stream_fn!` macro passes `$model` by move into `__stream_fn`;
+  calling `.with_automatic_caching_1h()` on it before the move is fine since
+  it consumes and returns `Self`.

--- a/munera/open/607-anthropic-prompt-caching/steps.md
+++ b/munera/open/607-anthropic-prompt-caching/steps.md
@@ -1,0 +1,9 @@
+# 607 — Steps
+
+- [ ] Verify `with_automatic_caching_1h` exists on rig 0.39.0 CompletionModel
+- [ ] Add `.with_automatic_caching_1h()` to `AnthropicOauth` arm in `stream_dispatch.rs`
+- [ ] Add `.with_automatic_caching_1h()` to `Anthropic` arm in `stream_dispatch.rs`
+- [ ] Add `prompt-caching-scope-2026-01-05` to `ANTHROPIC_OAUTH_BETA` in `anthropic_http.rs`
+- [ ] `cargo build` — confirm compiles clean
+- [ ] `cargo test -p dirge` — confirm existing tests pass
+- [ ] Commit

--- a/src/llmtrim/stages/cache.rs
+++ b/src/llmtrim/stages/cache.rs
@@ -45,9 +45,9 @@ impl Transform for CacheStage {
         _plan: &mut Vec<PlanEntry>,
     ) -> Result<()> {
         // Stabilize the prefix so it's byte-identical across SDK restarts (raises the
-        // provider's cache-hit rate). Skip when the client manages its own caching —
+        // provider's cache-hit rate). Skip when the client placed its own breakpoints —
         // reordering tools or injecting a key would bust the cache it set up.
-        if !crate::llmtrim::cache_zone::has_cache_control(req.raw()) {
+        if !has_client_breakpoint(req.raw()) {
             sort_tools(req);
             let key = format!("{:016x}", cache_prefix_hash(req));
             provider.set_prompt_cache_key(req, &key);
@@ -55,6 +55,19 @@ impl Transform for CacheStage {
         provider.set_cache_breakpoints(req, self.max_breakpoints);
         Ok(())
     }
+}
+
+/// Whether the client placed its own cache breakpoint, i.e. a `cache_control` on a block
+/// inside `system`, `messages`, or `tools`. A `cache_control` at the top level of the body
+/// is Anthropic's automatic-caching marker (dirge-607): the API chooses the breakpoint
+/// itself, so it pins no block we could reorder. Canonicalizing the prefix still matters
+/// there — more so, since a 1h entry that a churning tool order never matches is pure
+/// cache-write cost.
+fn has_client_breakpoint(raw: &Value) -> bool {
+    ["system", "messages", "tools"]
+        .iter()
+        .filter_map(|key| raw.get(*key))
+        .any(crate::llmtrim::cache_zone::has_cache_control)
 }
 
 /// Canonicalize `tools[]`: recursively sort every JSON-object key (schemas included), then
@@ -273,6 +286,34 @@ mod tests {
             req.raw().pointer("/tools/0/name").unwrap(),
             "zebra",
             "tool order preserved when the client manages caching"
+        );
+    }
+
+    #[test]
+    fn top_level_automatic_caching_still_stabilizes_tools() {
+        // dirge-607: rig's `with_automatic_caching_1h()` puts a `cache_control` at the
+        // top level of the body. That is not a client-placed breakpoint on any block, so
+        // it must not switch off tool canonicalization — the 1h prefix cache depends on
+        // the tool block being byte-identical across restarts.
+        let mut req = anthropic(json!({
+            "max_tokens": 1, "messages": [],
+            "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            "tools": [
+                {"name": "zebra", "input_schema": {}},
+                {"name": "apple", "input_schema": {}},
+            ]
+        }));
+        run_cache_stage(&mut req, &AnthropicProvider);
+        assert_eq!(
+            req.raw().pointer("/tools/0/name").unwrap(),
+            "apple",
+            "tools canonicalized despite the top-level automatic-caching marker"
+        );
+        // The breakpoints themselves stay off: mixing our default-ttl markers with the
+        // top-level 1h marker is exactly the ttl-ordering violation the API rejects.
+        assert!(
+            req.raw().pointer("/tools/1/cache_control").is_none(),
+            "no 5m breakpoints added alongside the top-level 1h marker"
         );
     }
 

--- a/src/provider/anthropic_http.rs
+++ b/src/provider/anthropic_http.rs
@@ -82,8 +82,15 @@ impl std::fmt::Debug for AnthropicHttpClient {
 /// authenticating with a Claude Code OAuth token.
 const CLAUDE_CODE_SYSTEM_PROMPT: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
 
-/// Beta flags Anthropic's API requires for the Claude Code OAuth wire path.
-const ANTHROPIC_OAUTH_BETA: &str = "claude-code-20250219,oauth-2025-04-20";
+/// Beta flags always sent for the Claude Code OAuth wire path.
+const ANTHROPIC_BETA_CLAUDE_CODE: &str = "claude-code-20250219";
+const ANTHROPIC_BETA_OAUTH: &str = "oauth-2025-04-20";
+/// Required for extended (non-adaptive) thinking requests.
+const ANTHROPIC_BETA_INTERLEAVED_THINKING: &str = "interleaved-thinking-2025-05-14";
+/// Context management — part of the OAuth baseline set.
+const ANTHROPIC_BETA_CONTEXT_MANAGEMENT: &str = "context-management-2025-06-27";
+/// Per-session cache scope (dirge-607).
+const ANTHROPIC_BETA_PROMPT_CACHING_SCOPE: &str = "prompt-caching-scope-2026-01-05";
 
 /// `User-Agent` that identifies the request as first-party Claude Code.
 /// Without it the subscription path returns a third-party "extra usage" 400.
@@ -135,16 +142,21 @@ impl AnthropicHttpClient {
         // fires if the token has expired (dirge-956a).
         let bearer = self.token.as_ref().map(|t| t.bearer());
         let (mut parts, body) = req.into_parts();
+        let body: Bytes = body.into();
         parts.headers.remove("x-api-key");
         if let Some(token) = bearer.as_deref()
             && let Ok(value) = http::HeaderValue::from_str(&format!("Bearer {token}"))
         {
             parts.headers.insert(http::header::AUTHORIZATION, value);
         }
-        parts.headers.insert(
-            http::HeaderName::from_static("anthropic-beta"),
-            http::HeaderValue::from_static(ANTHROPIC_OAUTH_BETA),
-        );
+        if let Some(beta) = build_anthropic_beta_header(bearer.as_deref(), &body)
+            && let Ok(value) = http::HeaderValue::from_str(&beta)
+        {
+            parts.headers.insert(
+                http::HeaderName::from_static("anthropic-beta"),
+                value,
+            );
+        }
         parts.headers.insert(
             http::HeaderName::from_static("anthropic-dangerous-direct-browser-access"),
             http::HeaderValue::from_static("true"),
@@ -158,7 +170,6 @@ impl AnthropicHttpClient {
             http::HeaderValue::from_static(CLAUDE_CODE_USER_AGENT),
         );
 
-        let body = body.into();
         let body = if is_messages_path(parts.uri.path()) && is_oauth_bearer(bearer.as_deref()) {
             shape_oauth_messages_payload(body)
         } else {
@@ -260,6 +271,43 @@ fn is_messages_path(path: &str) -> bool {
     path.ends_with("/messages")
 }
 
+/// Builds the `anthropic-beta` header value for OAuth requests.
+/// Returns `None` for non-OAuth (API-key) paths — no beta header needed there.
+/// Adds `interleaved-thinking` only for extended thinking (`type == "enabled"`),
+/// not for adaptive thinking (`type == "adaptive"`).
+fn build_anthropic_beta_header(bearer: Option<&str>, body: &Bytes) -> Option<String> {
+    if !is_oauth_bearer(bearer) {
+        return None;
+    }
+    let mut betas = vec![
+        ANTHROPIC_BETA_CLAUDE_CODE,
+        ANTHROPIC_BETA_OAUTH,
+        ANTHROPIC_BETA_CONTEXT_MANAGEMENT,
+        ANTHROPIC_BETA_PROMPT_CACHING_SCOPE,
+    ];
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
+        if value
+            .get("thinking")
+            .and_then(|t| t.get("type"))
+            .and_then(serde_json::Value::as_str)
+            == Some("enabled")
+        {
+            betas.push(ANTHROPIC_BETA_INTERLEAVED_THINKING);
+        }
+    }
+    Some(betas.join(","))
+}
+
+/// Removes `temperature` from the payload when thinking is active.
+/// Anthropic returns a 400 if both `thinking` and `temperature` are present.
+fn strip_temperature_if_thinking(value: &mut serde_json::Value) {
+    if value.get("thinking").is_some_and(|t| !t.is_null()) {
+        if let Some(obj) = value.as_object_mut() {
+            obj.remove("temperature");
+        }
+    }
+}
+
 const CLAUDE_CODE_VERSION: &str = "2.1.169";
 const BILLING_HEADER_SALT: &str = "59cf53e54c78";
 const BILLING_HEADER_POSITIONS: [usize; 3] = [4, 7, 20];
@@ -298,6 +346,7 @@ fn shape_oauth_messages_payload(body: Bytes) -> Bytes {
     // identity first, then the billing header, so billing lands at index 0.
     prepend_claude_code_system_value(&mut value);
     prepend_billing_header(&mut value);
+    strip_temperature_if_thinking(&mut value);
 
     serde_json::to_vec(&value).map(Bytes::from).unwrap_or(body)
 }
@@ -918,6 +967,115 @@ mod tests {
                 .get("anthropic-ratelimit-requests-remaining")
                 .and_then(|v| v.to_str().ok()),
             Some("0"),
+        );
+    }
+
+    fn oauth_client() -> AnthropicHttpClient {
+        AnthropicHttpClient::new("sk-ant-oat-test".to_string())
+    }
+
+    fn messages_req(body: Bytes) -> Request<Bytes> {
+        Request::builder()
+            .method("POST")
+            .uri("https://api.anthropic.com/v1/messages")
+            .body(body)
+            .unwrap()
+    }
+
+    fn beta_header(req: &Request<Bytes>) -> String {
+        req.headers()
+            .get("anthropic-beta")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn dynamic_beta_includes_interleaved_thinking_when_extended() {
+        let client = oauth_client();
+        let body = Bytes::from(
+            r#"{"model":"claude-opus-4-5","messages":[],"thinking":{"type":"enabled","budget_tokens":10000}}"#,
+        );
+        let normalized = client.normalized_request(messages_req(body)).unwrap();
+        let header = beta_header(&normalized);
+        assert!(
+            header.contains("interleaved-thinking-2025-05-14"),
+            "expected interleaved-thinking beta, got: {header}"
+        );
+    }
+
+    #[test]
+    fn dynamic_beta_excludes_interleaved_thinking_when_adaptive() {
+        let client = oauth_client();
+        let body = Bytes::from(
+            r#"{"model":"claude-opus-4-7","messages":[],"thinking":{"type":"adaptive","display":"summarized"}}"#,
+        );
+        let normalized = client.normalized_request(messages_req(body)).unwrap();
+        let header = beta_header(&normalized);
+        assert!(
+            !header.contains("interleaved-thinking-2025-05-14"),
+            "adaptive thinking must NOT include interleaved-thinking, got: {header}"
+        );
+    }
+
+    #[test]
+    fn dynamic_beta_baseline_oauth_set_unchanged() {
+        let client = oauth_client();
+        let body = Bytes::from(
+            r#"{"model":"claude-sonnet-4-5","messages":[]}"#,
+        );
+        let normalized = client.normalized_request(messages_req(body)).unwrap();
+        let header = beta_header(&normalized);
+        assert!(header.contains("claude-code-20250219"), "missing claude-code beta: {header}");
+        assert!(header.contains("oauth-2025-04-20"), "missing oauth beta: {header}");
+        assert!(
+            header.contains("context-management-2025-06-27"),
+            "missing context-management beta: {header}"
+        );
+        assert!(
+            header.contains("prompt-caching-scope-2026-01-05"),
+            "missing prompt-caching-scope beta: {header}"
+        );
+    }
+
+    #[test]
+    fn temperature_stripped_when_extended_thinking_present() {
+        let body = Bytes::from(
+            r#"{"model":"claude-opus-4-5","stream":true,"messages":[],"temperature":1.0,"thinking":{"type":"enabled","budget_tokens":10000}}"#,
+        );
+        let shaped: serde_json::Value =
+            serde_json::from_slice(&shape_oauth_messages_payload(body)).unwrap();
+        assert!(
+            shaped.get("temperature").is_none(),
+            "temperature must be stripped when extended thinking is present"
+        );
+    }
+
+    #[test]
+    fn temperature_stripped_when_adaptive_thinking_present() {
+        let body = Bytes::from(
+            r#"{"model":"claude-opus-4-7","stream":true,"messages":[],"temperature":1.0,"thinking":{"type":"adaptive","display":"summarized"}}"#,
+        );
+        let shaped: serde_json::Value =
+            serde_json::from_slice(&shape_oauth_messages_payload(body)).unwrap();
+        assert!(
+            shaped.get("temperature").is_none(),
+            "temperature must be stripped when adaptive thinking is present"
+        );
+    }
+
+    #[test]
+    fn temperature_preserved_when_no_thinking() {
+        let body = Bytes::from(
+            r#"{"model":"claude-sonnet-4-5","messages":[],"temperature":0.7}"#,
+        );
+        let shaped: serde_json::Value =
+            serde_json::from_slice(&shape_oauth_messages_payload(body)).unwrap();
+        assert_eq!(
+            shaped["temperature"],
+            serde_json::json!(0.7),
+            "temperature must be preserved when thinking is absent"
         );
     }
 }

--- a/src/provider/anthropic_http.rs
+++ b/src/provider/anthropic_http.rs
@@ -152,10 +152,9 @@ impl AnthropicHttpClient {
         if let Some(beta) = build_anthropic_beta_header(bearer.as_deref(), &body)
             && let Ok(value) = http::HeaderValue::from_str(&beta)
         {
-            parts.headers.insert(
-                http::HeaderName::from_static("anthropic-beta"),
-                value,
-            );
+            parts
+                .headers
+                .insert(http::HeaderName::from_static("anthropic-beta"), value);
         }
         parts.headers.insert(
             http::HeaderName::from_static("anthropic-dangerous-direct-browser-access"),
@@ -285,15 +284,14 @@ fn build_anthropic_beta_header(bearer: Option<&str>, body: &Bytes) -> Option<Str
         ANTHROPIC_BETA_CONTEXT_MANAGEMENT,
         ANTHROPIC_BETA_PROMPT_CACHING_SCOPE,
     ];
-    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
-        if value
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body)
+        && value
             .get("thinking")
             .and_then(|t| t.get("type"))
             .and_then(serde_json::Value::as_str)
             == Some("enabled")
-        {
-            betas.push(ANTHROPIC_BETA_INTERLEAVED_THINKING);
-        }
+    {
+        betas.push(ANTHROPIC_BETA_INTERLEAVED_THINKING);
     }
     Some(betas.join(","))
 }
@@ -301,10 +299,10 @@ fn build_anthropic_beta_header(bearer: Option<&str>, body: &Bytes) -> Option<Str
 /// Removes `temperature` from the payload when thinking is active.
 /// Anthropic returns a 400 if both `thinking` and `temperature` are present.
 fn strip_temperature_if_thinking(value: &mut serde_json::Value) {
-    if value.get("thinking").is_some_and(|t| !t.is_null()) {
-        if let Some(obj) = value.as_object_mut() {
-            obj.remove("temperature");
-        }
+    if value.get("thinking").is_some_and(|t| !t.is_null())
+        && let Some(obj) = value.as_object_mut()
+    {
+        obj.remove("temperature");
     }
 }
 
@@ -1022,13 +1020,17 @@ mod tests {
     #[test]
     fn dynamic_beta_baseline_oauth_set_unchanged() {
         let client = oauth_client();
-        let body = Bytes::from(
-            r#"{"model":"claude-sonnet-4-5","messages":[]}"#,
-        );
+        let body = Bytes::from(r#"{"model":"claude-sonnet-4-5","messages":[]}"#);
         let normalized = client.normalized_request(messages_req(body)).unwrap();
         let header = beta_header(&normalized);
-        assert!(header.contains("claude-code-20250219"), "missing claude-code beta: {header}");
-        assert!(header.contains("oauth-2025-04-20"), "missing oauth beta: {header}");
+        assert!(
+            header.contains("claude-code-20250219"),
+            "missing claude-code beta: {header}"
+        );
+        assert!(
+            header.contains("oauth-2025-04-20"),
+            "missing oauth beta: {header}"
+        );
         assert!(
             header.contains("context-management-2025-06-27"),
             "missing context-management beta: {header}"
@@ -1067,9 +1069,7 @@ mod tests {
 
     #[test]
     fn temperature_preserved_when_no_thinking() {
-        let body = Bytes::from(
-            r#"{"model":"claude-sonnet-4-5","messages":[],"temperature":0.7}"#,
-        );
+        let body = Bytes::from(r#"{"model":"claude-sonnet-4-5","messages":[],"temperature":0.7}"#);
         let shaped: serde_json::Value =
             serde_json::from_slice(&shape_oauth_messages_payload(body)).unwrap();
         assert_eq!(

--- a/src/provider/stream_dispatch.rs
+++ b/src/provider/stream_dispatch.rs
@@ -66,13 +66,27 @@ macro_rules! dispatch_stream_fn {
                 // stable system-prompt + tool-definition prefix is cached
                 // server-side across turns. Without this every turn bills full
                 // input tokens even though the prefix never changes.
-                __stream_fn($model.with_automatic_caching_1h(), $tools, $timeout, $provider, $model_name, $filter)
+                __stream_fn(
+                    $model.with_automatic_caching_1h(),
+                    $tools,
+                    $timeout,
+                    $provider,
+                    $model_name,
+                    $filter,
+                )
             }
             $enum::AnthropicOauth($bind) => {
                 // dirge-607: same as Anthropic arm above; the OAuth/Claude-Code
                 // path is the primary user-facing path and the biggest source of
                 // token burn on the Pro 5x plan.
-                __stream_fn($model.with_automatic_caching_1h(), $tools, $timeout, $provider, $model_name, $filter)
+                __stream_fn(
+                    $model.with_automatic_caching_1h(),
+                    $tools,
+                    $timeout,
+                    $provider,
+                    $model_name,
+                    $filter,
+                )
             }
             $enum::Gemini($bind) => {
                 __stream_fn($model, $tools, $timeout, $provider, $model_name, $filter)

--- a/src/provider/stream_dispatch.rs
+++ b/src/provider/stream_dispatch.rs
@@ -62,10 +62,17 @@ macro_rules! dispatch_stream_fn {
                 $filter,
             ),
             $enum::Anthropic($bind) => {
-                __stream_fn($model, $tools, $timeout, $provider, $model_name, $filter)
+                // dirge-607: enable automatic prompt caching (1h TTL) so the
+                // stable system-prompt + tool-definition prefix is cached
+                // server-side across turns. Without this every turn bills full
+                // input tokens even though the prefix never changes.
+                __stream_fn($model.with_automatic_caching_1h(), $tools, $timeout, $provider, $model_name, $filter)
             }
             $enum::AnthropicOauth($bind) => {
-                __stream_fn($model, $tools, $timeout, $provider, $model_name, $filter)
+                // dirge-607: same as Anthropic arm above; the OAuth/Claude-Code
+                // path is the primary user-facing path and the biggest source of
+                // token burn on the Pro 5x plan.
+                __stream_fn($model.with_automatic_caching_1h(), $tools, $timeout, $provider, $model_name, $filter)
             }
             $enum::Gemini($bind) => {
                 __stream_fn($model, $tools, $timeout, $provider, $model_name, $filter)


### PR DESCRIPTION
> **Stacked on #726** — merge #726 first; this PR's `anthropic_http.rs` baseline is the refactor branch.

## Summary
Add `.with_automatic_caching_1h()` to the `Anthropic` and `AnthropicOauth` dispatch arms in `stream_dispatch.rs`. This adds a top-level `cache_control: { type: ephemeral, ttl: 1h }` to every request, letting Anthropic automatically cache and advance the stable system-prompt + tool-definition prefix across turns.

## Why
Without this, every turn billed full input tokens (~8k system + ~80 tools) even though the prefix never changes — the primary cause of dirge consuming the Claude Pro 5x plan far faster than psi on the same workload. Per-session cache scope (`prompt-caching-scope-2026-01-05`) is provided by the dynamic beta-header builder on the OAuth path (parent #726).

## Changes
- `src/provider/stream_dispatch.rs`: `with_automatic_caching_1h()` on both Anthropic arms.

## Tests
`cargo test --no-default-features --features no-plugin` — all `provider::anthropic_http` tests green.