### PR TITLE
Bump rig to 0.41 so reasoning shows on LocalAI (#745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
-- Dependency sweep. `rmcp` was on two versions at once — our own 1.7 plus a 2.2
-  that `rig`'s unused `rmcp` feature dragged in, and a third from
+- Dependency sweep. `rmcp` was on three versions at once — our own 1.7, a 2.2
+  that `rig`'s unused `rmcp` feature dragged in, and a 1.8 from
   `agent-client-protocol`. Nothing here ever touched rig's MCP bridge, so that
   feature is gone; `agent-client-protocol` moves 0.12 → 2.0 (its types live under
   `schema::v1` now, and `respond_with_error` moved from `Dispatch` to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to dirge are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Dependency sweep. `rmcp` was on two versions at once — our own 1.7 plus a 2.2
+  that `rig`'s unused `rmcp` feature dragged in, and a third from
+  `agent-client-protocol`. Nothing here ever touched rig's MCP bridge, so that
+  feature is gone; `agent-client-protocol` moves 0.12 → 2.0 (its types live under
+  `schema::v1` now, and `respond_with_error` moved from `Dispatch` to the
+  `Responder` that only the request variant carries); and `rmcp` goes to 3.1,
+  where `Annotated<RawContent>` is flattened to `ContentBlock`. One rmcp, latest.
+
+  Also current: `rusqlite` 0.31 → 0.40 (no `ToSql for usize`), `sysinfo`
+  0.32 → 0.39 (`RefreshKind::new` → `nothing`), `sha2` 0.10 → 0.11 (digest output
+  dropped `LowerHex`, so the two hex helpers encode explicitly), `jsonschema`
+  0.46 → 0.49, `base64` 0.23, `compact_str` 0.10, `http` 1.5, `notify-rust` 4.18.
+  `tree-sitter` stays at 0.25 — 0.26 does not resolve against the grammar crates.
+
+### Fixed
+- Reasoning is shown again for providers that stream it as `delta.reasoning`
+  rather than `delta.reasoning_content` (GH #745, reported against LocalAI).
+  rig 0.39 only deserialized `reasoning_content`, so serde dropped the field and
+  the panel stayed empty while text and tool calls — carried in the same delta —
+  worked fine. rig 0.40 added the fallback upstream; this bumps rig to 0.41.
+
+  The bump is not small. 0.41 splits the classic runtime into `rig-agent` behind
+  an `agent` feature, replaces `Tool::definition` with `description`/`parameters`
+  across all 37 tools, drops `ToolDyn` in favour of a concrete struct, and makes
+  `Agent::preamble` and `Agent::model` private. Dirge's tools move to the
+  context-free `PortableTool` contract, which is the honest fit — the agent loop
+  has driven its own dispatch since 4.5h-6 and never used rig's `ToolContext`.
+  The erased-tool seam is now dirge's own `DynTool`; it has broken on two
+  consecutive rig releases and does not need to be rig's. `AnyAgentInner` holds
+  the completion model directly instead of a rig `Agent` it only ever read the
+  model back out of.
+
+- Cerebras no longer 400s on the turn after a reasoning turn. It streams
+  reasoning as `delta.reasoning` — the same field LocalAI uses — so the fix
+  above meant dirge started capturing it and replaying it as `reasoning_content`,
+  which Cerebras rejects outright. The field is renamed to `reasoning` at the
+  wire boundary rather than dropped, so the model keeps its own chain of thought
+  in context on the next turn. Backends that want `reasoning_content` are
+  untouched: DeepSeek needs it on tool-call turns, and llama.cpp/LocalAI chat
+  templates read `message.reasoning_content` back out of the assistant turn.
+  Only the OpenAI Responses API still has the block dropped, because it keys
+  reasoning to encrypted ids dirge does not retain.
+
 ## [0.21.6] - 2026-08-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,44 +41,43 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.12.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
+ "async-io",
  "async-process",
  "blocking",
  "futures",
  "futures-concurrency",
- "jsonrpcmsg",
- "rmcp",
  "rustc-hash 2.1.3",
+ "rustix",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "shell-words",
- "tokio",
- "tokio-util",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -414,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,7 +432,7 @@ checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -767,7 +772,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -776,7 +781,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -821,8 +826,21 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
  "serde",
  "static_assertions",
+ "zmij",
 ]
 
 [[package]]
@@ -1114,6 +1132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,7 +1151,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -1136,8 +1164,21 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -1163,6 +1204,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,47 +1226,6 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
-dependencies = [
- "deluxe-core",
- "deluxe-macros",
- "once_cell",
- "proc-macro2",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
-dependencies = [
- "arrayvec",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "deluxe-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
-dependencies = [
- "deluxe-core",
- "heck 0.4.1",
- "if_chain",
- "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1308,12 +1319,12 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "async-stream",
- "base64",
+ "base64 0.23.1",
  "bm25",
  "bytes",
  "chrono",
  "clap",
- "compact_str",
+ "compact_str 0.10.0",
  "crossterm",
  "csv",
  "ctor",
@@ -1349,7 +1360,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec 1.15.2",
  "stop-words 0.10.0",
  "streaming-iterator",
@@ -1484,7 +1495,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.10.1",
  "serde",
- "sha2 0.11.0",
+ "sha2",
  "signature",
  "subtle",
  "zeroize",
@@ -1647,9 +1658,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2062,15 +2073,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2104,15 +2106,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
@@ -2121,10 +2114,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.1"
+name = "hashlink"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -2192,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2283,7 +2279,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2434,12 +2430,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "ignore"
@@ -2676,20 +2666,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpcmsg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "jsonschema"
-version = "0.46.10"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+checksum = "8da60094fc1968bbd091e2cfa004415cb7b19e25e592376e66a64aa832bb6039"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2701,6 +2681,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2710,17 +2691,32 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.46.10"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+checksum = "36539f34ef9e5da418433fbbf7294522d8f930ecf6a540ccd1ec6481c9ff9056"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc513dfee68c6fe29498451df95a32951ea227801b476f4a1f236433986c891"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2804,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3010,15 +3006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.7",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.17.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -3240,6 +3227,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,7 +3295,7 @@ dependencies = [
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -3312,7 +3309,7 @@ dependencies = [
  "fiat-crypto",
  "primefield",
  "primeorder",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -3326,7 +3323,7 @@ dependencies = [
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -3342,7 +3339,7 @@ dependencies = [
  "futures",
  "log",
  "rand 0.10.2",
- "sha2 0.11.0",
+ "sha2",
  "thiserror 2.0.19",
  "tokio",
  "windows 0.62.2",
@@ -3541,7 +3538,7 @@ dependencies = [
  "pbkdf2",
  "rand_core 0.10.1",
  "scrypt",
- "sha2 0.11.0",
+ "sha2",
  "spki",
 ]
 
@@ -3621,15 +3618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,21 +3662,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3779,17 +3757,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -3797,16 +3764,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3829,9 +3786,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -3877,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.1",
- "compact_str",
+ "compact_str 0.9.1",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
@@ -3994,14 +3948,14 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.10"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+checksum = "05915176d843da9ec5c925e5e2631be9aa61b27430acfdd562e79cae8f559725"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
  "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "micromap",
  "parking_lot",
@@ -4044,7 +3998,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -4094,22 +4048,44 @@ dependencies = [
 
 [[package]]
 name = "rig"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98e2e8f01c4c5bc23f577983634fa4d5244ffb070ea14c23b1ea5bd406e5cac"
+checksum = "2ce03971e6115d30ef53fb3244d06718a4e62bbde82c103065600c09459b989a"
 dependencies = [
+ "rig-agent",
  "rig-core",
 ]
 
 [[package]]
-name = "rig-core"
-version = "0.39.0"
+name = "rig-agent"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4bc7a93b329c4e1a66d5fd211d79990e7331e3c701f057c29f135f548686d"
+checksum = "2b0796bbf47d7b76670401aac975bc619cf7fba3482b22dfe14992edaa9c2e04"
+dependencies = [
+ "async-stream",
+ "fastrand",
+ "futures",
+ "http",
+ "indexmap 2.14.0",
+ "rig-core",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5520515ae8f6851adcbc6fde9eea8e96f657418c062e16c82cd81cce44e8e"
 dependencies = [
  "as-any",
  "async-stream",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "eventsource-stream",
  "fastrand",
@@ -4120,12 +4096,10 @@ dependencies = [
  "indexmap 2.14.0",
  "mime",
  "mime_guess",
- "nanoid",
  "ordered-float",
  "pin-project-lite",
  "reqwest",
  "rig-derive",
- "rmcp",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -4138,17 +4112,14 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5531bfa887b371eab658a92de7db35003370bbeee208ff5e68bbb81a5ae92d3d"
+checksum = "eb868fcebdf3ba425e3afad2e4926bb6d9e1188a856843b00bcee2e15c07424f"
 dependencies = [
  "convert_case 0.11.0",
- "deluxe",
- "indoc",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.119",
 ]
 
@@ -4168,12 +4139,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "094c075f6698deef5a657cf4df6b684dff65157d255978b92b552ec22503f17a"
 dependencies = [
- "async-trait",
- "base64",
+ "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
  "http",
@@ -4191,33 +4162,45 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "737d947bcfd946fae6a179a4ef6487be6dcf25c930c2393856b820f1386e52a6"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink 0.12.1",
  "libsqlite3-sys",
  "smallvec 1.15.2",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -4275,7 +4258,7 @@ dependencies = [
  "scrypt",
  "sec1",
  "sha1",
- "sha2 0.11.0",
+ "sha2",
  "sha3 0.12.0",
  "signature",
  "spki",
@@ -4523,7 +4506,7 @@ dependencies = [
  "cfg-if",
  "pbkdf2",
  "salsa20",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -4662,7 +4645,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4718,17 +4701,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -4907,6 +4879,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,7 +4953,7 @@ dependencies = [
  "rand_core 0.10.1",
  "sec1",
  "sha1",
- "sha2 0.11.0",
+ "sha2",
  "signature",
  "ssh-cipher",
  "ssh-encoding",
@@ -5038,12 +5022,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5063,7 +5041,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5119,15 +5097,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5299,7 +5278,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5347,7 +5325,6 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5362,17 +5339,11 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -5385,25 +5356,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5412,7 +5372,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -6092,16 +6052,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -6145,24 +6095,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -6174,8 +6112,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -6205,31 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6288,15 +6204,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]
@@ -6446,15 +6353,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6548,7 +6446,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.4",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6560,7 +6458,7 @@ version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6576,7 +6474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.4",
+ "winnow",
  "zvariant",
 ]
 
@@ -6675,7 +6573,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.4",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6686,7 +6584,7 @@ version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6703,5 +6601,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.119",
- "winnow 1.0.4",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,13 +194,13 @@ libc = "0.2"
 #   - Linux: needs a D-Bus backend. `z` = zbus, a pure-Rust client, so we avoid
 #     a system libdbus build/link dependency.
 [target.'cfg(target_os = "macos")'.dependencies]
-notify-rust = { version = "4", default-features = false }
+notify-rust = { version = "4.18", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-notify-rust = { version = "4", default-features = false }
+notify-rust = { version = "4.18", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-notify-rust = { version = "4", default-features = false, features = ["z"] }
+notify-rust = { version = "4.18", default-features = false, features = ["z"] }
 
 [dependencies]
 # CVE-2026 audit (2026-05-27): rig's default features pull a
@@ -216,24 +216,31 @@ notify-rust = { version = "4", default-features = false, features = ["z"] }
 #   default → rig-lancedb → lance → tantivy → lru 0.12.5
 #     ← RUSTSEC-2026-0002 (unsound)
 #
-# Dirge only uses rig's MCP transport (`rmcp` feature) and the core
-# provider/agent/completion APIs. By disabling default features we
-# drop ~370 transitive crates (881→508 deps) and eliminate all 6
-# cargo-audit findings.
+# Dirge uses the core provider/completion APIs plus the classic agent
+# runtime. By disabling default features we drop ~370 transitive crates
+# (881→508 deps) and eliminate all 6 cargo-audit findings.
+#
+# `agent` is required: 0.41 split the classic runtime into `rig-agent`,
+# and without it `rig::agent::AgentBuilder` and the `rig::tool` traits
+# vanish. `rmcp` is inherited from before the split and is a candidate
+# for removal — nothing here references rig's MCP bridge, and dropping
+# it would also drop the duplicate `rmcp 2.2.0` that rig-agent pulls in
+# alongside our own `rmcp 1.7`.
+#
 # Pinned to an exact version, not a caret. rig ships breaking API
 # changes in patch/minor releases (0.37.0 -> 0.37.1 added a required
 # `Text.additional_params` field), and `cargo install dirge-agent`
 # resolves without our Cargo.lock, so a caret would let a published
 # dirge drift onto an incompatible rig and fail to build (GH #616).
 # Bump this deliberately when adopting a new rig.
-rig = { version = "=0.39.0", default-features = false, features = ["rmcp"] }
+rig = { version = "=0.41.0", default-features = false, features = ["agent"] }
 # Explicit dep to pin feature flags. Without this, rig (our only
 # dep on rig-core) enables `derive` and `reqwest` via its own
 # feature resolution, but we want `rustls` explicitly declared so
 # future readers understand the TLS backend choice is deliberate.
 # cargo-machete reports this as unused — the package.metadata
 # block at the top of this file suppresses that false positive.
-rig-core = { version = "=0.39.0", default-features = false, features = ["reqwest", "derive"] }
+rig-core = { version = "=0.41.0", default-features = false, features = ["reqwest", "derive"] }
 # Macros for emitting `Stream<Item = …>` from async generator-style
 # code blocks. Used by `agent_loop::rig_stream` to wrap rig's
 # `StreamingCompletionResponse` into our pi-style `StreamEvent`
@@ -246,7 +253,7 @@ async-stream = "0.3"
 # undercounts emoji (e.g. ✅ takes 2 cells in most terminals); markdown
 # tables misaligned the right border when cells contained them.
 unicode-width = "0.2"
-rmcp = { version = "1.7", optional = true, default-features = false, features = [
+rmcp = { version = "3.1", optional = true, default-features = false, features = [
     "client",
     "transport-child-process",
     "transport-streamable-http-client-reqwest",
@@ -292,16 +299,16 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # sub-panel. `default-features = false` + only the modules we use
 # keeps the dep small (no disks / networks / processes — just CPU
 # + memory polling).
-sysinfo = { version = "0.32", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 dirs = "6"
-compact_str = { version = "0.9", features = ["serde"] }
+compact_str = { version = "0.10", features = ["serde"] }
 smallvec = "1"
 regex = "1"
 ignore = "0.4.27"
 pulldown-cmark = "0.13"
 include_dir = "0.7"
-http = "1"
-agent-client-protocol = { version = "0.12.0", optional = true }
+http = "1.5"
+agent-client-protocol = { version = "2.0.0", optional = true }
 tree-sitter = { version = "0.25", optional = true }
 tree-sitter-typescript = { version = "0.23", optional = true }
 tree-sitter-python = { version = "0.25", optional = true }
@@ -314,7 +321,7 @@ tree-sitter-java = { version = "0.23", optional = true }
 tree-sitter-c = { version = "0.24", optional = true }
 tree-sitter-cpp = { version = "0.23", optional = true }
 streaming-iterator = { version = "0.1", optional = true }
-jsonschema = { version = "0.46", default-features = false, features = ["resolve-http", "resolve-file", "tls-ring"] }
+jsonschema = { version = "0.49", default-features = false, features = ["resolve-http", "resolve-file", "tls-ring"] }
 janetrs = { version = "0.8", optional = true }
 html2text = "0.17"
 indexmap = "2"
@@ -326,7 +333,7 @@ lsp-types = { version = "0.97", optional = true }
 tree-sitter-elixir = { version = "0.3.5", optional = true }
 tree-sitter-sequel = { version = "0.3", optional = true }
 tree-sitter-dafny = { version = "0.1", optional = true }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 # DAP (Debug Adapter Protocol) — optional feature for driving
 # debuggers (lldb-dap, dlv, debugpy, node) to fix crashes instead
 # of sprinkling print statements. Types are hand-rolled in
@@ -349,10 +356,10 @@ russh = { version = "0.62.5", default-features = false, features = ["ring"], opt
 # sha2 + hex: OCI layer digest verification for the microVM sandbox.
 # Every blob downloaded from the registry is SHA-256 hashed and compared
 # against the manifest's declared digest before extraction.
-sha2 = "0.10"
+sha2 = "0.11"
 hex = { version = "0.4", optional = true }
 # base64: decode OpenSSH-format public keys for host-key verification.
-base64 = "0.22"
+base64 = "0.23"
 # YAML parser for skill frontmatter (replaces hand-rolled parser in
 # `src/extras/skills/format.rs`). `yaml-rust2` is the maintained fork
 # of the abandoned `yaml-rust` crate, fully YAML 1.2 compliant.

--- a/src/agent/agent_loop/heal.rs
+++ b/src/agent/agent_loop/heal.rs
@@ -8,11 +8,19 @@
 //! 1. Shrink oversized tool results (char cap, not token cap)
 //! 2. Fix unpaired tool calls (drops assistant.tool_calls with no
 //!    matching tool responses + stray tool messages)
-//! 3. Stamp missing `reasoning_content` on thinking-mode sessions
 //!
 //! The rationale: oversized tool results would 400 the next call
 //! before the user types. Unpaired tool calls would similarly
 //! fail API validation.
+//!
+//! Reasonix's third repair — stamping an empty `reasoning_content` onto
+//! assistant turns that lack one — is deliberately NOT ported, and the
+//! claim that it was has been removed from this list. opencode carries an
+//! equivalent for DeepSeek, but only because its own transform lifts
+//! reasoning out of the message content, so it has to put an empty one
+//! back. Dirge replays the reasoning block as-is (see
+//! `rig_stream_factory::provider_rejects_reasoning_echo`), so there is
+//! nothing to restore; the DeepSeek and GLM live smoke tests cover it.
 
 use serde_json::Value;
 

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -505,6 +505,14 @@ where
                         });
                     }
                 }
+                // rig 0.40 started surfacing provider output items it does
+                // not model (reasoning_details and friends) instead of
+                // dropping them. Dirge builds its own content blocks, so
+                // there is nothing to render — but the chunk still counted
+                // as forward motion for the stall detector above, which is
+                // the behaviour we want. Ignore the payload rather than
+                // guessing at a block type for it.
+                Ok(StreamedAssistantContent::Unknown(_)) => {}
                 Err(err) => {
                     let error_msg = err.to_string();
                     use crate::agent::recovery::classify_error;

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -595,7 +595,7 @@ fn value_to_rig_message_for_provider(
         }
         "assistant" => {
             let blocks = value.get("content").and_then(|c| c.as_array())?;
-            let include_reasoning = !provider_requires_openai_reasoning_ids(provider_name);
+            let include_reasoning = !provider_rejects_reasoning_echo(provider_name);
             let synthesize_call_id = provider_requires_openai_call_ids(provider_name);
             let assistant_contents: Vec<AssistantContent> = blocks
                 .iter()
@@ -675,7 +675,20 @@ fn value_to_rig_message(value: &Value) -> Option<Message> {
     value_to_rig_message_for_provider(value, None, None)
 }
 
-fn provider_requires_openai_reasoning_ids(provider_name: Option<&str>) -> bool {
+/// Providers that must NOT receive an echoed-back assistant reasoning block.
+///
+/// Only `openai` qualifies: its Responses API wants reasoning items keyed by
+/// the encrypted ids it issued, which dirge does not retain, so a bare block is
+/// rejected and there is no field to rename it to.
+///
+/// Every other backend keeps its reasoning. Dropping it would lose the model's
+/// own chain of thought from the next turn's context, so a backend that spells
+/// the field differently is handled by renaming at the wire boundary instead —
+/// see `CompressingHttpClient::rewrite_provider_quirks`, which moves
+/// `reasoning_content` to `reasoning` for Cerebras. DeepSeek requires the echo
+/// on tool-call turns, and llama.cpp/LocalAI chat templates read
+/// `message.reasoning_content` back out of the assistant turn.
+fn provider_rejects_reasoning_echo(provider_name: Option<&str>) -> bool {
     matches!(provider_name, Some(provider) if provider.eq_ignore_ascii_case("openai"))
 }
 
@@ -1124,6 +1137,49 @@ mod tests {
                 _ => panic!("expected Reasoning"),
             },
             _ => panic!("expected Assistant"),
+        }
+    }
+
+    /// GH #745 fallout. Cerebras streams reasoning as `delta.reasoning` — the
+    /// same non-standard field LocalAI uses. rig 0.39 discarded it, so dirge
+    /// never had a thinking block to replay; rig 0.40+ keeps it, and replaying
+    /// it as `reasoning_content` makes Cerebras 400 with
+    /// `property 'messages.N.assistant.reasoning_content' is unsupported`.
+    ///
+    /// The block must still be BUILT here — dropping it would lose the model's
+    /// reasoning from the next turn's context. The field is renamed at the wire
+    /// boundary instead (`CompressingHttpClient::rewrite_provider_quirks`).
+    /// `h7_cerebras_tool_dispatch_completes_round_trip` covers the live round
+    /// trip; this pins the half that needs no API key.
+    #[test]
+    fn reasoning_echo_is_preserved_for_every_backend_but_openai() {
+        let v = serde_json::json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "text": "let me think"},
+                {"type": "text", "text": "the answer"},
+            ],
+        });
+        for provider in ["cerebras", "deepseek", "custom", "ollama", "glm"] {
+            let msg = value_to_rig_message_for_provider(&v, Some(provider), None)
+                .unwrap_or_else(|| panic!("{provider} must keep the reasoning block"));
+            match msg {
+                Message::Assistant { content, .. } => {
+                    assert!(
+                        content
+                            .iter()
+                            .any(|c| matches!(c, AssistantContent::Reasoning(_))),
+                        "{provider} must retain reasoning",
+                    );
+                    assert!(
+                        content
+                            .iter()
+                            .any(|c| matches!(c, AssistantContent::Text(_))),
+                        "{provider} must retain the assistant's text",
+                    );
+                }
+                _ => panic!("expected Assistant"),
+            }
         }
     }
 

--- a/src/agent/agent_loop/rig_tool.rs
+++ b/src/agent/agent_loop/rig_tool.rs
@@ -31,7 +31,9 @@
 
 use std::pin::Pin;
 
-use rig::tool::{ToolDyn, ToolError};
+use rig::completion::ToolDefinition;
+use rig::tool::{IntoToolOutput, PortableTool};
+use rig::wasm_compat::WasmBoxedFuture;
 use serde_json::Value;
 
 use super::result::LoopToolResult;
@@ -41,6 +43,72 @@ use super::tool::{AbortSignal, LoopTool, LoopToolUpdate};
 use super::types::ToolExecutionMode;
 #[cfg(test)]
 use std::sync::Arc;
+
+/// Object-safe erased tool surface, replacing the removed
+/// `rig::tool::ToolDyn` (rig 0.41 made `ErasedTool` private and
+/// exposed only the concrete `DynamicTool`). dirge drives its own
+/// agent loop — no rig `ToolContext`/`ToolSet` — so it erases typed
+/// tools through this trait instead: any `PortableTool` implements
+/// it for free (the same blanket rig 0.39 provided for `ToolDyn`),
+/// and hand-rolled tools (MCP, hook-decorated) implement it
+/// directly.
+pub trait DynTool: Send + Sync {
+    fn name(&self) -> String;
+    fn definition(&self) -> WasmBoxedFuture<'_, ToolDefinition>;
+    fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, DynToolError>>;
+}
+
+/// Error surface for an erased tool call, mirroring rig 0.39's
+/// `ToolError` (removed in rig 0.41).
+#[derive(Debug, thiserror::Error)]
+pub enum DynToolError {
+    #[error("{0}")]
+    ToolCallError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("{0}")]
+    JsonError(#[from] serde_json::Error),
+}
+
+impl<T> DynTool for T
+where
+    T: PortableTool + Send + Sync + 'static,
+{
+    fn name(&self) -> String {
+        T::NAME.to_string()
+    }
+
+    fn definition(&self) -> WasmBoxedFuture<'_, ToolDefinition> {
+        Box::pin(async move {
+            ToolDefinition {
+                name: T::NAME.to_string(),
+                description: self.description(),
+                parameters: self.parameters(),
+            }
+        })
+    }
+
+    fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, DynToolError>> {
+        Box::pin(async move {
+            // Replicates rig 0.39's blanket `ToolDyn::call`: a bare
+            // `null` args payload falls back to `{}` so tools whose
+            // args are all optional still deserialize.
+            let parsed = match serde_json::from_str::<T::Args>(&args) {
+                Ok(args) => args,
+                Err(err) if args.trim() == "null" => serde_json::from_str("{}").map_err(|_| err)?,
+                Err(err) => return Err(err.into()),
+            };
+            let output = <T as PortableTool>::call(self, parsed)
+                .await
+                .map_err(|e| DynToolError::ToolCallError(Box::new(e)))?;
+            // Replicates 0.39's output shaping: a plain string comes
+            // out unquoted; anything else renders as its JSON text.
+            // `ToolOutput::render` applies exactly that rule.
+            let tool_output = output
+                .into_tool_output()
+                .map_err(|e| DynToolError::ToolCallError(Box::new(e)))?;
+            Ok(tool_output.render())
+        })
+    }
+}
 
 /// Wraps a `Box<dyn rig::ToolDyn>` and exposes it as a `LoopTool`.
 ///
@@ -54,7 +122,7 @@ use std::sync::Arc;
 /// construction time (Reasonix tools.ts:36-38). The LLM sees flat
 /// dot-notation keys; `prepare_arguments` re-nests them at dispatch.
 pub struct RigToolAdapter {
-    inner: Box<dyn ToolDyn>,
+    inner: Box<dyn DynTool>,
     name: String,
     description: String,
     parameters: Value,
@@ -89,8 +157,8 @@ impl RigToolAdapter {
     /// leaves), flattens it and stores the flat variant so
     /// `prepare_arguments` can re-nest at dispatch (Reasonix
     /// tools.ts:36-38).
-    pub async fn new(inner: Box<dyn ToolDyn>) -> Self {
-        let def = inner.definition(String::new()).await;
+    pub async fn new(inner: Box<dyn DynTool>) -> Self {
+        let def = inner.definition().await;
         let flat_parameters = match analyze_schema(&def.parameters) {
             FlattenDecision {
                 should_flatten: true,
@@ -121,7 +189,7 @@ impl RigToolAdapter {
     /// Production callers should use `new`.
     #[cfg(test)]
     fn from_parts(
-        inner: Box<dyn ToolDyn>,
+        inner: Box<dyn DynTool>,
         name: String,
         description: String,
         parameters: Value,
@@ -221,7 +289,7 @@ impl LoopTool for RigToolAdapter {
 /// repair layer; this function handles runtime tool errors. If a
 /// schema error leaks through (defense-in-depth), wrap it in a
 /// model-readable retry hint rather than leaking raw serde diagnostics.
-fn format_tool_error(err: ToolError) -> String {
+fn format_tool_error(err: DynToolError) -> String {
     let raw = err.to_string();
     if raw.contains("missing field") || raw.contains("expected") || raw.contains("invalid type") {
         format!(
@@ -238,7 +306,7 @@ fn format_tool_error(err: ToolError) -> String {
 mod tests {
     use super::*;
     use rig::completion::ToolDefinition;
-    use rig::tool::Tool;
+    use rig::tool::PortableTool;
     use serde::{Deserialize, Serialize};
 
     /// Mock rig tool that echoes its input back. Mirrors the
@@ -258,24 +326,24 @@ mod tests {
         Generic(String),
     }
 
-    impl Tool for EchoTool {
+    impl PortableTool for EchoTool {
         const NAME: &'static str = "echo";
         type Error = EchoError;
         type Args = EchoArgs;
         type Output = String;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            ToolDefinition {
-                name: "echo".to_string(),
-                description: "Echo the input back".to_string(),
-                parameters: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string"}
-                    },
-                    "required": ["value"]
-                }),
-            }
+        fn description(&self) -> String {
+            "Echo the input back".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string"}
+                },
+                "required": ["value"]
+            })
         }
 
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -287,18 +355,18 @@ mod tests {
     #[derive(Debug, Clone)]
     struct FailingTool;
 
-    impl Tool for FailingTool {
+    impl PortableTool for FailingTool {
         const NAME: &'static str = "failing";
         type Error = EchoError;
         type Args = EchoArgs;
         type Output = String;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            ToolDefinition {
-                name: "failing".to_string(),
-                description: "Always fails".to_string(),
-                parameters: serde_json::json!({"type": "object"}),
-            }
+        fn description(&self) -> String {
+            "Always fails".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -444,8 +512,8 @@ mod tests {
     /// returned by each path must match.
     #[tokio::test]
     async fn adapter_matches_rig_path_for_real_dirge_tool() {
+        use super::DynTool;
         use crate::agent::tools::ReadTool;
-        use rig::tool::ToolDyn;
 
         // Set up a temp file with known content. Reuses the
         // same TestDir pattern as fs_atomic tests for cleanup.
@@ -465,7 +533,7 @@ mod tests {
         // both traits are in scope.
         let tool_a = ReadTool::new(None, None);
         let rig_args = serde_json::json!({"path": path_str}).to_string();
-        let rig_output = <ReadTool as ToolDyn>::call(&tool_a, rig_args)
+        let rig_output = <ReadTool as DynTool>::call(&tool_a, rig_args)
             .await
             .expect("rig direct call should succeed");
 

--- a/src/agent/builder/agent_inner.rs
+++ b/src/agent/builder/agent_inner.rs
@@ -48,6 +48,9 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     // caller (provider::build_agent) can attach it to AnyAgent for
     // session-lifecycle hook dispatch. `None` when load failed.
     Option<Arc<dyn crate::extras::memory_provider::MemoryProvider>>,
+    // rig 0.41 made `Agent::preamble` private, so hand the assembled
+    // system prompt back instead of reading it off the built agent.
+    String,
 ) {
     // The `plan_file`-keyed gate on edit/write/apply_patch was
     // removed: prompt-level tool restrictions now live in the
@@ -316,7 +319,7 @@ pub async fn build_agent_inner<M: CompletionModel + 'static>(
     // `--no-tools`, collects MCP/semantic tools, and applies plugin hooks).
     // Attaching them here too only duplicated every tool construction and
     // double-collected MCP tools at startup [dirge-tfip].
-    (builder.build(), ToolCache::new(), memory_store)
+    (builder.build(), ToolCache::new(), memory_store, preamble)
 }
 
 /// Wall-clock bound for the blocking SQLite loads in `build_agent_inner`

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -264,7 +264,7 @@ pub async fn build_rooted_writer_tools(
 
     async fn wrap<T>(inner: T, mode: Option<ToolExecutionMode>) -> Arc<dyn LoopTool>
     where
-        T: rig::tool::ToolDyn + 'static,
+        T: crate::agent::agent_loop::rig_tool::DynTool + 'static,
     {
         let adapter = RigToolAdapter::new(Box::new(inner)).await;
         Arc::new(match mode {
@@ -505,7 +505,7 @@ pub async fn build_loop_tools(
     // is async (RigToolAdapter::new resolves it eagerly).
     async fn wrap<T>(inner: T, mode: Option<ToolExecutionMode>) -> Arc<dyn LoopTool>
     where
-        T: rig::tool::ToolDyn + 'static,
+        T: crate::agent::agent_loop::rig_tool::DynTool + 'static,
     {
         let adapter = RigToolAdapter::new(Box::new(inner)).await;
         let adapter = match mode {

--- a/src/agent/builder/reminder_tests.rs
+++ b/src/agent/builder/reminder_tests.rs
@@ -536,10 +536,10 @@ async fn build_agent_inner_emits_assembled_preamble() {
     let client = openai::Client::new("test-key").expect("openai client builds");
     let model = client.completion_model("gpt-4o");
 
-    let (agent, _cache, _provider) =
+    let (_agent, _cache, _provider, agent_preamble) =
         build_agent_inner(model, &cli, &cfg, &context, "openai", "gpt-4o").await;
 
-    let preamble = agent.preamble.unwrap_or_default();
+    let preamble = agent_preamble;
 
     // SKILLS_GUIDANCE markers (dirge-xxun).
     assert!(
@@ -677,14 +677,14 @@ async fn preamble_lists_global_tier_skills() {
     let prev_home = std::env::var_os("HOME");
     // SAFETY: guarded by HOME_LOCK; restored before the lock drops.
     unsafe { std::env::set_var("HOME", &home) };
-    let (agent, _cache, _provider) =
+    let (_agent, _cache, _provider, agent_preamble) =
         build_agent_inner(model, &cli, &cfg, &context, "openai", "gpt-4o").await;
     match prev_home {
         Some(h) => unsafe { std::env::set_var("HOME", h) },
         None => unsafe { std::env::remove_var("HOME") },
     }
 
-    let preamble = agent.preamble.unwrap_or_default();
+    let preamble = agent_preamble;
     assert!(
         preamble.contains("global-preamble-skill"),
         "preamble must advertise a skill from the global ~/.dirge/skills tier; got:\n{preamble}"
@@ -726,25 +726,20 @@ async fn steering_fragment_tracks_active_model_not_cli() {
     // though the openai client/model and the CLI default are not DeepSeek.
     let ctx = empty_ctx();
     let model = client.completion_model("gpt-4o");
-    let (agent, _c, _p) =
+    let (_agent, _c, _p, agent_preamble) =
         build_agent_inner(model, &cli, &cfg, &ctx, "deepseek", "deepseek-v4-pro").await;
     assert!(
-        agent
-            .preamble
-            .unwrap_or_default()
-            .contains("Plan-Execute-Verify"),
+        agent_preamble.contains("Plan-Execute-Verify"),
         "DeepSeek-chat active model must inject the steering fragment"
     );
 
     // Active model = a non-DeepSeek model → fragment absent.
     let ctx = empty_ctx();
     let model = client.completion_model("gpt-4o");
-    let (agent, _c, _p) = build_agent_inner(model, &cli, &cfg, &ctx, "openai", "gpt-4o").await;
+    let (_agent, _c, _p, agent_preamble) =
+        build_agent_inner(model, &cli, &cfg, &ctx, "openai", "gpt-4o").await;
     assert!(
-        !agent
-            .preamble
-            .unwrap_or_default()
-            .contains("Plan-Execute-Verify"),
+        !agent_preamble.contains("Plan-Execute-Verify"),
         "non-DeepSeek active model must NOT inject the steering fragment"
     );
 }

--- a/src/agent/review.rs
+++ b/src/agent/review.rs
@@ -763,11 +763,10 @@ mod tests {
             .build()
             .expect("openai client");
         let model = client.completion_model("gpt-4o");
-        let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingEndProvider::default());
         let provider_dyn: Arc<dyn MemoryProvider> = provider.clone();
         let agent = AnyAgent::new(
-            AnyAgentInner::OpenAI(inner_agent),
+            AnyAgentInner::OpenAI(model),
             ToolCache::new(),
             std::time::Duration::from_secs(300),
             Vec::new(),
@@ -871,11 +870,10 @@ mod tests {
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");
-        let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingSwitchProvider::default());
         let provider_dyn: Arc<dyn MemoryProvider> = provider.clone();
         let agent = AnyAgent::new(
-            AnyAgentInner::OpenAI(inner_agent),
+            AnyAgentInner::OpenAI(model),
             ToolCache::new(),
             std::time::Duration::from_secs(300),
             Vec::new(),
@@ -905,9 +903,8 @@ mod tests {
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");
-        let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let agent = AnyAgent::new(
-            AnyAgentInner::OpenAI(inner_agent),
+            AnyAgentInner::OpenAI(model),
             ToolCache::new(),
             std::time::Duration::from_secs(300),
             Vec::new(),
@@ -929,9 +926,8 @@ mod tests {
             .build()
             .unwrap();
         let model = client.completion_model("gpt-4o");
-        let inner_agent = rig::agent::AgentBuilder::new(model).build();
         let agent = AnyAgent::new(
-            AnyAgentInner::OpenAI(inner_agent),
+            AnyAgentInner::OpenAI(model),
             ToolCache::new(),
             std::time::Duration::from_secs(300),
             Vec::new(),

--- a/src/agent/tools/apply_patch.rs
+++ b/src/agent/tools/apply_patch.rs
@@ -1,5 +1,4 @@
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -197,62 +196,62 @@ async fn apply_rename(path: &str, new_path: &str) -> Result<String, String> {
     Ok(format!("renamed {} -> {}", path, new_path))
 }
 
-impl Tool for ApplyPatchTool {
+impl PortableTool for ApplyPatchTool {
     const NAME: &'static str = "apply_patch";
 
     type Error = ToolError;
     type Args = ApplyPatchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "apply_patch".to_string(),
-            description: crate::agent::agent_loop::tool_input_repair::with_contract_hint(
-                "apply_patch",
-                "Apply multiple file operations in a single call. Supports create, update (by exact text match), delete, and rename. Operations execute in order and stop on first failure — prior operations that succeeded remain applied.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "operations": {
-                        "type": "array",
-                        "description": "Ordered list of file operations to execute",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "action": {
-                                    "type": "string",
-                                    "enum": ["create", "update", "delete", "rename"],
-                                    "description": "The type of operation"
-                                },
-                                "path": {
-                                    "type": "string",
-                                    "description": "Target file path"
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "File content (required for create)"
-                                },
-                                "old_text": {
-                                    "type": "string",
-                                    "description": "Exact text to find and replace (required for update)"
-                                },
-                                "new_text": {
-                                    "type": "string",
-                                    "description": "Replacement text (required for update)"
-                                },
-                                "new_path": {
-                                    "type": "string",
-                                    "description": "New file path (required for rename)"
-                                }
+    fn description(&self) -> String {
+        crate::agent::agent_loop::tool_input_repair::with_contract_hint(
+            "apply_patch",
+            "Apply multiple file operations in a single call. Supports create, update (by exact text match), delete, and rename. Operations execute in order and stop on first failure — prior operations that succeeded remain applied.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "description": "Ordered list of file operations to execute",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string",
+                                "enum": ["create", "update", "delete", "rename"],
+                                "description": "The type of operation"
                             },
-                            "required": ["action", "path"]
-                        }
+                            "path": {
+                                "type": "string",
+                                "description": "Target file path"
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "File content (required for create)"
+                            },
+                            "old_text": {
+                                "type": "string",
+                                "description": "Exact text to find and replace (required for update)"
+                            },
+                            "new_text": {
+                                "type": "string",
+                                "description": "Replacement text (required for update)"
+                            },
+                            "new_path": {
+                                "type": "string",
+                                "description": "New file path (required for rename)"
+                            }
+                        },
+                        "required": ["action", "path"]
                     }
-                },
-                "required": ["operations"]
-            }),
-        }
+                }
+            },
+            "required": ["operations"]
+        })
     }
 
     async fn call(&self, args: ApplyPatchArgs) -> Result<String, ToolError> {
@@ -597,7 +596,7 @@ mod tests {
     #[tokio::test]
     async fn test_definition_has_correct_name() {
         let tool = ApplyPatchTool::new(None, None);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "apply_patch");
     }
 

--- a/src/agent/tools/bash/mod.rs
+++ b/src/agent/tools/bash/mod.rs
@@ -1,5 +1,4 @@
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 pub(crate) mod check;
 pub(crate) mod exec;
@@ -87,31 +86,31 @@ impl BashTool {
     }
 }
 
-impl Tool for BashTool {
+impl PortableTool for BashTool {
     const NAME: &'static str = "bash";
 
     type Error = ToolError;
     type Args = BashArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "bash".to_string(),
-            description: with_contract_hint(
+    fn description(&self) -> String {
+        with_contract_hint(
                 "bash",
                 &("Execute a bash command in the current working directory. Returns stdout and stderr.".to_owned()
                 + cfg!(feature = "experimental-ui-computer-use").then_some("\n\nDesktop automation: prefix commands with `computer:` to control the desktop GUI. Actions: `computer:open_url <url>` (opens in browser), `computer:screenshot` (captures screen), `computer:type <text>`, `computer:key <keys>`, `computer:click <button>`, `computer:move <x> <y>`. Each action prompts for user confirmation.").unwrap_or("")),
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "command": { "type": "string", "description": "Bash command to execute" },
-                    "timeout": { "type": "integer", "description": "Timeout in seconds (optional; default 120, or 600 when background)" },
-                    "background": { "type": "boolean", "description": "Run detached and unbounded: returns immediately with a shell id (does NOT block the turn). Use for long-running commands — dev servers, watch builds, tails. Read its accumulated output with the bash_output tool (pass the id; poll it to follow progress) and stop it with kill_shell (pass the id). Output is NOT auto-delivered. If `timeout` is set, the shell is auto-killed after that many seconds; otherwise it runs until it exits or you kill it." }
-                },
-                "required": ["command"]
-            }),
-        }
+            )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string", "description": "Bash command to execute" },
+                "timeout": { "type": "integer", "description": "Timeout in seconds (optional; default 120, or 600 when background)" },
+                "background": { "type": "boolean", "description": "Run detached and unbounded: returns immediately with a shell id (does NOT block the turn). Use for long-running commands — dev servers, watch builds, tails. Read its accumulated output with the bash_output tool (pass the id; poll it to follow progress) and stop it with kill_shell (pass the id). Output is NOT auto-delivered. If `timeout` is set, the shell is auto-killed after that many seconds; otherwise it runs until it exits or you kill it." }
+            },
+            "required": ["command"]
+        })
     }
 
     async fn call(&self, args: BashArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/bash/tests.rs
+++ b/src/agent/tools/bash/tests.rs
@@ -1474,7 +1474,7 @@ fn target_expands_outside_cwd_predicate() {
 async fn bash_description_has_exactly_one_contract_line() {
     use crate::sandbox::{Sandbox, SandboxMode};
     let tool = BashTool::new(None, None, Sandbox::new(SandboxMode::Off));
-    let def = tool.definition("".to_string()).await;
+    let def = rig::tool::tool_definition(&tool);
     let count = def.description.matches("CONTRACT:").count();
     assert_eq!(
         count, 1,

--- a/src/agent/tools/bg_shell.rs
+++ b/src/agent/tools/bg_shell.rs
@@ -18,8 +18,7 @@
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
 use indexmap::IndexMap;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
@@ -329,24 +328,24 @@ impl BashOutputTool {
     }
 }
 
-impl Tool for BashOutputTool {
+impl PortableTool for BashOutputTool {
     const NAME: &'static str = "bash_output";
     type Error = ToolError;
     type Args = BashOutputArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "bash_output".to_string(),
-            description: "Read new output from a background shell (one started with bash(background=true)). Returns the output produced since your last call plus the shell's status (running / exited(code) / killed / failed). Poll this to follow a long-running command; call kill_shell to stop it.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "id": { "type": "string", "description": "The background shell id returned by bash(background=true)." }
-                },
-                "required": ["id"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Read new output from a background shell (one started with bash(background=true)). Returns the output produced since your last call plus the shell's status (running / exited(code) / killed / failed). Poll this to follow a long-running command; call kill_shell to stop it.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The background shell id returned by bash(background=true)." }
+            },
+            "required": ["id"]
+        })
     }
 
     async fn call(&self, args: BashOutputArgs) -> Result<String, ToolError> {
@@ -389,24 +388,24 @@ impl KillShellTool {
     }
 }
 
-impl Tool for KillShellTool {
+impl PortableTool for KillShellTool {
     const NAME: &'static str = "kill_shell";
     type Error = ToolError;
     type Args = KillShellArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "kill_shell".to_string(),
-            description: "Stop a running background shell (one started with bash(background=true)) by id. Kills the whole process group. No-op if it already exited.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "id": { "type": "string", "description": "The background shell id to kill." }
-                },
-                "required": ["id"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Stop a running background shell (one started with bash(background=true)) by id. Kills the whole process group. No-op if it already exited.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "description": "The background shell id to kill." }
+            },
+            "required": ["id"]
+        })
     }
 
     async fn call(&self, args: KillShellArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/debug.rs
+++ b/src/agent/tools/debug.rs
@@ -13,8 +13,7 @@ use crate::sync_util::LockExt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -237,56 +236,56 @@ fn resolve_attach_adapter(
     }
 }
 
-impl Tool for DebugTool {
+impl PortableTool for DebugTool {
     const NAME: &'static str = "debug";
 
     type Error = ToolError;
     type Args = DebugArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "debug".to_string(),
-            description: DESCRIPTION.to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "description": "Debug action to perform",
-                        "enum": [
-                            "launch", "attach", "set_breakpoints", "remove_breakpoints",
-                            "continue", "step_over", "step_in", "step_out",
-                            "pause", "evaluate", "stack_trace", "threads",
-                            "scopes", "variables", "terminate", "sessions",
-                            "run_to_cursor", "restart_frame",
-                            "backtrace_diagnostics", "error_analysis"
-                        ]
-                    },
-                    "program": { "type": "string", "description": "Path to the program to debug (launch)" },
-                    "args": { "type": "array", "items": { "type": "string" }, "description": "Command line arguments for the program (launch)" },
-                    "adapter": { "type": "string", "description": "Debug adapter name (auto-detected if omitted)" },
-                    "cwd": { "type": "string", "description": "Working directory for the debug session" },
-                    "file": { "type": "string", "description": "Source file path (set_breakpoints, remove_breakpoints)" },
-                    "line": { "type": "integer", "description": "Line number (set_breakpoints)" },
-                    "condition": { "type": "string", "description": "Conditional breakpoint expression" },
-                    "expression": { "type": "string", "description": "Expression to evaluate" },
-                    "frame_id": { "type": "integer", "description": "Stack frame ID (scopes, evaluate)" },
-                    "pid": { "type": "integer", "description": "Process ID to attach to" },
-                    "port": { "type": "integer", "description": "Port for remote attach" },
-                    "host": { "type": "string", "description": "Host for remote attach" },
-                    "levels": { "type": "integer", "description": "Number of stack frames to fetch" },
-                    "variable_ref": { "type": "integer", "description": "Variable reference ID from a scope" },
-                    "timeout": { "type": "integer", "description": "Timeout in seconds (default 30, min 5, max 300)" },
-                    "thread_id": { "type": "integer", "description": "Thread ID (continue, step, pause, stack_trace)" },
-                    "stop_on_entry": { "type": "boolean", "description": "Stop at program entry (launch)" },
-                    "context": { "type": "string", "description": "Evaluation context: watch, repl, hover" },
-                    "restart": { "type": "boolean", "description": "Restart after disconnect (terminate)" },
-                    "env": { "type": "object", "description": "Environment variables as key-value pairs (launch)", "additionalProperties": { "type": "string" } }
+    fn description(&self) -> String {
+        DESCRIPTION.to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Debug action to perform",
+                    "enum": [
+                        "launch", "attach", "set_breakpoints", "remove_breakpoints",
+                        "continue", "step_over", "step_in", "step_out",
+                        "pause", "evaluate", "stack_trace", "threads",
+                        "scopes", "variables", "terminate", "sessions",
+                        "run_to_cursor", "restart_frame",
+                        "backtrace_diagnostics", "error_analysis"
+                    ]
                 },
-                "required": ["action"]
-            }),
-        }
+                "program": { "type": "string", "description": "Path to the program to debug (launch)" },
+                "args": { "type": "array", "items": { "type": "string" }, "description": "Command line arguments for the program (launch)" },
+                "adapter": { "type": "string", "description": "Debug adapter name (auto-detected if omitted)" },
+                "cwd": { "type": "string", "description": "Working directory for the debug session" },
+                "file": { "type": "string", "description": "Source file path (set_breakpoints, remove_breakpoints)" },
+                "line": { "type": "integer", "description": "Line number (set_breakpoints)" },
+                "condition": { "type": "string", "description": "Conditional breakpoint expression" },
+                "expression": { "type": "string", "description": "Expression to evaluate" },
+                "frame_id": { "type": "integer", "description": "Stack frame ID (scopes, evaluate)" },
+                "pid": { "type": "integer", "description": "Process ID to attach to" },
+                "port": { "type": "integer", "description": "Port for remote attach" },
+                "host": { "type": "string", "description": "Host for remote attach" },
+                "levels": { "type": "integer", "description": "Number of stack frames to fetch" },
+                "variable_ref": { "type": "integer", "description": "Variable reference ID from a scope" },
+                "timeout": { "type": "integer", "description": "Timeout in seconds (default 30, min 5, max 300)" },
+                "thread_id": { "type": "integer", "description": "Thread ID (continue, step, pause, stack_trace)" },
+                "stop_on_entry": { "type": "boolean", "description": "Stop at program entry (launch)" },
+                "context": { "type": "string", "description": "Evaluation context: watch, repl, hover" },
+                "restart": { "type": "boolean", "description": "Restart after disconnect (terminate)" },
+                "env": { "type": "object", "description": "Environment variables as key-value pairs (launch)", "additionalProperties": { "type": "string" } }
+            },
+            "required": ["action"]
+        })
     }
 
     async fn call(&self, args: DebugArgs) -> Result<String, ToolError> {
@@ -994,7 +993,7 @@ mod tests {
     #[tokio::test]
     async fn definition_has_all_actions() {
         let tool = DebugTool::new(None, None);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         let params: Value = def.parameters;
 
         // Every action in the enum list must be in the schema.
@@ -1037,7 +1036,7 @@ mod tests {
     #[tokio::test]
     async fn definition_name_matches() {
         let tool = DebugTool::new(None, None);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "debug");
     }
 

--- a/src/agent/tools/edit.rs
+++ b/src/agent/tools/edit.rs
@@ -1,8 +1,7 @@
 #[cfg(feature = "lsp")]
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -108,31 +107,31 @@ impl EditTool {
     }
 }
 
-impl Tool for EditTool {
+impl PortableTool for EditTool {
     const NAME: &'static str = "edit";
 
     type Error = ToolError;
     type Args = EditArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "edit".to_string(),
-            description: with_contract_hint(
-                "edit",
-                "Edit a file by replacing exact text. If old_text appears once, replaces it. If it appears multiple times and replace_all is false, returns all match locations with line numbers. Use replaceAll: true to replace every occurrence. Handles both LF and CRLF line endings.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)" },
-                    "old_text": { "type": "string", "description": "Exact text to find and replace" },
-                    "new_text": { "type": "string", "description": "New text to replace with" },
-                    "replace_all": { "type": "boolean", "description": "Replace all occurrences instead of just the first" }
-                },
-                "required": ["path", "old_text", "new_text"]
-            }),
-        }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "edit",
+            "Edit a file by replacing exact text. If old_text appears once, replaces it. If it appears multiple times and replace_all is false, returns all match locations with line numbers. Use replaceAll: true to replace every occurrence. Handles both LF and CRLF line endings.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)" },
+                "old_text": { "type": "string", "description": "Exact text to find and replace" },
+                "new_text": { "type": "string", "description": "New text to replace with" },
+                "replace_all": { "type": "boolean", "description": "Replace all occurrences instead of just the first" }
+            },
+            "required": ["path", "old_text", "new_text"]
+        })
     }
 
     async fn call(&self, args: EditArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/edit_lines.rs
+++ b/src/agent/tools/edit_lines.rs
@@ -18,8 +18,7 @@
 #[cfg(feature = "lsp")]
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -163,37 +162,37 @@ pub(crate) fn apply_line_edit(
     Ok(output)
 }
 
-impl Tool for EditLinesTool {
+impl PortableTool for EditLinesTool {
     const NAME: &'static str = "edit_lines";
 
     type Error = ToolError;
     type Args = EditLinesArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "edit_lines".to_string(),
-            description: with_contract_hint(
-                "edit_lines",
-                "Replace a range of lines by line number, guarded by per-line content hashes. \
+    fn description(&self) -> String {
+        with_contract_hint(
+            "edit_lines",
+            "Replace a range of lines by line number, guarded by per-line content hashes. \
                  First read the file with line_hashes=true to get `N hhh: ...` lines, then call \
                  edit_lines with start_line/end_line (1-indexed, inclusive), expected_hashes (one \
                  per line in the range, in order), and new_text (the replacement block; empty \
                  deletes the range). Cheaper than `edit` for large blocks — you don't retype the \
                  old text. The edit is rejected if any line changed since you read it.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)", "dirge-hints": {"semantic": "absolute_path"} },
-                    "start_line": { "type": "integer", "description": "First line to replace (1-indexed, inclusive)" },
-                    "end_line": { "type": "integer", "description": "Last line to replace (1-indexed, inclusive)" },
-                    "expected_hashes": { "type": "array", "items": {"type": "string"}, "description": "The 3-char content hash for each line in [start_line, end_line], in order, exactly as shown by read(line_hashes=true)" },
-                    "new_text": { "type": "string", "description": "Replacement text for the range. Empty string deletes the lines." }
-                },
-                "required": ["path", "start_line", "end_line", "expected_hashes", "new_text"]
-            }),
-        }
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)", "dirge-hints": {"semantic": "absolute_path"} },
+                "start_line": { "type": "integer", "description": "First line to replace (1-indexed, inclusive)" },
+                "end_line": { "type": "integer", "description": "Last line to replace (1-indexed, inclusive)" },
+                "expected_hashes": { "type": "array", "items": {"type": "string"}, "description": "The 3-char content hash for each line in [start_line, end_line], in order, exactly as shown by read(line_hashes=true)" },
+                "new_text": { "type": "string", "description": "Replacement text for the range. Empty string deletes the lines." }
+            },
+            "required": ["path", "start_line", "end_line", "expected_hashes", "new_text"]
+        })
     }
 
     async fn call(&self, args: EditLinesArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/edit_minified.rs
+++ b/src/agent/tools/edit_minified.rs
@@ -11,8 +11,7 @@
 #[cfg(feature = "lsp")]
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -54,31 +53,31 @@ impl EditMinifiedTool {
     }
 }
 
-impl Tool for EditMinifiedTool {
+impl PortableTool for EditMinifiedTool {
     const NAME: &'static str = "edit_minified";
 
     type Error = ToolError;
     type Args = EditArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "edit_minified".to_string(),
-            description: with_contract_hint(
-                "edit_minified",
-                "Edit a file by replacing text matched against its MINIFIED form (as shown by read_minified). `old_text` must be the minified text — copy it from a prior read_minified of the same file — and must be unique and align to whole tokens. The change is mapped back to the original source and applied in place, preserving the file's formatting; the result is syntax-checked before writing. For normal (non-minified) edits use `edit`.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)" },
-                    "old_text": { "type": "string", "description": "Exact text to find in the file's MINIFIED form (from read_minified). Must be unique and align to whole tokens." },
-                    "new_text": { "type": "string", "description": "Replacement text (written into the original source verbatim)" },
-                    "reason": { "type": "string", "description": "Why you're making this edit and how it serves the task." }
-                },
-                "required": ["path", "old_text", "new_text"]
-            }),
-        }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "edit_minified",
+            "Edit a file by replacing text matched against its MINIFIED form (as shown by read_minified). `old_text` must be the minified text — copy it from a prior read_minified of the same file — and must be unique and align to whole tokens. The change is mapped back to the original source and applied in place, preserving the file's formatting; the result is syntax-checked before writing. For normal (non-minified) edits use `edit`.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "The absolute path to the file to edit (must be absolute, not relative)" },
+                "old_text": { "type": "string", "description": "Exact text to find in the file's MINIFIED form (from read_minified). Must be unique and align to whole tokens." },
+                "new_text": { "type": "string", "description": "Replacement text (written into the original source verbatim)" },
+                "reason": { "type": "string", "description": "Why you're making this edit and how it serves the task." }
+            },
+            "required": ["path", "old_text", "new_text"]
+        })
     }
 
     async fn call(&self, args: EditArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/find_files.rs
+++ b/src/agent/tools/find_files.rs
@@ -1,7 +1,6 @@
 use ignore::WalkBuilder;
 use regex::Regex;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -47,40 +46,40 @@ impl FindFilesTool {
     }
 }
 
-impl Tool for FindFilesTool {
+impl PortableTool for FindFilesTool {
     const NAME: &'static str = "find_files";
 
     type Error = ToolError;
     type Args = FindFilesArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "find_files".to_string(),
-            description: with_contract_hint(
-                "find_files",
-                "Recursively find FILES whose FILENAME matches a regex pattern. Use this to locate a file by name (e.g. `^Cargo\\.toml$`, `.*_test\\.py$`). NOT for finding symbol definitions — use `find_definition` for that. NOT for content search — use `grep`. Respects .gitignore; skips node_modules and target.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Regex pattern to match file names against"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Directory to search in (defaults to current working directory)"
-                    },
-                    "include_hidden": {
-                        "type": "boolean",
-                        "description": "Include dotfiles (.env, .gitignore, etc.) in results. Default false to avoid surfacing secrets and config files."
-                    },
-                    "reason": { "type": "string", "description": "Why you're searching for these files: the specific question this answers and how it serves the current task. Be targeted." }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "find_files",
+            "Recursively find FILES whose FILENAME matches a regex pattern. Use this to locate a file by name (e.g. `^Cargo\\.toml$`, `.*_test\\.py$`). NOT for finding symbol definitions — use `find_definition` for that. NOT for content search — use `grep`. Respects .gitignore; skips node_modules and target.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to match file names against"
                 },
-                "required": ["pattern", "reason"]
-            }),
-        }
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search in (defaults to current working directory)"
+                },
+                "include_hidden": {
+                    "type": "boolean",
+                    "description": "Include dotfiles (.env, .gitignore, etc.) in results. Default false to avoid surfacing secrets and config files."
+                },
+                "reason": { "type": "string", "description": "Why you're searching for these files: the specific question this answers and how it serves the current task. Be targeted." }
+            },
+            "required": ["pattern", "reason"]
+        })
     }
 
     async fn call(&self, args: FindFilesArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/glob.rs
+++ b/src/agent/tools/glob.rs
@@ -1,6 +1,5 @@
 use ignore::WalkBuilder;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -95,40 +94,40 @@ fn glob_to_regex(pattern: &str) -> Result<regex::Regex, String> {
     regex::Regex::new(&regex_str).map_err(|e| format!("invalid glob pattern: {}", e))
 }
 
-impl Tool for GlobTool {
+impl PortableTool for GlobTool {
     const NAME: &'static str = "glob";
 
     type Error = ToolError;
     type Args = GlobArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "glob".to_string(),
-            description: crate::agent::agent_loop::tool_input_repair::with_contract_hint(
-                "glob",
-                "Find files matching a glob pattern (e.g., '**/*.rs', 'src/**/*.tsx'). Respects .gitignore via ignore crate. Returns matching relative file paths sorted by modification time (newest first). Returns empty string when no files match. Use this for natural path pattern matching instead of regex-based find_files.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Glob pattern to match file paths (e.g. '**/*.rs', 'src/agent/**/*.rs')"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Root directory to search in (default: current working directory)"
-                    },
-                    "include_hidden": {
-                        "type": "boolean",
-                        "description": "Include dotfiles (.env, .gitignore, etc.) in results. Default false to avoid surfacing secrets and config files."
-                    },
-                    "reason": { "type": "string", "description": "Why you're globbing: the specific question this answers and how it serves the current task. Be targeted." }
+    fn description(&self) -> String {
+        crate::agent::agent_loop::tool_input_repair::with_contract_hint(
+            "glob",
+            "Find files matching a glob pattern (e.g., '**/*.rs', 'src/**/*.tsx'). Respects .gitignore via ignore crate. Returns matching relative file paths sorted by modification time (newest first). Returns empty string when no files match. Use this for natural path pattern matching instead of regex-based find_files.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern to match file paths (e.g. '**/*.rs', 'src/agent/**/*.rs')"
                 },
-                "required": ["pattern", "reason"]
-            }),
-        }
+                "path": {
+                    "type": "string",
+                    "description": "Root directory to search in (default: current working directory)"
+                },
+                "include_hidden": {
+                    "type": "boolean",
+                    "description": "Include dotfiles (.env, .gitignore, etc.) in results. Default false to avoid surfacing secrets and config files."
+                },
+                "reason": { "type": "string", "description": "Why you're globbing: the specific question this answers and how it serves the current task. Be targeted." }
+            },
+            "required": ["pattern", "reason"]
+        })
     }
 
     async fn call(&self, args: GlobArgs) -> Result<String, ToolError> {
@@ -274,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn test_definition_has_correct_name() {
         let tool = GlobTool::new(None, None);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "glob");
     }
 

--- a/src/agent/tools/graph.rs
+++ b/src/agent/tools/graph.rs
@@ -248,8 +248,7 @@ mod tests {
     #[test]
     fn test_definition_includes_actions() {
         let tool = GraphTool::new(temp_db(), None, None, None);
-        let rt = make_runtime();
-        let def = rt.block_on(rig::tool::tool_definition(&tool));
+        let def = rig::tool::tool_definition(&tool);
         assert!(def.description.contains("search_graph"));
         assert!(def.description.contains("traverse_graph"));
         assert!(def.description.contains("entity/relation"));

--- a/src/agent/tools/graph.rs
+++ b/src/agent/tools/graph.rs
@@ -11,8 +11,7 @@
 
 use std::path::PathBuf;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -51,64 +50,64 @@ pub struct GraphArgs {
     compress: Option<bool>,
 }
 
-impl Tool for GraphTool {
+impl PortableTool for GraphTool {
     const NAME: &'static str = "search_graph";
 
     type Error = ToolError;
     type Args = GraphArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "search_graph".to_string(),
-            description: concat!(
-                "Search the entity/relation graph for files, errors, commits, ",
-                "and their relationships. Use when reasoning about code structure ",
-                "across turns.\n\n",
-                "Two actions:\n",
-                "- `search_graph`: FTS5 search over entities by name and kind\n",
-                "- `traverse_graph`: recursive CTE traversal from an entity ID, ",
-                "returning typed relation paths\n\n",
-                "Entities are facts extracted from tool output: files, errors, ",
-                "commits, and other structured items with typed relationships ",
-                "between them.",
-            )
-            .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "description": "search_graph (FTS5 search) or traverse_graph (CTE traversal from entity)"
-                    },
-                    "query": {
-                        "type": "string",
-                        "description": "FTS5 search query for search_graph (e.g. 'E0308', 'src/main.rs')"
-                    },
-                    "kind": {
-                        "type": "string",
-                        "description": "Optional entity kind filter for search_graph (e.g. 'file', 'error', 'commit')"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Max results for search_graph (default 10)"
-                    },
-                    "entity_id": {
-                        "type": "integer",
-                        "description": "Entity ID seed for traverse_graph"
-                    },
-                    "depth": {
-                        "type": "integer",
-                        "description": "Max traversal depth for traverse_graph (default 2)"
-                    },
-                    "compress": {
-                        "type": "boolean",
-                        "description": "Compress traversal output into kind-grouped summary (default false)"
-                    }
+    fn description(&self) -> String {
+        concat!(
+            "Search the entity/relation graph for files, errors, commits, ",
+            "and their relationships. Use when reasoning about code structure ",
+            "across turns.\n\n",
+            "Two actions:\n",
+            "- `search_graph`: FTS5 search over entities by name and kind\n",
+            "- `traverse_graph`: recursive CTE traversal from an entity ID, ",
+            "returning typed relation paths\n\n",
+            "Entities are facts extracted from tool output: files, errors, ",
+            "commits, and other structured items with typed relationships ",
+            "between them.",
+        )
+        .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "search_graph (FTS5 search) or traverse_graph (CTE traversal from entity)"
                 },
-                "required": ["action"]
-            }),
-        }
+                "query": {
+                    "type": "string",
+                    "description": "FTS5 search query for search_graph (e.g. 'E0308', 'src/main.rs')"
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Optional entity kind filter for search_graph (e.g. 'file', 'error', 'commit')"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results for search_graph (default 10)"
+                },
+                "entity_id": {
+                    "type": "integer",
+                    "description": "Entity ID seed for traverse_graph"
+                },
+                "depth": {
+                    "type": "integer",
+                    "description": "Max traversal depth for traverse_graph (default 2)"
+                },
+                "compress": {
+                    "type": "boolean",
+                    "description": "Compress traversal output into kind-grouped summary (default false)"
+                }
+            },
+            "required": ["action"]
+        })
     }
 
     async fn call(&self, args: GraphArgs) -> Result<String, ToolError> {
@@ -250,7 +249,7 @@ mod tests {
     fn test_definition_includes_actions() {
         let tool = GraphTool::new(temp_db(), None, None, None);
         let rt = make_runtime();
-        let def = rt.block_on(tool.definition(String::new()));
+        let def = rt.block_on(rig::tool::tool_definition(&tool));
         assert!(def.description.contains("search_graph"));
         assert!(def.description.contains("traverse_graph"));
         assert!(def.description.contains("entity/relation"));

--- a/src/agent/tools/grep.rs
+++ b/src/agent/tools/grep.rs
@@ -1,7 +1,6 @@
 use ignore::WalkBuilder;
 use regex::Regex;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -76,48 +75,48 @@ impl GrepTool {
     }
 }
 
-impl Tool for GrepTool {
+impl PortableTool for GrepTool {
     const NAME: &'static str = "grep";
 
     type Error = ToolError;
     type Args = GrepArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "grep".to_string(),
-            description: with_contract_hint(
-                "grep",
-                "Search FILE CONTENTS for a regex pattern (Rust regex syntax) and return matching lines as file:line. Use this to find where text or code appears across the project. NOT for matching FILENAMES — use `glob` (path patterns) or `find_files` (filename regex); NOT for locating a symbol's definition — use `find_definition`. Respects .gitignore; skips binary files, node_modules, and target.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Regex pattern to search for (supports Rust regex syntax)"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Directory to search in (defaults to current working directory)"
-                    },
-                    "include": {
-                        "type": "string",
-                        "description": "Optional file glob pattern to filter (e.g. '*.rs', '*.{ts,tsx}')"
-                    },
-                    "context_lines": {
-                        "type": "integer",
-                        "description": "Number of context lines to show before and after each match (like grep -C)"
-                    },
-                    "include_hidden": {
-                        "type": "boolean",
-                        "description": "Include dotfiles (.env, .gitignore, etc.) in the search. Default false to avoid surfacing secrets and config files."
-                    },
-                    "reason": { "type": "string", "description": "Why you're searching: the specific question this answers and how it serves the current task. Be targeted." }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "grep",
+            "Search FILE CONTENTS for a regex pattern (Rust regex syntax) and return matching lines as file:line. Use this to find where text or code appears across the project. NOT for matching FILENAMES — use `glob` (path patterns) or `find_files` (filename regex); NOT for locating a symbol's definition — use `find_definition`. Respects .gitignore; skips binary files, node_modules, and target.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for (supports Rust regex syntax)"
                 },
-                "required": ["pattern", "reason"]
-            }),
-        }
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search in (defaults to current working directory)"
+                },
+                "include": {
+                    "type": "string",
+                    "description": "Optional file glob pattern to filter (e.g. '*.rs', '*.{ts,tsx}')"
+                },
+                "context_lines": {
+                    "type": "integer",
+                    "description": "Number of context lines to show before and after each match (like grep -C)"
+                },
+                "include_hidden": {
+                    "type": "boolean",
+                    "description": "Include dotfiles (.env, .gitignore, etc.) in the search. Default false to avoid surfacing secrets and config files."
+                },
+                "reason": { "type": "string", "description": "Why you're searching: the specific question this answers and how it serves the current task. Be targeted." }
+            },
+            "required": ["pattern", "reason"]
+        })
     }
 
     async fn call(&self, args: GrepArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/issue.rs
+++ b/src/agent/tools/issue.rs
@@ -13,8 +13,7 @@
 
 use std::path::PathBuf;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -95,37 +94,37 @@ fn render_issue(i: &crate::extras::issue_db::Issue) -> String {
     out
 }
 
-impl Tool for IssueTool {
+impl PortableTool for IssueTool {
     const NAME: &'static str = "issue";
 
     type Error = ToolError;
     type Args = IssueArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "issue".to_string(),
-            description: "Persistent issue/kanban board for tracking work (stored in the project DB, persists ACROSS sessions). The harness shows your open board at the start of each turn, so you don't need to list it constantly. This is the incremental, single-item surface; `write_todo_list` writes to the SAME board in bulk for laying out a multi-step plan. Actions: \
+    fn description(&self) -> String {
+        "Persistent issue/kanban board for tracking work (stored in the project DB, persists ACROSS sessions). The harness shows your open board at the start of each turn, so you don't need to list it constantly. This is the incremental, single-item surface; `write_todo_list` writes to the SAME board in bulk for laying out a multi-step plan. Actions: \
                 create (title, optional body/priority high|normal|low, optional epic=<id>) — files to the BACKLOG for later (NOT on your active work queue; use `start` to pick it up when you actually begin it); \
                 start (id → in_progress) — claims the issue onto your active work queue; block (id → blocked); close (id → done); \
                 update (id, optional status open|in_progress|blocked|done|cancelled / priority / body); \
                 show (id) — shows detail, and for an epic also lists its live children; list (optional status filter); search (query). \
-                Ids look like \"drg-a1b2\" (legacy \"7\"/\"#7\" also accepted). Create issues as you discover work; start one when you begin it; close it when done.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "action": { "type": "string", "description": "create | list | show | start | block | close | update | search" },
-                    "title": { "type": "string", "description": "Title (create)" },
-                    "body": { "type": "string", "description": "Optional details (create/update)" },
-                    "id": { "type": ["integer", "string"], "description": "Issue id for show/update/start/block/close (e.g. \"drg-a1b2\"; legacy 7/\"#7\" also accepted)" },
-                    "status": { "type": "string", "description": "open | in_progress | blocked | done | cancelled (update)" },
-                    "priority": { "type": "string", "description": "high | normal | low (create/update)" },
-                    "epic": { "type": ["integer", "string"], "description": "Parent epic id (create only; e.g. \"drg-a1b2\" or 7)" },
-                    "query": { "type": "string", "description": "Status filter for list, or search term for search" }
-                },
-                "required": ["action"]
-            }),
-        }
+                Ids look like \"drg-a1b2\" (legacy \"7\"/\"#7\" also accepted). Create issues as you discover work; start one when you begin it; close it when done.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": { "type": "string", "description": "create | list | show | start | block | close | update | search" },
+                "title": { "type": "string", "description": "Title (create)" },
+                "body": { "type": "string", "description": "Optional details (create/update)" },
+                "id": { "type": ["integer", "string"], "description": "Issue id for show/update/start/block/close (e.g. \"drg-a1b2\"; legacy 7/\"#7\" also accepted)" },
+                "status": { "type": "string", "description": "open | in_progress | blocked | done | cancelled (update)" },
+                "priority": { "type": "string", "description": "high | normal | low (create/update)" },
+                "epic": { "type": ["integer", "string"], "description": "Parent epic id (create only; e.g. \"drg-a1b2\" or 7)" },
+                "query": { "type": "string", "description": "Status filter for list, or search term for search" }
+            },
+            "required": ["action"]
+        })
     }
 
     async fn call(&self, args: IssueArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/list_dir.rs
+++ b/src/agent/tools/list_dir.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 
 use ignore::WalkBuilder;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -68,35 +67,35 @@ impl ListDirTool {
     }
 }
 
-impl Tool for ListDirTool {
+impl PortableTool for ListDirTool {
     const NAME: &'static str = "list_dir";
 
     type Error = ToolError;
     type Args = ListDirArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "list_dir".to_string(),
-            description: with_contract_hint(
-                "list_dir",
-                "List the immediate files and directories in ONE directory (non-recursive). Shows type, size, and subdirectory entry counts; sorted directories-first then alphabetically. Respects .gitignore. Use `repo_overview` for a whole-project tree, `glob`/`find_files` to locate files by pattern, and `grep` to search contents.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Directory path (defaults to current working directory)"
-                    },
-                    "include_hidden": {
-                        "type": "boolean",
-                        "description": "Include dotfiles (.env, .gitignore, etc.) in the listing. Default false to avoid surfacing secrets and config files."
-                    }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "list_dir",
+            "List the immediate files and directories in ONE directory (non-recursive). Shows type, size, and subdirectory entry counts; sorted directories-first then alphabetically. Respects .gitignore. Use `repo_overview` for a whole-project tree, `glob`/`find_files` to locate files by pattern, and `grep` to search contents.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory path (defaults to current working directory)"
                 },
-                "required": []
-            }),
-        }
+                "include_hidden": {
+                    "type": "boolean",
+                    "description": "Include dotfiles (.env, .gitignore, etc.) in the listing. Default false to avoid surfacing secrets and config files."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: ListDirArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/lsp.rs
+++ b/src/agent/tools/lsp.rs
@@ -7,8 +7,7 @@
 
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -76,59 +75,59 @@ pub struct LspArgs {
     pub query: Option<String>,
 }
 
-impl Tool for LspTool {
+impl PortableTool for LspTool {
     const NAME: &'static str = "lsp";
 
     type Error = ToolError;
     type Args = LspArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "lsp".to_string(),
-            description: DESCRIPTION.to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "operation": {
-                        "type": "string",
-                        "enum": [
-                            "definition",
-                            "references",
-                            "hover",
-                            "documentSymbol",
-                            "workspaceSymbol",
-                            "implementation",
-                            "prepareCallHierarchy",
-                            "incomingCalls",
-                            "outgoingCalls"
-                        ],
-                        "description": "Which LSP capability to invoke."
-                    },
-                    "file_path": {
-                        "type": "string",
-                        "description": "Absolute file path (must be absolute, not relative). Required for every operation.",
-                        "dirge-hints": {"semantic": "absolute_path"}
-                    },
-                    "line": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "1-based line number (as shown in editors). Required for position-based operations."
-                    },
-                    "character": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "1-based character offset. Required for position-based operations."
-                    },
-                    "query": {
-                        "type": "string",
-                        "description": "Search string for workspaceSymbol — REQUIRED when operation is 'workspaceSymbol' (pass empty string to list all symbols). Ignored for other operations."
-                    },
-                    "reason": { "type": "string", "description": "Why you're querying: the specific code-structure question this answers and how it serves the current task. Be targeted." }
+    fn description(&self) -> String {
+        DESCRIPTION.to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "definition",
+                        "references",
+                        "hover",
+                        "documentSymbol",
+                        "workspaceSymbol",
+                        "implementation",
+                        "prepareCallHierarchy",
+                        "incomingCalls",
+                        "outgoingCalls"
+                    ],
+                    "description": "Which LSP capability to invoke."
                 },
-                "required": ["operation", "file_path", "reason"]
-            }),
-        }
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute file path (must be absolute, not relative). Required for every operation.",
+                    "dirge-hints": {"semantic": "absolute_path"}
+                },
+                "line": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "1-based line number (as shown in editors). Required for position-based operations."
+                },
+                "character": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "1-based character offset. Required for position-based operations."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search string for workspaceSymbol — REQUIRED when operation is 'workspaceSymbol' (pass empty string to list all symbols). Ignored for other operations."
+                },
+                "reason": { "type": "string", "description": "Why you're querying: the specific code-structure question this answers and how it serves the current task. Be targeted." }
+            },
+            "required": ["operation", "file_path", "reason"]
+        })
     }
 
     async fn call(&self, args: LspArgs) -> Result<String, ToolError> {
@@ -338,7 +337,7 @@ mod tests {
     async fn definition_has_correct_name() {
         let (tree, _) = cargo_tree("def-name");
         let tool = make_tool(Value::Null, tree.clone());
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "lsp");
         let _ = std::fs::remove_dir_all(&tree);
     }

--- a/src/agent/tools/memory.rs
+++ b/src/agent/tools/memory.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -106,14 +105,8 @@ fn default_kind() -> Option<String> {
     None
 }
 
-impl Tool for MemoryTool {
-    const NAME: &'static str = "memory";
-
-    type Error = ToolError;
-    type Args = Args;
-    type Output = String;
-
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
+impl MemoryTool {
+    fn definition_parts(&self) -> (String, serde_json::Value) {
         // dirge-ygm3: `mark`/`supersede` are background-review-only. They live
         // in the action enum (parameters), not the prose description, so gating
         // them changes only the schema's allowed values — never the
@@ -134,9 +127,8 @@ impl Tool for MemoryTool {
                  rather than was reworded.",
             );
         }
-        ToolDefinition {
-            name: "memory".to_string(),
-            description: r#"Persistent long-term memory for project facts and pitfalls.
+        (
+            r#"Persistent long-term memory for project facts and pitfalls.
 
 SAVE WHEN: the user corrects you or says "remember this"; you discover build/test commands, conventions, architecture patterns, or library quirks; something was tried and failed (pitfall).
 
@@ -155,7 +147,7 @@ ACTIONS:
 
 old_text matches a unique substring or the exact "urn:ump:…" id from view/index."#
                 .to_string(),
-            parameters: {
+            {
                 let mut params = serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -217,7 +209,23 @@ old_text matches a unique substring or the exact "urn:ump:…" id from view/inde
                 }
                 params
             },
-        }
+        )
+    }
+}
+
+impl PortableTool for MemoryTool {
+    const NAME: &'static str = "memory";
+
+    type Error = ToolError;
+    type Args = Args;
+    type Output = String;
+
+    fn description(&self) -> String {
+        self.definition_parts().0
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.definition_parts().1
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {
@@ -464,8 +472,8 @@ mod tests {
         }
     }
 
-    fn action_enum(tool: &MemoryTool, rt: &tokio::runtime::Runtime) -> Vec<String> {
-        let def = rt.block_on(tool.definition(String::new()));
+    fn action_enum(tool: &MemoryTool) -> Vec<String> {
+        let def = rig::tool::portable_tool_definition(tool);
         def.parameters["properties"]["action"]["enum"]
             .as_array()
             .unwrap()
@@ -480,8 +488,7 @@ mod tests {
     fn default_tool_hides_review_actions_from_schema() {
         let (store, _d) = temp_store();
         let tool = MemoryTool::new(store, None, None);
-        let rt = make_runtime();
-        let actions = action_enum(&tool, &rt);
+        let actions = action_enum(&tool);
         assert!(
             !actions.iter().any(|a| a == "mark" || a == "supersede"),
             "main agent schema must omit mark/supersede: {actions:?}",
@@ -499,8 +506,7 @@ mod tests {
     fn review_tool_exposes_review_actions() {
         let (store, _d) = temp_store();
         let tool = MemoryTool::new(store, None, None).with_review_actions(true);
-        let rt = make_runtime();
-        let actions = action_enum(&tool, &rt);
+        let actions = action_enum(&tool);
         assert!(
             actions.iter().any(|a| a == "mark"),
             "mark present: {actions:?}"
@@ -827,8 +833,7 @@ mod tests {
     fn test_definition_includes_both_targets() {
         let (store, _dir) = temp_store();
         let tool = MemoryTool::new(store, None, None);
-        let rt = make_runtime();
-        let def = rt.block_on(tool.definition(String::new()));
+        let def = rig::tool::portable_tool_definition(&tool);
         assert!(def.description.contains("memory"));
         assert!(def.description.contains("pitfalls"));
     }

--- a/src/agent/tools/plan.rs
+++ b/src/agent/tools/plan.rs
@@ -11,8 +11,7 @@
 
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
 
@@ -86,24 +85,24 @@ impl PlanEnterTool {
 #[derive(Deserialize)]
 pub struct PlanEnterArgs {}
 
-impl Tool for PlanEnterTool {
+impl PortableTool for PlanEnterTool {
     const NAME: &'static str = "plan_enter";
 
     type Error = ToolError;
     type Args = PlanEnterArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "plan_enter".to_string(),
-            description: "Suggest switching to plan mode for complex tasks. The user will be asked to confirm. In plan mode, the agent uses a planning prompt that focuses on analysis and creating a detailed implementation plan rather than writing code."
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Suggest switching to plan mode for complex tasks. The user will be asked to confirm. In plan mode, the agent uses a planning prompt that focuses on analysis and creating a detailed implementation plan rather than writing code."
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, _args: PlanEnterArgs) -> Result<String, ToolError> {
@@ -165,24 +164,24 @@ impl PlanExitTool {
 #[derive(Deserialize)]
 pub struct PlanExitArgs {}
 
-impl Tool for PlanExitTool {
+impl PortableTool for PlanExitTool {
     const NAME: &'static str = "plan_exit";
 
     type Error = ToolError;
     type Args = PlanExitArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "plan_exit".to_string(),
-            description: "Suggest switching from plan mode to implementation mode. The user will be asked to confirm. The agent will switch to the code prompt for writing and executing code."
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Suggest switching from plan mode to implementation mode. The user will be asked to confirm. The agent will switch to the code prompt for writing and executing code."
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, _args: PlanExitArgs) -> Result<String, ToolError> {
@@ -281,10 +280,10 @@ mod tests {
         let (tx1, _rx) = mpsc::channel(1);
         let (tx2, _rx) = mpsc::channel(1);
 
-        let enter = PlanEnterTool::new(tx1).definition(String::new()).await;
+        let enter = rig::tool::tool_definition(&PlanEnterTool::new(tx1));
         assert_eq!(enter.name, "plan_enter");
 
-        let exit = PlanExitTool::new(tx2).definition(String::new()).await;
+        let exit = rig::tool::tool_definition(&PlanExitTool::new(tx2));
         assert_eq!(exit.name, "plan_exit");
     }
 
@@ -300,7 +299,7 @@ mod tests {
         // The impl block for PlanExitTool. We don't want fs::write or PLAN.md
         // string literals anywhere in the call() path.
         let impl_start = src
-            .find("impl Tool for PlanExitTool")
+            .find("impl PortableTool for PlanExitTool")
             .expect("PlanExitTool impl present");
         let impl_end = src[impl_start..]
             .find("\n}\n")

--- a/src/agent/tools/question.rs
+++ b/src/agent/tools/question.rs
@@ -1,5 +1,4 @@
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
 
@@ -75,24 +74,15 @@ impl QuestionTool {
     }
 }
 
-impl Tool for QuestionTool {
+impl PortableTool for QuestionTool {
     const NAME: &'static str = "question";
 
     type Error = ToolError;
     type Args = QuestionArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        // Description mirrors opencode's question.txt structure —
-        // the explicit \"when to use\" list + \"usage notes\" gets
-        // the model to actually reach for this tool instead of
-        // either guessing or asking in plain prose. The
-        // \"(Recommended)\" convention helps the model communicate
-        // its preferred answer without taking choice away from
-        // the user.
-        ToolDefinition {
-            name: "question".to_string(),
-            description: "Ask the user structured questions during execution. Use this when you need to:\n\
+    fn description(&self) -> String {
+        "Ask the user structured questions during execution. Use this when you need to:\n\
                 1. Gather user preferences or requirements\n\
                 2. Clarify ambiguous instructions before proceeding\n\
                 3. Get decisions on implementation choices as you work\n\
@@ -106,52 +96,54 @@ impl Tool for QuestionTool {
                 - If you recommend a specific option, make it the first option and add \" (Recommended)\" at the end of the label.\n\
                 - Use `header` to group related questions under a short section title.\n\
                 - Prefer asking over guessing when the user's request is genuinely ambiguous — but don't over-ask for clearly-decidable details."
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "questions": {
-                        "type": "array",
-                        "description": "List of questions to ask the user",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "question": {
-                                    "type": "string",
-                                    "description": "The question text"
-                                },
-                                "header": {
-                                    "type": "string",
-                                    "description": "Optional section heading displayed above the question"
-                                },
-                                "options": {
-                                    "type": "array",
-                                    "description": "Answer choices for the user",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "label": {"type": "string", "description": "Short display label for the option"},
-                                            "description": {"type": "string", "description": "Explanation of what this choice means"}
-                                        },
-                                        "required": ["label", "description"]
-                                    }
-                                },
-                                "multi_select": {
-                                    "type": "boolean",
-                                    "description": "Allow selecting multiple options (default: false)"
-                                },
-                                "custom": {
-                                    "type": "boolean",
-                                    "description": "Whether to show a 'Type your own answer' option (default: true)"
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "description": "List of questions to ask the user",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question": {
+                                "type": "string",
+                                "description": "The question text"
+                            },
+                            "header": {
+                                "type": "string",
+                                "description": "Optional section heading displayed above the question"
+                            },
+                            "options": {
+                                "type": "array",
+                                "description": "Answer choices for the user",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": {"type": "string", "description": "Short display label for the option"},
+                                        "description": {"type": "string", "description": "Explanation of what this choice means"}
+                                    },
+                                    "required": ["label", "description"]
                                 }
                             },
-                            "required": ["question", "options"]
-                        }
+                            "multi_select": {
+                                "type": "boolean",
+                                "description": "Allow selecting multiple options (default: false)"
+                            },
+                            "custom": {
+                                "type": "boolean",
+                                "description": "Whether to show a 'Type your own answer' option (default: true)"
+                            }
+                        },
+                        "required": ["question", "options"]
                     }
-                },
-                "required": ["questions"]
-            }),
-        }
+                }
+            },
+            "required": ["questions"]
+        })
     }
 
     async fn call(&self, args: QuestionArgs) -> Result<String, ToolError> {
@@ -227,7 +219,7 @@ mod tests {
     async fn test_definition_has_correct_name() {
         let (tx, _rx) = mpsc::channel(1);
         let tool = QuestionTool::new(tx);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "question");
     }
 

--- a/src/agent/tools/read.rs
+++ b/src/agent/tools/read.rs
@@ -1,8 +1,7 @@
 #[cfg(feature = "lsp")]
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::agent_loop::types::InjectionScanMode;
@@ -153,52 +152,52 @@ impl ReadTool {
     }
 }
 
-impl Tool for ReadTool {
+impl PortableTool for ReadTool {
     const NAME: &'static str = "read";
 
     type Error = ToolError;
     type Args = ReadArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read".to_string(),
-            description: with_contract_hint(
-                "read",
-                "Read the contents of a file. Supports text files. Defaults to first 2000 lines. Use offset/limit for large files.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "The absolute path to the file to read (must be absolute, not relative)",
-                        "dirge-hints": {"semantic": "absolute_path"}
-                    },
-                    "offset": { "type": "integer", "description": "Line number to start from (1-indexed)" },
-                    "limit": { "type": "integer", "description": "Maximum number of lines to read" },
-                    "line_hashes": { "type": "boolean", "description": "Prefix each line with its 3-char content hash (e.g. `42 a3f: ...`) for hash-anchored editing with edit_lines. Pass the start/end line numbers and these hashes to edit_lines to replace a range without retyping the old text." },
-                    "reason": { "type": "string", "description": "Why you're reading this file: what you expect to learn and how it serves the current task. Be specific and targeted — don't read files for general orientation." }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "read",
+            "Read the contents of a file. Supports text files. Defaults to first 2000 lines. Use offset/limit for large files.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The absolute path to the file to read (must be absolute, not relative)",
+                    "dirge-hints": {"semantic": "absolute_path"}
                 },
-                "required": ["path", "reason"],
-                // Phase-2: when `limit` is given but `offset` is
-                // not (or vice versa), the harness auto-fills the
-                // missing one with `offset = 0` and prepends a
-                // Note: to the tool result so the model knows the
-                // default was applied. Replaces the hardcoded note
-                // in `read::call`'s body — that path can be
-                // removed once every relational pairing migrates
-                // here.
-                "dirge-hints": {
-                    "relational": [
-                        {
-                            "requires": ["offset", "limit"],
-                            "defaults": {"offset": 0}
-                        }
-                    ]
-                }
-            }),
-        }
+                "offset": { "type": "integer", "description": "Line number to start from (1-indexed)" },
+                "limit": { "type": "integer", "description": "Maximum number of lines to read" },
+                "line_hashes": { "type": "boolean", "description": "Prefix each line with its 3-char content hash (e.g. `42 a3f: ...`) for hash-anchored editing with edit_lines. Pass the start/end line numbers and these hashes to edit_lines to replace a range without retyping the old text." },
+                "reason": { "type": "string", "description": "Why you're reading this file: what you expect to learn and how it serves the current task. Be specific and targeted — don't read files for general orientation." }
+            },
+            "required": ["path", "reason"],
+            // Phase-2: when `limit` is given but `offset` is
+            // not (or vice versa), the harness auto-fills the
+            // missing one with `offset = 0` and prepends a
+            // Note: to the tool result so the model knows the
+            // default was applied. Replaces the hardcoded note
+            // in `read::call`'s body — that path can be
+            // removed once every relational pairing migrates
+            // here.
+            "dirge-hints": {
+                "relational": [
+                    {
+                        "requires": ["offset", "limit"],
+                        "defaults": {"offset": 0}
+                    }
+                ]
+            }
+        })
     }
 
     async fn call(&self, args: ReadArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/read_minified.rs
+++ b/src/agent/tools/read_minified.rs
@@ -12,8 +12,7 @@
 #[cfg(feature = "lsp")]
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -69,31 +68,31 @@ impl ReadMinifiedTool {
     }
 }
 
-impl Tool for ReadMinifiedTool {
+impl PortableTool for ReadMinifiedTool {
     const NAME: &'static str = "read_minified";
 
     type Error = ToolError;
     type Args = ReadArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_minified".to_string(),
-            description: with_contract_hint(
-                "read_minified",
-                "Read a source file with comments stripped (and, for brace languages like Rust/Go/Java, redundant whitespace collapsed) via tree-sitter, for token efficiency. Works across the supported source languages (Rust, Go, Java, C, C++, TypeScript, Python, Ruby, Bash, Clojure, Elixir); non-source files, ranged reads (offset/limit), or unparseable files transparently fall back to a normal read. Use plain `read` when you need exact line numbers.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "The absolute path to the file to read (must be absolute, not relative)" },
-                    "offset": { "type": "integer", "description": "Line number to start from (1-indexed). Ranged reads skip minification and read normally." },
-                    "limit": { "type": "integer", "description": "Maximum number of lines to read. Ranged reads skip minification." },
-                    "reason": { "type": "string", "description": "Why you're reading this file: what you expect to learn and how it serves the current task. Be specific and targeted." }
-                },
-                "required": ["path", "reason"]
-            }),
-        }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "read_minified",
+            "Read a source file with comments stripped (and, for brace languages like Rust/Go/Java, redundant whitespace collapsed) via tree-sitter, for token efficiency. Works across the supported source languages (Rust, Go, Java, C, C++, TypeScript, Python, Ruby, Bash, Clojure, Elixir); non-source files, ranged reads (offset/limit), or unparseable files transparently fall back to a normal read. Use plain `read` when you need exact line numbers.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "The absolute path to the file to read (must be absolute, not relative)" },
+                "offset": { "type": "integer", "description": "Line number to start from (1-indexed). Ranged reads skip minification and read normally." },
+                "limit": { "type": "integer", "description": "Maximum number of lines to read. Ranged reads skip minification." },
+                "reason": { "type": "string", "description": "Why you're reading this file: what you expect to learn and how it serves the current task. Be specific and targeted." }
+            },
+            "required": ["path", "reason"]
+        })
     }
 
     async fn call(&self, args: ReadArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/repo_overview.rs
+++ b/src/agent/tools/repo_overview.rs
@@ -1,8 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::cache::ToolCache;
@@ -71,36 +70,36 @@ impl RepoOverviewTool {
     }
 }
 
-impl Tool for RepoOverviewTool {
+impl PortableTool for RepoOverviewTool {
     const NAME: &'static str = "repo_overview";
 
     type Error = ToolError;
     type Args = RepoOverviewArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "repo_overview".to_string(),
-            description: "Structural map of a codebase: directory tree with per-directory file counts and optionally per-file line counts. Use this BEFORE diving into specific files when you need a sense of project layout — much cheaper than reading every file. Honors .gitignore and skips common noise dirs (node_modules, target, .git, __pycache__).".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Root path to summarize (relative to cwd or absolute). Defaults to '.' (cwd).",
-                    },
-                    "max_depth": {
-                        "type": "integer",
-                        "description": "Subdirectory depth cap (default 3, hard max 6).",
-                    },
-                    "include_line_counts": {
-                        "type": "boolean",
-                        "description": "Include per-file line count. Default false (cheaper).",
-                    },
+    fn description(&self) -> String {
+        "Structural map of a codebase: directory tree with per-directory file counts and optionally per-file line counts. Use this BEFORE diving into specific files when you need a sense of project layout — much cheaper than reading every file. Honors .gitignore and skips common noise dirs (node_modules, target, .git, __pycache__).".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Root path to summarize (relative to cwd or absolute). Defaults to '.' (cwd).",
                 },
-                "required": [],
-            }),
-        }
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Subdirectory depth cap (default 3, hard max 6).",
+                },
+                "include_line_counts": {
+                    "type": "boolean",
+                    "description": "Include per-file line count. Default false (cheaper).",
+                },
+            },
+            "required": [],
+        })
     }
 
     async fn call(&self, args: RepoOverviewArgs) -> Result<String, ToolError> {

--- a/src/agent/tools/semantic/find_callees.rs
+++ b/src/agent/tools/semantic/find_callees.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path};
@@ -34,32 +33,32 @@ pub struct Args {
     name: String,
 }
 
-impl Tool for FindCalleesTool {
+impl PortableTool for FindCalleesTool {
     const NAME: &'static str = "find_callees";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "find_callees".to_string(),
-            description: "Find all functions/methods called by a given symbol (its callees). Uses tree-sitter to extract call expressions from the symbol body. Supports TypeScript, Python, and more.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file containing the symbol"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the function/method to analyze"
-                    }
+    fn description(&self) -> String {
+        "Find all functions/methods called by a given symbol (its callees). Uses tree-sitter to extract call expressions from the symbol body. Supports TypeScript, Python, and more.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file containing the symbol"
                 },
-                "required": ["path", "name"]
-            }),
-        }
+                "name": {
+                    "type": "string",
+                    "description": "Name of the function/method to analyze"
+                }
+            },
+            "required": ["path", "name"]
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/semantic/find_callers.rs
+++ b/src/agent/tools/semantic/find_callers.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm, check_perm_path};
@@ -34,32 +33,32 @@ pub struct Args {
     path: Option<String>,
 }
 
-impl Tool for FindCallersTool {
+impl PortableTool for FindCallersTool {
     const NAME: &'static str = "find_callers";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "find_callers".to_string(),
-            description: "Find all call sites of a function or method across the project. Searches source files for references, excluding the definition site. Supports all tree-sitter supported languages.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the function/method to find callers of"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Directory to search in (defaults to current working directory)"
-                    }
+    fn description(&self) -> String {
+        "Find all call sites of a function or method across the project. Searches source files for references, excluding the definition site. Supports all tree-sitter supported languages.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the function/method to find callers of"
                 },
-                "required": ["name"]
-            }),
-        }
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search in (defaults to current working directory)"
+                }
+            },
+            "required": ["name"]
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/semantic/find_definition.rs
+++ b/src/agent/tools/semantic/find_definition.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -33,28 +32,28 @@ pub struct Args {
     name: String,
 }
 
-impl Tool for FindDefinitionTool {
+impl PortableTool for FindDefinitionTool {
     const NAME: &'static str = "find_definition";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "find_definition".to_string(),
-            description: "Find where a SYMBOL (function, class, type, etc.) is DEFINED across the project. Uses tree-sitter for precise structural matching. NOT for finding files by name — use `find_files` for that. NOT for content search — use `grep`.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the symbol to find"
-                    }
-                },
-                "required": ["name"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Find where a SYMBOL (function, class, type, etc.) is DEFINED across the project. Uses tree-sitter for precise structural matching. NOT for finding files by name — use `find_files` for that. NOT for content search — use `grep`.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the symbol to find"
+                }
+            },
+            "required": ["name"]
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/semantic/get_symbol_body.rs
+++ b/src/agent/tools/semantic/get_symbol_body.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path};
@@ -34,32 +33,32 @@ pub struct Args {
     name: String,
 }
 
-impl Tool for GetSymbolBodyTool {
+impl PortableTool for GetSymbolBodyTool {
     const NAME: &'static str = "get_symbol_body";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_symbol_body".to_string(),
-            description: "Get the full source code of a named symbol (function, class, method, etc.) from a file. Uses tree-sitter to precisely extract by byte range.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file containing the symbol"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the symbol to retrieve"
-                    }
+    fn description(&self) -> String {
+        "Get the full source code of a named symbol (function, class, method, etc.) from a file. Uses tree-sitter to precisely extract by byte range.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file containing the symbol"
                 },
-                "required": ["path", "name"]
-            }),
-        }
+                "name": {
+                    "type": "string",
+                    "description": "Name of the symbol to retrieve"
+                }
+            },
+            "required": ["path", "name"]
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/semantic/list_symbols.rs
+++ b/src/agent/tools/semantic/list_symbols.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm_path};
@@ -35,31 +34,31 @@ pub struct Args {
     kind: Option<String>,
 }
 
-impl Tool for ListSymbolsTool {
+impl PortableTool for ListSymbolsTool {
     const NAME: &'static str = "list_symbols";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "list_symbols".to_string(),
-            description: "List symbols (functions, classes, methods, etc.) in a file or across the project. Parses code with tree-sitter for accurate results. Use this instead of grep when looking for code structure.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "File path to list symbols from. Omit to list across all indexed files."
-                    },
-                    "kind": {
-                        "type": "string",
-                        "description": "Filter by symbol kind: function, class, method, interface, type, or variable"
-                    }
+    fn description(&self) -> String {
+        "List symbols (functions, classes, methods, etc.) in a file or across the project. Parses code with tree-sitter for accurate results. Use this instead of grep when looking for code structure.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path to list symbols from. Omit to list across all indexed files."
+                },
+                "kind": {
+                    "type": "string",
+                    "description": "Filter by symbol kind: function, class, method, interface, type, or variable"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/session_search.rs
+++ b/src/agent/tools/session_search.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -74,17 +73,15 @@ fn default_window() -> usize {
     5
 }
 
-impl Tool for SessionSearchTool {
+impl PortableTool for SessionSearchTool {
     const NAME: &'static str = "session_search";
 
     type Error = ToolError;
     type Args = SearchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "session_search".to_string(),
-            description: r#"Search past sessions on this project. Three calling modes (inferred from args):
+    fn description(&self) -> String {
+        r#"Search past sessions on this project. Three calling modes (inferred from args):
 
 1. DISCOVERY: pass `query` — FTS5 full-text search. Returns top sessions with snippets, message windows around matches, and bookends (first/last messages). Deduped by session lineage. Zero LLM cost — pure DB queries.
 
@@ -93,30 +90,32 @@ impl Tool for SessionSearchTool {
 3. BROWSE: no args — returns recent sessions chronologically (titles, previews, timestamps).
 
 FTS5 syntax: AND (default), OR, NOT, "quoted phrases", * prefix wildcards."#
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "FTS5 query for DISCOVERY mode. Omit for BROWSE or SCROLL."
-                    },
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session id for SCROLL mode."
-                    },
-                    "around_message_id": {
-                        "type": "integer",
-                        "description": "Message id anchor for SCROLL mode."
-                    },
-                    "window": {
-                        "type": "integer",
-                        "description": "Window size for SCROLL (default 5, max 20)."
-                    }
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "FTS5 query for DISCOVERY mode. Omit for BROWSE or SCROLL."
                 },
-                "required": []
-            }),
-        }
+                "session_id": {
+                    "type": "string",
+                    "description": "Session id for SCROLL mode."
+                },
+                "around_message_id": {
+                    "type": "integer",
+                    "description": "Message id anchor for SCROLL mode."
+                },
+                "window": {
+                    "type": "integer",
+                    "description": "Window size for SCROLL (default 5, max 20)."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: SearchArgs) -> Result<String, ToolError> {
@@ -264,8 +263,7 @@ mod tests {
     fn test_definition_includes_modes() {
         let db_path = temp_db_path();
         let tool = SessionSearchTool::new(db_path, None, None, None);
-        let rt = make_runtime();
-        let def = rt.block_on(tool.definition(String::new()));
+        let def = rig::tool::portable_tool_definition(&tool);
         assert!(def.description.contains("DISCOVERY"));
         assert!(def.description.contains("SCROLL"));
         assert!(def.description.contains("BROWSE"));

--- a/src/agent/tools/skill.rs
+++ b/src/agent/tools/skill.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -58,14 +57,8 @@ pub struct SkillArgs {
     force: Option<bool>,
 }
 
-impl Tool for SkillTool {
-    const NAME: &'static str = "skill";
-
-    type Error = ToolError;
-    type Args = SkillArgs;
-    type Output = String;
-
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
+impl SkillTool {
+    fn definition_parts(&self) -> (String, serde_json::Value) {
         // The available-skills catalog (name + description) is already injected
         // into the system preamble, so it is NOT duplicated here — doing so
         // bloated the tool schema on every request and pushed the description
@@ -81,11 +74,9 @@ impl Tool for SkillTool {
              only for a major overhaul. The available skills are listed in your system context — \
              `load` one by name to read its full content. Skills live in .dirge/skills/<name>/SKILL.md.",
         );
-
-        ToolDefinition {
-            name: "skill".to_string(),
+        (
             description,
-            parameters: serde_json::json!({
+            serde_json::json!({
                 "type": "object",
                 "properties": {
                     "action": {
@@ -116,7 +107,23 @@ impl Tool for SkillTool {
                 },
                 "required": ["action"]
             }),
-        }
+        )
+    }
+}
+
+impl PortableTool for SkillTool {
+    const NAME: &'static str = "skill";
+
+    type Error = ToolError;
+    type Args = SkillArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        self.definition_parts().0
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.definition_parts().1
     }
 
     async fn call(&self, args: SkillArgs) -> Result<String, ToolError> {
@@ -838,8 +845,7 @@ mod tests {
         let skills = make_skills();
         let (mgr, _dir) = temp_skills_dir();
         let tool = SkillTool::new(skills, mgr, None, None, None);
-        let rt = make_runtime();
-        let def = rt.block_on(tool.definition(String::new()));
+        let def = rig::tool::portable_tool_definition(&tool);
         for action in ["load", "create", "edit", "patch", "delete", "list"] {
             assert!(
                 def.description.contains(action),

--- a/src/agent/tools/spec.rs
+++ b/src/agent/tools/spec.rs
@@ -8,8 +8,7 @@
 
 use std::sync::Arc;
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -102,17 +101,15 @@ fn json(v: &serde_json::Value) -> String {
     serde_json::to_string_pretty(v).unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.into())
 }
 
-impl Tool for SpecTool {
+impl PortableTool for SpecTool {
     const NAME: &'static str = "spec";
 
     type Error = ToolError;
     type Args = Args;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "spec".to_string(),
-            description: r#"Spec-driven workflow tracker (SQLite-backed). Align on WHAT before HOW, then track implementation. Living specs (capability → requirement → scenario) are the current truth; a CHANGE carries requirement deltas + a task checklist; ARCHIVE folds the deltas into the living specs.
+    fn description(&self) -> String {
+        r#"Spec-driven workflow tracker (SQLite-backed). Align on WHAT before HOW, then track implementation. Living specs (capability → requirement → scenario) are the current truth; a CHANGE carries requirement deltas + a task checklist; ARCHIVE folds the deltas into the living specs.
 
 Actions:
 - propose (slug, why, what): new change.
@@ -125,41 +122,43 @@ Actions:
 - set_field (slug, field=title|why|what|design, value): edit a change field.
 
 scenarios = array of {name, when_then} (when_then in WHEN/THEN form)."#
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["propose", "set_field", "add_delta", "add_task", "set_task", "archive", "status", "specs"],
-                        "description": "The action to perform."
-                    },
-                    "slug": {"type": "string", "description": "Change identifier, kebab-case (e.g. add-dark-mode)."},
-                    "title": {"type": "string", "description": "Human title for propose."},
-                    "why": {"type": "string", "description": "Why this change is needed (propose)."},
-                    "what": {"type": "string", "description": "What changes (propose)."},
-                    "field": {"type": "string", "enum": ["title", "why", "what", "design"], "description": "Field to update (set_field)."},
-                    "value": {"type": "string", "description": "New value (set_field)."},
-                    "group_no": {"type": "integer", "description": "Task group number (add_task; default 1)."},
-                    "seq": {"type": "integer", "description": "Task order within its group (add_task; auto if omitted)."},
-                    "text": {"type": "string", "description": "Task description (add_task)."},
-                    "task_id": {"type": "integer", "description": "Task id (set_task)."},
-                    "status": {"type": "string", "enum": ["pending", "in_progress", "done", "blocked"], "description": "Task status (set_task)."},
-                    "op": {"type": "string", "enum": ["added", "modified", "removed", "renamed"], "description": "Delta operation (add_delta)."},
-                    "capability": {"type": "string", "description": "Capability (kebab-case) the requirement belongs to."},
-                    "requirement": {"type": "string", "description": "Requirement name."},
-                    "scenarios": {
-                        "type": "array",
-                        "items": {"type": "object", "properties": {"name": {"type": "string"}, "when_then": {"type": "string"}}, "required": ["name", "when_then"]},
-                        "description": "Behavior examples for added/modified requirements."
-                    },
-                    "reason": {"type": "string", "description": "Why a requirement is removed (removed)."},
-                    "migration": {"type": "string", "description": "Migration path for a removed requirement (removed)."},
-                    "rename_to": {"type": "string", "description": "New requirement name (renamed)."}
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["propose", "set_field", "add_delta", "add_task", "set_task", "archive", "status", "specs"],
+                    "description": "The action to perform."
                 },
-                "required": ["action"]
-            }),
-        }
+                "slug": {"type": "string", "description": "Change identifier, kebab-case (e.g. add-dark-mode)."},
+                "title": {"type": "string", "description": "Human title for propose."},
+                "why": {"type": "string", "description": "Why this change is needed (propose)."},
+                "what": {"type": "string", "description": "What changes (propose)."},
+                "field": {"type": "string", "enum": ["title", "why", "what", "design"], "description": "Field to update (set_field)."},
+                "value": {"type": "string", "description": "New value (set_field)."},
+                "group_no": {"type": "integer", "description": "Task group number (add_task; default 1)."},
+                "seq": {"type": "integer", "description": "Task order within its group (add_task; auto if omitted)."},
+                "text": {"type": "string", "description": "Task description (add_task)."},
+                "task_id": {"type": "integer", "description": "Task id (set_task)."},
+                "status": {"type": "string", "enum": ["pending", "in_progress", "done", "blocked"], "description": "Task status (set_task)."},
+                "op": {"type": "string", "enum": ["added", "modified", "removed", "renamed"], "description": "Delta operation (add_delta)."},
+                "capability": {"type": "string", "description": "Capability (kebab-case) the requirement belongs to."},
+                "requirement": {"type": "string", "description": "Requirement name."},
+                "scenarios": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"name": {"type": "string"}, "when_then": {"type": "string"}}, "required": ["name", "when_then"]},
+                    "description": "Behavior examples for added/modified requirements."
+                },
+                "reason": {"type": "string", "description": "Why a requirement is removed (removed)."},
+                "migration": {"type": "string", "description": "Migration path for a removed requirement (removed)."},
+                "rename_to": {"type": "string", "description": "New requirement name (renamed)."}
+            },
+            "required": ["action"]
+        })
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {

--- a/src/agent/tools/task.rs
+++ b/src/agent/tools/task.rs
@@ -9,8 +9,7 @@
 
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -1400,14 +1399,8 @@ fn normalize_retry_of(retry_of: Option<String>) -> Option<String> {
         .filter(|id| !id.is_empty())
 }
 
-impl Tool for TaskTool {
-    const NAME: &'static str = "task";
-
-    type Error = ToolError;
-    type Args = Args;
-    type Output = String;
-
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
+impl TaskTool {
+    fn definition_parts(&self) -> (String, serde_json::Value) {
         let mut description = "Spawn a subagent to handle a specific subtask. The subagent runs as a one-shot query (no tools) and returns its result inline. Use for research, analysis, or planning subtasks that don't require file access. Set background=true to run asynchronously — completion is delivered to you automatically as a <system-reminder> at the start of your next turn. Do NOT poll task_status in a loop or sleep waiting; continue with other work."
             .to_string();
 
@@ -1482,12 +1475,23 @@ impl Tool for TaskTool {
                 }
             }
         }
+        (description, properties)
+    }
+}
 
-        ToolDefinition {
-            name: "task".to_string(),
-            description,
-            parameters: properties,
-        }
+impl PortableTool for TaskTool {
+    const NAME: &'static str = "task";
+
+    type Error = ToolError;
+    type Args = Args;
+    type Output = String;
+
+    fn description(&self) -> String {
+        self.definition_parts().0
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.definition_parts().1
     }
 
     async fn call(&self, args: Args) -> Result<String, ToolError> {
@@ -2021,7 +2025,7 @@ mod tests {
     #[tokio::test]
     async fn definition_steers_agent_away_from_polling() {
         let tool = mock_tool();
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         let desc = def.description.to_lowercase();
         assert!(
             desc.contains("system-reminder") || desc.contains("automatically"),
@@ -2588,7 +2592,7 @@ mod tests {
         assert!(subagent_route("ghost").is_none());
 
         let tool = mock_tool();
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert!(
             def.description.contains("Available profiles: reviewer"),
             "definition must list installed profiles: {}",
@@ -2606,7 +2610,7 @@ mod tests {
     #[tokio::test]
     async fn definition_advertises_background_field() {
         let tool = mock_tool();
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         let props = def
             .parameters
             .get("properties")

--- a/src/agent/tools/task_status.rs
+++ b/src/agent/tools/task_status.rs
@@ -5,8 +5,7 @@
 //! See the canonical map of the four work-tracking concepts in
 //! [`crate::agent::plan`].
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -46,32 +45,32 @@ pub struct TaskStatusArgs {
     pub wait: Option<bool>,
 }
 
-impl Tool for TaskStatusTool {
+impl PortableTool for TaskStatusTool {
     const NAME: &'static str = "task_status";
 
     type Error = ToolError;
     type Args = TaskStatusArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "task_status".to_string(),
-            description: "Look up the state of a background task by id. You usually do NOT need this — completion notifications arrive automatically as a <system-reminder> on your next turn. Use task_status only when you need to re-check a task's status mid-turn or look up a task whose notification you've already consumed. Returns running / completed / failed plus the result text. Set wait=true to block until the task transitions out of running (rarely useful — prefer letting the notification arrive).".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "task_id": {
-                        "type": "string",
-                        "description": "The task ID returned by the task tool with background=true"
-                    },
-                    "wait": {
-                        "type": "boolean",
-                        "description": "Block until the task completes (default: false)"
-                    }
+    fn description(&self) -> String {
+        "Look up the state of a background task by id. You usually do NOT need this — completion notifications arrive automatically as a <system-reminder> on your next turn. Use task_status only when you need to re-check a task's status mid-turn or look up a task whose notification you've already consumed. Returns running / completed / failed plus the result text. Set wait=true to block until the task transitions out of running (rarely useful — prefer letting the notification arrive).".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "The task ID returned by the task tool with background=true"
                 },
-                "required": ["task_id"]
-            }),
-        }
+                "wait": {
+                    "type": "boolean",
+                    "description": "Block until the task completes (default: false)"
+                }
+            },
+            "required": ["task_id"]
+        })
     }
 
     async fn call(&self, args: TaskStatusArgs) -> Result<String, ToolError> {
@@ -282,7 +281,7 @@ mod tests {
     async fn test_definition_has_correct_name() {
         let store = BackgroundStore::new();
         let tool = TaskStatusTool::new(store);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "task_status");
     }
 
@@ -294,7 +293,7 @@ mod tests {
     async fn definition_discourages_polling() {
         let store = BackgroundStore::new();
         let tool = TaskStatusTool::new(store);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         let desc = def.description.to_lowercase();
         assert!(
             desc.contains("system-reminder") || desc.contains("automatically"),

--- a/src/agent/tools/todo.rs
+++ b/src/agent/tools/todo.rs
@@ -24,8 +24,7 @@ use std::path::{Path, PathBuf};
 
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -165,37 +164,37 @@ impl WriteTodoList {
     }
 }
 
-impl Tool for WriteTodoList {
+impl PortableTool for WriteTodoList {
     const NAME: &'static str = "write_todo_list";
 
     type Error = ToolError;
     type Args = TodoWriteArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "write_todo_list".to_string(),
-            description: "Lay out or update a structured plan for a COMPLEX, MULTI-STEP task — work that takes several distinct steps, not several tool calls for one step.\n\nDo NOT use this for single-step work, for questions, or as a step toward changing a file. Writing a plan is not doing the work: to create or change a file, call `write` or `edit`. \"Add a hello-world script\" is one edit — just make it.\n\nEach item is a tracked issue on this session's board (shared with the `issue` tool). Listing an item creates it or updates a matching one by title (case/whitespace-insensitive); statuses are pending|in_progress|completed|cancelled|blocked. Keep exactly ONE item in_progress. Omitted items are NOT auto-closed — restate one as completed/cancelled to close it. Use `issue` for single-item or cross-session edits, `task` to delegate independent work to a background subagent.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "todos": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "content": { "type": "string", "description": "Task description (matched by title on later calls)" },
-                                "status": { "type": "string", "description": "pending, in_progress, blocked, completed, or cancelled" },
-                                "priority": { "type": "string", "description": "high, normal, or low" }
-                            },
-                            "required": ["content", "status", "priority"]
+    fn description(&self) -> String {
+        "Lay out or update a structured plan for a COMPLEX, MULTI-STEP task — work that takes several distinct steps, not several tool calls for one step.\n\nDo NOT use this for single-step work, for questions, or as a step toward changing a file. Writing a plan is not doing the work: to create or change a file, call `write` or `edit`. \"Add a hello-world script\" is one edit — just make it.\n\nEach item is a tracked issue on this session's board (shared with the `issue` tool). Listing an item creates it or updates a matching one by title (case/whitespace-insensitive); statuses are pending|in_progress|completed|cancelled|blocked. Keep exactly ONE item in_progress. Omitted items are NOT auto-closed — restate one as completed/cancelled to close it. Use `issue` for single-item or cross-session edits, `task` to delegate independent work to a background subagent.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "content": { "type": "string", "description": "Task description (matched by title on later calls)" },
+                            "status": { "type": "string", "description": "pending, in_progress, blocked, completed, or cancelled" },
+                            "priority": { "type": "string", "description": "high, normal, or low" }
                         },
-                        "description": "Full list of tasks to track"
-                    }
-                },
-                "required": ["todos"]
-            }),
-        }
+                        "required": ["content", "status", "priority"]
+                    },
+                    "description": "Full list of tasks to track"
+                }
+            },
+            "required": ["todos"]
+        })
     }
 
     async fn call(&self, args: TodoWriteArgs) -> Result<String, ToolError> {
@@ -269,7 +268,6 @@ impl Tool for WriteTodoList {
 #[cfg(test)]
 mod description_tests {
     use super::*;
-    use rig::tool::Tool;
 
     /// dirge-5xvn (GH #734): the description has to carry its own
     /// when-NOT-to-use guidance. The board semantics used to fill the first
@@ -280,7 +278,7 @@ mod description_tests {
     #[tokio::test]
     async fn description_says_when_not_to_use_and_names_the_write_tool() {
         let tool = WriteTodoList::new(PathBuf::from("/tmp/none.db"), None, None, None);
-        let desc = tool.definition(String::new()).await.description;
+        let desc = rig::tool::tool_definition(&tool).description;
         let lower = desc.to_lowercase();
 
         assert!(

--- a/src/agent/tools/webfetch.rs
+++ b/src/agent/tools/webfetch.rs
@@ -1,5 +1,4 @@
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::tools::{AskSender, PermCheck, ToolError, check_perm};
@@ -472,37 +471,37 @@ async fn fetch_url(client: &reqwest::Client, url: &str) -> Result<String, String
     Ok(html_to_markdown(&body))
 }
 
-impl Tool for WebFetchTool {
+impl PortableTool for WebFetchTool {
     const NAME: &'static str = "webfetch";
 
     type Error = ToolError;
     type Args = WebFetchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "webfetch".to_string(),
-            description: crate::agent::agent_loop::tool_input_repair::with_contract_hint(
-                "webfetch",
-                "Fetch the content of one or more URLs and return it as markdown. Schemeless URLs get https:// prepended. Private/loopback/link-local addresses (127.0.0.0/8, 10.x, 172.16.x, 192.168.x, 169.254.x cloud metadata, ::1, fc00::/7, fe80::/10) and bare 'localhost' are refused by default; set DIRGE_WEBFETCH_ALLOW_PRIVATE=1 to permit them for local-dev workflows. Use for reading documentation pages, API references, or any web content.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "urls": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "URLs to fetch (may be comma-separated)"
-                    },
-                    "max_chars": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "Maximum characters to return per URL (default: 3000)"
-                    }
+    fn description(&self) -> String {
+        crate::agent::agent_loop::tool_input_repair::with_contract_hint(
+            "webfetch",
+            "Fetch the content of one or more URLs and return it as markdown. Schemeless URLs get https:// prepended. Private/loopback/link-local addresses (127.0.0.0/8, 10.x, 172.16.x, 192.168.x, 169.254.x cloud metadata, ::1, fc00::/7, fe80::/10) and bare 'localhost' are refused by default; set DIRGE_WEBFETCH_ALLOW_PRIVATE=1 to permit them for local-dev workflows. Use for reading documentation pages, API references, or any web content.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "urls": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "URLs to fetch (may be comma-separated)"
                 },
-                "required": ["urls"]
-            }),
-        }
+                "max_chars": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum characters to return per URL (default: 3000)"
+                }
+            },
+            "required": ["urls"]
+        })
     }
 
     async fn call(&self, args: WebFetchArgs) -> Result<String, ToolError> {
@@ -676,7 +675,7 @@ mod tests {
     #[tokio::test]
     async fn test_definition_has_correct_name() {
         let tool = WebFetchTool::new(None, None);
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "webfetch");
     }
 

--- a/src/agent/tools/websearch.rs
+++ b/src/agent/tools/websearch.rs
@@ -1,5 +1,4 @@
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 use serde::Deserialize;
 
 use crate::agent::agent_loop::types::InjectionScanMode;
@@ -109,36 +108,36 @@ fn format_search_results(results: &[ExaResult]) -> String {
     )
 }
 
-impl Tool for WebSearchTool {
+impl PortableTool for WebSearchTool {
     const NAME: &'static str = "websearch";
 
     type Error = ToolError;
     type Args = WebSearchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "websearch".to_string(),
-            description: crate::agent::agent_loop::tool_input_repair::with_contract_hint(
-                "websearch",
-                "Search the web. Returns titles, URLs, and snippets. Use for looking up current documentation, API references, or up-to-date information beyond your training cutoff. Works out of the box without any API key — rotates between Exa and Parallel.ai hosted MCP endpoints (50/50 per process, pin with `DIRGE_WEBSEARCH_PROVIDER=exa|parallel`). Optional `EXA_API_KEY` / `PARALLEL_API_KEY` raise the respective rate limits. DuckDuckGo HTML scrape is the last-resort fallback if both upstream MCP endpoints fail.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query"
-                    },
-                    "num_results": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "description": "Maximum number of results (default: 10)"
-                    }
+    fn description(&self) -> String {
+        crate::agent::agent_loop::tool_input_repair::with_contract_hint(
+            "websearch",
+            "Search the web. Returns titles, URLs, and snippets. Use for looking up current documentation, API references, or up-to-date information beyond your training cutoff. Works out of the box without any API key — rotates between Exa and Parallel.ai hosted MCP endpoints (50/50 per process, pin with `DIRGE_WEBSEARCH_PROVIDER=exa|parallel`). Optional `EXA_API_KEY` / `PARALLEL_API_KEY` raise the respective rate limits. DuckDuckGo HTML scrape is the last-resort fallback if both upstream MCP endpoints fail.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query"
                 },
-                "required": ["query"]
-            }),
-        }
+                "num_results": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Maximum number of results (default: 10)"
+                }
+            },
+            "required": ["query"]
+        })
     }
 
     async fn call(&self, args: WebSearchArgs) -> Result<String, ToolError> {
@@ -731,7 +730,7 @@ mod tests {
     #[tokio::test]
     async fn test_definition_has_correct_name() {
         let tool = WebSearchTool::new(None, None, Some("test-key".to_string()));
-        let def = tool.definition(String::new()).await;
+        let def = rig::tool::tool_definition(&tool);
         assert_eq!(def.name, "websearch");
     }
 

--- a/src/agent/tools/write.rs
+++ b/src/agent/tools/write.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 #[cfg(feature = "lsp")]
 use std::time::{Duration, Instant};
 
-use rig::completion::ToolDefinition;
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 use crate::agent::agent_loop::tool_input_repair::with_contract_hint;
 use crate::agent::tools::cache::ToolCache;
@@ -69,29 +68,29 @@ impl WriteTool {
     }
 }
 
-impl Tool for WriteTool {
+impl PortableTool for WriteTool {
     const NAME: &'static str = "write";
 
     type Error = ToolError;
     type Args = WriteArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "write".to_string(),
-            description: with_contract_hint(
-                "write",
-                "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
-            ),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "The absolute path to the file to write (must be absolute, not relative)" },
-                    "content": { "type": "string", "description": "Content to write to the file" }
-                },
-                "required": ["path", "content"]
-            }),
-        }
+    fn description(&self) -> String {
+        with_contract_hint(
+            "write",
+            "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type":"string","description":"The absolute path to the file to write (must be absolute, not relative)"},
+                "content": {"type":"string","description":"Content to write to the file"}
+            },
+            "required": ["path","content"]
+        })
     }
 
     async fn call(&self, args: WriteArgs) -> Result<String, ToolError> {

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -2,7 +2,7 @@ pub mod config;
 
 use std::sync::Arc;
 
-use agent_client_protocol::schema::*;
+use agent_client_protocol::schema::v1::*;
 use agent_client_protocol::{Agent, Client, ConnectionTo, Dispatch, Responder, Stdio};
 use agent_client_protocol::{on_receive_notification, on_receive_request};
 
@@ -229,12 +229,19 @@ pub async fn serve(cli: Cli, cfg: Config, context: ContextFiles) -> anyhow::Resu
             on_receive_notification!(),
         )
         .on_receive_dispatch(
-            |dispatch: Dispatch<AgentRequest, AgentNotification>, cx: ConnectionTo<Client>| {
+            |dispatch: Dispatch<AgentRequest, AgentNotification>, _cx: ConnectionTo<Client>| {
                 async move {
-                    dispatch.respond_with_error(
-                        agent_client_protocol::util::internal_error("Unhandled ACP message"),
-                        cx,
-                    )
+                    // acp 2.0 moved `respond_with_error` off `Dispatch` and onto
+                    // the `Responder` that only the request variant carries. A
+                    // notification or a stray response has no reply channel, so
+                    // there is nothing to answer — dropping it matches what the
+                    // old blanket call did for those arms.
+                    match dispatch {
+                        Dispatch::Request(_, responder) => responder.respond_with_error(
+                            agent_client_protocol::util::internal_error("Unhandled ACP message"),
+                        ),
+                        _ => Ok(()),
+                    }
                 }
             },
             agent_client_protocol::on_receive_dispatch!(),

--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::agent::agent_loop::rig_tool::{DynTool, DynToolError};
 use rig::completion::ToolDefinition;
-use rig::tool::{ToolDyn, ToolError};
 use rig::wasm_compat::WasmBoxedFuture;
 use rmcp::ServiceError;
-use rmcp::model::{CallToolRequestParams, JsonObject, RawContent};
+use rmcp::model::{CallToolRequestParams, ContentBlock, JsonObject};
 use tokio::sync::Mutex;
 
 use crate::agent::agent_loop::types::InjectionScanMode;
@@ -156,12 +156,12 @@ fn mcp_args_detail(args: &str) -> Option<String> {
 /// `PermissionChecker::check` plus the explicit `any_prompt_denied`
 /// probe below), so plan-mode `deny_tools: [edit]` does block an
 /// MCP-exported `edit`. Built-in tool *rule tables* don't alias.
-impl ToolDyn for McpTool {
+impl DynTool for McpTool {
     fn name(&self) -> String {
         self.definition.name.to_string()
     }
 
-    fn definition(&self, _prompt: String) -> WasmBoxedFuture<'_, ToolDefinition> {
+    fn definition(&self) -> WasmBoxedFuture<'_, ToolDefinition> {
         let name = self.definition.name.to_string();
         let description = self
             .definition
@@ -187,7 +187,7 @@ impl ToolDyn for McpTool {
         })
     }
 
-    fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
+    fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, DynToolError>> {
         let server_name = self.server_name.clone();
         let tool_name = self.definition.name.to_string();
         let connection = Arc::clone(&self.connection);
@@ -214,10 +214,12 @@ impl ToolDyn for McpTool {
                     guard.any_prompt_denied(&[tool_name.as_str(), qualified.as_str(), "mcp_tool"])
                 };
                 if denied {
-                    return Err(ToolError::ToolCallError(Box::new(McpToolError(format!(
-                        "MCP tool {}::{} is denied by the active prompt's `deny_tools` frontmatter. Switch with `/prompt <other>` to use it.",
-                        server_name, tool_name,
-                    )))));
+                    return Err(DynToolError::ToolCallError(Box::new(McpToolError(
+                        format!(
+                            "MCP tool {}::{} is denied by the active prompt's `deny_tools` frontmatter. Switch with `/prompt <other>` to use it.",
+                            server_name, tool_name,
+                        ),
+                    ))));
                 }
             }
             let perm_key = format!("mcp_tool:{server_name}:{tool_name}");
@@ -233,7 +235,7 @@ impl ToolDyn for McpTool {
                 mcp_args_detail(&args).as_deref(),
             )
             .await
-            .map_err(|e| ToolError::ToolCallError(Box::new(McpToolError(e.to_string()))))?;
+            .map_err(|e| DynToolError::ToolCallError(Box::new(McpToolError(e.to_string()))))?;
 
             // Malformed JSON used to silently default to `None` via
             // `unwrap_or_default()` — the MCP server got an empty
@@ -252,10 +254,12 @@ impl ToolDyn for McpTool {
                 match serde_json::from_str::<JsonObject>(trimmed) {
                     Ok(obj) => Some(obj),
                     Err(e) => {
-                        return Err(ToolError::ToolCallError(Box::new(McpToolError(format!(
-                            "MCP tool {}::{}: malformed JSON arguments ({e}). Got: {trimmed:.200}",
-                            server_name, tool_name,
-                        )))));
+                        return Err(DynToolError::ToolCallError(Box::new(McpToolError(
+                            format!(
+                                "MCP tool {}::{}: malformed JSON arguments ({e}). Got: {trimmed:.200}",
+                                server_name, tool_name,
+                            ),
+                        ))));
                     }
                 }
             };
@@ -282,10 +286,12 @@ impl ToolDyn for McpTool {
                 && let Some(args_obj) = arguments.as_ref()
                 && let Some(p) = first_external_path(perm, args_obj, allow_external)
             {
-                return Err(ToolError::ToolCallError(Box::new(McpToolError(format!(
-                    "MCP tool {server_name}::{tool_name} refused: path {p:?} is outside the working directory. \
+                return Err(DynToolError::ToolCallError(Box::new(McpToolError(
+                    format!(
+                        "MCP tool {server_name}::{tool_name} refused: path {p:?} is outside the working directory. \
                      Set `allow_external_paths: true` on the `{server_name}` server config to permit external paths for this server."
-                )))));
+                    ),
+                ))));
             }
 
             let params = arguments
@@ -319,7 +325,7 @@ impl ToolDyn for McpTool {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    return Err(ToolError::ToolCallError(Box::new(McpToolError(e))));
+                    return Err(DynToolError::ToolCallError(Box::new(McpToolError(e))));
                 }
             };
 
@@ -327,8 +333,8 @@ impl ToolDyn for McpTool {
                 let error_msg = result
                     .content
                     .iter()
-                    .filter_map(|c| match &c.raw {
-                        RawContent::Text(t) => Some(t.text.clone()),
+                    .filter_map(|c| match c {
+                        ContentBlock::Text(t) => Some(t.text.clone()),
                         _ => None,
                     })
                     .collect::<Vec<_>>()
@@ -338,7 +344,7 @@ impl ToolDyn for McpTool {
                 } else {
                     error_msg
                 };
-                return Err(ToolError::ToolCallError(Box::new(McpToolError(msg))));
+                return Err(DynToolError::ToolCallError(Box::new(McpToolError(msg))));
             }
 
             // Cap aggregate MCP result at 256 KiB before it
@@ -355,14 +361,16 @@ impl ToolDyn for McpTool {
                 if truncated {
                     break;
                 }
-                let chunk: String = match item.raw {
-                    RawContent::Text(t) => t.text,
-                    RawContent::Image(img) => {
+                let chunk: String = match item {
+                    ContentBlock::Text(t) => t.text,
+                    ContentBlock::Image(img) => {
                         format!("data:{};base64,{}", img.mime_type, img.data)
                     }
-                    RawContent::Resource(r) => match r.resource {
+                    ContentBlock::Resource(r) => match r.resource {
                         rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
                         rmcp::model::ResourceContents::BlobResourceContents { blob, .. } => blob,
+                        // `ResourceContents` is #[non_exhaustive] as of rmcp 3.
+                        _ => continue,
                     },
                     _ => continue,
                 };

--- a/src/extras/mcp_server.rs
+++ b/src/extras/mcp_server.rs
@@ -25,7 +25,7 @@ use rmcp::handler::server::ServerHandler;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, Content, Implementation, InitializeResult, ServerCapabilities, ServerInfo,
+    CallToolResult, ContentBlock, Implementation, InitializeResult, ServerCapabilities, ServerInfo,
 };
 use rmcp::transport::stdio;
 use rmcp::{schemars, tool, tool_handler, tool_router};
@@ -589,11 +589,11 @@ fn load_or_create_pointer(project_dir: &Path) -> anyhow::Result<(String, Option<
 
 fn tool_json(value: &serde_json::Value) -> CallToolResult {
     let body = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
-    CallToolResult::success(vec![Content::text(body)])
+    CallToolResult::success(vec![ContentBlock::text(body)])
 }
 
 fn tool_err(msg: String) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(msg)])
+    CallToolResult::error(vec![ContentBlock::text(msg)])
 }
 
 /// Entry point for `dirge mcp`. Runs the MCP server over stdio until the

--- a/src/extras/memory_graduation.rs
+++ b/src/extras/memory_graduation.rs
@@ -155,7 +155,12 @@ pub(crate) fn recurrence_clusters(
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();
                 hasher.update(hash_input.as_bytes());
-                format!("{:x}", hasher.finalize())
+                // sha2 0.11 no longer implements `LowerHex` on the digest output.
+                hasher
+                    .finalize()
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect::<String>()
             };
 
             member_uids.sort();

--- a/src/extras/session_db.rs
+++ b/src/extras/session_db.rs
@@ -1876,14 +1876,17 @@ impl SessionDb {
             .map_err(|e| format!("Failed to prepare anchored view: {e}"))?;
 
         let messages: Vec<AnchorMessage> = stmt
-            .query_map(params![session_id, before + 1 + after, offset], |row| {
-                Ok(AnchorMessage {
-                    id: row.get(0)?,
-                    role: row.get(1)?,
-                    content: row.get(2)?,
-                    timestamp: row.get(3)?,
-                })
-            })
+            .query_map(
+                params![session_id, (before + 1 + after) as i64, offset],
+                |row| {
+                    Ok(AnchorMessage {
+                        id: row.get(0)?,
+                        role: row.get(1)?,
+                        content: row.get(2)?,
+                        timestamp: row.get(3)?,
+                    })
+                },
+            )
             .map_err(|e| format!("Failed to query anchored view: {e}"))?
             .filter_map(|r| r.ok())
             .collect();

--- a/src/plugin/hook.rs
+++ b/src/plugin/hook.rs
@@ -1,11 +1,11 @@
 //! Plugin-driven interception of rig tool calls.
 //!
-//! [`HookedToolDyn`] wraps any `Box<dyn rig::tool::ToolDyn>` and runs the
+//! [`HookedToolDyn`] wraps any `Box<dyn DynTool>` and runs the
 //! `on-tool-start` Janet hook before delegating to the inner tool, and the
 //! `on-tool-end` hook after. Plugins can:
 //!
 //! - **block** the call entirely by calling `(harness/block "reason")` in
-//!   `on-tool-start` — the wrapper returns a `ToolError` with that reason
+//!   `on-tool-start` — the wrapper returns a `DynToolError` with that reason
 //!   instead of invoking the inner tool.
 //! - **mutate input** by calling `(harness/mutate-input json-string)` in
 //!   `on-tool-start` — the wrapper invokes the inner tool with `json-string`
@@ -22,7 +22,7 @@
 use crate::sync_util::LockExt;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use rig::tool::{ToolDyn, ToolError};
+use crate::agent::agent_loop::rig_tool::{DynTool, DynToolError};
 
 use super::{PluginManager, escape_janet_string};
 
@@ -42,12 +42,12 @@ pub fn global() -> Option<Arc<Mutex<PluginManager>>> {
     PLUGIN_MANAGER.get().cloned()
 }
 
-/// Wraps an inner `Box<dyn ToolDyn>` and surfaces plugin tool-hooks.
+/// Wraps an inner `Box<dyn DynTool>` and surfaces plugin tool-hooks.
 /// Cheap to construct; the actual hook dispatch happens lazily inside
 /// `call()` so non-plugin builds (where `pm` is always `None`) pay only
 /// one Option check per tool invocation.
 pub struct HookedToolDyn {
-    inner: Box<dyn ToolDyn>,
+    inner: Box<dyn DynTool>,
     pm: Option<Arc<Mutex<PluginManager>>>,
 }
 
@@ -61,7 +61,7 @@ impl HookedToolDyn {
     /// `hookify` that wrapped each tool here is gone. The live loop hooks
     /// plugins via `agent_loop::plugin_hooks` instead [dirge-tfip].
     #[allow(dead_code)]
-    pub fn wrap_global(inner: Box<dyn ToolDyn>) -> Box<dyn ToolDyn> {
+    pub fn wrap_global(inner: Box<dyn DynTool>) -> Box<dyn DynTool> {
         let pm = global();
         if pm.is_none() {
             // Avoid an extra dispatch box for the no-plugin case so
@@ -74,30 +74,30 @@ impl HookedToolDyn {
     /// Wrap with an explicit manager, bypassing the global. Used by tests
     /// and by callers that hold their own PluginManager.
     #[allow(dead_code)] // retained for future callers; tests stopped using it
-    pub fn with_manager(inner: Box<dyn ToolDyn>, pm: Option<Arc<Mutex<PluginManager>>>) -> Self {
+    pub fn with_manager(inner: Box<dyn DynTool>, pm: Option<Arc<Mutex<PluginManager>>>) -> Self {
         HookedToolDyn { inner, pm }
     }
 }
 
-impl ToolDyn for HookedToolDyn {
+impl DynTool for HookedToolDyn {
     fn name(&self) -> String {
         self.inner.name()
     }
 
-    fn definition<'a>(
-        &'a self,
-        prompt: String,
+    fn definition(
+        &self,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = rig::completion::ToolDefinition> + Send + 'a>,
+        Box<dyn std::future::Future<Output = rig::completion::ToolDefinition> + Send + '_>,
     > {
-        self.inner.definition(prompt)
+        self.inner.definition()
     }
 
     fn call<'a>(
         &'a self,
         args: String,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String, ToolError>> + Send + 'a>>
-    {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<String, DynToolError>> + Send + 'a>,
+    > {
         Box::pin(async move {
             let name = self.inner.name();
 
@@ -122,12 +122,14 @@ impl ToolDyn for HookedToolDyn {
             };
 
             if let Some(reason) = block {
-                return Err(ToolError::ToolCallError(Box::<
+                return Err(DynToolError::ToolCallError(Box::<
                     dyn std::error::Error + Send + Sync,
-                >::from(format!(
+                >::from(
+                    format!(
                     "blocked by plugin: {}",
                     reason
-                ))));
+                )
+                )));
             }
 
             let final_args = mutated.unwrap_or(args);
@@ -179,15 +181,14 @@ mod tests {
     /// Lets us assert that mutation actually changed what reached the tool.
     struct Echo;
 
-    impl ToolDyn for Echo {
+    impl DynTool for Echo {
         fn name(&self) -> String {
             "echo".to_string()
         }
 
-        fn definition<'a>(
-            &'a self,
-            _prompt: String,
-        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ToolDefinition> + Send + 'a>>
+        fn definition(
+            &self,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ToolDefinition> + Send + '_>>
         {
             Box::pin(async move {
                 ToolDefinition {
@@ -202,7 +203,7 @@ mod tests {
             &'a self,
             args: String,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Result<String, ToolError>> + Send + 'a>,
+            Box<dyn std::future::Future<Output = Result<String, DynToolError>> + Send + 'a>,
         > {
             Box::pin(async move { Ok(args) })
         }
@@ -215,7 +216,7 @@ mod tests {
     async fn wrap_and_call(
         pm_arc: Arc<Mutex<PluginManager>>,
         args: &str,
-    ) -> Result<String, ToolError> {
+    ) -> Result<String, DynToolError> {
         let wrapper = HookedToolDyn::with_manager(Box::new(Echo), Some(pm_arc));
         wrapper.call(args.to_string()).await
     }
@@ -330,14 +331,13 @@ mod tests {
         /// `on-tool-end` after this, allowing the hook to substitute
         /// a replacement output.
         struct AlwaysFail;
-        impl ToolDyn for AlwaysFail {
+        impl DynTool for AlwaysFail {
             fn name(&self) -> String {
                 "always_fail".to_string()
             }
-            fn definition<'a>(
-                &'a self,
-                _prompt: String,
-            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ToolDefinition> + Send + 'a>>
+            fn definition(
+                &self,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ToolDefinition> + Send + '_>>
             {
                 Box::pin(async move {
                     ToolDefinition {
@@ -351,13 +351,13 @@ mod tests {
                 &'a self,
                 _args: String,
             ) -> std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<String, ToolError>> + Send + 'a>,
+                Box<dyn std::future::Future<Output = Result<String, DynToolError>> + Send + 'a>,
             > {
                 Box::pin(async move {
-                    Err(ToolError::ToolCallError(Box::<
+                    Err(DynToolError::ToolCallError(Box::<
                         dyn std::error::Error + Send + Sync,
                     >::from(
-                        "deliberate failure".to_string()
+                        "deliberate failure".to_string(),
                     )))
                 })
             }

--- a/src/provider/anthropic_http.rs
+++ b/src/provider/anthropic_http.rs
@@ -552,7 +552,12 @@ fn hex_sha256(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    // sha2 0.11 no longer implements `LowerHex` on the digest output.
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 fn normalize_system_block(value: serde_json::Value) -> serde_json::Value {

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -160,7 +160,14 @@ pub async fn build_agent(
             // [dirge-tfip]. The ACTIVE model name + provider are passed
             // explicitly so model-family steering tracks /model and /agent
             // swaps instead of the launch-time CLI model (dirge-5db6).
-            let (agent, cache, memory_provider) =
+            // `AnyAgentInner` stores the model itself now, not a rig
+            // `Agent` (rig 0.41 made `Agent::model` private). Keep a
+            // clone for the stream dispatcher before `$m` is consumed.
+            let model_for_inner = $m.clone();
+            // `_agent` is the rig `Agent`. Nothing reads it any more —
+            // dirge's own loop drives requests — but building it is what
+            // assembles the preamble, so it stays until that is untangled.
+            let (_agent, cache, memory_provider, agent_preamble) =
                 builder::build_agent_inner($m, cli, cfg, context, &provider_name, &model_name)
                     .await;
 
@@ -197,13 +204,13 @@ pub async fn build_agent(
                 )
                 .await;
 
-            // Phase 4.5h-6: extract the rig Agent's preamble so
-            // the new path can pass it as Context.system_prompt.
-            // rig's Agent has `preamble: Option<String>` public.
+            // Phase 4.5h-6: the new path passes the rig Agent's
+            // preamble as Context.system_prompt. rig 0.41 made that
+            // field private, so `build_agent_inner` hands it back.
             // Phase-3: when dynamic-tool-search is on, append a
             // one-liner nudge so the model knows to call
             // `tool_search` before reaching for unknown tools.
-            let mut preamble = agent.preamble.clone().unwrap_or_default();
+            let mut preamble = agent_preamble;
             if dyn_search.is_some() {
                 if !preamble.is_empty() {
                     preamble.push_str("\n\n");
@@ -218,7 +225,7 @@ pub async fn build_agent(
             }
 
             let mut agent = AnyAgent::new(
-                AnyAgentInner::$variant(agent),
+                AnyAgentInner::$variant(model_for_inner),
                 cache,
                 chunk_timeout,
                 loop_tools,

--- a/src/provider/client.rs
+++ b/src/provider/client.rs
@@ -1014,6 +1014,9 @@ fn compressing<Inner>(
         )),
         resolve_compression_enabled(),
     )
+    // `wire_kind` collapses every OpenAI-compatible backend to one shape, so
+    // keep the concrete kind too for per-backend body quirks.
+    .with_backend(kind)
 }
 
 /// Which of the three request shapes a provider's bodies take. Everything that isn't

--- a/src/provider/compressing_http.rs
+++ b/src/provider/compressing_http.rs
@@ -47,6 +47,11 @@ pub(crate) struct CompressingHttpClient<Inner> {
     enabled: bool,
     provider: crate::llmtrim::ir::ProviderKind,
     config: std::sync::Arc<crate::llmtrim::config::DenseConfig>,
+    /// The concrete backend, as opposed to `provider`, which is only the wire
+    /// *shape* (every OpenAI-compatible backend collapses to `OpenAi` there).
+    /// Needed to apply per-backend body quirks that survive rig's serializer —
+    /// see [`Self::rewrite_provider_quirks`]. `None` on the default/test path.
+    backend: Option<super::resolve::ProviderKind>,
 }
 
 impl<Inner: Default> Default for CompressingHttpClient<Inner> {
@@ -56,6 +61,7 @@ impl<Inner: Default> Default for CompressingHttpClient<Inner> {
             enabled: true,
             provider: crate::llmtrim::ir::ProviderKind::OpenAi,
             config: std::sync::Arc::new(crate::compression::dirge_default_config()),
+            backend: None,
         }
     }
 }
@@ -83,7 +89,14 @@ impl<Inner> CompressingHttpClient<Inner> {
             enabled,
             provider,
             config,
+            backend: None,
         }
+    }
+
+    /// Record the concrete backend so per-backend body quirks can be applied.
+    pub fn with_backend(mut self, backend: super::resolve::ProviderKind) -> Self {
+        self.backend = Some(backend);
+        self
     }
 }
 
@@ -118,6 +131,56 @@ impl<Inner> CompressingHttpClient<Inner> {
         body
     }
 
+    /// Per-backend fixups applied to the serialized body, after rig has built
+    /// it and after compression. Fail-open: anything unparseable or unexpected
+    /// passes through untouched.
+    ///
+    /// Cerebras rejects the assistant `reasoning_content` that rig emits for a
+    /// replayed thinking block —
+    /// `property 'messages.N.assistant.reasoning_content' is unsupported` — but
+    /// accepts the same payload under `reasoning`. Renaming rather than
+    /// dropping keeps the model's own reasoning in context across turns; this
+    /// is what the `@ai-sdk/cerebras` provider does for opencode.
+    fn rewrite_provider_quirks(&self, body: Bytes) -> Bytes {
+        if self.backend != Some(super::resolve::ProviderKind::Cerebras) {
+            return body;
+        }
+        let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+            return body;
+        };
+        let Some(messages) = value.get_mut("messages").and_then(|m| m.as_array_mut()) else {
+            return body;
+        };
+        let mut renamed = false;
+        for message in messages {
+            let Some(object) = message.as_object_mut() else {
+                continue;
+            };
+            if object.get("role").and_then(serde_json::Value::as_str) != Some("assistant") {
+                continue;
+            }
+            // Only move it when the target is free; a body that already carries
+            // `reasoning` is left exactly as-is rather than silently clobbered.
+            // Test `contains_key` BEFORE removing: removing first and bailing on
+            // the check would drop the field on this message while a later
+            // message still triggered the re-serialize, losing it silently.
+            if object.contains_key("reasoning") {
+                continue;
+            }
+            if let Some(reasoning) = object.remove("reasoning_content") {
+                object.insert("reasoning".to_string(), reasoning);
+                renamed = true;
+            }
+        }
+        if !renamed {
+            return body;
+        }
+        match serde_json::to_vec(&value) {
+            Ok(bytes) => Bytes::from(bytes),
+            Err(_) => body,
+        }
+    }
+
     fn normalized_request<T>(&self, req: Request<T>) -> http_client::Result<Request<Bytes>>
     where
         T: Into<Bytes>,
@@ -125,6 +188,7 @@ impl<Inner> CompressingHttpClient<Inner> {
         let (parts, body) = req.into_parts();
         let body: Bytes = body.into();
         let body = self.maybe_compress(body);
+        let body = self.rewrite_provider_quirks(body);
         let mut builder = Request::builder()
             .method(parts.method)
             .uri(parts.uri)
@@ -390,7 +454,111 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::CompressingHttpClient;
     use super::log_safe_uri;
+    use crate::provider::resolve::ProviderKind;
+    use bytes::Bytes;
+
+    fn cerebras_client() -> CompressingHttpClient<()> {
+        CompressingHttpClient::<()>::default().with_backend(ProviderKind::Cerebras)
+    }
+
+    fn rewrite(client: &CompressingHttpClient<()>, body: serde_json::Value) -> serde_json::Value {
+        let out = client.rewrite_provider_quirks(Bytes::from(body.to_string()));
+        serde_json::from_slice(&out).expect("rewritten body stays valid json")
+    }
+
+    /// Cerebras rejects `reasoning_content` on an assistant message but accepts
+    /// the same payload under `reasoning`. Rename rather than drop, so the
+    /// model's own reasoning survives into the next turn (GH #745 follow-on).
+    #[test]
+    fn cerebras_renames_assistant_reasoning_content() {
+        let out = rewrite(
+            &cerebras_client(),
+            serde_json::json!({"messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "answer", "reasoning_content": "thinking"},
+            ]}),
+        );
+        let assistant = &out["messages"][1];
+        assert_eq!(assistant["reasoning"], "thinking");
+        assert!(
+            assistant.get("reasoning_content").is_none(),
+            "the rejected field must be gone, not duplicated",
+        );
+        assert_eq!(assistant["content"], "answer");
+        assert_eq!(out["messages"][0]["content"], "hi", "user turns untouched");
+    }
+
+    /// Only assistant turns carry the field, and only Cerebras needs the move.
+    #[test]
+    fn rename_is_scoped_to_cerebras_assistant_turns() {
+        let body = serde_json::json!({"messages": [
+            {"role": "user", "content": "hi", "reasoning_content": "not mine"},
+            {"role": "assistant", "content": "a", "reasoning_content": "thinking"},
+        ]});
+        // A non-Cerebras backend keeps `reasoning_content` — llama.cpp/LocalAI
+        // chat templates read it back out of the assistant turn.
+        let other = rewrite(
+            &CompressingHttpClient::<()>::default().with_backend(ProviderKind::Custom),
+            body.clone(),
+        );
+        assert_eq!(other["messages"][1]["reasoning_content"], "thinking");
+        assert!(other["messages"][1].get("reasoning").is_none());
+
+        // On Cerebras a non-assistant turn is still left alone.
+        let cerebras = rewrite(&cerebras_client(), body);
+        assert_eq!(cerebras["messages"][0]["reasoning_content"], "not mine");
+    }
+
+    /// A body that already carries `reasoning` must not be clobbered, and a
+    /// body with nothing to move must come back byte-identical.
+    #[test]
+    fn rename_never_clobbers_or_rewrites_needlessly() {
+        let out = rewrite(
+            &cerebras_client(),
+            serde_json::json!({"messages": [
+                {"role": "assistant", "reasoning": "kept", "reasoning_content": "dropped"},
+            ]}),
+        );
+        assert_eq!(out["messages"][0]["reasoning"], "kept");
+
+        let untouched = serde_json::json!({"messages": [{"role": "assistant", "content": "a"}]});
+        let bytes = Bytes::from(untouched.to_string());
+        assert_eq!(
+            cerebras_client().rewrite_provider_quirks(bytes.clone()),
+            bytes,
+        );
+    }
+
+    /// A message that is skipped (already has `reasoning`) must keep its
+    /// `reasoning_content` even when a LATER message does trigger the rewrite.
+    /// Removing before the skip check dropped it silently — the re-serialize
+    /// fired for the later message and carried the deletion with it.
+    #[test]
+    fn skipped_message_keeps_its_field_when_a_later_one_is_renamed() {
+        let out = rewrite(
+            &cerebras_client(),
+            serde_json::json!({"messages": [
+                {"role": "assistant", "reasoning": "kept", "reasoning_content": "must survive"},
+                {"role": "assistant", "reasoning_content": "moved"},
+            ]}),
+        );
+        assert_eq!(out["messages"][0]["reasoning"], "kept");
+        assert_eq!(
+            out["messages"][0]["reasoning_content"], "must survive",
+            "the skipped message must not lose its field",
+        );
+        assert_eq!(out["messages"][1]["reasoning"], "moved");
+        assert!(out["messages"][1].get("reasoning_content").is_none());
+    }
+
+    /// Fail-open: a body that is not JSON at all passes straight through.
+    #[test]
+    fn rename_passes_through_non_json_bodies() {
+        let raw = Bytes::from_static(b"not json at all");
+        assert_eq!(cerebras_client().rewrite_provider_quirks(raw.clone()), raw);
+    }
 
     #[test]
     fn log_safe_uri_strips_the_query_string() {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -47,7 +47,6 @@ pub fn current_agent() -> Option<std::sync::Arc<AnyAgent>> {
 
 #[allow(unused_imports)]
 use crate::sync_util::LockExt;
-use rig::agent::Agent;
 use rig::providers::{anthropic, chatgpt, gemini, ollama, openai, openrouter};
 
 use crate::agent::tools::ToolCache;
@@ -69,8 +68,8 @@ pub struct AnyAgent {
     /// clone-cheap (Arc bump).
     loop_tools: Vec<std::sync::Arc<dyn crate::agent::agent_loop::LoopTool>>,
     /// Phase 4.5h-6: system prompt for the new loop path.
-    /// Extracted from the rig Agent's preamble field at build
-    /// time (every variant exposes `Agent.preamble: Option<String>`).
+    /// Returned by `build_agent_inner`, which assembles it. It used to be
+    /// read back off the rig `Agent`, but rig 0.41 made that field private.
     preamble: String,
     /// Model identifier — the same string the user passed via
     /// `--model` or pulled from config. Carried so `spawn_runner`
@@ -240,93 +239,74 @@ pub struct AnyAgent {
 }
 
 #[derive(Clone)]
+/// The per-provider completion model behind an [`AnyAgent`].
+///
+/// This holds the MODEL, not a rig `Agent`. Dirge drives its own agent
+/// loop (`agent_loop`) and only ever needed the rig `Agent` here to read
+/// the model back out of it; rig 0.41 made `Agent::model` private, and
+/// the wrapper was carrying no other weight — request shaping, tool
+/// dispatch and reasoning params are all applied by dirge's own loop.
 pub(crate) enum AnyAgentInner {
     OpenRouter(
-        Agent<
-            openrouter::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openrouter::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     OpenAI(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     ChatGptOpenAI(
-        Agent<
-            openai::responses_api::ResponsesCompletionModel<
-                compressing_http::CompressingHttpClient<codex_http::CodexHttpClient>,
-            >,
+        openai::responses_api::ResponsesCompletionModel<
+            compressing_http::CompressingHttpClient<codex_http::CodexHttpClient>,
         >,
     ),
-    OpenAICodex(Agent<chatgpt::ResponsesCompletionModel>),
+    OpenAICodex(chatgpt::ResponsesCompletionModel),
     Anthropic(
-        Agent<
-            anthropic::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        anthropic::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     AnthropicOauth(
-        Agent<
-            anthropic::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<anthropic_http::AnthropicHttpClient>,
-            >,
+        anthropic::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<anthropic_http::AnthropicHttpClient>,
         >,
     ),
     Gemini(
-        Agent<
-            gemini::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        gemini::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     DeepSeek(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     Glm(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     Cerebras(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     OpenCode(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
     Kimi(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<kimi_http::KimiHttpClient>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<kimi_http::KimiHttpClient>,
         >,
     ),
-    Ollama(
-        Agent<ollama::CompletionModel<compressing_http::CompressingHttpClient<reqwest::Client>>>,
-    ),
+    Ollama(ollama::CompletionModel<compressing_http::CompressingHttpClient<reqwest::Client>>),
     Custom(
-        Agent<
-            openai::completion::CompletionModel<
-                compressing_http::CompressingHttpClient<reqwest::Client>,
-            >,
+        openai::completion::CompletionModel<
+            compressing_http::CompressingHttpClient<reqwest::Client>,
         >,
     ),
 }

--- a/src/provider/mod_tests.rs
+++ b/src/provider/mod_tests.rs
@@ -275,9 +275,8 @@ fn build_openai_any_agent() -> AnyAgent {
         .build()
         .expect("openai CompletionsClient::new should work");
     let model = client.completion_model("gpt-4o");
-    let agent = rig::agent::AgentBuilder::new(model).build();
     AnyAgent::new(
-        AnyAgentInner::OpenAI(agent),
+        AnyAgentInner::OpenAI(model),
         ToolCache::new(),
         std::time::Duration::from_secs(300),
         Vec::new(),    // loop_tools — empty for test fixture

--- a/src/provider/spawn.rs
+++ b/src/provider/spawn.rs
@@ -659,7 +659,7 @@ impl AnyAgent {
         // one arm runs, so the moves are exclusive.
         crate::provider::stream_dispatch::dispatch_stream_fn! {
             match &self.inner;
-            AnyAgentInner(a) => (*a.model).clone(),
+            AnyAgentInner(a) => a.clone(),
             tools = tools.clone(),
             timeout = Some(chunk_timeout),
             provider = provider,

--- a/src/provider/summarize.rs
+++ b/src/provider/summarize.rs
@@ -213,7 +213,7 @@ where
 
             let mut stream = agent
                 .stream_chat(prompt, Vec::<rig::completion::Message>::new())
-                .multi_turn(1)
+                .max_turns(1)
                 .await;
 
             let mut response = String::new();
@@ -224,7 +224,7 @@ where
                         rig::streaming::StreamedAssistantContent::Text(text),
                     )) => response.push_str(&text.text),
                     Ok(rig::agent::MultiTurnStreamItem::FinalResponse(res)) => {
-                        return Ok(res.response().to_string());
+                        return Ok(res.output.clone());
                     }
                     Err(e) => return Err(e.to_string()),
                     _ => {}

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -81,7 +81,7 @@ impl SemanticManager {
         &self,
         permission: Option<PermCheck>,
         ask_tx: Option<AskSender>,
-    ) -> Vec<Box<dyn rig::tool::ToolDyn>> {
+    ) -> Vec<Box<dyn crate::agent::agent_loop::rig_tool::DynTool>> {
         let idx = self.index.clone();
         vec![
             Box::new(semantic::ListSymbolsTool::new(

--- a/src/tests/edit_tests.rs
+++ b/src/tests/edit_tests.rs
@@ -1,6 +1,6 @@
 use crate::agent::tools::edit::EditTool;
 use crate::agent::tools::{EditArgs, ToolError};
-use rig::tool::Tool;
+use rig::tool::PortableTool;
 
 struct TempFile(String);
 

--- a/src/ui/plugin_tree.rs
+++ b/src/ui/plugin_tree.rs
@@ -543,11 +543,10 @@ mod tests {
             .build()
             .expect("openai client");
         let model = client.completion_model("gpt-4o");
-        let inner = rig::agent::AgentBuilder::new(model).build();
         let provider = Arc::new(RecordingProvider::default());
         let provider_dyn: Arc<dyn MemoryProvider> = provider.clone();
         let agent = AnyAgent::new(
-            AnyAgentInner::OpenAI(inner),
+            AnyAgentInner::OpenAI(model),
             ToolCache::new(),
             std::time::Duration::from_secs(300),
             Vec::new(),

--- a/src/ui/sysload.rs
+++ b/src/ui/sysload.rs
@@ -60,9 +60,9 @@ pub fn spawn_poller(interval: Duration) -> SharedSysLoad {
         // computed across the window between two refresh_cpu_all
         // calls. Prime with one refresh + sleep before the loop.
         let mut sys = System::new_with_specifics(
-            RefreshKind::new()
-                .with_cpu(CpuRefreshKind::new().with_cpu_usage())
-                .with_memory(MemoryRefreshKind::new().with_ram()),
+            RefreshKind::nothing()
+                .with_cpu(CpuRefreshKind::nothing().with_cpu_usage())
+                .with_memory(MemoryRefreshKind::nothing().with_ram()),
         );
         sys.refresh_cpu_all();
         sys.refresh_memory();


### PR DESCRIPTION
Fixes #745.

rig 0.39 only deserialized `delta.reasoning_content`. Providers that stream reasoning as `delta.reasoning` — LocalAI, and as it turns out Cerebras — had it dropped by serde, while text and tool calls carried in the same delta worked fine. That's why the reporter saw an empty reasoning panel and normal output otherwise. Parsing the log they attached: 196 chunks, 188 with `reasoning`, zero with `reasoning_content`.

rig 0.40 added `reasoning_content.or_else(|| reasoning)` upstream. Checked against opencode, which the reporter noted does not have the bug: `@ai-sdk/openai-compatible` does `delta.reasoning_content ?? delta.reasoning`. Same precedence, so this matches the reference implementation.

## The bump

0.41 splits the classic runtime into `rig-agent` behind an `agent` feature, replaces `Tool::definition` with `description`/`parameters` across all 37 tools, drops `ToolDyn` for a concrete struct, and makes `Agent::preamble` and `Agent::model` private.

- Tools move to the context-free `PortableTool` contract. The loop has driven its own dispatch since 4.5h-6 and never used rig's `ToolContext`.
- The erased-tool seam is now dirge's own `DynTool`. It has broken on two consecutive rig releases and does not need to be rig's. 0.39's semantics are ported exactly, including the `null` -> `{}` fallback for all-optional args and the rule that a `String` output is not double-quoted.
- `AnyAgentInner` holds the completion model directly instead of a rig `Agent` it only ever read the model back out of.

## Cerebras fallout

Capturing the reasoning made Cerebras 400 on the next turn: `property 'messages.N.assistant.reasoning_content' is unsupported`. Confirmed a real regression by running the smoke test on 0.39 (passes) and 0.41 (fails), not just assuming a flaky live API.

The field is renamed to `reasoning` at the wire boundary rather than dropped, so the model keeps its own reasoning in context. That is what `@ai-sdk/cerebras` does for opencode. Backends that want `reasoning_content` are untouched — DeepSeek needs it on tool-call turns, and llama.cpp/LocalAI chat templates read it back out of the assistant turn. Only the OpenAI Responses API still has the block dropped, since it keys reasoning to encrypted ids we don't retain.

## Dependencies

`rmcp` was on three versions at once: ours, one from rig's `rmcp` feature (which nothing here used), and one from `agent-client-protocol`. That feature is gone, acp goes to 2.0 and rmcp to 3.1 — one copy, at latest. `rusqlite`, `sysinfo`, `sha2`, `jsonschema`, `base64`, `compact_str`, `http` and `notify-rust` go current too. `tree-sitter` stays at 0.25; 0.26 does not resolve against the grammar crates.

## Verification

- `cargo fmt --all` clean
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets` exit 0
- `cargo nextest run --bin dirge --retries 2 --no-fail-fast` — 4995 passed, 1 skipped, 0 failed (baseline 4960)

The live `h7_cerebras_tool_dispatch_completes_round_trip` passes, so the rename is verified against the real API rather than only in unit tests.

Two things worth a reviewer's eye:

- The migration reindented raw string literals in three tool descriptions (`memory`, `session_search`, `spec`), silently changing model-visible prompt text. Restored, and every changed file is now checked so no long or multi-line literal value differs from HEAD.
- My first cut of the Cerebras rewrite removed `reasoning_content` before checking whether `reasoning` was already present, which lost the field on a skipped message when a later one triggered the re-serialize. Fixed, with a test that fails against the buggy version.