### PR TITLE
Three audit fixes in the streaming and context path

### DIFF
--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -598,6 +598,49 @@ where
             }
         }
 
+        // dirge-vpma.23: drop tool calls that never got a name.
+        //
+        // A delta-built call starts from a placeholder with an empty name and
+        // fills in as fragments arrive. If the stream ends mid-assembly — the
+        // provider cut off, or rig's chat-completions path silently discarded
+        // a call whose name never came — the block survives here with `name:
+        // ""`. It then counts as a tool call below, flips the turn to
+        // `ToolUse`, and the loop dispatches a tool named "", burning a turn
+        // on an error that describes nothing.
+        //
+        // Keyed on the NAME rather than on `open_tool_calls` membership,
+        // deliberately: some providers emit only deltas and never a complete
+        // ToolCall event, so their calls stay "open" for the whole stream and
+        // dropping by openness would discard perfectly good work. A call with
+        // no name cannot dispatch under any provider, which makes it the one
+        // safe discriminator.
+        let mut partial = partial;
+        let dropped: Vec<String> = partial
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolCall { name, id, .. } if name.trim().is_empty() => {
+                    Some(id.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        if !dropped.is_empty() {
+            // Counted, not just discarded: a filter whose reject path is
+            // silent is one nobody can audit.
+            tracing::warn!(
+                target: "dirge::agent_loop",
+                count = dropped.len(),
+                call_ids = %dropped.join(", "),
+                "dropping {} incomplete tool call(s) at stream end — the name never arrived, \
+                 so they could not have dispatched",
+                dropped.len(),
+            );
+            partial
+                .content
+                .retain(|b| !matches!(b, ContentBlock::ToolCall { name, .. } if name.trim().is_empty()));
+        }
+
         // Stream ended normally — finalize with the assembled
         // partial. `stop_reason` is `ToolUse` iff any toolCall
         // block is present (pi's stopReason inference for raw
@@ -845,6 +888,89 @@ mod tests {
                 }
             }
             _ => panic!("expected Done"),
+        }
+    }
+
+    /// dirge-vpma.23: a call whose NAME never arrived must not survive to the
+    /// final message.
+    ///
+    /// A delta-built call starts from a placeholder with an empty name. If the
+    /// stream ends mid-assembly — the provider cut off, or rig's
+    /// chat-completions path discarded a call whose name never came — the
+    /// block used to survive with `name: ""`, count as a tool call, flip the
+    /// turn to `ToolUse`, and make the loop dispatch a tool named "". That
+    /// burns a turn on an error describing nothing.
+    #[tokio::test]
+    async fn a_tool_call_whose_name_never_arrived_is_dropped() {
+        let raw = raw_stream(vec![
+            // Arguments only — no `Name` delta ever comes.
+            Ok(StreamedAssistantContent::ToolCallDelta {
+                id: "call_x".to_string(),
+                internal_call_id: "internal_x".to_string(),
+                content: ToolCallDeltaContent::Delta("{\"pa".to_string()),
+            }),
+            Ok(StreamedAssistantContent::ToolCallDelta {
+                id: "call_x".to_string(),
+                internal_call_id: "internal_x".to_string(),
+                content: ToolCallDeltaContent::Delta("th\":\"/tmp/x\"}".to_string()),
+            }),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        match events.last().expect("a final event") {
+            StreamEvent::Done {
+                message, reason, ..
+            } => {
+                assert!(
+                    !message
+                        .content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolCall { .. })),
+                    "a nameless tool call survived into the final message: {:?}",
+                    message.content
+                );
+                assert_ne!(
+                    *reason,
+                    StopReason::ToolUse,
+                    "the turn must not report ToolUse when there is no dispatchable call"
+                );
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    /// The discrimination half: a call that DID get its name still survives.
+    /// Without this, the test above would pass against a change that dropped
+    /// every delta-built call — which would break every provider that streams
+    /// tool calls as deltas and never sends a complete event.
+    #[tokio::test]
+    async fn a_named_delta_built_call_still_survives() {
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::ToolCallDelta {
+                id: "call_y".to_string(),
+                internal_call_id: "internal_y".to_string(),
+                content: ToolCallDeltaContent::Name("write".to_string()),
+            }),
+            Ok(StreamedAssistantContent::ToolCallDelta {
+                id: "call_y".to_string(),
+                internal_call_id: "internal_y".to_string(),
+                content: ToolCallDeltaContent::Delta("{}".to_string()),
+            }),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        match events.last().expect("a final event") {
+            StreamEvent::Done {
+                message, reason, ..
+            } => {
+                assert!(
+                    message.content.iter().any(
+                        |b| matches!(b, ContentBlock::ToolCall { name, .. } if name == "write")
+                    ),
+                    "a named delta-built call was dropped: {:?}",
+                    message.content
+                );
+                assert_eq!(*reason, StopReason::ToolUse);
+            }
+            other => panic!("expected Done, got {other:?}"),
         }
     }
 

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -885,11 +885,15 @@ pub fn loop_tool_to_rig_definition(tool: &dyn LoopTool) -> ToolDefinition {
 ///   - None: generic `reasoning_level` key for debugging /
 ///     ad-hoc consumers.
 ///
-/// **Headers and metadata** are passed through under
-/// conventional keys (`headers`, `metadata`) regardless of
-/// provider — rig's openai-shaped clients merge `metadata`
-/// into the request body; headers are honored where the
-/// provider impl reads them.
+/// **Metadata** is passed through under the conventional `metadata` key
+/// regardless of provider — rig's openai-shaped clients merge it into the
+/// request body.
+///
+/// **Headers are not.** They used to be, under a `headers` key, on the belief
+/// that "headers are honored where the provider impl reads them". No provider
+/// reads them: rig flattens `additional_params` into the request BODY, so the
+/// only thing that key ever did was ship `Authorization: Bearer <key>` to the
+/// endpoint as body content (dirge-vpma.25).
 pub fn build_provider_additional_params(
     provider_name: Option<&str>,
     opts: &super::stream::StreamOptions,
@@ -919,13 +923,27 @@ pub fn build_provider_additional_params(
         additional.extend(m);
     }
 
-    // ----- headers (provider-agnostic) -----
-    let headers = merged_request_headers(provider_name, opts);
-    if !headers.is_empty()
-        && let Ok(v) = serde_json::to_value(&headers)
-    {
-        additional.insert("headers".to_string(), v);
-    }
+    // ----- headers -----
+    //
+    // dirge-vpma.25: these used to be serialized into `additional_params` under
+    // a "headers" key. That could never work and was actively unsafe. rig
+    // serde-FLATTENS additional_params into the JSON request BODY, and no
+    // provider extracts a body-level "headers" field and promotes it to an HTTP
+    // header — so a request built this way (a) did not authenticate and (b)
+    // shipped `Authorization: Bearer <key>` inside the body, to an endpoint
+    // that may log it.
+    //
+    // Nothing in production set these (integration.rs passes `api_key: None`
+    // and an empty `headers` map on every spawn), so removing the injection
+    // changes no live behaviour. It is deliberately NOT replaced with a
+    // real-header implementation here: per-request headers belong at the HTTP
+    // client layer alongside the transports that already own auth, not in the
+    // completion-request builder.
+    //
+    // Warn rather than drop silently. A knob that quietly does nothing is how
+    // this survived — anyone who sets one should learn immediately that it has
+    // no consumer, instead of discovering it from an auth failure.
+    warn_unapplied_request_overrides(opts);
 
     // ----- metadata (provider-agnostic) -----
     if !opts.metadata.is_empty() {
@@ -947,22 +965,37 @@ pub fn build_provider_additional_params(
     }
 }
 
-fn merged_request_headers(
-    _provider_name: Option<&str>,
-    opts: &super::stream::StreamOptions,
-) -> std::collections::HashMap<String, String> {
-    let mut headers = opts.headers.clone();
-    if let Some(key) = opts
+/// Say so, once per process, when a request-override knob is set but has no
+/// consumer (dirge-vpma.25).
+///
+/// `StreamOptions::headers` and `::api_key` are resolved from `LoopConfig` —
+/// including through the `get_api_key` hook — and then reach nothing. They
+/// used to be flattened into the request body, which did not authenticate and
+/// leaked the bearer; that path is gone and no replacement exists yet.
+///
+/// Never logs the value of either. The whole point of the bug was a secret
+/// going somewhere it should not.
+fn warn_unapplied_request_overrides(opts: &super::stream::StreamOptions) {
+    use std::sync::Once;
+    static WARNED: Once = Once::new();
+    let has_key = opts
         .api_key
         .as_deref()
         .map(str::trim)
-        .filter(|key| !key.is_empty())
-    {
-        headers
-            .entry("Authorization".to_string())
-            .or_insert_with(|| format!("Bearer {key}"));
+        .is_some_and(|key| !key.is_empty());
+    if !has_key && opts.headers.is_empty() {
+        return;
     }
-    headers
+    WARNED.call_once(|| {
+        tracing::warn!(
+            target: "dirge::provider",
+            api_key_set = has_key,
+            header_names = %opts.headers.keys().cloned().collect::<Vec<_>>().join(", "),
+            "per-request api_key/headers are set but nothing applies them; they \
+             reach no HTTP header and are NOT sent. Configure credentials \
+             through the provider entry instead",
+        );
+    });
 }
 
 #[cfg(test)]
@@ -2079,42 +2112,64 @@ mod tests {
         assert_eq!(v["thinking_config"]["thinking_budget"], 16384);
     }
 
-    /// Headers and metadata pass through under conventional
-    /// keys regardless of provider.
+    /// Metadata passes through under its conventional key regardless of
+    /// provider. Headers do NOT — see below.
     #[test]
-    fn headers_and_metadata_pass_through_for_all_providers() {
+    fn metadata_passes_through_for_all_providers() {
         let mut opts = StreamOptions::from_signal(AbortSignal::new());
-        opts.headers
-            .insert("X-Tenant".to_string(), "acme".to_string());
         opts.metadata
             .insert("user_id".to_string(), serde_json::json!("u-42"));
         for provider in ["anthropic", "openai", "gemini", "ollama", "unknown"] {
             let v = build_provider_additional_params(Some(provider), &opts).unwrap();
-            assert_eq!(v["headers"]["X-Tenant"], "acme", "provider {provider}");
             assert_eq!(v["metadata"]["user_id"], "u-42", "provider {provider}");
         }
     }
 
+    /// dirge-vpma.25. These three assertions replace tests that asserted the
+    /// OPPOSITE — that `api_key` produced `headers.Authorization = "Bearer …"`
+    /// in the params, that an explicit header won over it, and that headers
+    /// passed through for every provider.
+    ///
+    /// Those tests were written down from the implementation's output, so the
+    /// bug became the contract. What they were pinning is a credential being
+    /// serialized into the JSON request BODY (`additional_params` is
+    /// serde-flattened into it), where it authenticates nothing — no provider
+    /// promotes a body field to an HTTP header — and can be logged by the
+    /// endpoint.
     #[test]
-    fn stream_options_api_key_adds_authorization_header() {
+    fn request_header_knobs_contribute_nothing_to_the_body() {
         let mut opts = StreamOptions::from_signal(AbortSignal::new());
         opts.api_key = Some("dynamic-token".to_string());
-
-        let v = build_provider_additional_params(Some("openai"), &opts).unwrap();
-        assert_eq!(v["headers"]["Authorization"], "Bearer dynamic-token");
-    }
-
-    #[test]
-    fn explicit_authorization_header_wins_over_stream_api_key() {
-        let mut opts = StreamOptions::from_signal(AbortSignal::new());
-        opts.api_key = Some("dynamic-token".to_string());
+        opts.headers
+            .insert("X-Tenant".to_string(), "acme".to_string());
         opts.headers.insert(
             "Authorization".to_string(),
             "Bearer explicit-token".to_string(),
         );
 
-        let v = build_provider_additional_params(Some("openai"), &opts).unwrap();
-        assert_eq!(v["headers"]["Authorization"], "Bearer explicit-token");
+        // Nothing else is set, so the whole params object must be absent.
+        assert!(
+            build_provider_additional_params(Some("openai"), &opts).is_none(),
+            "api_key/headers must contribute nothing to the request body"
+        );
+
+        // And they must not ride along beside something that IS legitimate.
+        opts.metadata
+            .insert("user_id".to_string(), serde_json::json!("u-42"));
+        let v = build_provider_additional_params(Some("openai"), &opts).expect("metadata present");
+        let body = serde_json::to_string(&v).expect("serializable");
+        assert!(body.contains("u-42"), "metadata should still pass: {body}");
+        for leaked in [
+            "dynamic-token",
+            "explicit-token",
+            "Authorization",
+            "X-Tenant",
+        ] {
+            assert!(
+                !body.contains(leaked),
+                "{leaked} reached the request body: {body}"
+            );
+        }
     }
 
     #[test]
@@ -2450,6 +2505,52 @@ mod tool_choice_tests {
             params.get("tool_choice").and_then(|v| v.as_str()),
             Some("none")
         );
+    }
+
+    /// dirge-vpma.25: a credential must never reach the request body.
+    ///
+    /// `additional_params` is serde-flattened into the JSON body, so anything
+    /// put there is sent as body content. The old `headers` key meant that
+    /// setting `api_key` shipped `Authorization: Bearer <key>` to the endpoint
+    /// as data — where it can be logged — while still failing to authenticate,
+    /// because no provider promotes a body field to an HTTP header.
+    #[test]
+    fn a_credential_never_reaches_the_request_body() {
+        let mut o = opts(None);
+        o.api_key = Some("sk-super-secret".to_string());
+        o.headers
+            .insert("X-Custom".to_string(), "value".to_string());
+
+        let params = build_provider_additional_params(Some("openai"), &o);
+
+        // Nothing at all is the expected shape here: `headers` was the only
+        // thing these two knobs contributed.
+        let body = params
+            .map(|p| serde_json::to_string(&p).expect("serializable"))
+            .unwrap_or_default();
+        assert!(
+            !body.contains("sk-super-secret"),
+            "the api key reached the request body: {body}"
+        );
+        assert!(
+            !body.contains("Authorization"),
+            "an Authorization header was serialized into the request body: {body}"
+        );
+        assert!(
+            !body.contains("X-Custom"),
+            "request headers were serialized into the request body: {body}"
+        );
+    }
+
+    /// The discrimination half: the builder still emits what it is supposed
+    /// to. Without this, the assertions above would pass just as well against
+    /// a builder that had been broken into returning nothing at all.
+    #[test]
+    fn the_builder_still_emits_real_params() {
+        let params =
+            build_provider_additional_params(Some("openai"), &opts(Some(ToolChoice::None)))
+                .expect("tool_choice must still be emitted");
+        assert!(params.get("tool_choice").is_some());
     }
 
     /// An unconstrained turn must send NOTHING — not `"auto"`. Some

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -2605,6 +2605,12 @@ pub async fn run_loop(
         // the nudge rides in context.messages, so the flag alone drives
         // the next turn when no tool calls or steering are pending.
         let mut recovery_pending = false;
+        // dirge-vpma.22: set by the `ExitWithSummary` post-usage tier, which
+        // is the last line of defence when context is critically over the
+        // threshold. It has to survive to the bottom of the iteration rather
+        // than breaking on the spot, so the checkpoint-schedule reset and the
+        // per-iteration snip-credit cleanup below it still run.
+        let mut force_turn_end = false;
         while has_more_tool_calls || !pending_messages.is_empty() || recovery_pending {
             recovery_pending = false;
             // Circuit-breaker bookkeeping is at-most-once per iteration:
@@ -3646,6 +3652,17 @@ pub async fn run_loop(
                             ratio = %decision.ratio,
                             "context-manager: forcing summary and ending turn",
                         );
+                        // dirge-vpma.22: and actually end it. This arm logged
+                        // "ending turn" and then fell through to
+                        // prepareNextTurn/steering with `has_more_tool_calls`
+                        // untouched, so the turn continued. That is the exact
+                        // case this tier exists to prevent: when the summarizer
+                        // fails or the circuit breaker is already open at >80%
+                        // context, the loop went round again against a context
+                        // still over the threshold and the next request could
+                        // overflow or 400. Honoured below, after the
+                        // checkpoint-schedule reset.
+                        force_turn_end = true;
                         // When context is critically over the threshold,
                         // prune aggressively then run the structured-summary
                         // pass if a summarizer is wired.
@@ -3705,6 +3722,16 @@ pub async fn run_loop(
                 // decision; clear it so a later iteration's fold isn't
                 // suppressed by a stale snip (IMPROVEMENTS_PLAN #4).
                 snip_tokens_freed = 0;
+            }
+
+            // dirge-vpma.22: the critical-context tier asked for the turn to
+            // end. Clearing `has_more_tool_calls` would not be enough on its
+            // own — the loop condition also admits pending messages and a
+            // pending recovery — so break outright, which leaves the flag
+            // unread. Anything queued is picked up by the next turn, against
+            // a context that has just been folded.
+            if force_turn_end {
+                break;
             }
 
             // Pi lines 220-239: prepareNextTurn.


### PR DESCRIPTION
Three from the Wavescope audit epic, all in the agent-loop area.

### vpma.25 — a credential was serialized into the request body

`merged_request_headers` put `Authorization: Bearer <key>` into `additional_params`. rig serde-flattens that into the JSON request **body**, and no provider promotes a body field to an HTTP header — so the mechanism (a) did not authenticate and (b) shipped the bearer to the endpoint as body content, where it can be logged.

Nothing in production set it (`integration.rs` passes `api_key: None` and an empty header map on every spawn), so removing the injection changes no live behaviour. Deliberately **not** replaced with a real-header implementation: per-request headers belong at the HTTP client layer beside the transports that already own auth, not in the completion-request builder. The knob now warns once instead of silently doing nothing — silence is how it survived.

Three existing tests asserted the old behaviour, one of them asserting that the credential *is* in the body. They were written down from the implementation's output, so the bug had become the contract.

### vpma.23 — a nameless tool call reached dispatch

A delta-built call starts from a placeholder with an empty name. If the stream ended mid-assembly, the block survived with `name: ""`, counted as a tool call, flipped the turn to `ToolUse`, and made the loop dispatch a tool named `""` — burning a turn on an error describing nothing.

Dropped at finalization, keyed on the empty **name** rather than `open_tool_calls` membership: some providers emit only deltas and never a complete event, so their calls stay "open" for the whole stream and dropping by openness would discard perfectly good work. Counted in the log rather than silently discarded.

### vpma.22 — `ExitWithSummary` never ended the turn

The arm logged "forcing summary and ending turn" and then fell through to `prepareNextTurn` with `has_more_tool_calls` untouched. When the summarizer fails or the circuit breaker is already open at >80% context, the loop went round again against a context still over the threshold and the next request could overflow or 400 — the exact case this defence-in-depth tier exists to prevent.

It now breaks, and does so at the bottom of the iteration so the checkpoint-schedule reset and the per-iteration snip cleanup still run.

Closes dirge-vpma.22, dirge-vpma.23, dirge-vpma.25.

Verified: 5484 tests, `cargo fmt --check`, all four CI clippy configs.