### PR TITLE
Add `ixx` to recognized C++ extensions.

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -25,7 +25,7 @@ discovering it later via `cargo check`.
 | `clojure-lsp` | `clojure-lsp` | `.clj`, `.cljs`, `.cljc`, `.edn`, `.bb` |
 | `gopls` | `gopls` | `.go` |
 | `jdtls` | `jdtls` | `.java` |
-| `clangd` | `clangd` | `.c`, `.cc`, `.cpp`, `.cxx`, `.h`, `.hh`, `.hpp`, `.hxx`, `.m`, `.mm` |
+| `clangd` | `clangd` | `.c`, `.cc`, `.cpp`, `.cxx`, `.ixx`, `.h`, `.hh`, `.hpp`, `.hxx`, `.m`, `.mm` |
 | `ruby-lsp` | `ruby-lsp` | `.rb`, `.rake`, `.gemspec` |
 | `bash-language-server` | `bash-language-server start` | `.sh`, `.bash` |
 | `cmake` | `cmake-language-server` | `.cmake` (+ `CMakeLists.txt` by name) |

--- a/docs/semantic.md
+++ b/docs/semantic.md
@@ -14,7 +14,7 @@ tree-sitter:
 
 Supports TypeScript/TSX, Python, Clojure (`.clj`/`.cljs`/`.cljc`/`.edn`/`.bb`),
 Go, Ruby (`.rb`/`.rake`/`.gemspec`), Rust, Java, C (`.c`/`.h`), and C++
-(`.cpp`/`.cc`/`.cxx`/`.hpp`/`.hh`/`.hxx`). Index is built lazily on first use and
+(`.cpp`/`.cc`/`.cxx`/`.ixx`/`.hpp`/`.hh`/`.hxx`). Index is built lazily on first use and
 cached by file mtime.
 
 ## Export detection per language

--- a/docs/semantic.md
+++ b/docs/semantic.md
@@ -14,8 +14,14 @@ tree-sitter:
 
 Supports TypeScript/TSX, Python, Clojure (`.clj`/`.cljs`/`.cljc`/`.edn`/`.bb`),
 Go, Ruby (`.rb`/`.rake`/`.gemspec`), Rust, Java, C (`.c`/`.h`), and C++
-(`.cpp`/`.cc`/`.cxx`/`.ixx`/`.hpp`/`.hh`/`.hxx`). Index is built lazily on first use and
-cached by file mtime.
+(`.cpp`/`.cc`/`.cxx`/`.ixx`/`.hpp`/`.hh`/`.hxx`). Index is built lazily on first
+use and cached by file mtime.
+
+`.ixx` is indexed on a best-effort basis: tree-sitter-cpp has no grammar for
+C++20 modules, so `export module M;` and `import std;` parse as errors and the
+declarations after them may be missed. For the same reason `.ixx` is left off
+the write-time syntax gate — see `GATE_EXCLUSIONS` in
+`src/semantic/syntax_validator.rs`.
 
 ## Export detection per language
 

--- a/src/agent/agent_loop/verifier.rs
+++ b/src/agent/agent_loop/verifier.rs
@@ -1440,8 +1440,8 @@ fn code_paths_touched(args: &serde_json::Value) -> u32 {
 /// so a doc-only edit never triggers the verify nudge.
 const CODE_EXTS: &[&str] = &[
     "rs", "py", "ts", "tsx", "js", "jsx", "mjs", "cjs", "go", "rb", "java", "kt", "kts", "c", "h",
-    "cc", "cpp", "hpp", "cxx", "cs", "swift", "php", "scala", "clj", "cljs", "cljc", "ex", "exs",
-    "sh", "bash", "lua", "pl", "hs", "ml", "sql", "vue", "svelte",
+    "cc", "cpp", "hpp", "cxx", "ixx", "cs", "swift", "php", "scala", "clj", "cljs", "cljc", "ex",
+    "exs", "sh", "bash", "lua", "pl", "hs", "ml", "sql", "vue", "svelte",
 ];
 
 fn is_code_path(path: &str) -> bool {

--- a/src/lsp/language.rs
+++ b/src/lsp/language.rs
@@ -54,6 +54,7 @@ const LANGUAGES: &[(&str, &str)] = &[
     ("h", "c"),
     ("cpp", "cpp"),
     ("cxx", "cpp"),
+    ("ixx", "cpp"),
     ("cc", "cpp"),
     ("hpp", "cpp"),
     ("hxx", "cpp"),

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -298,7 +298,7 @@ pub fn builtin_servers() -> Vec<ServerInfo> {
         },
         ServerInfo {
             id: "clangd",
-            extensions: owned(&["c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx", "m", "mm"]),
+            extensions: owned(&["c", "cc", "cpp", "cxx", "ixx", "h", "hh", "hpp", "hxx", "m", "mm"]),
             filenames: owned(&[]),
             root: cfamily_root,
         },

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -298,7 +298,9 @@ pub fn builtin_servers() -> Vec<ServerInfo> {
         },
         ServerInfo {
             id: "clangd",
-            extensions: owned(&["c", "cc", "cpp", "cxx", "ixx", "h", "hh", "hpp", "hxx", "m", "mm"]),
+            extensions: owned(&[
+                "c", "cc", "cpp", "cxx", "ixx", "h", "hh", "hpp", "hxx", "m", "mm",
+            ]),
             filenames: owned(&[]),
             root: cfamily_root,
         },

--- a/src/semantic/adapters/cpp.rs
+++ b/src/semantic/adapters/cpp.rs
@@ -377,7 +377,7 @@ impl LanguageAdapter for CppAdapter {
         // `SemanticManager` so C wins for `.h`. If a project is
         // primarily C++ users can flip the file extension to
         // `.hpp` / `.hh` / `.hxx` to route through here.
-        &[".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"]
+        &[".cpp", ".cc", ".cxx", ".ixx", ".hpp", ".hh", ".hxx"]
     }
 
     fn extract(&self, file_path: &Path, source: &str) -> Result<ExtractedFile, String> {

--- a/src/semantic/syntax_validator.rs
+++ b/src/semantic/syntax_validator.rs
@@ -1771,6 +1771,15 @@ const GATE_EXCLUSIONS: &[(&str, &str)] = &[
          stays indexed-but-ungated. `.hpp`/`.hh`/`.hxx` ARE gated, via the C++ \
          grammar.",
     ),
+    (
+        "ixx",
+        "C++20 module interface unit, and tree-sitter-cpp 0.23 has no module \
+         grammar at all — `export module M;` and `import std;` parse as ERROR. \
+         Gating it would hard-block writes to every valid .ixx. Indexed by \
+         CppAdapter, which only warns on parse errors. See \
+         `the_cpp_grammar_does_not_understand_modules`; when the grammar gains \
+         module support that test fails and .ixx can move onto the gate.",
+    ),
 ];
 
 #[cfg(test)]
@@ -1880,6 +1889,28 @@ mod gate_coverage {
         assert!(
             rejected.is_empty(),
             "the gate is a hard write block and the grammar rejects valid Swift: {rejected:?}"
+        );
+    }
+
+    /// The evidence behind keeping `.ixx` OFF the gate. A module interface unit
+    /// is ordinary C++ except for the two declarations that make it one, and
+    /// tree-sitter-cpp 0.23 knows neither — so the gate would refuse every valid
+    /// `.ixx`. If a grammar bump makes this pass, drop the `ixx` entry from
+    /// [`GATE_EXCLUSIONS`] and let the gate have it.
+    #[cfg(feature = "semantic-cpp")]
+    #[test]
+    fn the_cpp_grammar_does_not_understand_modules() {
+        let lang: tree_sitter::Language = tree_sitter_cpp::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&lang).expect("cpp grammar loads");
+        let module_unit = "export module math;\n\
+                           import std;\n\
+                           export int add(int a, int b) { return a + b; }\n";
+        let tree = parser.parse(module_unit, None).expect("parses");
+        assert!(
+            tree.root_node().has_error(),
+            "tree-sitter-cpp now parses module declarations — .ixx no longer \
+             needs a GATE_EXCLUSIONS entry"
         );
     }
 }

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -84,7 +84,7 @@ fn normalize_lang(lang: &str) -> &str {
         "rs" | "rust" => "rust",
         "java" => "java",
         "c" | "h" => "c",
-        "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx" | "c++" => "cpp",
+        "cpp" | "cc" | "cxx" | "ixx" | "hpp" | "hh" | "hxx" | "c++" => "cpp",
         "json" | "jsonc" => "json",
         "yaml" | "yml" => "yaml",
         "toml" => "toml",


### PR DESCRIPTION
`ixx` is the MSVC's standard for C++ module interfaces.
I use it with clang because I prefer it over clang's default of `cppm`, which isn't on the list either.
