### PR TITLE
fix(ci): box ServiceError in CallErr

### DIFF
--- a/src/dap/config.rs
+++ b/src/dap/config.rs
@@ -211,11 +211,11 @@ fn sort_adapters_for_launch(program: &Path, cwd: &Path, adapters: &mut [Resolved
         let left_rank = EXTENSIONLESS_DEBUGGER_ORDER
             .iter()
             .position(|n| *n == left.name)
-            .map_or(usize::MAX, |i| i);
+            .unwrap_or(usize::MAX);
         let right_rank = EXTENSIONLESS_DEBUGGER_ORDER
             .iter()
             .position(|n| *n == right.name)
-            .map_or(usize::MAX, |i| i);
+            .unwrap_or(usize::MAX);
         if left_rank != right_rank {
             return left_rank.cmp(&right_rank);
         }

--- a/src/extras/mcp/tool.rs
+++ b/src/extras/mcp/tool.rs
@@ -520,12 +520,12 @@ async fn try_call_with_reconnect(
 /// (surface as-is).
 struct CallErr {
     message: String,
-    service_error: Option<ServiceError>,
+    service_error: Option<Box<ServiceError>>,
 }
 
 impl CallErr {
     fn as_service_error(&self) -> Option<&ServiceError> {
-        self.service_error.as_ref()
+        self.service_error.as_ref().map(Box::as_ref)
     }
 }
 
@@ -547,7 +547,7 @@ async fn call_once(
             let msg = format!("MCP tool error ({server_name}::{tool_name}): {svc_err}");
             Err(CallErr {
                 message: msg,
-                service_error: Some(svc_err),
+                service_error: Some(Box::new(svc_err)),
             })
         }
         Err(_) => Err(CallErr {
@@ -555,7 +555,7 @@ async fn call_once(
                 "MCP tool {server_name}::{tool_name} timed out after {}s",
                 timeout.as_secs(),
             ),
-            service_error: Some(ServiceError::Timeout { timeout }),
+            service_error: Some(Box::new(ServiceError::Timeout { timeout })),
         }),
     }
 }

--- a/src/sandbox/microvm/pty_harness.rs
+++ b/src/sandbox/microvm/pty_harness.rs
@@ -104,11 +104,13 @@ impl KeystrokeDriver {
         let interval = std::time::Duration::from_secs_f64(1.0 / bytes_per_sec as f64);
         let mut primary = pair.primary;
         std::thread::spawn(move || {
-            for i in 0u64.. {
+            let mut i = 0u64;
+            loop {
                 let b = charset[i as usize % charset.len()];
                 let _ = std::io::Write::write_all(&mut primary, &[b]);
                 let _ = std::io::Write::flush(&mut primary);
                 std::thread::sleep(interval);
+                i += 1;
             }
         });
 

--- a/src/ui/relay_tests/crossterm_suite.rs
+++ b/src/ui/relay_tests/crossterm_suite.rs
@@ -147,12 +147,14 @@ mod tests {
                 .collect();
             let mut pri = primary.try_clone().expect("clone primary");
             let injector = std::thread::spawn(move || {
-                for i in 0u64.. {
+                let mut i = 0u64;
+                loop {
                     if !injector_running2.load(Ordering::Relaxed) {
                         break;
                     }
                     if injector_paused2.load(Ordering::Relaxed) {
                         std::thread::sleep(Duration::from_millis(1));
+                        i += 1;
                         continue;
                     }
                     let b = charset[i as usize % charset.len()];
@@ -162,6 +164,7 @@ mod tests {
                         injector_bytes2.fetch_add(1, Ordering::Relaxed);
                     }
                     std::thread::sleep(Duration::from_micros(1000));
+                    i += 1;
                 }
             });
 

--- a/src/ui/relay_tests/e2e_attach.rs
+++ b/src/ui/relay_tests/e2e_attach.rs
@@ -76,7 +76,8 @@ mod tests {
             .expect("clone secondary for HUP trigger");
         let mut secondary_for_injector = fake_secondary;
         let injector = std::thread::spawn(move || {
-            for i in 0u64.. {
+            let mut i = 0u64;
+            loop {
                 if !injector_running2.load(Ordering::Relaxed) {
                     break;
                 }
@@ -89,6 +90,7 @@ mod tests {
                     injector_bytes2.fetch_add(1, Ordering::Relaxed);
                 }
                 std::thread::sleep(interval);
+                i += 1;
             }
         });
 
@@ -341,7 +343,8 @@ mod tests {
         let secondary_for_hup = fake_secondary.try_clone().expect("clone secondary for HUP");
         let mut secondary_for_injector = fake_secondary;
         let injector = std::thread::spawn(move || {
-            for i in 0u64.. {
+            let mut i = 0u64;
+            loop {
                 if !injector_running2.load(Ordering::Relaxed) {
                     break;
                 }
@@ -352,6 +355,7 @@ mod tests {
                     injector_bytes2.fetch_add(1, Ordering::Relaxed);
                 }
                 std::thread::sleep(interval);
+                i += 1;
             }
         });
 

--- a/src/ui/relay_tests/reader_shutdown.rs
+++ b/src/ui/relay_tests/reader_shutdown.rs
@@ -87,7 +87,8 @@ mod tests {
         let interval = Duration::from_micros(1000);
         let injector = std::thread::spawn(move || {
             let mut pri = primary;
-            for i in 0u64.. {
+            let mut i = 0u64;
+            loop {
                 if !injector_running2.load(Ordering::Relaxed) {
                     break;
                 }
@@ -98,6 +99,7 @@ mod tests {
                     injector_bytes2.fetch_add(1, Ordering::Relaxed);
                 }
                 std::thread::sleep(interval);
+                i += 1;
             }
         });
 


### PR DESCRIPTION
rustc 1.98 (released 2026-08-18) tightened `result_large_err`. `CallErr`'s unboxed `Option<ServiceError>` puts the Err variant at/over the 128-byte threshold, so clippy is red on main right now with no code change on our side. CI uses `toolchain: stable`, so it picked this up as soon as 1.98 shipped.

Main's last green clippy run (2026-08-20) was on 1.97.1. #803's run today was on 1.98.0 and failed on this, despite `CallErr` being identical on both branches.

Boxing the field is the same fix #765 already landed on its branch for this lint.

Side note worth a separate issue: `release.yml` skips clippy/tests at tag time on the reasoning that "a SHA that was green stays green." That holds for a pinned toolchain but not a floating `stable`. A `rust-toolchain.toml` would make it true again.