### PR TITLE
plugin: add harness/call-tool so plugins can invoke dirge's tools - #1

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -304,6 +304,68 @@ or unusually slow, the call returns `nil` instead of freezing the plugin.
   (harness/notify (string "definition sites: " (length defs))))
 ```
 
+### Calling dirge's tools
+
+A plugin can invoke the agent's own tools — built-ins, MCP, semantic — instead
+of reimplementing them. This is what lets a plugin build a tool *on top of*
+the existing set: batching, filtering, or running several and returning only
+the part that matters.
+
+Feature-detect with `(harness/tools?)` and fall back gracefully, exactly as
+with LSP. It is true only when the bridge is wired **and** a tool registry has
+been published (i.e. an agent exists), so a true answer means a following
+`harness/call-tool` will reach the dispatcher.
+
+| Function | Signature | Effect |
+|----------|-----------|--------|
+| `harness/tools?` | `()` | `true` when the bridge is live |
+| `harness/list-tools` | `()` | JSON array of `{name, description, parameters}` for every callable tool, or `nil` |
+| `harness/call-tool` | `(name &opt args-json)` | Runs the tool. Returns `@{:ok bool :output string}`, or `nil` when the bridge is not wired |
+
+`args-json` is a **JSON string**, not a Janet structure — the plugin
+environment has no JSON encoder, and the host re-parses it anyway. Omitting it
+means `{}`. `:ok false` carries the tool's own error text in `:output`.
+
+```janet
+(defn on-prompt [ctx]
+  (when (harness/tools?)
+    (def r (harness/call-tool "read" `{"path": "README.md"}`))
+    (when (and r (r :ok))
+      (harness/notify (string "README is " (length (r :output)) " bytes")))))
+```
+
+**Permission checks still apply, unchanged.** `check_perm*` runs inside each
+tool, so a call through the bridge is gated exactly as the model's own call
+would be: under `--restrictive` a plugin's `bash` and `write` come back
+`:ok false` with `"Permission denied by user"` and nothing runs.
+
+Read that as "no bypass", not as "extra protection". The bridge inherits
+whatever policy is in force, and headless `-p` auto-approves by default — so
+there a plugin's `bash` executes without a prompt, precisely as the model's
+would. A plugin also chooses the arguments, and plugins already sit inside
+dirge's trust boundary. The bridge grants a plugin the model's privileges,
+neither more nor less.
+
+**Two things you cannot call**, both refused with an explanatory error rather
+than attempted:
+
+- **Plugin-registered tools.** Their handlers run on the Janet worker, which
+  is blocked waiting for your call to return — attempting one would deadlock
+  until the timeout.
+- **`task`.** Subagents run isolated from plugin hooks and tool access;
+  reaching one from a plugin would smuggle a whole agent run past that
+  boundary.
+
+Hooks do **not** fire for tools invoked this way. `on-tool-start` /
+`on-tool-end` would re-enter the blocked worker, and a plugin calling a tool
+from inside `on-tool-start` would recurse. Calls are therefore silent: they do
+not appear in the transcript and do not trigger other plugins.
+
+The call blocks the Janet worker for its duration, bounded at 300 seconds.
+That is much longer than the LSP bound because tools legitimately run for
+minutes, but it is still a bound — everything else in Janet waits behind it,
+so do not call a long tool from `on-message-update`.
+
 ### Custom LLM providers
 
 | Function | Signature | Effect |

--- a/plugins/call_tool_example.janet
+++ b/plugins/call_tool_example.janet
@@ -1,0 +1,57 @@
+# harness/call-tool end to end.
+#
+# Registers `/deps <file>`, which reads a file through dirge's own `read`
+# tool and reports its import lines — the small case the bridge exists for:
+# run a real tool, keep the part that matters, throw the rest away.
+#
+# Note what is NOT here: no file reading, no path resolution, no permission
+# handling. All of that belongs to the `read` tool and is inherited.
+
+(defn- json-escape [s]
+  (def out @"")
+  (each byte s
+    (cond
+      (= byte 34) (buffer/push-string out `\"`)
+      (= byte 92) (buffer/push-string out `\\`)
+      (= byte 10) (buffer/push-string out `\n`)
+      (= byte 13) (buffer/push-string out `\r`)
+      (= byte 9) (buffer/push-string out `\t`)
+      (< byte 32) (buffer/push-string out (string/format `\u%04x` byte))
+      (buffer/push-byte out byte)))
+  (string out))
+
+(defn- import-lines [text]
+  (def hits @[])
+  (each line (string/split "\n" text)
+    (def trimmed (string/trim line))
+    (when (or (string/has-prefix? "use " trimmed)
+              (string/has-prefix? "import " trimmed)
+              (string/has-prefix? "from " trimmed)
+              (string/has-prefix? "#include" trimmed))
+      (array/push hits trimmed)))
+  hits)
+
+(defn deps-command [args]
+  (def path (string/trim (or args "")))
+  (when (empty? path)
+    (break "usage: /deps <file>"))
+
+  (unless (harness/tools?)
+    (break "the tool bridge is not available in this build"))
+
+  # args are a JSON string: the plugin env has no JSON encoder, and the
+  # host re-parses whatever we hand it.
+  (def result
+    (harness/call-tool "read" (string `{"path":"` (json-escape path) `"}`)))
+
+  (cond
+    (nil? result) "the tool bridge went away mid-call"
+    # `:ok false` is the tool's own failure — a missing file, a denied
+    # permission — and its text is already user-facing.
+    (not (result :ok)) (string "read failed: " (result :output))
+    (let [hits (import-lines (result :output))]
+      (if (empty? hits)
+        (string "no imports found in " path)
+        (string path " imports:\n" (string/join hits "\n"))))))
+
+(harness/register-command "deps" "deps-command")

--- a/src/agent/builder/loop_tools.rs
+++ b/src/agent/builder/loop_tools.rs
@@ -1040,6 +1040,15 @@ pub async fn build_loop_tools(
             Ok(mut guard) => guard.list_plugin_tools(),
             Err(_) => Vec::new(),
         };
+        // Cache the names for the tool bridge. It must never take this lock
+        // itself: `harness/call-tool` runs while the hook dispatcher already
+        // holds the PluginManager, and the lock is not reentrant — asking for
+        // it from the Janet worker (or from the responder, which the worker is
+        // blocked on) deadlocks the whole agent. Publishing here, on the build
+        // path, keeps the bridge's refusal check lock-free.
+        crate::plugin::tool_bridge::publish_plugin_tool_names(
+            metas.iter().map(|m| m.name.clone()).collect(),
+        );
         for meta in metas {
             if shadows_builtin(&meta.name, "plugin") {
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1499,6 +1499,19 @@ async fn main() -> anyhow::Result<()> {
              File tools (read, write, edit, etc.) operate on the host filesystem."
         );
     }
+    // ── Spawn the plugin tool-call drainer ───────────────────────────
+    // Plugins call (harness/call-tool "read" args-json), which reaches the
+    // worker C function; it sends a ToolCallRequest here and blocks. The
+    // responder looks the tool up in the registry published at each agent
+    // build and runs it, permission checks included (they live inside each
+    // tool, so dispatching straight to `execute` keeps the gate).
+    #[cfg(feature = "plugin")]
+    {
+        let (tool_call_tx, tool_call_rx) =
+            tokio::sync::mpsc::unbounded_channel::<plugin::tool_bridge::ToolCallRequest>();
+        plugin::tool_bridge::install_tool_call_tx(tool_call_tx);
+        plugin::tool_bridge::spawn_tool_responder(tool_call_rx);
+    }
     // ── Spawn the Computer-Use sandbox exec drainer ──────────────────
     // Computer-use plugins call (harness/computer-use-exec ...) which
     // reaches the worker C function. The C function sends a

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -25,6 +25,12 @@ pub mod interrupt;
 pub mod loader;
 #[cfg(feature = "plugin")]
 pub mod notebook;
+
+// Gated as a whole: every item in it is reachable only through the Janet
+// C functions, so a no-plugin build would otherwise trip `-D warnings` on a
+// dozen dead statics.
+#[cfg(feature = "plugin")]
+pub mod tool_bridge;
 pub mod worker;
 
 /// Per-process sentinel the Rust host prepends to a plugin error string

--- a/src/plugin/mod_tests.rs
+++ b/src/plugin/mod_tests.rs
@@ -3354,3 +3354,69 @@ fn notebook_tools_are_registered_with_a_persistence_contract() {
         eval.description
     );
 }
+
+// ── Tool bridge (harness/call-tool) ──────────────────────────────────
+//
+// These run against a real Janet env with the preludes installed but no
+// responder wired, which is exactly the degraded state a plugin has to cope
+// with: the symbols must exist and answer safely rather than blow up.
+
+#[test]
+fn tool_bridge_symbols_are_defined() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    for sym in ["harness/tools?", "harness/list-tools", "harness/call-tool"] {
+        let result = mgr.eval(&format!("(harness/has-symbol? \"{sym}\")"));
+        assert_eq!(result, Ok("true".to_string()), "{sym} must be defined");
+    }
+}
+
+#[test]
+fn tools_predicate_is_false_without_a_responder() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert_eq!(mgr.eval("(harness/tools?)"), Ok("false".to_string()));
+}
+
+/// The documented contract: feature-detect, and a false predicate means the
+/// query functions return nil rather than erroring.
+#[test]
+fn list_tools_is_nil_without_a_responder() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert_eq!(mgr.eval("(harness/list-tools)"), Ok("nil".to_string()));
+}
+
+#[test]
+fn call_tool_is_nil_without_a_responder() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert_eq!(
+        mgr.eval("(harness/call-tool \"read\" \"{}\")"),
+        Ok("nil".to_string())
+    );
+}
+
+/// Validation happens in the Janet wrapper so a plugin gets a normal
+/// catchable error, not a silent nil that looks like "bridge down".
+#[test]
+fn call_tool_rejects_a_non_string_name() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert!(mgr.eval("(harness/call-tool 42)").is_err());
+}
+
+#[test]
+fn call_tool_rejects_non_string_args() {
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert!(
+        mgr.eval("(harness/call-tool \"read\" @{:path \"x\"})")
+            .is_err()
+    );
+}
+
+#[test]
+fn call_tool_defaults_missing_args_to_empty_object() {
+    // Reaches the C function (returning nil, no responder) rather than
+    // erroring on the missing argument.
+    let mut mgr = PluginManager::try_new().unwrap();
+    assert_eq!(
+        mgr.eval("(harness/call-tool \"read\")"),
+        Ok("nil".to_string())
+    );
+}

--- a/src/plugin/tool_bridge.rs
+++ b/src/plugin/tool_bridge.rs
@@ -1,0 +1,306 @@
+//! Let Janet plugins invoke dirge's own tools.
+//!
+//! Plugins can *register* tools (`harness/register-tool`) and *intercept*
+//! them (`on-tool-start` / `on-tool-end`), but until now could not *call*
+//! one. A plugin that wanted a tool's output had to reimplement it, which
+//! means it also had to reimplement the permission checks, and could never
+//! reach MCP or semantic tools at all.
+//!
+//! This module owns the policy and the tokio-side responder. The Janet FFI
+//! lives in [`super::worker`] with the other C functions.
+//!
+//! Two hazards shape the design.
+//!
+//! **Deadlock.** `harness/call-tool` blocks the Janet worker thread until
+//! the responder answers. Any tool that itself needs that thread can never
+//! be answered, so plugin-registered tools (which run through
+//! [`super::extension::JanetLoopTool`]) are refused by name rather than
+//! attempted. For the same reason the responder dispatches
+//! [`LoopTool::execute`] directly instead of going through the loop's
+//! hook-firing path — an `on-tool-start` hook would re-enter the blocked
+//! worker. maki solves the identical problem with `Emit::Silent`.
+//!
+//! **Permission.** dirge's `check_perm*` runs *inside* each tool, after the
+//! plugin pre-hook, so dispatching straight to `execute` keeps the gate
+//! intact: a plugin calling `bash` still prompts the user. That is the
+//! reason this is a thin call rather than a reimplementation of dispatch.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde_json::Value;
+
+use crate::agent::agent_loop::tool::{AbortSignal, LoopToolUpdate};
+use crate::agent::agent_loop::{LoopTool, LoopToolResult};
+
+/// A tool invocation forwarded from the Janet worker to the tokio runtime.
+/// Mirrors [`super::worker::LspRequest`]: the worker blocks on `reply`
+/// while the responder does the async work.
+#[derive(Debug)]
+#[cfg_attr(not(feature = "plugin"), allow(dead_code))]
+pub struct ToolCallRequest {
+    pub name: String,
+    /// Raw JSON object of arguments, as the plugin wrote it.
+    pub args_json: String,
+    pub reply: std::sync::mpsc::Sender<Result<String, String>>,
+}
+
+static TOOL_CALL_TX: OnceLock<tokio::sync::mpsc::UnboundedSender<ToolCallRequest>> =
+    OnceLock::new();
+
+/// Install the sender the Janet C function reads. Called once from
+/// `main.rs`, mirroring `install_sandbox_exec_tx`.
+#[cfg(feature = "plugin")]
+pub fn install_tool_call_tx(tx: tokio::sync::mpsc::UnboundedSender<ToolCallRequest>) {
+    let _ = TOOL_CALL_TX.set(tx);
+}
+
+#[cfg(feature = "plugin")]
+pub fn tool_call_tx() -> Option<&'static tokio::sync::mpsc::UnboundedSender<ToolCallRequest>> {
+    TOOL_CALL_TX.get()
+}
+
+/// The live `LoopTool` registry.
+///
+/// Republished on every agent build rather than captured once: the agent is
+/// rebuilt at run boundaries (model switch, `prepare-next-run`), and MCP
+/// tools can attach late. A stale snapshot would silently lose them.
+static REGISTRY: OnceLock<Mutex<Vec<Arc<dyn LoopTool>>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<Vec<Arc<dyn LoopTool>>> {
+    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Publish the tool set the agent was just built with.
+pub fn publish_registry(tools: &[Arc<dyn LoopTool>]) {
+    if let Ok(mut guard) = registry().lock() {
+        *guard = tools.to_vec();
+    }
+}
+
+fn snapshot() -> Vec<Arc<dyn LoopTool>> {
+    registry()
+        .lock()
+        .map(|guard| guard.clone())
+        .unwrap_or_default()
+}
+
+/// True once a registry has been published *and* the responder is wired,
+/// so `(harness/tools?)` reflects runtime availability rather than mere
+/// compile-time presence — the same contract `harness/lsp?` has.
+#[cfg(feature = "plugin")]
+pub fn is_live() -> bool {
+    let wired = TOOL_CALL_TX
+        .get()
+        .map(|tx| !tx.is_closed())
+        .unwrap_or(false);
+    wired && !snapshot().is_empty()
+}
+
+/// Tools that must never be reached from a plugin, independent of the
+/// plugin-registered check below.
+const NEVER_CALLABLE: &[&str] = &[
+    // Subagents run isolated — no tool access, no plugin hooks (see
+    // docs/plugins.md). Reaching one from inside a plugin would smuggle a
+    // whole agent run behind that boundary.
+    "task",
+];
+
+/// Names of tools backed by Janet handlers, which cannot be called while
+/// the Janet worker is blocked waiting for this very reply.
+///
+/// Cached rather than read from the `PluginManager` on demand, and that is
+/// load-bearing: the hook dispatcher holds the PluginManager lock for the
+/// duration of a Janet call, so a `harness/*` C function that asks for the
+/// same (non-reentrant) lock deadlocks the agent outright. The responder
+/// thread is no safer — the worker it must answer is blocked holding it.
+/// `publish_plugin_tool_names` fills this from the agent build path, where
+/// the lock is genuinely free.
+static PLUGIN_TOOL_NAMES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn plugin_tool_names_cell() -> &'static Mutex<Vec<String>> {
+    PLUGIN_TOOL_NAMES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Publish the plugin-registered tool names. Called from
+/// `build_loop_tools`, which already has them in hand.
+pub fn publish_plugin_tool_names(names: Vec<String>) {
+    if let Ok(mut guard) = plugin_tool_names_cell().lock() {
+        *guard = names;
+    }
+}
+
+fn plugin_tool_names() -> Vec<String> {
+    plugin_tool_names_cell()
+        .lock()
+        .map(|guard| guard.clone())
+        .unwrap_or_default()
+}
+
+/// Why `name` may not be called, or `None` if it may.
+///
+/// Split out from dispatch so the policy is unit-testable without a
+/// runtime, a registry or a Janet worker.
+pub fn refusal(name: &str, plugin_tools: &[String]) -> Option<String> {
+    if NEVER_CALLABLE.contains(&name) {
+        return Some(format!(
+            "'{name}' cannot be called from a plugin: subagents run isolated from \
+             plugin hooks and tool access"
+        ));
+    }
+    if plugin_tools.iter().any(|n| n == name) {
+        return Some(format!(
+            "'{name}' is a plugin-registered tool and cannot be called from a plugin: \
+             its handler needs the Janet worker, which is blocked awaiting this call"
+        ));
+    }
+    None
+}
+
+/// Render a tool's LLM-visible content as plain text.
+fn flatten(result: &LoopToolResult) -> String {
+    let mut out = String::new();
+    for block in &result.content {
+        let text = match block {
+            Value::String(s) => Some(s.as_str()),
+            Value::Object(map) => map.get("text").and_then(|t| t.as_str()),
+            _ => None,
+        };
+        if let Some(text) = text {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text);
+        }
+    }
+    // A tool that returned only structured details still owes the caller
+    // something readable.
+    if out.is_empty() && !result.details.is_null() {
+        out = result.details.to_string();
+    }
+    out
+}
+
+/// Look up and run one tool. Errors are returned, never panicked.
+async fn dispatch(name: &str, args_json: &str) -> Result<String, String> {
+    if let Some(reason) = refusal(name, &plugin_tool_names()) {
+        return Err(reason);
+    }
+
+    let args: Value = if args_json.trim().is_empty() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_str(args_json).map_err(|e| format!("arguments are not valid JSON: {e}"))?
+    };
+    if !args.is_object() {
+        return Err("arguments must be a JSON object".to_string());
+    }
+
+    let tool = snapshot()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .ok_or_else(|| format!("no tool named '{name}'"))?;
+
+    let args = tool.prepare_arguments(args);
+    // A no-op progress sink: streaming updates have nowhere to go while the
+    // caller is a blocked synchronous Janet call.
+    let on_update: LoopToolUpdate = Arc::new(|_: &LoopToolResult| {});
+
+    match tool
+        .execute("plugin-call-tool", args, AbortSignal::new(), on_update)
+        .await
+    {
+        Ok(result) => Ok(flatten(&result)),
+        Err(e) => Err(e),
+    }
+}
+
+/// Drain `harness/call-tool` requests and answer them against the live
+/// registry. Runs until the channel closes at worker shutdown. Mirrors
+/// [`super::spawn_lsp_responder`].
+#[cfg(feature = "plugin")]
+pub fn spawn_tool_responder(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<ToolCallRequest>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(req) = rx.recv().await {
+            let answer = dispatch(&req.name, &req.args_json).await;
+            let _ = req.reply.send(answer);
+        }
+    })
+}
+
+/// JSON array of `{name, description, parameters}` for every live tool,
+/// minus the ones a plugin may not call — so what is advertised is what is
+/// callable, which is the invariant maki's `interpreter_tools` predicate
+/// exists to hold.
+pub fn list_json() -> String {
+    let refused = plugin_tool_names();
+    let entries: Vec<Value> = snapshot()
+        .iter()
+        .filter(|t| refusal(t.name(), &refused).is_none())
+        .map(|t| {
+            serde_json::json!({
+                "name": t.name(),
+                "description": t.description(),
+                "parameters": t.parameters(),
+            })
+        })
+        .collect();
+    Value::Array(entries).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordinary_tools_are_callable() {
+        assert!(refusal("read", &[]).is_none());
+        assert!(refusal("bash", &[]).is_none());
+    }
+
+    /// The deadlock guard. A plugin tool's handler runs on the Janet
+    /// worker, which is blocked waiting for this call to return, so
+    /// attempting it would hang until the call timed out.
+    #[test]
+    fn plugin_registered_tools_are_refused() {
+        let plugins = vec!["code_execution".to_string()];
+        let reason = refusal("code_execution", &plugins).expect("must refuse");
+        assert!(reason.contains("Janet worker"), "{reason}");
+    }
+
+    #[test]
+    fn subagents_are_refused() {
+        let reason = refusal("task", &[]).expect("must refuse");
+        assert!(reason.contains("isolated"), "{reason}");
+    }
+
+    #[test]
+    fn refusal_is_exact_not_substring() {
+        // `read_minified` must not be refused because `read` is in a list.
+        assert!(refusal("read_minified", &["read".to_string()]).is_none());
+    }
+
+    #[test]
+    fn flatten_reads_text_blocks() {
+        let result = LoopToolResult {
+            content: vec![
+                serde_json::json!({"type": "text", "text": "one"}),
+                serde_json::json!({"type": "text", "text": "two"}),
+            ],
+            details: Value::Null,
+            terminate: None,
+        };
+        assert_eq!(flatten(&result), "one\ntwo");
+    }
+
+    #[test]
+    fn flatten_falls_back_to_details() {
+        let result = LoopToolResult {
+            content: vec![],
+            details: serde_json::json!({"count": 2}),
+            terminate: None,
+        };
+        assert_eq!(flatten(&result), r#"{"count":2}"#);
+    }
+}

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -1009,6 +1009,36 @@ const HARNESS_LSP_INIT: &str = r#"
 (defn harness/lsp-diagnostics [file] (harness/lsp "diagnostics" file))
 "#;
 
+/// Janet wrappers for the tool bridge, installed after the C functions.
+///
+/// `harness/call-tool` returns `@{:ok bool :output string}` so a plugin can
+/// distinguish a tool's error from its output, and `nil` when the bridge
+/// isn't wired at all (no responder — e.g. a build that never constructed
+/// an agent). Feature-detect with `(harness/tools?)`, exactly as with LSP.
+///
+/// Arguments are validated here rather than in the C function so a plugin
+/// gets a normal catchable Janet error instead of a silent nil.
+#[cfg(feature = "plugin")]
+const HARNESS_TOOL_INIT: &str = r#"
+(defn harness/tools? []
+  (if-let [entry (get (curenv) 'harness/__tools-live)]
+    (truthy? ((get entry :value)))
+    false))
+
+(defn harness/list-tools []
+  (when (harness/tools?)
+    (harness/__list-tools)))
+
+(defn harness/call-tool [name &opt args]
+  (when (not (string? name))
+    (error "harness/call-tool: tool name must be a string"))
+  (def payload (cond
+                 (nil? args) "{}"
+                 (string? args) args
+                 (error "harness/call-tool: args must be a JSON string")))
+  (harness/__call-tool name payload))
+"#;
+
 /// dirge-l6bf: neuter the Janet escape hatches that can terminate or
 /// destabilize the HOST process. Every hook / command / tool handler is
 /// already run inside a Janet `(try ...)` (see `mod.rs`), so an ordinary
@@ -1920,6 +1950,12 @@ fn worker_loop(
             CFunOptions::new(c"__computer-use-exec", janet_computer_use_exec_cfn)
                 .namespace(c"harness"),
         );
+        // Tool bridge: lets a plugin call dirge's own tools. Like the
+        // computer-use bridge these read a global set by main.rs, so they
+        // degrade to nil when the responder was never spawned.
+        env.add_c_fn(CFunOptions::new(c"__call-tool", janet_call_tool_cfn).namespace(c"harness"));
+        env.add_c_fn(CFunOptions::new(c"__list-tools", janet_list_tools_cfn).namespace(c"harness"));
+        env.add_c_fn(CFunOptions::new(c"__tools-live", janet_tools_live_cfn).namespace(c"harness"));
     }
     // Register DAP C functions when both features are enabled.
     #[cfg(feature = "dap")]
@@ -1950,6 +1986,10 @@ fn worker_loop(
     }
     if let Err(e) = client.run(HARNESS_LSP_INIT) {
         let _ = init_tx.send(Err(format!("harness lsp init failed: {e}")));
+        return;
+    }
+    if let Err(e) = client.run(HARNESS_TOOL_INIT) {
+        let _ = init_tx.send(Err(format!("harness tool-bridge init failed: {e}")));
         return;
     }
     // dirge-l6bf: disable host-terminating Janet functions. MUST run after
@@ -3246,6 +3286,167 @@ unsafe fn computer_use_exec_body(
         }
         None => unsafe { janet_wrap_nil() },
     }
+}
+
+/// Upper bound on a single `harness/call-tool`. Generous compared to
+/// [`LSP_QUERY_TIMEOUT`] because the callee is a real tool — `bash` alone
+/// defaults to minutes — but still bounded: the Janet worker is blocked for
+/// the whole call, so an unbounded wait would freeze every hook and every
+/// other plugin behind it.
+#[cfg(feature = "plugin")]
+const TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Send a tool call and block on the reply, polling the shutdown flag so
+/// `Worker::Drop` can unblock us. Same shape as [`send_lsp`].
+#[cfg(feature = "plugin")]
+fn send_tool_call(
+    tx: &tmpsc::UnboundedSender<super::tool_bridge::ToolCallRequest>,
+    name: String,
+    args_json: String,
+) -> Option<Result<String, String>> {
+    let (reply_tx, reply_rx) = mpsc::channel::<Result<String, String>>();
+    tx.send(super::tool_bridge::ToolCallRequest {
+        name,
+        args_json,
+        reply: reply_tx,
+    })
+    .ok()?;
+    let start = std::time::Instant::now();
+    loop {
+        match reply_rx.recv_timeout(DIALOG_POLL) {
+            Ok(r) => return Some(r),
+            Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let shutting_down = SHUTDOWN.with(|cell| {
+                    cell.borrow()
+                        .as_ref()
+                        .map(|f| f.load(Ordering::SeqCst))
+                        .unwrap_or(false)
+                });
+                if shutting_down {
+                    return None;
+                }
+                if start.elapsed() >= TOOL_CALL_TIMEOUT {
+                    return Some(Err(format!(
+                        "tool call exceeded {}s and was abandoned",
+                        TOOL_CALL_TIMEOUT.as_secs()
+                    )));
+                }
+            }
+        }
+    }
+}
+
+/// C-function backing `harness/__call-tool`. Reads (name, args-json),
+/// forwards to the tokio responder and blocks on the reply. Returns a Janet
+/// table `{:ok bool :output string}`, or nil when the bridge is not wired.
+/// A table rather than a bare string because the caller has to be able to
+/// tell "the tool said no" from "the tool returned text".
+#[cfg(feature = "plugin")]
+unsafe extern "C-unwind" fn janet_call_tool_cfn(
+    argc: i32,
+    argv: *mut janetrs::lowlevel::Janet,
+) -> janetrs::lowlevel::Janet {
+    use janetrs::lowlevel::*;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        call_tool_body(argc, argv)
+    }));
+    match result {
+        Ok(j) => j,
+        Err(payload) => {
+            let msg = panic_payload_to_string(&payload);
+            tracing::error!(
+                target: "dirge::plugin",
+                cfn = "harness/call-tool",
+                panic = %msg,
+                "FFI panic in call-tool cfn — returning nil",
+            );
+            unsafe { janet_wrap_nil() }
+        }
+    }
+}
+
+#[cfg(feature = "plugin")]
+unsafe fn call_tool_body(
+    argc: i32,
+    argv: *mut janetrs::lowlevel::Janet,
+) -> janetrs::lowlevel::Janet {
+    use janetrs::lowlevel::*;
+    if argc < 2 {
+        return unsafe { janet_wrap_nil() };
+    }
+    let name = match unsafe { read_string_arg(argv, 0) } {
+        Some(s) => s,
+        None => return unsafe { janet_wrap_nil() },
+    };
+    let args_json = unsafe { read_string_arg(argv, 1) }.unwrap_or_else(|| "{}".to_string());
+
+    let answer = match super::tool_bridge::tool_call_tx() {
+        Some(tx) => send_tool_call(tx, name, args_json),
+        None => None,
+    };
+
+    let (ok, output) = match answer {
+        Some(Ok(text)) => (true, text),
+        Some(Err(err)) => (false, err),
+        None => return unsafe { janet_wrap_nil() },
+    };
+
+    let table = unsafe { janet_table(0) };
+    let ok_value = unsafe { janet_wrap_boolean(if ok { 1 } else { 0 }) };
+    let out_value = unsafe { wrap_string(&output) };
+    unsafe {
+        janet_table_put(
+            table,
+            janet_ckeywordv(c"ok".as_ptr() as *const u8, 2),
+            ok_value,
+        );
+        janet_table_put(
+            table,
+            janet_ckeywordv(c"output".as_ptr() as *const u8, 6),
+            out_value,
+        );
+    }
+    unsafe { janet_wrap_table(table) }
+}
+
+/// C-function backing `harness/__list-tools`. Returns a JSON string of the
+/// callable tools, or nil when the bridge is not wired.
+#[cfg(feature = "plugin")]
+unsafe extern "C-unwind" fn janet_list_tools_cfn(
+    _argc: i32,
+    _argv: *mut janetrs::lowlevel::Janet,
+) -> janetrs::lowlevel::Janet {
+    use janetrs::lowlevel::*;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        super::tool_bridge::list_json()
+    }));
+    match result {
+        Ok(json) => unsafe { wrap_string(&json) },
+        Err(payload) => {
+            let msg = panic_payload_to_string(&payload);
+            tracing::error!(
+                target: "dirge::plugin",
+                cfn = "harness/list-tools",
+                panic = %msg,
+                "FFI panic in list-tools cfn — returning nil",
+            );
+            unsafe { janet_wrap_nil() }
+        }
+    }
+}
+
+/// C-function backing `harness/__tools-live`. True only when the responder
+/// is wired AND a registry has been published, so `(harness/tools?)` reports
+/// runtime availability — the same contract `harness/lsp?` holds.
+#[cfg(feature = "plugin")]
+unsafe extern "C-unwind" fn janet_tools_live_cfn(
+    _argc: i32,
+    _argv: *mut janetrs::lowlevel::Janet,
+) -> janetrs::lowlevel::Janet {
+    use janetrs::lowlevel::janet_wrap_boolean;
+    let live = super::tool_bridge::is_live();
+    unsafe { janet_wrap_boolean(if live { 1 } else { 0 }) }
 }
 
 /// Wrap an `i32` as a Janet value, portably. `janet_wrap_integer` is only

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -204,6 +204,13 @@ pub async fn build_agent(
                 )
                 .await;
 
+            // Publish the tool set so `harness/call-tool` can reach it.
+            // Done on every build, not once: the agent is rebuilt at run
+            // boundaries and MCP tools can attach late, so a captured
+            // snapshot would quietly go stale.
+            #[cfg(feature = "plugin")]
+            crate::plugin::tool_bridge::publish_registry(&loop_tools);
+
             // Phase 4.5h-6: the new path passes the rig Agent's
             // preamble as Context.system_prompt. rig 0.41 made that
             // field private, so `build_agent_inner` hands it back.

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -324,12 +324,34 @@ impl AnyAgent {
         // Plugin `on-prompt` dispatch. Headless modes (--print, --loop)
         // previously skipped this — plugins that mutate the user prompt
         // or block it never fired in CI/script contexts.
+        //
+        // Dispatched via `spawn_blocking`, matching the tool hooks
+        // (plugin_hooks.rs:231). This is not a style preference: the runtime
+        // is `flavor = "current_thread"`, so running the synchronous Janet
+        // dispatch inline pins its only thread. Any harness bridge that
+        // blocks on a reply from the runtime — `harness/call-tool`,
+        // `harness/lsp`, `harness/confirm` — could then never be answered,
+        // and the hook would hang until its own timeout. The TUI path
+        // already dispatches off-loop for the same reason (ui/state.rs).
         let effective_prompt: String = {
             #[cfg(feature = "plugin")]
             {
                 if let Some(pm_arc) = crate::plugin::hook::global() {
-                    let mut mgr = pm_arc.lock_ignore_poison();
-                    runner::resolve_prompt_with_hooks(prompt, &mut mgr)
+                    let owned = prompt.to_string();
+                    let fallback = owned.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let mut mgr = pm_arc.lock_ignore_poison();
+                        runner::resolve_prompt_with_hooks(&owned, &mut mgr)
+                    })
+                    .await
+                    .unwrap_or_else(|join_err| {
+                        tracing::warn!(
+                            target: "dirge::provider::run",
+                            error = %join_err,
+                            "on-prompt hook panicked; using the original prompt",
+                        );
+                        fallback
+                    })
                 } else {
                     prompt.to_string()
                 }


### PR DESCRIPTION
Plugins could register tools and intercept them, but not call one. A plugin that wanted a tool's output had to reimplement it — and therefore reimplement its permission checks — and could never reach MCP or semantic tools at all.

Adds three Janet functions, modelled on the LSP bridge:

  (harness/tools?)                 bridge live?
  (harness/list-tools)             JSON of {name, description, parameters}
  (harness/call-tool name args)    -> @{:ok bool :output string}

src/plugin/tool_bridge.rs holds the policy and the tokio responder; the FFI sits in worker.rs with the other C functions. The registry is republished on every agent build rather than captured once, since the agent is rebuilt at run boundaries and MCP tools attach late.

Permission checks are unaffected: check_perm* runs inside each tool, so dispatching straight to LoopTool::execute keeps the gate. Verified — under --restrictive a plugin's bash and write return "Permission denied by user" and nothing runs.

Two calls are refused rather than attempted, both of which would hang: plugin-registered tools (their handlers need the Janet worker, which is blocked awaiting the reply) and `task` (subagents run isolated from plugin hooks). Hooks do not fire for bridged calls, for the same re-entrancy reason maki's Emit::Silent exists.

Two deadlocks found by running it, not by reading it:

- The bridge must not touch the PluginManager lock. The hook dispatcher holds it across the Janet call and it is not reentrant, so asking for it from a harness C function — or from the responder the worker is blocked on — hangs the agent. Plugin tool names are now cached from the build path instead.

- Headless --print dispatched on-prompt inline on the runtime thread, and the runtime is flavor = "current_thread". Any harness bridge that waits on a reply from the runtime could never be answered. Now dispatched via spawn_blocking, matching the tool hooks and the TUI path. This also fixes harness/lsp and harness/confirm from on-prompt under -p.

Adds docs/plugins.md coverage, plugins/call_tool_example.janet, refusal and flatten unit tests, and Janet-level tests that the symbols exist and degrade to nil when the bridge is unwired.