### PR TITLE
Set max_tokens on non-reasoning Anthropic requests (#816)

### DIFF
--- a/src/agent/agent_loop/h7_smoke.rs
+++ b/src/agent/agent_loop/h7_smoke.rs
@@ -332,6 +332,7 @@ async fn h7_scenario_1_simple_text() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -434,6 +435,7 @@ async fn h7_scenario_2_turn_boundaries() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -570,6 +572,7 @@ async fn h7_scenario_5_auth_error_surfaces() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -759,6 +762,7 @@ async fn h7_scenario_3_tool_dispatch() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -909,6 +913,7 @@ async fn h7_glm_scenario_1_simple_text() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -1067,6 +1072,7 @@ async fn h7_glm_scenario_3_tool_dispatch() {
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     };
@@ -1177,6 +1183,7 @@ fn cerebras_spawn_config(
         goal: None,
         max_turns: None,
         reasoning: None,
+        max_tokens: None,
         bg_store: None,
         memory_provider: None,
     }

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -526,6 +526,15 @@ pub struct LoopSpawnConfig {
     /// default (`ThinkingLevel::Off`).
     pub reasoning: Option<super::types::ThinkingLevel>,
 
+    /// GH #816: `max_tokens` to pin on non-reasoning requests — the user's
+    /// explicitly configured cap, or dirge's default only for Anthropic
+    /// model ids rig has no per-model default for. Seeded from the agent
+    /// and forwarded to `LoopConfig.max_tokens` — the field the stream
+    /// builder reads per turn so non-reasoning Anthropic requests carry the
+    /// `max_tokens` rig 0.41 requires. `None` leaves requests unset so the
+    /// provider's own default applies (rig-recognised ids; tests).
+    pub max_tokens: Option<u64>,
+
     /// dirge-9tfq: per-session background-task store. When `Some`,
     /// `spawn_loop_runner` installs a `get_followup_messages` hook
     /// that drains the store's pending notifications at every
@@ -595,6 +604,7 @@ impl LoopSpawnConfig {
             goal: None,
             max_turns: None,
             reasoning: None,
+            max_tokens: None,
             bg_store: None,
             memory_provider: None,
         }
@@ -645,6 +655,7 @@ pub fn spawn_loop_runner(cfg: LoopSpawnConfig) -> LoopRunner {
         }),
         reasoning: cfg.reasoning,
         thinking_budgets: None,
+        max_tokens: cfg.max_tokens,
         headers: std::collections::HashMap::new(),
         metadata: std::collections::HashMap::new(),
         provider_name: cfg.provider_name.clone(),

--- a/src/agent/agent_loop/integration_tests.rs
+++ b/src/agent/agent_loop/integration_tests.rs
@@ -62,6 +62,7 @@ fn build_config() -> LoopConfig {
         should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
+        max_tokens: None,
         headers: std::collections::HashMap::new(),
         metadata: std::collections::HashMap::new(),
         provider_name: None,

--- a/src/agent/agent_loop/plugin_hooks_tests.rs
+++ b/src/agent/agent_loop/plugin_hooks_tests.rs
@@ -80,6 +80,7 @@ fn build_config() -> LoopConfig {
         should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
+        max_tokens: None,
         headers: std::collections::HashMap::new(),
         metadata: std::collections::HashMap::new(),
         provider_name: None,

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -312,19 +312,12 @@ where
         if let Some(v) = additional {
             builder = builder.additional_params(v);
         }
-        // Pin `max_tokens` whenever a thinking BUDGET is on the wire. Anthropic
-        // counts thinking against max_tokens and rejects the request unless
-        // budget_tokens is strictly below it — and if we leave max_tokens unset
-        // rig picks 2048 for any model id it doesn't recognise, which is every
-        // Claude 5 id. That combination 400s every turn above `minimal`.
-        if let Some(level) = opts.reasoning
-            && let Some(ceiling) = crate::provider::adapter::max_tokens_for_reasoning(
-                provider,
-                level,
-                opts.thinking_budgets.as_ref(),
-            )
-        {
-            builder = builder.max_tokens(ceiling);
+        // Pin `max_tokens` when this request needs one — the reasoning
+        // ceiling on thinking turns, the resolved `max_tokens` config on
+        // non-reasoning Anthropic turns (GH #816). The rules live in
+        // `request_max_tokens`.
+        if let Some(max_tokens) = request_max_tokens(provider, &opts) {
+            builder = builder.max_tokens(max_tokens);
         }
         let request = builder.build();
 
@@ -1168,6 +1161,47 @@ pub fn turn_reasoning_enabled(
     opts: &super::stream::StreamOptions,
 ) -> bool {
     reasoning_params(provider_name, opts).is_some()
+}
+
+/// The `max_tokens` to pin on this request, or `None` to leave the field
+/// unset (the provider's own default applies).
+///
+/// Two independent reasons to set one:
+///   - A turn that puts a thinking BUDGET on the wire carries the reasoning
+///     ceiling. Anthropic counts thinking against `max_tokens` and rejects
+///     the request unless `budget_tokens` is strictly below it — and if we
+///     leave `max_tokens` unset rig picks 2048 for any model id it doesn't
+///     recognise, which is every Claude 5 id. That combination 400s every
+///     turn above `minimal`. The ceiling always wins over the configured
+///     value: a user-configured 8192 must never undercut a 16384+ budget.
+///   - A NON-reasoning turn on an Anthropic-shaped provider carries the
+///     resolved `max_tokens` config (GH #816). rig 0.41 hard-errors with
+///     "`max_tokens` must be set for Anthropic" when the request has none
+///     and the model id is one it has no default for — again every Claude 5
+///     id — so with reasoning off every request failed before the HTTP call.
+///
+/// Every other case stays unset, byte-identical to before: effort-string
+/// providers send no budget, their backends accept an absent `max_tokens`,
+/// and forcing a cap on a reasoning turn there could strangle reasoning
+/// output (OpenAI counts reasoning tokens against the output limit).
+fn request_max_tokens(provider: Option<&str>, opts: &super::stream::StreamOptions) -> Option<u64> {
+    if let Some(level) = opts.reasoning
+        && let Some(ceiling) = crate::provider::adapter::max_tokens_for_reasoning(
+            provider,
+            level,
+            opts.thinking_budgets.as_ref(),
+        )
+    {
+        return Some(ceiling);
+    }
+    let anthropic_shaped = matches!(
+        crate::provider::adapter::reasoning_profile(provider).effort,
+        crate::provider::adapter::EffortWire::AnthropicBudget
+    );
+    if anthropic_shaped && !turn_reasoning_enabled(provider, opts) {
+        return opts.max_tokens;
+    }
+    None
 }
 
 /// Say so, once per process, when a request-override knob is set but has no
@@ -2334,6 +2368,90 @@ mod tests {
         let mut o = StreamOptions::from_signal(AbortSignal::new());
         o.reasoning = Some(level);
         o
+    }
+
+    // ============================================================
+    // request_max_tokens (GH #816)
+    // ============================================================
+
+    /// GH #816: with reasoning off, an Anthropic request must still carry
+    /// the resolved `max_tokens` — rig 0.41 hard-errors ("`max_tokens` must
+    /// be set for Anthropic") before the HTTP call when the field is unset
+    /// and the model id is one it has no default for (every Claude 5 id).
+    #[test]
+    fn non_reasoning_anthropic_request_carries_configured_max_tokens() {
+        let mut o = StreamOptions::from_signal(AbortSignal::new());
+        o.max_tokens = Some(8192);
+        assert_eq!(request_max_tokens(Some("anthropic"), &o), Some(8192));
+    }
+
+    /// `Some(Off)` puts no thinking params on the wire, so it is a
+    /// non-reasoning turn and gets the configured value too.
+    #[test]
+    fn reasoning_off_level_anthropic_request_carries_configured_max_tokens() {
+        let mut o = opts_with_reasoning(ThinkingLevel::Off);
+        o.max_tokens = Some(8192);
+        assert_eq!(request_max_tokens(Some("anthropic"), &o), Some(8192));
+    }
+
+    /// A reasoning turn keeps the budget ceiling, NOT the configured value:
+    /// Anthropic requires `budget_tokens` strictly below `max_tokens`, so a
+    /// configured 8192 must never undercut a level's budget + headroom
+    /// (the invariant `anthropic_ceiling_clears_every_budget` pins).
+    #[test]
+    fn reasoning_anthropic_request_keeps_ceiling_over_configured_value() {
+        let mut o = opts_with_reasoning(ThinkingLevel::High);
+        o.max_tokens = Some(8192);
+        let expected = crate::provider::adapter::max_tokens_for_reasoning(
+            Some("anthropic"),
+            ThinkingLevel::High,
+            None,
+        )
+        .expect("high puts a budget on the wire");
+        assert_eq!(request_max_tokens(Some("anthropic"), &o), Some(expected));
+        assert!(
+            expected > 8192,
+            "the ceiling must clear the configured value for this test to bite",
+        );
+    }
+
+    /// No resolved config (tests, paths built without one) leaves the
+    /// request unset — byte-identical to the pre-fix behaviour.
+    #[test]
+    fn non_reasoning_anthropic_request_without_config_stays_unset() {
+        let o = StreamOptions::from_signal(AbortSignal::new());
+        assert_eq!(request_max_tokens(Some("anthropic"), &o), None);
+    }
+
+    /// Effort-string providers never had a cap forced on them and still
+    /// don't — their backends accept an absent `max_tokens`, and capping an
+    /// OpenAI reasoning turn could strangle output (reasoning tokens count
+    /// against the output limit there).
+    #[test]
+    fn other_providers_stay_uncapped_with_and_without_reasoning() {
+        for provider in [
+            "openai",
+            "deepseek",
+            "glm",
+            "cerebras",
+            "custom",
+            "openrouter",
+        ] {
+            let mut off = StreamOptions::from_signal(AbortSignal::new());
+            off.max_tokens = Some(8192);
+            assert_eq!(
+                request_max_tokens(Some(provider), &off),
+                None,
+                "{provider}: non-reasoning turn must stay uncapped",
+            );
+            let mut on = opts_with_reasoning(ThinkingLevel::High);
+            on.max_tokens = Some(8192);
+            assert_eq!(
+                request_max_tokens(Some(provider), &on),
+                None,
+                "{provider}: reasoning turn must stay uncapped",
+            );
+        }
     }
 
     /// Anthropic gets `thinking: { type: "enabled", budget_tokens

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -112,6 +112,7 @@ fn build_config() -> LoopConfig {
         should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
+        max_tokens: None,
         headers: std::collections::HashMap::new(),
         metadata: std::collections::HashMap::new(),
         provider_name: None,

--- a/src/agent/agent_loop/steering.rs
+++ b/src/agent/agent_loop/steering.rs
@@ -362,6 +362,7 @@ mod tests {
             should_defer_finalization: None,
             reasoning: None,
             thinking_budgets: None,
+            max_tokens: None,
             headers: std::collections::HashMap::new(),
             metadata: std::collections::HashMap::new(),
             provider_name: None,

--- a/src/agent/agent_loop/stream.rs
+++ b/src/agent/agent_loop/stream.rs
@@ -98,6 +98,13 @@ pub struct StreamOptions {
     pub api_key: Option<String>,
     pub reasoning: Option<super::types::ThinkingLevel>,
     pub thinking_budgets: Option<super::types::ThinkingBudgets>,
+    /// GH #816: `max_tokens` to pin on non-reasoning requests — the user's
+    /// explicitly configured cap, or dirge's default only for Anthropic
+    /// model ids rig has no per-model default for. Applied on providers
+    /// that require the field (Anthropic). `None` leaves the request field
+    /// unset so the provider's own (often larger) per-model default
+    /// applies — kept by tests and by any path with nothing configured.
+    pub max_tokens: Option<u64>,
     pub headers: std::collections::HashMap<String, String>,
     pub metadata: std::collections::HashMap<String, serde_json::Value>,
     /// dirge-e31n.6: per-request tool gating. `None` sends nothing and leaves
@@ -116,6 +123,7 @@ impl StreamOptions {
             api_key: None,
             reasoning: None,
             thinking_budgets: None,
+            max_tokens: None,
             headers: std::collections::HashMap::new(),
             metadata: std::collections::HashMap::new(),
             tool_choice: None,
@@ -204,6 +212,7 @@ pub async fn stream_assistant_response(
         api_key: resolved_api_key,
         reasoning: config.reasoning,
         thinking_budgets: config.thinking_budgets.clone(),
+        max_tokens: config.max_tokens,
         headers: config.headers.clone(),
         metadata: config.metadata.clone(),
         tool_choice,
@@ -581,6 +590,7 @@ mod tests {
             high: Some(8192),
             ..Default::default()
         });
+        config.max_tokens = Some(4096);
         config
             .headers
             .insert("X-Test".to_string(), "yes".to_string());
@@ -605,6 +615,7 @@ mod tests {
             opts.thinking_budgets.as_ref().and_then(|b| b.high),
             Some(8192)
         );
+        assert_eq!(opts.max_tokens, Some(4096));
         assert_eq!(opts.headers.get("X-Test").map(String::as_str), Some("yes"));
         assert_eq!(
             opts.metadata.get("user_id"),

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -212,6 +212,7 @@ fn build_config() -> LoopConfig {
         should_defer_finalization: None,
         reasoning: None,
         thinking_budgets: None,
+        max_tokens: None,
         headers: std::collections::HashMap::new(),
         metadata: std::collections::HashMap::new(),
         provider_name: None,

--- a/src/agent/agent_loop/trace.rs
+++ b/src/agent/agent_loop/trace.rs
@@ -472,13 +472,25 @@ mod tests {
 
     /// The one path every test in this module shares, since the sink is set
     /// once per process.
+    ///
+    /// The name carries the PID as well as the run stamp. `traced` selects
+    /// records by sequence number, and `SEQ` is a process-global counter that
+    /// starts at zero in every process — so the filter is only sound while a
+    /// file belongs to one process. Under a process-per-test runner the run
+    /// stamp alone is not enough to guarantee that: it is a `SystemTime`
+    /// reading taken as each process starts, and two processes launched in the
+    /// same clock tick read the same value, land on the same file, and then
+    /// read each other's records back through overlapping sequence ranges.
+    /// That surfaced as a macOS CI failure where `recs[0]` was another test's
+    /// record. The PID makes the file private to the process that writes it.
     fn sink_path() -> std::path::PathBuf {
         static FIRST: OnceLock<std::path::PathBuf> = OnceLock::new();
         FIRST
             .get_or_init(|| {
                 std::env::temp_dir().join(format!(
-                    "dirge-trace-test-{}.jsonl",
-                    crate::text::test_run_stamp()
+                    "dirge-trace-test-{}-{}.jsonl",
+                    crate::text::test_run_stamp(),
+                    std::process::id()
                 ))
             })
             .clone()

--- a/src/agent/agent_loop/types.rs
+++ b/src/agent/agent_loop/types.rs
@@ -480,6 +480,15 @@ pub struct LoopConfig {
     /// Port of pi `SimpleStreamOptions.thinkingBudgets?`
     /// (types.ts:195).
     pub thinking_budgets: Option<ThinkingBudgets>,
+    /// GH #816: `max_tokens` to pin on non-reasoning requests — the user's
+    /// explicitly configured cap, or dirge's default only for Anthropic
+    /// model ids rig has no per-model default for. Seeded from the agent at
+    /// spawn time and forwarded to `StreamOptions.max_tokens` per call. The
+    /// stream factory applies it to non-reasoning requests on providers
+    /// that require the field (Anthropic); a reasoning turn's budget
+    /// ceiling always wins over it. `None` leaves the request field unset
+    /// so the provider's own default applies.
+    pub max_tokens: Option<u64>,
     /// Custom HTTP headers merged with provider defaults. Pi
     /// `StreamOptions.headers?` (types.ts:120). Some rig
     /// providers honor at request build time; others at client
@@ -860,6 +869,7 @@ impl std::fmt::Debug for LoopConfig {
             )
             .field("reasoning", &self.reasoning)
             .field("thinking_budgets", &self.thinking_budgets)
+            .field("max_tokens", &self.max_tokens)
             .field("headers", &self.headers)
             .field("metadata", &self.metadata)
             .field("provider_name", &self.provider_name)
@@ -936,6 +946,7 @@ impl Clone for LoopConfig {
             should_defer_finalization: self.should_defer_finalization.clone(),
             reasoning: self.reasoning,
             thinking_budgets: self.thinking_budgets.clone(),
+            max_tokens: self.max_tokens,
             headers: self.headers.clone(),
             metadata: self.metadata.clone(),
             provider_name: self.provider_name.clone(),
@@ -1004,6 +1015,7 @@ impl LoopConfig {
             should_defer_finalization: None,
             reasoning: None,
             thinking_budgets: None,
+            max_tokens: None,
             headers: std::collections::HashMap::new(),
             metadata: std::collections::HashMap::new(),
             provider_name: None,

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -707,6 +707,24 @@ pub async fn build_agent(
     // builder; this wires it through the agent_loop path so `run_print`
     // and the interactive flow both honor it.
     agent = agent.with_max_turns(Some(cli.resolve_max_agent_turns(cfg)));
+    // GH #816: with reasoning off nothing else sets `max_tokens` on the
+    // streamed request, and rig 0.41 rejects an Anthropic request without
+    // one before the HTTP call when the model id is outside its per-model
+    // default table — every Claude 5 id. Thread the cap the user explicitly
+    // configured (CLI `--max-tokens` > config `max_tokens`); when nothing
+    // is configured, invent `resolve_max_tokens`'s 8192 default ONLY where
+    // rig has no default of its own. For a recognised id (opus-4.x 128k,
+    // sonnet-4/haiku-4.5 64k) the request stays unset so rig's larger
+    // per-model default keeps applying instead of being silently cut to
+    // 8192 — an unconfigured user must never trade working long outputs
+    // for quiet truncation.
+    let configured_max_tokens = cli.max_tokens.or(cfg.max_tokens);
+    let max_tokens = configured_max_tokens.or_else(|| {
+        agent
+            .anthropic_needs_max_tokens_fallback()
+            .then(|| cli.resolve_max_tokens(cfg))
+    });
+    agent = agent.with_max_tokens(max_tokens);
     // Seed default reasoning effort from the active provider's `effort`
     // config. A live `/effort` override later mutates `agent.reasoning`
     // and the next rebuild re-seeds from config, so this is the config-

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -236,6 +236,19 @@ pub struct AnyAgent {
     ///
     /// [`with_reasoning`]: AnyAgent::with_reasoning
     reasoning: Option<crate::agent::agent_loop::types::ThinkingLevel>,
+    /// GH #816: `max_tokens` to pin on non-reasoning requests. Set by
+    /// `build_agent` via [`with_max_tokens`]: the user's explicitly
+    /// configured cap (CLI `--max-tokens` > config `max_tokens`), or
+    /// dirge's default only when rig has no per-model default for this
+    /// Anthropic model id. Forwarded to `LoopSpawnConfig.max_tokens` at
+    /// spawn time; the stream builder applies it to non-reasoning requests
+    /// on providers that require the field (Anthropic), and a reasoning
+    /// turn's budget ceiling wins over it. `None` (unconfigured on a
+    /// rig-recognised id, non-Anthropic backends, test agents) leaves
+    /// requests unset so rig's own per-model default keeps applying.
+    ///
+    /// [`with_max_tokens`]: AnyAgent::with_max_tokens
+    max_tokens: Option<u64>,
     /// dirge-z73i: alternate stream_fn for the background-review
     /// path. Built at `build_agent` time when `ConfigRole::Review`
     /// resolves to a different provider than `ConfigRole::Default`.
@@ -408,6 +421,7 @@ impl AnyAgent {
             progress_prologue_cap: None,
             max_turns: None,
             reasoning: None,
+            max_tokens: None,
             review_stream_fn: None,
             review_provider_name: None,
             review_model_name: None,
@@ -556,6 +570,39 @@ impl AnyAgent {
     pub fn with_max_turns(mut self, max_turns: Option<usize>) -> Self {
         self.max_turns = max_turns;
         self
+    }
+
+    /// GH #816: install the per-request output cap for non-reasoning
+    /// Anthropic turns. `build_agent` passes the user's explicitly
+    /// configured `max_tokens` (CLI > config), or dirge's default only when
+    /// [`anthropic_needs_max_tokens_fallback`] says rig has no per-model
+    /// default of its own. Forwarded to `LoopSpawnConfig.max_tokens` at
+    /// spawn time. `None` leaves requests unset so rig's own per-model
+    /// default keeps applying.
+    ///
+    /// [`anthropic_needs_max_tokens_fallback`]: AnyAgent::anthropic_needs_max_tokens_fallback
+    pub fn with_max_tokens(mut self, max_tokens: Option<u64>) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Whether dirge must invent a `max_tokens` for this agent's requests
+    /// because rig itself has none (GH #816). True only for the Anthropic
+    /// variants whose model id is outside rig's per-model default table
+    /// (`default_max_tokens_for_model` — every Claude 5 id as of rig 0.41):
+    /// those requests hard-error before the HTTP call unless a value is
+    /// pinned. For a recognised id rig fills its own, larger per-model
+    /// default (64k/128k), which an invented fallback must never silently
+    /// undercut; and non-Anthropic backends accept an absent `max_tokens`,
+    /// so they never need one invented. Reading rig's resolved
+    /// `default_max_tokens` off the model keeps this exact without
+    /// duplicating rig's model-prefix list, which would drift.
+    pub(crate) fn anthropic_needs_max_tokens_fallback(&self) -> bool {
+        match &self.inner {
+            AnyAgentInner::Anthropic(model) => model.default_max_tokens.is_none(),
+            AnyAgentInner::AnthropicOauth(model) => model.default_max_tokens.is_none(),
+            _ => false,
+        }
     }
 
     /// Install / replace the agent's default reasoning effort. `None`

--- a/src/provider/mod_tests.rs
+++ b/src/provider/mod_tests.rs
@@ -461,6 +461,154 @@ async fn any_model_filtered_stream_fn_hides_unloaded_dynamic_tools() {
     assert!(!tool_names.contains(&"mcp_hidden"));
 }
 
+// ============================================================
+// GH #816: max_tokens fallback decision + no-config wire pin
+// ============================================================
+
+mod max_tokens_816_tests {
+    use super::*;
+    use crate::agent::agent_loop::stream::{LlmContext, StreamOptions};
+    use crate::agent::agent_loop::tool::AbortSignal;
+    use futures::StreamExt;
+    use rig::client::CompletionClient;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Offline Anthropic `AnyAgent` for the given model id — mirrors
+    /// `build_openai_any_agent` (no network until the first request).
+    fn build_anthropic_any_agent(model_id: &str) -> AnyAgent {
+        let client = rig::providers::anthropic::Client::builder()
+            .api_key("test-key")
+            .http_client(crate::provider::compressing_http::CompressingHttpClient::default())
+            .build()
+            .expect("anthropic client builds offline");
+        AnyAgent::new(
+            AnyAgentInner::Anthropic(client.completion_model(model_id)),
+            ToolCache::new(),
+            std::time::Duration::from_secs(300),
+            Vec::new(),
+            String::new(),
+            model_id.to_string(),
+        )
+    }
+
+    /// A rig-recognised Anthropic id has a per-model default (64k/128k), so
+    /// dirge must NOT invent one: an unconfigured user keeps rig's larger
+    /// cap instead of a silent cut to 8192.
+    #[test]
+    fn recognized_anthropic_ids_need_no_fallback() {
+        for id in ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"] {
+            assert!(
+                !build_anthropic_any_agent(id).anthropic_needs_max_tokens_fallback(),
+                "{id}: rig has its own default — dirge must not invent one",
+            );
+        }
+    }
+
+    /// An id outside rig's table (every Claude 5 id) hard-errors without a
+    /// value, so dirge must supply one.
+    #[test]
+    fn unrecognized_anthropic_id_needs_fallback() {
+        assert!(build_anthropic_any_agent("claude-opus-5").anthropic_needs_max_tokens_fallback());
+    }
+
+    /// Non-Anthropic backends accept an absent `max_tokens`; no fallback.
+    #[test]
+    fn non_anthropic_agent_needs_no_fallback() {
+        assert!(!build_openai_any_agent().anthropic_needs_max_tokens_fallback());
+    }
+
+    /// The no-config regression pin, at the wire: an UNCONFIGURED
+    /// (`StreamOptions.max_tokens = None`) non-reasoning request on a
+    /// rig-recognised Anthropic id must carry rig's own per-model default —
+    /// read off the model, not hardcoded — and must NOT be capped at 8192.
+    #[tokio::test]
+    async fn unconfigured_recognized_anthropic_request_keeps_rigs_default() {
+        fn header_end(buf: &[u8]) -> Option<usize> {
+            buf.windows(4).position(|window| window == b"\r\n\r\n")
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (body_tx, body_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            let body_start = loop {
+                let mut chunk = [0u8; 1024];
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "client closed before sending request headers");
+                buf.extend_from_slice(&chunk[..read]);
+                if let Some(end) = header_end(&buf) {
+                    break end + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&buf[..body_start]);
+            let content_length = headers
+                .lines()
+                .filter_map(|line| line.split_once(':'))
+                .find_map(|(name, value)| {
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap();
+            while buf.len() < body_start + content_length {
+                let mut chunk = [0u8; 1024];
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "client closed before sending full request body");
+                buf.extend_from_slice(&chunk[..read]);
+            }
+            let body = serde_json::from_slice::<serde_json::Value>(
+                &buf[body_start..body_start + content_length],
+            )
+            .unwrap();
+            body_tx.send(body).ok();
+            socket
+                .write_all(
+                    b"HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = rig::providers::anthropic::Client::builder()
+            .api_key("test-key")
+            .base_url(&base_url)
+            .http_client(crate::provider::compressing_http::CompressingHttpClient::default())
+            .build()
+            .unwrap();
+        let model = client.completion_model("claude-opus-4-6");
+        let expected = model
+            .default_max_tokens
+            .expect("rig must recognise claude-opus-4-6");
+        let stream_fn = AnyModel::Anthropic(model).build_stream_fn(
+            vec![],
+            std::time::Duration::from_secs(5),
+            Some("anthropic".to_string()),
+        );
+        // Unconfigured: `from_signal` leaves `max_tokens: None` and
+        // `reasoning: None` — the exact shape of an untouched config.
+        let mut stream = stream_fn(
+            LlmContext {
+                system_prompt: String::new(),
+                messages: vec![serde_json::json!({"role": "user", "content": "hi"})],
+                asset_dir: None,
+            },
+            StreamOptions::from_signal(AbortSignal::new()),
+        );
+        while stream.next().await.is_some() {}
+
+        let body = body_rx.await.unwrap();
+        server.await.unwrap();
+        let wire = body["max_tokens"].as_u64().expect("max_tokens on the wire");
+        assert_eq!(
+            wire, expected,
+            "unconfigured request must keep rig's per-model default",
+        );
+        assert_ne!(wire, 8192, "must not be silently cut to dirge's default");
+    }
+}
+
 mod cerebras_alias_stream_tests {
     use crate::agent::agent_loop::stream::{LlmContext, StreamOptions};
     use crate::agent::agent_loop::tool::AbortSignal;

--- a/src/provider/spawn.rs
+++ b/src/provider/spawn.rs
@@ -302,6 +302,9 @@ impl AnyAgent {
         // the loop default (`Off`). A `/effort` live override mutates
         // `self.reasoning` before the next spawn, so this picks it up.
         cfg.reasoning = self.reasoning;
+        // GH #816: forward the resolved `max_tokens` so non-reasoning
+        // Anthropic requests carry the field rig 0.41 requires.
+        cfg.max_tokens = self.max_tokens;
         // dirge-9tfq: forward the BackgroundStore so the spawn pipeline
         // installs a `get_followup_messages` hook that drains pending
         // subagent completions at the outer-loop boundary. `None`
@@ -520,6 +523,9 @@ impl AnyAgent {
         // who configures `effort` gets it on the main turn only, and every
         // review/critic/curator pass silently runs with reasoning off.
         cfg.reasoning = self.reasoning;
+        // GH #816: forward the resolved `max_tokens` so non-reasoning
+        // Anthropic requests carry the field rig 0.41 requires.
+        cfg.max_tokens = self.max_tokens;
 
         let loop_runner = spawn_loop_runner(cfg);
         (loop_runner.into_agent_runner(), review_cache)
@@ -560,6 +566,9 @@ impl AnyAgent {
         cfg.tools = tools;
         cfg.provider_name = Some(provider);
         cfg.reasoning = self.reasoning;
+        // GH #816: forward the resolved `max_tokens` so non-reasoning
+        // Anthropic requests carry the field rig 0.41 requires.
+        cfg.max_tokens = self.max_tokens;
         cfg.model_name = match model_override {
             Some(model) => Some(model.name()),
             None => Self::model_name_opt(&self.model_name),


### PR DESCRIPTION
Fixes #816.

## Problem

With reasoning off, an Anthropic request carries no `max_tokens` and fails before the HTTP call:

```
Error: rig stream call failed: RequestError: `max_tokens` must be set for Anthropic
```

Reproduced 3/3 on v0.25.0 with `{"provider_type":"anthropic","model":"claude-opus-5","auth":"claude-code","effort":"off"}`, and via `/model claude-opus-5` interactively.

## Root cause

`rig_stream_factory.rs` set `max_tokens` on the per-request builder only from the reasoning-ceiling branch, so with reasoning off nothing set it. rig's Anthropic model then falls back to `default_max_tokens_for_model()`, which recognizes only `claude-opus-4*` / `claude-sonnet-4*` / `claude-haiku-4-5*` — every Claude 5 id yields `None` and the request is rejected.

The streaming path never carried the agent's `max_tokens`: `build_agent` sets it on the `AgentBuilder`, but since 0.41 `AnyAgentInner` stores the model directly rather than a rig `Agent`, and the per-request builder is constructed independently. rig's per-model default was papering over the gap for recognized ids.

## Fix

Thread the resolved cap along the same path `reasoning` already travels — no factory signature changes — into a small pure helper:

```rust
fn request_max_tokens(provider: Option<&str>, opts: &StreamOptions) -> Option<u64> {
    if let Some(level) = opts.reasoning
        && let Some(ceiling) = adapter::max_tokens_for_reasoning(provider, level, opts.thinking_budgets.as_ref())
    { return Some(ceiling); }                       // reasoning ceiling still wins
    let anthropic_shaped = matches!(adapter::reasoning_profile(provider).effort, EffortWire::AnthropicBudget);
    if anthropic_shaped && !turn_reasoning_enabled(provider, opts) {
        return opts.max_tokens;
    }
    None                                            // every other provider unchanged
}
```

The reasoning ceiling short-circuits first, so the `budget_tokens < max_tokens` invariant from v0.24.1 is untouched (`anthropic_ceiling_clears_every_budget` still passes; `adapter.rs` is not modified). Gating on `turn_reasoning_enabled` means an OpenAI `effort: high` turn — which produces no ceiling — is not capped, and gating on `EffortWire::AnthropicBudget` keeps every non-Anthropic provider byte-identical.

## Not lowering existing defaults

A first cut used `resolve_max_tokens` unconditionally, whose `unwrap_or(8192)` erased the difference between "user chose 8192" and "nobody said". That would have cut unconfigured `claude-opus-4-6` from rig's 128,000 to 8,192 — silent truncation for users who never hit the bug. Instead a value is invented **only where rig has none**, decided by reading rig's own resolved default off the stored model:

```rust
let configured_max_tokens = cli.max_tokens.or(cfg.max_tokens);
let max_tokens = configured_max_tokens
    .or_else(|| agent.anthropic_needs_max_tokens_fallback().then(|| cli.resolve_max_tokens(cfg)));
```

No model-prefix list is duplicated in dirge, so this tracks rig with no drift. Unconfigured recognized ids keep rig's exact per-model values; an explicitly configured cap is honored (the `max_tokens` config key and `--max-tokens` flag reach the streaming path for the first time).

## Tests

4 new in `provider::tests::max_tokens_816_tests`, including a wire-level pin that stands a local capture server up and asserts an unconfigured non-reasoning request for `claude-opus-4-6` carries rig's own default (read off the model, not hardcoded) and **not** 8192. Plus 5 in `rig_stream_factory.rs` covering the helper across providers and reasoning states, and an extended propagation assertion in `stream.rs`.

Full suite: **5414 passed, 0 failed, 1 ignored**. `clippy --all-targets -- -D warnings` clean, `fmt --check` clean.

End-to-end: the failing repro above now completes normally.

## Disclosures / known adjacent cases

- Build, clippy and tests were run with `--no-default-features --features no-plugin` — the `plugin` feature's janet toolchain is unavailable on this host (#712). The single `max_tokens: None,` literal added to `plugin_hooks_tests.rs` is therefore verified only by CI with default features.
- **Escalation/review edge:** the value is computed once per agent from the main model. An escalation or review route to a *different* Anthropic model shares it, so a Claude-5 escalation model behind a recognized-id main model could still hit the original error. Per-model threading would widen the diff considerably — left out of scope deliberately.
- **`dispatch.rs` `one_shot!` / `btw_query`** builds an `AgentBuilder` with no `max_tokens`, so one-shot side calls on unrecognized Anthropic ids have the same latent failure. Not addressed here.
