### PR TITLE
Echo Anthropic thinking-block signatures on replay (#821)

### DIFF
--- a/src/agent/agent_loop/bridge.rs
+++ b/src/agent/agent_loop/bridge.rs
@@ -447,7 +447,7 @@ impl EventBridge {
                             .content
                             .iter()
                             .filter_map(|b| match b {
-                                ContentBlock::Thinking { text } => Some(text.as_str()),
+                                ContentBlock::Thinking { text, .. } => Some(text.as_str()),
                                 _ => None,
                             })
                             .collect::<Vec<_>>()

--- a/src/agent/agent_loop/bridge_tests.rs
+++ b/src/agent/agent_loop/bridge_tests.rs
@@ -20,6 +20,8 @@ fn assistant_with_thinking(s: &str) -> AssistantMessage {
     AssistantMessage::new(
         vec![ContentBlock::Thinking {
             text: s.to_string(),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::Stop,
     )
@@ -287,6 +289,8 @@ fn text_and_reasoning_tracked_independently() {
         message: AssistantMessage::new(
             vec![ContentBlock::Thinking {
                 text: "thinking".to_string(),
+                signature: None,
+                signature_model: None,
             }],
             StopReason::Stop,
         ),
@@ -298,6 +302,8 @@ fn text_and_reasoning_tracked_independently() {
             vec![
                 ContentBlock::Thinking {
                     text: "thinking".to_string(),
+                    signature: None,
+                    signature_model: None,
                 },
                 ContentBlock::Text {
                     text: "answer".to_string(),

--- a/src/agent/agent_loop/call_syntax.rs
+++ b/src/agent/agent_loop/call_syntax.rs
@@ -990,13 +990,15 @@ mod tests {
         let msg = super::super::message::AssistantMessage::new(
             vec![ContentBlock::Thinking {
                 text: thought.to_string(),
+                signature: None,
+                signature_model: None,
             }],
             super::super::message::StopReason::ToolUse,
         );
         let out = absorb_text_calls(&msg, &[call("scav-1", "bash")], &tools(&["bash"]));
         match out.content.as_slice() {
             [
-                ContentBlock::Thinking { text },
+                ContentBlock::Thinking { text, .. },
                 ContentBlock::ToolCall { .. },
             ] => {
                 assert_eq!(text, thought)

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -278,7 +278,11 @@ pub fn rig_message_to_loop_messages(m: rig::completion::Message) -> Vec<LoopMess
                             })
                             .collect::<Vec<_>>()
                             .join("\n");
-                        blocks.push(ContentBlock::Thinking { text });
+                        blocks.push(ContentBlock::Thinking {
+                            text,
+                            signature: None,
+                            signature_model: None,
+                        });
                     }
                     AssistantContent::Image(_) => {}
                 }

--- a/src/agent/agent_loop/message.rs
+++ b/src/agent/agent_loop/message.rs
@@ -58,6 +58,30 @@ pub enum ContentBlock {
     },
     Thinking {
         text: String,
+        /// Provider-issued cryptographic signature over the thinking text
+        /// (GH #821). Anthropic mints one per thinking block and requires
+        /// it echoed back verbatim when the block is replayed — a thinking
+        /// block without it is schema-rejected (`signature: Field
+        /// required`). `None` for providers that don't sign reasoning and
+        /// for blocks captured before this field existed; both serde
+        /// attributes keep the serialized shape byte-identical to the
+        /// legacy `{type, text}` form in that case, so existing saved
+        /// sessions round-trip unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+        /// The model that minted `signature` (GH #821). A signature is
+        /// only valid for the model that produced it — replaying it to a
+        /// different model is rejected (`Invalid signature in thinking
+        /// block`) — and dirge can switch models mid-session (`/model`,
+        /// escalation, subagents), so the replay path attaches the
+        /// signature only when this matches the request's model, and
+        /// drops the block otherwise.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "signatureModel"
+        )]
+        signature_model: Option<String>,
     },
     ToolCall {
         id: String,
@@ -777,6 +801,54 @@ impl LoopEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// GH #821 back-compat pin: `ContentBlock` is serde-serialized into
+    /// session storage, so the `Thinking` variant's new optional
+    /// signature fields must (a) deserialize legacy JSON that has no
+    /// such keys, and (b) serialize back to EXACTLY that legacy shape
+    /// when they are `None` — otherwise every saved session written
+    /// before (or without) the fields breaks on upgrade.
+    #[test]
+    fn legacy_thinking_block_json_round_trips_unchanged() {
+        let legacy = r#"{"type":"thinking","text":"pondering"}"#;
+        let block: ContentBlock = serde_json::from_str(legacy).expect("legacy JSON must parse");
+        assert_eq!(
+            block,
+            ContentBlock::Thinking {
+                text: "pondering".to_string(),
+                signature: None,
+                signature_model: None,
+            }
+        );
+        let reserialized = serde_json::to_string(&block).expect("must serialize");
+        assert_eq!(
+            reserialized, legacy,
+            "None signature fields must be omitted so the wire shape is byte-identical to pre-#821"
+        );
+    }
+
+    /// GH #821: a signed block round-trips both new fields (camelCase
+    /// `signatureModel`, matching the transcript key convention).
+    #[test]
+    fn signed_thinking_block_round_trips_signature_fields() {
+        let block = ContentBlock::Thinking {
+            text: "pondering".to_string(),
+            signature: Some("sig-abc".to_string()),
+            signature_model: Some("claude-opus-4-6".to_string()),
+        };
+        let json = serde_json::to_value(&block).expect("must serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "thinking",
+                "text": "pondering",
+                "signature": "sig-abc",
+                "signatureModel": "claude-opus-4-6",
+            })
+        );
+        let back: ContentBlock = serde_json::from_value(json).expect("must deserialize");
+        assert_eq!(back, block);
+    }
 
     /// `DeltaPhase::is_content()` is the single source of truth for
     /// "has downstream output already been emitted?" — it gates both

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -360,7 +360,7 @@ where
                     let over_budget = reasoning_meter.record(&reasoning);
                     match current_thinking_idx {
                         Some(idx) => {
-                            if let Some(ContentBlock::Thinking { text }) =
+                            if let Some(ContentBlock::Thinking { text, .. }) =
                                 partial.content.get_mut(idx)
                             {
                                 text.push_str(&reasoning);
@@ -372,7 +372,11 @@ where
                         }
                         None => {
                             current_thinking_idx = Some(partial.content.len());
-                            partial.content.push(ContentBlock::Thinking { text: reasoning });
+                            partial.content.push(ContentBlock::Thinking {
+                                text: reasoning,
+                                signature: None,
+                                signature_model: None,
+                            });
                             current_text_idx = None;
                             yield StreamEvent::Delta {
                                 partial: partial.clone(),
@@ -420,6 +424,19 @@ where
                         })
                         .collect::<Vec<_>>()
                         .join("\n");
+                    // GH #821: capture the provider-issued signature the
+                    // complete block carries (Anthropic sends it via a
+                    // `signature_delta` that rig folds into the final
+                    // `ReasoningContent::Text`). It must be echoed back
+                    // verbatim when the block is replayed, so dropping it
+                    // here — the old `Text { text, .. }` did — 400s the
+                    // first tool-use continuation with reasoning on.
+                    let signature: Option<String> = r.content.iter().find_map(|c| match c {
+                        rig::completion::message::ReasoningContent::Text {
+                            signature, ..
+                        } => signature.clone(),
+                        _ => None,
+                    });
                     // dirge-zf35: mirror the H-7 ToolCall dedupe. Some
                     // providers stream `ReasoningDelta`s and THEN send a
                     // complete `Reasoning` for the same content. If a
@@ -444,17 +461,32 @@ where
                                 Some(ContentBlock::Thinking { .. })
                             ) =>
                         {
-                            if let Some(ContentBlock::Thinking { text: acc }) =
-                                partial.content.get_mut(idx)
+                            if let Some(ContentBlock::Thinking {
+                                text: acc,
+                                signature: acc_signature,
+                                ..
+                            }) = partial.content.get_mut(idx)
                             {
                                 if acc.is_empty() || text.starts_with(acc.as_str()) {
                                     *acc = text;
                                 } else {
                                     acc.push_str(&text);
                                 }
+                                // GH #821: the fold must carry the signature
+                                // too — in the Anthropic flow the text arrives
+                                // as deltas and the signature ONLY on this
+                                // complete block. Never clobber a previously
+                                // captured signature with `None`.
+                                if signature.is_some() {
+                                    *acc_signature = signature;
+                                }
                             }
                         }
-                        _ => partial.content.push(ContentBlock::Thinking { text }),
+                        _ => partial.content.push(ContentBlock::Thinking {
+                            text,
+                            signature,
+                            signature_model: None,
+                        }),
                     }
                     current_thinking_idx = None;
                     current_text_idx = None;
@@ -1153,7 +1185,7 @@ mod tests {
             .content
             .iter()
             .filter_map(|b| match b {
-                ContentBlock::Thinking { text } => Some(text.clone()),
+                ContentBlock::Thinking { text, .. } => Some(text.clone()),
                 _ => None,
             })
             .collect();
@@ -1207,7 +1239,7 @@ mod tests {
         );
         match events.last().unwrap() {
             StreamEvent::Done { message, .. } => {
-                if let ContentBlock::Thinking { text } = &message.content[0] {
+                if let ContentBlock::Thinking { text, .. } = &message.content[0] {
                     assert_eq!(text, "Let me think about this");
                 } else {
                     panic!("expected thinking");
@@ -1263,7 +1295,7 @@ mod tests {
                     .content
                     .iter()
                     .filter_map(|b| match b {
-                        ContentBlock::Thinking { text } => Some(text),
+                        ContentBlock::Thinking { text, .. } => Some(text),
                         _ => None,
                     })
                     .collect();
@@ -1274,6 +1306,103 @@ mod tests {
                 );
                 assert_eq!(thinking[0], "Let me think about this");
             }
+            _ => panic!("expected Done last"),
+        }
+    }
+
+    /// GH #821: a complete reasoning block's signature must be captured,
+    /// not discarded — Anthropic requires it echoed back verbatim when
+    /// the block is replayed (the tool-use continuation 400s without it).
+    #[tokio::test]
+    async fn complete_reasoning_signature_is_captured() {
+        let raw = raw_stream(vec![Ok(StreamedAssistantContent::Reasoning(
+            Reasoning::new_with_signature("All thinking", Some("sig-821".to_string())),
+        ))]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        match events.last().unwrap() {
+            StreamEvent::Done { message, .. } => match &message.content[0] {
+                ContentBlock::Thinking {
+                    text, signature, ..
+                } => {
+                    assert_eq!(text, "All thinking");
+                    assert_eq!(signature.as_deref(), Some("sig-821"));
+                }
+                other => panic!("expected thinking, got {other:?}"),
+            },
+            _ => panic!("expected Done last"),
+        }
+    }
+
+    /// GH #821 + dirge-zf35: in the Anthropic flow the text arrives as
+    /// `ReasoningDelta`s and the signature ONLY on the trailing complete
+    /// `Reasoning`. The fold that merges the complete block into the open
+    /// delta-built block must carry the signature onto that block.
+    #[tokio::test]
+    async fn signature_survives_the_delta_fold() {
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: "Let me think".to_string(),
+            }),
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: " about this".to_string(),
+            }),
+            Ok(StreamedAssistantContent::Reasoning(
+                Reasoning::new_with_signature(
+                    "Let me think about this",
+                    Some("sig-821".to_string()),
+                ),
+            )),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        match events.last().unwrap() {
+            StreamEvent::Done { message, .. } => {
+                let blocks: Vec<_> = message
+                    .content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Thinking {
+                            text, signature, ..
+                        } => Some((text.as_str(), signature.as_deref())),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(
+                    blocks,
+                    vec![("Let me think about this", Some("sig-821"))],
+                    "fold must keep one block AND adopt the complete block's signature"
+                );
+            }
+            _ => panic!("expected Done last"),
+        }
+    }
+
+    /// GH #821, Gemini shape: when the complete `Reasoning` is only the
+    /// trailing chunk (append path of the dirge-zf35 fold), its signature
+    /// must still land on the accumulated block.
+    #[tokio::test]
+    async fn signature_survives_the_append_fold() {
+        let raw = raw_stream(vec![
+            Ok(StreamedAssistantContent::ReasoningDelta {
+                id: None,
+                reasoning: "chunk A".to_string(),
+            }),
+            Ok(StreamedAssistantContent::Reasoning(
+                Reasoning::new_with_signature("chunk Z", Some("sig-tail".to_string())),
+            )),
+        ]);
+        let events = drain(wrap_streamed_assistant(raw, None, None)).await;
+        match events.last().unwrap() {
+            StreamEvent::Done { message, .. } => match &message.content[0] {
+                ContentBlock::Thinking {
+                    text, signature, ..
+                } => {
+                    assert_eq!(text, "chunk Achunk Z");
+                    assert_eq!(signature.as_deref(), Some("sig-tail"));
+                }
+                other => panic!("expected thinking, got {other:?}"),
+            },
             _ => panic!("expected Done last"),
         }
     }
@@ -1305,7 +1434,7 @@ mod tests {
                     .content
                     .iter()
                     .filter_map(|b| match b {
-                        ContentBlock::Thinking { text } => Some(text),
+                        ContentBlock::Thinking { text, .. } => Some(text),
                         _ => None,
                     })
                     .collect();
@@ -1344,7 +1473,7 @@ mod tests {
                     .content
                     .iter()
                     .filter_map(|b| match b {
-                        ContentBlock::Thinking { text } => Some(text),
+                        ContentBlock::Thinking { text, .. } => Some(text),
                         _ => None,
                     })
                     .collect();
@@ -1413,7 +1542,7 @@ mod tests {
             .content
             .iter()
             .filter_map(|b| match b {
-                ContentBlock::Thinking { text } => Some(text.as_str()),
+                ContentBlock::Thinking { text, .. } => Some(text.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1835,7 +1964,7 @@ mod tests {
         ));
         assert!(matches!(
             &final_msg.content[1],
-            ContentBlock::Thinking { text } if text == "thinking"
+            ContentBlock::Thinking { text, .. } if text == "thinking"
         ));
         assert!(matches!(
             &final_msg.content[2],

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -60,7 +60,7 @@ use rig::completion::message::{
 use rig::completion::{CompletionModel, CompletionRequestBuilder, GetTokenUsage, ToolDefinition};
 use serde_json::Value;
 
-use super::message::StreamEvent;
+use super::message::{ContentBlock, StreamEvent};
 use super::rig_stream::wrap_rig_stream;
 use super::stream::{LlmContext, StreamFn};
 use super::tool::LoopTool;
@@ -215,10 +215,18 @@ where
     Box::pin(async_stream::stream! {
         // 1. Convert our messages to rig messages.
         let provider: Option<&str> = provider_name.as_ref().as_deref();
+        // GH #821: how a stored thinking block replays to THIS request —
+        // Anthropic schema-requires the block's original signature (minted
+        // per model), everyone else keeps the unsigned echo unchanged.
+        let thinking_replay = thinking_replay_for(
+            provider,
+            model_name.as_ref().as_deref(),
+            turn_reasoning_enabled(provider, &opts),
+        );
         let rig_messages: Vec<Message> = ctx
             .messages
             .iter()
-            .filter_map(|message| value_to_rig_message_for_provider(message, provider, ctx.asset_dir.as_deref()))
+            .filter_map(|message| value_to_rig_message_with_thinking_replay(message, provider, thinking_replay, ctx.asset_dir.as_deref()))
             .collect();
 
         // 2. Split: last is prompt; rest is chat_history.
@@ -346,6 +354,13 @@ where
                 );
                 use futures::stream::StreamExt;
                 while let Some(evt) = wrapped.next().await {
+                    // GH #821: a thinking-block signature is only valid for
+                    // the model that minted it, and the capture layer
+                    // (rig_stream) doesn't know which model it is streaming
+                    // from. Stamp it here — the one place that knows — so
+                    // the replay path can tell a same-model echo (attach)
+                    // from a cross-model one (drop).
+                    let evt = stamp_thinking_signature_model(evt, model_name.as_ref().as_deref());
                     yield evt;
                 }
             }
@@ -629,9 +644,29 @@ fn resolve_image(
 /// its tool call — see the call site in `value_to_rig_message_for_provider`.
 pub(crate) const EMPTY_TOOL_RESULT_PLACEHOLDER: &str = "(no output)";
 
+/// Legacy 2-knob entry point, kept so the existing tests (and
+/// `value_to_rig_message`) stay untouched: replays thinking blocks the way
+/// every provider other than Anthropic gets them — unsigned. Production goes
+/// through `value_to_rig_message_with_thinking_replay`, which the factory
+/// calls with the request's model + reasoning state (GH #821).
+#[cfg(test)]
 fn value_to_rig_message_for_provider(
     value: &Value,
     provider_name: Option<&str>,
+    asset_dir: Option<&std::path::Path>,
+) -> Option<Message> {
+    value_to_rig_message_with_thinking_replay(
+        value,
+        provider_name,
+        thinking_replay_for(provider_name, None, false),
+        asset_dir,
+    )
+}
+
+fn value_to_rig_message_with_thinking_replay(
+    value: &Value,
+    provider_name: Option<&str>,
+    thinking_replay: ThinkingReplay<'_>,
     asset_dir: Option<&std::path::Path>,
 ) -> Option<Message> {
     let role = value.get("role").and_then(|r| r.as_str())?;
@@ -682,7 +717,12 @@ fn value_to_rig_message_for_provider(
             let assistant_contents: Vec<AssistantContent> = blocks
                 .iter()
                 .filter_map(|block| {
-                    value_to_assistant_content(block, include_reasoning, synthesize_call_id)
+                    value_to_assistant_content(
+                        block,
+                        include_reasoning,
+                        synthesize_call_id,
+                        thinking_replay,
+                    )
                 })
                 .collect();
             // `OneOrMany::many` errors on empty input; rig
@@ -794,12 +834,88 @@ fn provider_requires_openai_call_ids(provider_name: Option<&str>) -> bool {
     matches!(provider_name, Some(provider) if provider.eq_ignore_ascii_case("openai"))
 }
 
+/// GH #821: how a stored thinking block replays to the current request.
+///
+/// Anthropic signs every thinking block it emits and schema-rejects a
+/// replayed block that lacks the signature (`thinking.signature: Field
+/// required`), so for that backend the choice is attach-or-drop — there is
+/// no unsigned echo. A signature is also only valid for the exact model
+/// that minted it (a foreign one is rejected with `Invalid signature in
+/// thinking block`), and dirge can replay one session's history to a
+/// different model (`/model`, escalation, subagent/review routes), so
+/// attaching is gated on the recorded `signatureModel` matching the
+/// request's model. Every other provider keeps today's unsigned echo,
+/// byte-identical on the wire.
+#[derive(Clone, Copy)]
+enum ThinkingReplay<'a> {
+    /// Replay as an unsigned `Reasoning` block — the pre-#821 behavior,
+    /// unchanged for every non-Anthropic provider.
+    Unsigned,
+    /// Anthropic: attach the stored signature when it was minted by
+    /// `model` and this turn has reasoning enabled; otherwise drop the
+    /// block (an unsigned or foreign-signed block would 400 either way,
+    /// and with reasoning off the echo is not required at all).
+    SignedOrDrop {
+        model: Option<&'a str>,
+        reasoning_enabled: bool,
+    },
+}
+
+/// Pick the [`ThinkingReplay`] policy for one request.
+fn thinking_replay_for<'a>(
+    provider_name: Option<&str>,
+    model: Option<&'a str>,
+    reasoning_enabled: bool,
+) -> ThinkingReplay<'a> {
+    let anthropic =
+        matches!(provider_name, Some(provider) if provider.eq_ignore_ascii_case("anthropic"));
+    if anthropic {
+        ThinkingReplay::SignedOrDrop {
+            model,
+            reasoning_enabled,
+        }
+    } else {
+        ThinkingReplay::Unsigned
+    }
+}
+
+/// GH #821: record which model minted each captured thinking-block
+/// signature. The capture layer (`rig_stream`) sees only the provider's
+/// stream, not the model identity, so the factory — which knows the model
+/// it was built for — stamps it on every event it forwards. Only blocks
+/// that carry a signature and haven't been stamped yet are touched, so
+/// everything else in the message is byte-identical.
+fn stamp_thinking_signature_model(mut evt: StreamEvent, model_name: Option<&str>) -> StreamEvent {
+    let Some(model) = model_name else {
+        return evt;
+    };
+    let message = match &mut evt {
+        StreamEvent::Start { partial } | StreamEvent::Delta { partial, .. } => partial,
+        StreamEvent::Done { message, .. } => message,
+        StreamEvent::Error { .. } | StreamEvent::Retry { .. } => return evt,
+    };
+    for block in &mut message.content {
+        if let ContentBlock::Thinking {
+            signature,
+            signature_model,
+            ..
+        } = block
+            && signature.is_some()
+            && signature_model.is_none()
+        {
+            *signature_model = Some(model.to_string());
+        }
+    }
+    evt
+}
+
 /// Convert one assistant content block to a rig `AssistantContent`.
 /// Recognizes `{type: "text"|"thinking"|"toolCall", ...}`.
 fn value_to_assistant_content(
     block: &Value,
     include_reasoning: bool,
     synthesize_call_id: bool,
+    thinking_replay: ThinkingReplay<'_>,
 ) -> Option<AssistantContent> {
     let obj = block.as_object()?;
     let kind = obj.get("type").and_then(|t| t.as_str())?;
@@ -826,7 +942,35 @@ fn value_to_assistant_content(
                 return None;
             }
             let text = obj.get("text").and_then(|t| t.as_str())?;
-            Some(AssistantContent::Reasoning(Reasoning::new(text)))
+            match thinking_replay {
+                ThinkingReplay::Unsigned => Some(AssistantContent::Reasoning(Reasoning::new(text))),
+                ThinkingReplay::SignedOrDrop {
+                    model,
+                    reasoning_enabled,
+                } => {
+                    // GH #821: attach the block's original signature only
+                    // when this request's model is the one that minted it
+                    // (recorded as `signatureModel` at capture time) and
+                    // reasoning is on this turn. Any other combination —
+                    // no signature (legacy/flattened history), a foreign
+                    // model's signature, or reasoning off — drops the
+                    // block, because Anthropic rejects both an unsigned
+                    // and a foreign-signed thinking block.
+                    let signature = obj.get("signature").and_then(|s| s.as_str());
+                    let signature_model = obj.get("signatureModel").and_then(|s| s.as_str());
+                    match (signature, signature_model, model) {
+                        (Some(signature), Some(minted_by), Some(current))
+                            if reasoning_enabled && minted_by == current =>
+                        {
+                            Some(AssistantContent::Reasoning(Reasoning::new_with_signature(
+                                text,
+                                Some(signature.to_string()),
+                            )))
+                        }
+                        _ => None,
+                    }
+                }
+            }
         }
         "toolCall" => {
             let id = obj.get("id").and_then(|t| t.as_str())?.to_string();
@@ -1384,6 +1528,191 @@ mod tests {
                 _ => panic!("expected Assistant"),
             }
         }
+    }
+
+    /// GH #821 helper: one assistant message with a signed thinking block
+    /// plus a text block, as `serialize_assistant` + the factory's stamp
+    /// write it.
+    fn signed_thinking_assistant() -> Value {
+        serde_json::json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "text": "let me think",
+                    "signature": "sig-821",
+                    "signatureModel": "claude-opus-4-6",
+                },
+                {"type": "text", "text": "the answer"},
+            ],
+        })
+    }
+
+    fn reasoning_signature(msg: &Message) -> Option<Option<String>> {
+        match msg {
+            Message::Assistant { content, .. } => content.iter().find_map(|c| match c {
+                AssistantContent::Reasoning(r) => Some(r.content.iter().find_map(|rc| match rc {
+                    rig::completion::message::ReasoningContent::Text { signature, .. } => {
+                        signature.clone()
+                    }
+                    _ => None,
+                })),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    /// GH #821: replaying a signed thinking block to Anthropic with the
+    /// SAME model that minted the signature (reasoning on) must attach
+    /// the signature verbatim — Anthropic schema-rejects the block
+    /// without it (`thinking.signature: Field required`).
+    #[test]
+    fn anthropic_same_model_replay_attaches_the_signature() {
+        let v = signed_thinking_assistant();
+        let replay = thinking_replay_for(Some("anthropic"), Some("claude-opus-4-6"), true);
+        let msg = value_to_rig_message_with_thinking_replay(&v, Some("anthropic"), replay, None)
+            .expect("must convert");
+        assert_eq!(
+            reasoning_signature(&msg),
+            Some(Some("sig-821".to_string())),
+            "the stored signature must ride the replayed Reasoning block"
+        );
+    }
+
+    /// GH #821: a signature is only valid for the model that minted it —
+    /// replaying it to a DIFFERENT model is rejected (`Invalid signature
+    /// in thinking block`) — and an unsigned block is schema-rejected, so
+    /// on a model mismatch (or a missing/unstamped signature, or reasoning
+    /// off) the whole thinking block must be dropped from the Anthropic
+    /// request. The rest of the message survives.
+    #[test]
+    fn anthropic_replay_drops_unattachable_thinking_blocks() {
+        let signed = signed_thinking_assistant();
+        let unsigned = serde_json::json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "text": "let me think"},
+                {"type": "text", "text": "the answer"},
+            ],
+        });
+        let cases: Vec<(&Value, ThinkingReplay<'_>, &str)> = vec![
+            (
+                &signed,
+                thinking_replay_for(Some("anthropic"), Some("claude-fable-5"), true),
+                "foreign-model signature",
+            ),
+            (
+                &signed,
+                thinking_replay_for(Some("anthropic"), Some("claude-opus-4-6"), false),
+                "reasoning off this turn",
+            ),
+            (
+                &signed,
+                thinking_replay_for(Some("anthropic"), None, true),
+                "request model unknown",
+            ),
+            (
+                &unsigned,
+                thinking_replay_for(Some("anthropic"), Some("claude-opus-4-6"), true),
+                "legacy/flattened block with no signature",
+            ),
+        ];
+        for (v, replay, case) in cases {
+            let msg = value_to_rig_message_with_thinking_replay(v, Some("anthropic"), replay, None)
+                .unwrap_or_else(|| panic!("{case}: message with text must survive"));
+            match msg {
+                Message::Assistant { content, .. } => {
+                    assert!(
+                        !content
+                            .iter()
+                            .any(|c| matches!(c, AssistantContent::Reasoning(_))),
+                        "{case}: the thinking block must be dropped",
+                    );
+                    assert!(
+                        content
+                            .iter()
+                            .any(|c| matches!(c, AssistantContent::Text(_))),
+                        "{case}: the text block must survive",
+                    );
+                }
+                _ => panic!("expected Assistant"),
+            }
+        }
+    }
+
+    /// GH #821 non-regression: every non-Anthropic backend keeps the
+    /// pre-#821 unsigned echo, byte-identical — a stored signature must
+    /// neither attach nor drop the block there.
+    #[test]
+    fn non_anthropic_replay_of_a_signed_block_is_unchanged() {
+        let v = signed_thinking_assistant();
+        for provider in [Some("cerebras"), Some("deepseek"), Some("custom"), None] {
+            let replay = thinking_replay_for(provider, Some("claude-opus-4-6"), true);
+            assert!(matches!(replay, ThinkingReplay::Unsigned));
+            let msg = value_to_rig_message_with_thinking_replay(&v, provider, replay, None)
+                .unwrap_or_else(|| panic!("{provider:?} must keep the message"));
+            assert_eq!(
+                reasoning_signature(&msg),
+                Some(None),
+                "{provider:?}: reasoning must replay unsigned, exactly as before",
+            );
+        }
+    }
+
+    /// GH #821: the factory stamps the model that minted each captured
+    /// signature onto the block (the capture layer doesn't know the
+    /// model). Only signed, not-yet-stamped blocks are touched.
+    #[test]
+    fn stamp_records_the_minting_model_on_signed_blocks_only() {
+        use super::super::message::{AssistantMessage, StopReason};
+        let message = AssistantMessage::new(
+            vec![
+                ContentBlock::Thinking {
+                    text: "signed".to_string(),
+                    signature: Some("sig-a".to_string()),
+                    signature_model: None,
+                },
+                ContentBlock::Thinking {
+                    text: "unsigned".to_string(),
+                    signature: None,
+                    signature_model: None,
+                },
+                ContentBlock::Thinking {
+                    text: "already stamped".to_string(),
+                    signature: Some("sig-b".to_string()),
+                    signature_model: Some("other-model".to_string()),
+                },
+                ContentBlock::Text {
+                    text: "hi".to_string(),
+                },
+            ],
+            StopReason::Stop,
+        );
+        let evt = StreamEvent::Done {
+            reason: StopReason::Stop,
+            message,
+            usage: None,
+        };
+        let stamped = stamp_thinking_signature_model(evt, Some("claude-opus-4-6"));
+        let StreamEvent::Done { message, .. } = stamped else {
+            panic!("expected Done back");
+        };
+        let models: Vec<Option<&str>> = message
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Thinking {
+                    signature_model, ..
+                } => Some(signature_model.as_deref()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            models,
+            vec![Some("claude-opus-4-6"), None, Some("other-model")],
+            "stamp signed+unstamped; leave unsigned and already-stamped alone"
+        );
     }
 
     /// dirge-byun. A turn where the model emitted only reasoning (or nothing

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -4835,7 +4835,7 @@ pub(crate) fn build_scavenge_source(blocks: &[ContentBlock]) -> String {
     blocks
         .iter()
         .filter_map(|b| match b {
-            ContentBlock::Thinking { text } => Some(text.as_str()),
+            ContentBlock::Thinking { text, .. } => Some(text.as_str()),
             ContentBlock::Text { text } => Some(text.as_str()),
             _ => None,
         })

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -3215,6 +3215,8 @@ fn scavenge_source_concatenates_thinking_and_text() {
     let blocks = vec![
         ContentBlock::Thinking {
             text: "Plan: call list_dir.".to_string(),
+            signature: None,
+            signature_model: None,
         },
         ContentBlock::Text {
             text: "Acting now.".to_string(),

--- a/src/agent/agent_loop/thinking_budget.rs
+++ b/src/agent/agent_loop/thinking_budget.rs
@@ -187,7 +187,7 @@ pub fn thinking_tokens(msg: &AssistantMessage) -> usize {
         .content
         .iter()
         .filter_map(|b| match b {
-            ContentBlock::Thinking { text } => Some(text.len()),
+            ContentBlock::Thinking { text, .. } => Some(text.len()),
             _ => None,
         })
         .sum();
@@ -272,6 +272,8 @@ mod tests {
         AssistantMessage {
             content: vec![ContentBlock::Thinking {
                 text: "x".repeat(thinking_chars),
+                signature: None,
+                signature_model: None,
             }],
             stop_reason: stop,
             error_message: None,
@@ -478,12 +480,16 @@ mod tests {
             content: vec![
                 ContentBlock::Thinking {
                     text: "a".repeat(CHARS_PER_TOKEN * 3),
+                    signature: None,
+                    signature_model: None,
                 },
                 ContentBlock::Text {
                     text: "ignored".repeat(100),
                 },
                 ContentBlock::Thinking {
                     text: "b".repeat(CHARS_PER_TOKEN * 2),
+                    signature: None,
+                    signature_model: None,
                 },
             ],
             stop_reason: StopReason::Stop,

--- a/src/agent/agent_loop/trace.rs
+++ b/src/agent/agent_loop/trace.rs
@@ -224,7 +224,7 @@ fn describe(evt: &LoopEvent) -> Option<(&'static str, Value)> {
                 .iter()
                 .map(|b| match b {
                     super::message::ContentBlock::Text { text }
-                    | super::message::ContentBlock::Thinking { text } => text.len(),
+                    | super::message::ContentBlock::Thinking { text, .. } => text.len(),
                     super::message::ContentBlock::ToolCall { arguments, .. } => {
                         arguments.to_string().len()
                     }


### PR DESCRIPTION
Fixes #821.

## Problem

Anthropic mints a cryptographic `signature` on every thinking block and requires it echoed back verbatim on replay. dirge stored only the text, so the first replay — the tool-use continuation request — failed:

```
400 invalid_request_error
messages.3.content.0.thinking.signature: Field required
```

Reproduced 100% with any Anthropic entry at reasoning-on plus a single tool call. In an interactive session the bad block replays on every subsequent prompt, wedging the session.

## Cause

Three places, all losing the same value:

- `ContentBlock::Thinking { text: String }` had nowhere to store it.
- Capture discarded it: `ReasoningContent::Text { text, .. } => Some(text.clone())` — the `..` is the signature.
- Replay rebuilt it unsigned: `Reasoning::new(text)`, which hardcodes `signature: None`.

rig 0.41 already carries the field and offers `Reasoning::new_with_signature`, so no upstream change was needed.

## Fix

`ContentBlock::Thinking` gains two optional fields, both `#[serde(default, skip_serializing_if = "Option::is_none")]`:

- `signature` — the provider-issued signature, extracted at capture from the trailing complete `Reasoning` block (both `dirge-zf35` fold arms adopt it, guarded so a captured signature is never clobbered by a later `None`).
- `signature_model` (`signatureModel` on the wire) — the model that minted it, stamped in the factory, which is the layer that knows the model identity.

Replay is governed by a policy computed once per request:

- **non-Anthropic providers** → unchanged, `Reasoning::new(text)`, byte-identical to before;
- **Anthropic** → attach via `new_with_signature` iff a signature is present **and** `signatureModel` equals this request's model **and** reasoning is enabled this turn; otherwise drop the block (the rest of the message survives, mirroring the existing openai path).

### Why the model has to be recorded

`provider_name` / `model_name` at the factory are not sufficient: serialized history carries no model identity, and `/model`, escalation and subagents switch models in-process. A signature replayed to a different model is rejected with `Invalid signature in thinking block` — so a naive always-attach fix trades this bug for a different 400. Recording the minting model makes the decision exact.

Dropping is safe in every case that reaches it: attach happens whenever the model matches and reasoning is on, which is precisely the tool-use continuation case, so a same-model continuation never loses its thinking block. The remaining paths are an unsigned legacy block (previously a guaranteed 400), a foreign model's signature (likewise), or reasoning off — where the echo isn't required at all.

## Back-compat

`default` + `skip_serializing_if` means legacy `{"type":"thinking","text":"..."}` deserializes, and a block with both fields `None` re-serializes to exactly that byte shape, so existing saved sessions round-trip unchanged. Pinned in both directions by `legacy_thinking_block_json_round_trips_unchanged`.

## Tests (9 new)

Legacy round-trip pin (both directions); signature captured from the complete-block path and from both fold arms; replay attaches on model match; replay drops for a foreign model, an unknown model, reasoning-off, and unsigned; non-Anthropic replay byte-identical; the stamp touches only signed, unstamped blocks.

Full suite **5414 passed, 0 failed, 1 ignored**. `clippy --all-targets -- -D warnings` clean, `fmt --check` clean.

## End-to-end, with a negative control

Same config and prompt, Opus 4.6 at `effort: medium`, tool call in the loop:

- **unpatched `upstream/main` binary** → `400 ... messages.3.content.0.thinking.signature: Field required`
- **patched binary, run 1** → completes normally
- **patched binary, run 2** → completes normally

The control confirms the repro was live in those exact runs (thinking engaged, block present at `content.0`), and the patched runs completing *with thinking on and a tool_use in flight* means the block was attached with a valid signature — a dropped block would have produced a different 400, so this is not passing by dropping.

## Known limitations / out of scope

- **Session persistence flattens thinking blocks.** The `messages` table stores `content TEXT`, and the resume path constructs `signature: None`, so cross-process `--session` reuse carries no signatures; those blocks are dropped from Anthropic replays. Safe (they previously 400'd), but it means a resumed session loses its reasoning context. No schema change made here.
- **Aliased escalation/review routes.** `provider::build` passes the config entry alias as `provider_name` for those stream fns and canonicalizes only openai, so an Anthropic escalation route configured under an alias falls to the unsigned path and still 400s exactly as before. Fixing that means canonicalizing at the dispatch site — separate change.
- **Gemini** sessions now store rig-provided thought signatures in session JSON. No wire change: attach is gated to Anthropic.
- Built and tested with `--no-default-features --features no-plugin` (no janet toolchain on this host — #712), so the mechanical field additions in `plugin_hooks_tests.rs` are verified only by CI with default features.
- Overlaps #822 in `rig_stream_factory.rs` but in disjoint regions (~40 lines apart); a rebase should be clean or trivial whichever merges first.
