### PR TITLE
feat(plugin): harness/emit-issue + open-source flow plugins

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1038,6 +1038,27 @@ async fn main() -> anyhow::Result<()> {
     if let Some(pm_arc) = plugin_manager.as_ref() {
         plugin::hook::init_global(pm_arc.clone());
     }
+    // Install the issue store for the Janet issue bridge (harness/emit-issue).
+    // Opened once here and shared with the worker thread; IssueStore is a
+    // Mutex<Connection> with a busy timeout, so concurrent session-persistence
+    // writes yield instead of erroring. Skipped when plugin support is off
+    // (the bridge CFn is never registered then, so the store would be unused).
+    #[cfg(feature = "plugin")]
+    if plugin_manager.is_some() {
+        let paths = crate::extras::dirge_paths::ProjectPaths::new(
+            &std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+        );
+        match crate::extras::issue_db::IssueStore::open(&paths) {
+            Ok(store) => {
+                crate::plugin::worker::issue_bridge::install_issue_store(std::sync::Arc::new(
+                    store,
+                ));
+            }
+            Err(e) => {
+                eprintln!("warning: issue bridge disabled ({e})");
+            }
+        }
+    }
     // Pull the dialog-request receiver out of the PluginManager once,
     // here, so we can hand it to the UI loop. After this point, calling
     // take_dialog_rx again returns None — single owner by design. Always

--- a/src/plugin/mod_tests.rs
+++ b/src/plugin/mod_tests.rs
@@ -1453,6 +1453,44 @@ fn emit_tool_progress_tags_entries_with_current_tool_call() {
     assert!(mgr.drain_tool_progress().is_empty());
 }
 
+/// `harness/emit-issue` files a durable, session-unscoped issue on the board
+/// and returns its id (e.g. `drg-a1b2`). The bridge reads the process-global
+/// store installed by `install_issue_store`; when absent it degrades to nil.
+#[cfg(feature = "plugin")]
+#[test]
+fn emit_issue_creates_board_issue_and_returns_id() {
+    use crate::extras::issue_db::IssueStore;
+    use crate::plugin::worker::issue_bridge;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "dirge-emit-issue-test-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed),
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("state.db");
+    let store = IssueStore::open_at(&db_path).unwrap();
+    issue_bridge::install_issue_store(std::sync::Arc::new(store));
+
+    let mut mgr = PluginManager::try_new().unwrap();
+    let id = mgr
+        .eval(r#"(harness/emit-issue "watch upstream" "upgrade to v2" "high")"#)
+        .unwrap();
+    let id = id.trim_matches('"');
+    assert!(id.starts_with("drg-"), "unexpected id: {id:?}");
+
+    // Re-open the same file to verify the row actually landed (the bridge
+    // owns the Arc'd store, so we can't read it back directly).
+    let reopened = IssueStore::open_at(&db_path).unwrap();
+    let issue = reopened.get(id).unwrap().expect("issue was persisted");
+    assert_eq!(issue.title, "watch upstream");
+    assert_eq!(issue.body, "upgrade to v2");
+    assert_eq!(issue.priority, "high");
+    assert_eq!(issue.status, "open");
+}
+
 // --- H3: register-tool prepare-arguments field ---------------------
 
 /// `(harness/register-tool ... :parallel "my-prep")` records the

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -1039,6 +1039,24 @@ const HARNESS_TOOL_INIT: &str = r#"
   (harness/__call-tool name payload))
 "#;
 
+/// Janet wrapper for the issue bridge, installed on the **plugin VM only**.
+///
+/// Kept out of `HARNESS_INIT` for the same reason as `HARNESS_NOTEBOOK_INIT`:
+/// the notebook VM runs that prelude but does NOT register `harness/__emit-issue`,
+/// so a `defn` body that names the symbol would fail to compile there.
+#[cfg(feature = "plugin")]
+const HARNESS_ISSUE_INIT: &str = r#"
+# (harness/emit-issue title &opt body priority) -> issue id string | nil
+# Files a durable, session-unscoped issue on the board and returns its id
+# (e.g. "drg-a1b2"). Returns nil when the issue bridge is not installed
+# (plugin tests, --no-session without the store) or the title is empty.
+(defn harness/emit-issue [title &opt body priority]
+  (harness/__emit-issue
+    (string title)
+    (if (nil? body) "" (string body))
+    (if (nil? priority) "" (string priority))))
+"#;
+
 /// Vigil Janet prelude — exposes vigil/emit, vigil/list, vigil/set-state,
 /// vigil/get, vigil/live? for plugins running inside a vigil-keeper.
 #[cfg(all(feature = "plugin", feature = "vigil"))]
@@ -2057,6 +2075,10 @@ fn worker_loop(
         env.add_c_fn(CFunOptions::new(c"__call-tool", janet_call_tool_cfn).namespace(c"harness"));
         env.add_c_fn(CFunOptions::new(c"__list-tools", janet_list_tools_cfn).namespace(c"harness"));
         env.add_c_fn(CFunOptions::new(c"__tools-live", janet_tools_live_cfn).namespace(c"harness"));
+        // Issue bridge: lets a plugin file a durable issue on the board.
+        env.add_c_fn(
+            CFunOptions::new(c"__emit-issue", issue_bridge::issue_emit_cfn).namespace(c"harness"),
+        );
     }
     // Register DAP C functions when both features are enabled.
     #[cfg(feature = "dap")]
@@ -2091,6 +2113,10 @@ fn worker_loop(
     }
     if let Err(e) = client.run(HARNESS_TOOL_INIT) {
         let _ = init_tx.send(Err(format!("harness tool-bridge init failed: {e}")));
+        return;
+    }
+    if let Err(e) = client.run(HARNESS_ISSUE_INIT) {
+        let _ = init_tx.send(Err(format!("harness issue-bridge init failed: {e}")));
         return;
     }
     // Vigil Janet prelude — defines (vigil/emit), (vigil/list),
@@ -3698,6 +3724,74 @@ unsafe fn get_dict_int_array(v: janetrs::lowlevel::Janet, key: &str) -> Option<V
         }
     }
     Some(out)
+}
+
+/// Bridge from the Janet worker thread to the durable issue board.
+///
+/// Exposes Janet function:
+/// - `harness/emit-issue` — (title [body] [priority]) -> issue id string or nil
+///
+/// Guarded by `plugin` only (issues are core, not vigil-gated): a flow plugin
+/// can file an issue in loop, vigil, or interactive mode. The issue is created
+/// session-unscoped (`session_id = None`); `assign_to_session` can pull it onto
+/// a conversation board later.
+#[cfg(feature = "plugin")]
+pub(crate) mod issue_bridge {
+    use super::{read_string_arg, wrap_string};
+    use crate::extras::issue_db::IssueStore;
+    use std::sync::Arc;
+
+    /// Process-global handle to the issue store, installed once at startup
+    /// and read from the Janet worker thread (mirrors `VIGIL_TX` /
+    /// `SANDBOX_EXEC_TX` — a thread-local would be invisible to the CFn).
+    static ISSUE_STORE: std::sync::OnceLock<Arc<IssueStore>> = std::sync::OnceLock::new();
+
+    /// Install the issue store for the bridge. Called from `main.rs` once at
+    /// plugin startup. No-op (warn) if already installed.
+    pub fn install_issue_store(store: Arc<IssueStore>) {
+        if ISSUE_STORE.set(store).is_err() {
+            tracing::warn!(target: "dirge::plugin", "issue bridge already installed");
+        }
+    }
+
+    /// (harness/emit-issue title [body] [priority]) -> issue id string or nil.
+    /// Files a durable, session-unscoped issue on the board and returns its id
+    /// (e.g. `drg-a1b2`), or nil when the store is absent / the title is empty.
+    pub unsafe extern "C-unwind" fn issue_emit_cfn(
+        argc: i32,
+        argv: *mut janetrs::lowlevel::Janet,
+    ) -> janetrs::lowlevel::Janet {
+        use janetrs::lowlevel::*;
+        if argc < 1 {
+            return unsafe { janet_wrap_nil() };
+        }
+        let Some(title) = (unsafe { read_string_arg(argv, 0) }) else {
+            return unsafe { janet_wrap_nil() };
+        };
+        let body = if argc > 1 {
+            unsafe { read_string_arg(argv, 1) }
+        } else {
+            None
+        };
+        let priority = if argc > 2 {
+            unsafe { read_string_arg(argv, 2) }
+        } else {
+            None
+        };
+        let Some(store) = ISSUE_STORE.get() else {
+            return unsafe { janet_wrap_nil() };
+        };
+        match store.create(
+            title.trim(),
+            body.as_deref().unwrap_or(""),
+            priority.as_deref(),
+            None,
+            None,
+        ) {
+            Ok(id) => unsafe { wrap_string(&id) },
+            Err(_) => unsafe { janet_wrap_nil() },
+        }
+    }
 }
 
 /// Bridge from the Janet worker thread to the vigil-keeper's event channel.

--- a/tests/fixtures/vigil/plugins/gh-releases.janet
+++ b/tests/fixtures/vigil/plugins/gh-releases.janet
@@ -1,0 +1,95 @@
+# GitHub release watcher — open-source flow plugin (slice 6).
+#
+# Polls the GitHub REST API for the latest release of each watched repo. When a
+# repo's tag is newer than the last-seen tag, it files a durable issue on the
+# LOCAL dirge board via (harness/emit-issue ...) — nothing is ever written back
+# to GitHub. If a vigil-keeper is running, it also emits a vigil event so the
+# agent wakes and triages the release; without vigil the issue still lands on
+# the board for loop / interactive mode to pick up.
+#
+# State: ~/.dirge/flow-state/gh-releases — one "owner/repo<TAB>tag" line per
+# watched repo. Unauthenticated GitHub API: 60 req/hr per IP.
+
+(def WATCH
+  "Repos to watch for new releases, as @[[owner repo] ...] pairs."
+  @[["dirge-code" "dirge"]
+    ["fish-shell" "fish-shell"]])
+
+(defn- sh-capture [cmd-str]
+  "Run via /bin/sh -c, capturing trimmed stdout to a temp file."
+  (let [tmp (string "/tmp/dirge-flow-" (os/time))]
+    (os/execute ["/bin/sh" "-c" (string cmd-str " > " tmp " 2>/dev/null")])
+    (try
+      (let [f (file/open tmp :r)
+            data (file/read f :all)]
+        (file/close f)
+        (os/execute ["/bin/rm" "-f" tmp])
+        (when (and data (not= data "")) (string/trim data)))
+      ([_] (do (os/execute ["/bin/rm" "-f" tmp]) nil)))))
+
+(defn- home [] (or (os/getenv "HOME") "/tmp"))
+(defn- state-dir [] (string (home) "/.dirge/flow-state"))
+(defn- state-path [] (string (state-dir) "/gh-releases"))
+
+(defn- read-state []
+  "Return the state file as a table of repoKey -> last-seen tag."
+  (var out @{})
+  (try
+    (let [f (file/open (state-path) :r)
+          data (file/read f :all)]
+      (file/close f)
+      (each line (string/split "\n" (or data ""))
+        (let [parts (string/split "\t" line)]
+          (when (= 2 (length parts))
+            (put out (get parts 0) (get parts 1))))))
+    ([_] nil))
+  out)
+
+(defn- write-state [table]
+  (os/execute ["/bin/sh" "-c" (string "mkdir -p " (state-dir) " 2>/dev/null")])
+  (try
+    (let [f (file/open (state-path) :w)]
+      (file/write f (string/join
+                      (map (fn [[k v]] (string k "\t" v)) (pairs table))
+                      "\n"))
+      (file/close f)
+      true)
+    ([_] false)))
+
+(defn- wake-agent [event-name data]
+  "Emit a vigil event when the bridge exists. (dyn ...) avoids a compile-time
+   unknown-symbol error in non-vigil builds, and vigil/emit itself no-ops when
+   no keeper is running."
+  (if-let [emit (dyn 'vigil/emit)]
+    (emit event-name data)))
+
+(defn- emit-release-issue [owner repo tag url body]
+  (let [title (string "New release: " owner "/" repo " " tag)
+        issue-body (string owner "/" repo " released " tag "\n" (or url "") "\n\n" (or body ""))
+        id (harness/emit-issue title issue-body "normal")]
+    (when id
+      (harness/notify (string "gh-releases: filed " id " for " owner "/" repo " " tag) :info))
+    id))
+
+(defn poll-releases [&opt _]
+  "One-shot: fetch latest releases and file issues for any new tags."
+  (let [state (read-state)]
+    (var any-new false)
+    (each pair WATCH
+      (let [owner (get pair 0)
+            repo (get pair 1)
+            repo-key (string owner "/" repo)
+            json (sh-capture (string "curl -s https://api.github.com/repos/" owner "/" repo "/releases/latest"))
+            parsed (when json (harness/json-decode json))
+            tag (when parsed (get parsed "tag_name"))]
+        (when (and tag (not= tag (get state repo-key)))
+          (emit-release-issue owner repo tag (get parsed "html_url") (get parsed "body"))
+          (put state repo-key tag)
+          (set any-new true)
+          (wake-agent "release-watch"
+                      {:repo repo-key :tag tag :url (get parsed "html_url")}))))
+    (when any-new (write-state state))
+    (harness/notify "gh-releases: poll complete" :info)))
+
+(harness/register-command "poll-releases" "poll-releases")
+(poll-releases)

--- a/tests/fixtures/vigil/plugins/gh-triage.janet
+++ b/tests/fixtures/vigil/plugins/gh-triage.janet
@@ -1,0 +1,96 @@
+# GitHub issue/PR triage — open-source flow plugin (slice 6).
+#
+# Polls a repo's OPEN issues (which include PRs — GitHub shares one number
+# space) and files a durable issue on the LOCAL dirge board for every item whose
+# number is higher than the last-seen max. This builds a standing triage queue
+# the agent works through. Nothing is ever written back to GitHub — "file an
+# issue" here means the dirge board, not the remote repo.
+#
+# State: ~/.dirge/flow-state/gh-triage — one "owner/repo<TAB>maxNumber" line per
+# watched repo.
+
+(def WATCH
+  "Repos to triage, as @[[owner repo] ...] pairs."
+  @[["dirge-code" "dirge"]])
+
+(defn- sh-capture [cmd-str]
+  "Run via /bin/sh -c, capturing trimmed stdout to a temp file."
+  (let [tmp (string "/tmp/dirge-flow-" (os/time))]
+    (os/execute ["/bin/sh" "-c" (string cmd-str " > " tmp " 2>/dev/null")])
+    (try
+      (let [f (file/open tmp :r)
+            data (file/read f :all)]
+        (file/close f)
+        (os/execute ["/bin/rm" "-f" tmp])
+        (when (and data (not= data "")) (string/trim data)))
+      ([_] (do (os/execute ["/bin/rm" "-f" tmp]) nil)))))
+
+(defn- home [] (or (os/getenv "HOME") "/tmp"))
+(defn- state-dir [] (string (home) "/.dirge/flow-state"))
+(defn- state-path [] (string (state-dir) "/gh-triage"))
+
+(defn- to-num [x]
+  "Coerce a state value to a number; non-numeric degrades to 0."
+  (if (number? x) x (or (scan-number x) 0)))
+
+(defn- read-state []
+  "Return the state file as a table of repoKey -> last-seen max item number."
+  (var out @{})
+  (try
+    (let [f (file/open (state-path) :r)
+          data (file/read f :all)]
+      (file/close f)
+      (each line (string/split "\n" (or data ""))
+        (let [parts (string/split "\t" line)]
+          (when (= 2 (length parts))
+            (put out (get parts 0) (to-num (get parts 1)))))))
+    ([_] nil))
+  out)
+
+(defn- write-state [table]
+  (os/execute ["/bin/sh" "-c" (string "mkdir -p " (state-dir) " 2>/dev/null")])
+  (try
+    (let [f (file/open (state-path) :w)]
+      (file/write f (string/join
+                      (map (fn [[k v]] (string k "\t" v)) (pairs table))
+                      "\n"))
+      (file/close f)
+      true)
+    ([_] false)))
+
+(defn- wake-agent [event-name data]
+  "Emit a vigil event when the bridge exists (no-op in non-vigil builds)."
+  (if-let [emit (dyn 'vigil/emit)]
+    (emit event-name data)))
+
+(defn- emit-triage-issue [repo-key number title url is-pr]
+  (let [kind (if is-pr "PR" "issue")
+        issue-title (string "Triage: " repo-key "#" number " (" kind ") " title)
+        issue-body (string "Open " kind " needs triage.\n" (or url "") "\n\n" title)]
+    (harness/emit-issue issue-title issue-body "normal")))
+
+(defn poll-triage [&opt _]
+  "One-shot: fetch open issues/PRs and file issues for any new item numbers."
+  (let [state (read-state)]
+    (each pair WATCH
+      (let [owner (get pair 0)
+            repo (get pair 1)
+            repo-key (string owner "/" repo)
+            json (sh-capture (string "curl -s \"https://api.github.com/repos/" owner "/" repo "/issues?state=open&per_page=100\""))
+            parsed (when json (harness/json-decode json))
+            items (if (indexed? parsed) parsed @[])
+            last-seen (to-num (get state repo-key))]
+        (var max-seen last-seen)
+        (each item items
+          (let [number (get item "number")]
+            (when (and (number? number) (> number last-seen))
+              (emit-triage-issue repo-key number (get item "title") (get item "html_url") (truthy? (get item "pull_request")))
+              (when (> number max-seen) (set max-seen number))
+              (wake-agent "triage-watch"
+                          {:repo repo-key :number (string number) :title (get item "title") :url (get item "html_url")}))))
+        (when (> max-seen last-seen) (put state repo-key max-seen))))
+    (write-state state)
+    (harness/notify "gh-triage: poll complete" :info)))
+
+(harness/register-command "poll-triage" "poll-triage")
+(poll-triage)

--- a/tests/fixtures/vigil/plugins/osv-advisories.janet
+++ b/tests/fixtures/vigil/plugins/osv-advisories.janet
@@ -1,0 +1,87 @@
+# Security advisory watcher — open-source flow plugin (slice 6).
+#
+# Polls the GitHub advisories API (sorted newest-first) for a chosen ecosystem
+# and files a durable issue on the LOCAL dirge board for every advisory newer
+# than the last-seen one. Advisory issues are priority "high"/"normal" based on
+# severity. Nothing is ever written back to GitHub — the board is the only sink.
+#
+# State: ~/.dirge/flow-state/osv-advisories — the latest seen GHSA id, so each
+# poll only files advisories that appeared after the previous run.
+
+(def ECOSYSTEM "cargo")
+(def PER-PAGE 10)
+
+(defn- sh-capture [cmd-str]
+  "Run via /bin/sh -c, capturing trimmed stdout to a temp file."
+  (let [tmp (string "/tmp/dirge-flow-" (os/time))]
+    (os/execute ["/bin/sh" "-c" (string cmd-str " > " tmp " 2>/dev/null")])
+    (try
+      (let [f (file/open tmp :r)
+            data (file/read f :all)]
+        (file/close f)
+        (os/execute ["/bin/rm" "-f" tmp])
+        (when (and data (not= data "")) (string/trim data)))
+      ([_] (do (os/execute ["/bin/rm" "-f" tmp]) nil)))))
+
+(defn- home [] (or (os/getenv "HOME") "/tmp"))
+(defn- state-dir [] (string (home) "/.dirge/flow-state"))
+(defn- state-path [] (string (state-dir) "/osv-advisories"))
+
+(defn- read-marker []
+  "Return the last-seen GHSA id, or nil on first run."
+  (try
+    (let [f (file/open (state-path) :r)
+          data (file/read f :all)]
+      (file/close f)
+      (when (and data (not= data "")) (string/trim data)))
+    ([_] nil)))
+
+(defn- write-marker [ghsa]
+  (os/execute ["/bin/sh" "-c" (string "mkdir -p " (state-dir) " 2>/dev/null")])
+  (try
+    (let [f (file/open (state-path) :w)]
+      (file/write f ghsa)
+      (file/close f)
+      true)
+    ([_] false)))
+
+(defn- wake-agent [event-name data]
+  "Emit a vigil event when the bridge exists (no-op in non-vigil builds)."
+  (if-let [emit (dyn 'vigil/emit)]
+    (emit event-name data)))
+
+(defn- severity-priority [sev]
+  (if (or (= sev "critical") (= sev "high")) "high" "normal"))
+
+(defn- emit-advisory-issue [item]
+  (let [ghsa (get item "ghsa_id")
+        summary (get item "summary")
+        severity (get item "severity")
+        url (get item "html_url")
+        cves (get item "cves")
+        cve-str (if (indexed? cves) (string/join cves ", ") "")
+        title (string "Security advisory: " ghsa " (" (or severity "unknown") ") " summary)
+        body (string ghsa "\n" (or url "") "\nSeverity: " (or severity "unknown") "\nCVEs: " cve-str "\n\n" summary)]
+    (harness/emit-issue title body (severity-priority severity))))
+
+(defn poll-advisories [&opt _]
+  "One-shot: fetch recent advisories and file issues for any newer than the marker."
+  (let [last-seen (read-marker)
+        json (sh-capture (string "curl -s \"https://api.github.com/advisories?ecosystem=" ECOSYSTEM "&sort=published&direction=desc&per_page=" PER-PAGE "\""))
+        parsed (when json (harness/json-decode json))
+        items (if (indexed? parsed) parsed @[])
+        new-marker nil]
+    (each item items
+      (let [ghsa (get item "ghsa_id")]
+        (if (= ghsa last-seen)
+          (break)
+          (do
+            (emit-advisory-issue item)
+            (when (nil? new-marker) (set new-marker ghsa))
+            (wake-agent "advisory-watch"
+                        {:ghsa ghsa :severity (get item "severity") :summary (get item "summary") :url (get item "html_url")})))))
+    (when new-marker (write-marker new-marker))
+    (harness/notify "osv-advisories: poll complete" :info)))
+
+(harness/register-command "poll-advisories" "poll-advisories")
+(poll-advisories)


### PR DESCRIPTION
## What

Adds a `harness/emit-issue` Janet bridge so any plugin (loop, vigil, or interactive) can file a durable issue on the dirge board, plus three open-source flow plugins that use it:

- `gh-releases.janet` — watches repos for new releases and files "upgrade" issues.
- `gh-triage.janet` — files a board issue per new open issue/PR needing triage. **Local board only; it never writes back to GitHub.**
- `osv-advisories.janet` — files a board issue per new GitHub security advisory.

## Notes / known gaps

- Issues are created session-unscoped (`session_id = None`); wiring them onto a conversation board via `assign_to_session` is left for a later slice.
- The flow plugins dedup via a `~/.dirge/flow-state/` marker file and fire one-shot at load plus a registered `/poll-*` command. They are not exercised by `cargo test` (they hit live APIs); they are manual e2e fixtures, same as the existing pollers.
- `harness/emit-issue` lives in its own `HARNESS_ISSUE_INIT` prelude (plugin VM only), because the notebook VM runs `HARNESS_INIT` but not the `__emit-issue` CFn. My first pass put the wrapper in `HARNESS_INIT` and broke notebook compilation — caught by `plugin::tests::` before commit and fixed.

## Test coverage

- `emit_issue_creates_board_issue_and_returns_id` — installs a temp `IssueStore`, evals `(harness/emit-issue ...)`, asserts the returned id and that the row persisted.
- Verified locally: `cargo fmt --check` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `plugin::tests::` 171 pass.