### PR TITLE
fix: gcroot janet_vm.top_dyns stop plugin-worker SIGSEGV

### DIFF
--- a/src/plugin/mod_tests.rs
+++ b/src/plugin/mod_tests.rs
@@ -3519,3 +3519,88 @@ fn plugin_worker_uaf_stress() {
     }
     println!("stress completed without crashing: {turns} turns");
 }
+
+/// dirge-eona: pins the `JanetVMPrefix` layout assumption that the fix rests
+/// on. `top_dyns_ptr` reads offset 8 of a struct whose definition is private
+/// to janet.c, and `janetrs` depends on `evil-janet = "1"`, so a `cargo
+/// update` can move the field under us. A wrong offset would not fail the
+/// build — it would hand `janet_gcroot` whatever now lives there, which is
+/// far worse than the crash it replaced. The stress harness above cannot
+/// catch that: it is `#[ignore]`d and needs the user's plugin dir.
+///
+/// This runs in the normal suite instead. It owns a bare VM on its own
+/// thread (no default env, so nothing but this test writes a dyn), and leans
+/// on the fact that no fiber is live here: `janet_setdyn` therefore writes
+/// `top_dyns` (janet.c:4657), which is the same state the worker mirrors in.
+///
+/// The null-before assertion is what discriminates the field: every nearby
+/// `JanetTable *` in `struct JanetVM` behaves differently across these
+/// steps. `abstract_registry` is already non-null after `janet_init`
+/// (janet.c:35577), and `core_env` stays null and never gains entries from
+/// `janet_setdyn`.
+#[cfg(feature = "plugin")]
+#[test]
+fn top_dyns_offset_is_stable() {
+    use janetrs::lowlevel::{janet_equals, janet_setdyn, janet_table, janet_wrap_table};
+
+    let _client = janetrs::client::JanetClient::init().expect("bare VM on a fresh test thread");
+
+    assert!(
+        worker::top_dyns_ptr().is_null(),
+        "top_dyns must start null (janet_init sets it NULL, janet.c:35592); \
+         a non-null read here means offset 8 is no longer top_dyns"
+    );
+
+    // A table, not a number: `janet_wrap_integer` is a macro under some
+    // nanbox configs and is not exported from libjanet, so it does not link.
+    // SAFETY: the VM is initialized on this thread, so `janet_table`
+    // allocates on its heap and `janet_wrap_table` only tags the pointer.
+    // Nothing collects during this test, so the value stays live unrooted.
+    let probe = unsafe { janet_wrap_table(janet_table(0)) };
+    // SAFETY: VM live on this thread and no fiber is running, so
+    // `janet_setdyn` lazily creates `top_dyns` and writes into it.
+    unsafe { janet_setdyn(c"dirge-eona-probe".as_ptr(), probe) };
+
+    let top = worker::top_dyns_ptr();
+    assert!(
+        !top.is_null(),
+        "the first janet_setdyn must create top_dyns"
+    );
+    // SAFETY: `top` is the table janet_setdyn just created; reading `count`
+    // is an in-bounds field read on a live JanetTable.
+    assert_eq!(
+        unsafe { (*top).count },
+        1,
+        "the table at offset 8 must be the one janet_setdyn wrote to"
+    );
+
+    // A second key lands in the SAME table, and the pointer does not move.
+    // SAFETY: as above — VM live on this thread, still no fiber.
+    unsafe { janet_setdyn(c"dirge-eona-probe-2".as_ptr(), probe) };
+    assert_eq!(
+        worker::top_dyns_ptr(),
+        top,
+        "top_dyns is created once, then reused (janet.c:4657)"
+    );
+    // SAFETY: as above.
+    assert_eq!(
+        unsafe { (*top).count },
+        2,
+        "both dyns must be in this table"
+    );
+
+    // And it is the table the public reader consults: with no fiber live,
+    // `janet_dyn` reads `top_dyns` directly (janet.c:4645).
+    // SAFETY: VM live on this thread, and both operands are live Janet
+    // values — `probe` and whatever the dyn lookup returns for its key.
+    assert_eq!(
+        unsafe {
+            janet_equals(
+                janetrs::lowlevel::janet_dyn(c"dirge-eona-probe".as_ptr()),
+                probe,
+            )
+        },
+        1,
+        "janet_dyn must read back what janet_setdyn wrote"
+    );
+}

--- a/src/plugin/mod_tests.rs
+++ b/src/plugin/mod_tests.rs
@@ -3443,7 +3443,10 @@ fn call_tool_defaults_missing_args_to_empty_object() {
 #[ignore]
 fn plugin_worker_uaf_stress() {
     fn env_usize(name: &str, default: usize) -> usize {
-        std::env::var(name).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(default)
     }
     let turns = env_usize("DIRGE_STRESS_TURNS", 200);
     let updates = env_usize("DIRGE_STRESS_UPDATES", 25);
@@ -3457,19 +3460,17 @@ fn plugin_worker_uaf_stress() {
     // The crashing sessions had the user's whole plugin dir loaded
     // (~38 entries, several of them response-capturing). Reproduce that
     // env; per-plugin failures are not the point of the harness.
-    if load_user_plugins {
-        if let Ok(home) = std::env::var("HOME") {
-            let dir = std::path::PathBuf::from(home).join(".config/dirge/plugins");
-            if dir.is_dir() {
-                let mut entries: Vec<_> = std::fs::read_dir(&dir)
-                    .unwrap()
-                    .filter_map(|e| e.ok().map(|e| e.path()))
-                    .filter(|p| p.extension().is_some_and(|e| e == "janet") || p.is_dir())
-                    .collect();
-                entries.sort();
-                for path in entries {
-                    let _ = load_plugin(&mut mgr, &path);
-                }
+    if load_user_plugins && let Ok(home) = std::env::var("HOME") {
+        let dir = std::path::PathBuf::from(home).join(".config/dirge/plugins");
+        if dir.is_dir() {
+            let mut entries: Vec<_> = std::fs::read_dir(&dir)
+                .unwrap()
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().is_some_and(|e| e == "janet") || p.is_dir())
+                .collect();
+            entries.sort();
+            for path in entries {
+                let _ = load_plugin(&mut mgr, &path);
             }
         }
     }
@@ -3481,7 +3482,8 @@ fn plugin_worker_uaf_stress() {
     let big_response = unit.repeat(response_bytes / unit.len() + 1);
 
     for turn in 0..turns {
-        mgr.dispatch("on-prompt", "@{:prompt \"stress turn\"}").unwrap();
+        mgr.dispatch("on-prompt", "@{:prompt \"stress turn\"}")
+            .unwrap();
         mgr.dispatch("on-turn-start", "@{}").unwrap();
         for u in 0..updates {
             let partial_len = turn * 100 + u * 50;
@@ -3509,7 +3511,10 @@ fn plugin_worker_uaf_stress() {
         mgr.eval("(gccollect)").unwrap();
         let r = mgr.invoke_command("resp-clipboard-handler", "").unwrap();
         if turn % 50 == 0 {
-            println!("turn {turn}: {:?}", r.map(|s| s.chars().take(60).collect::<String>()));
+            println!(
+                "turn {turn}: {:?}",
+                r.map(|s| s.chars().take(60).collect::<String>())
+            );
         }
     }
     println!("stress completed without crashing: {turns} turns");

--- a/src/plugin/mod_tests.rs
+++ b/src/plugin/mod_tests.rs
@@ -3420,3 +3420,97 @@ fn call_tool_defaults_missing_args_to_empty_object() {
         Ok("nil".to_string())
     );
 }
+
+// --- dirge-eona stress harness --------------------------------------
+//
+// Not a correctness test — a repro driver for the Janet-heap
+// use-after-free that SIGSEGVs the plugin worker (dirge-eona). It
+// replays the workload that precedes the crash: hook dispatch across a
+// session with a response-capturing plugin loaded, then a slash-command
+// invocation, under explicit GC pressure. Ignored so the normal suite
+// never runs it; drive it explicitly:
+//
+//   cargo test --bin dirge plugin_worker_uaf_stress -- --ignored --nocapture
+//
+// and under lldb for a symbolicated backtrace at the fault.
+//
+// Knobs (env): DIRGE_STRESS_TURNS (default 200),
+// DIRGE_STRESS_UPDATES (25 per turn), DIRGE_STRESS_RESPONSE_BYTES
+// (20000), DIRGE_STRESS_USER_PLUGINS (1 = load ~/.config/dirge/plugins,
+// exactly the crashing session's env).
+#[cfg(feature = "plugin")]
+#[test]
+#[ignore]
+fn plugin_worker_uaf_stress() {
+    fn env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+    }
+    let turns = env_usize("DIRGE_STRESS_TURNS", 200);
+    let updates = env_usize("DIRGE_STRESS_UPDATES", 25);
+    let response_bytes = env_usize("DIRGE_STRESS_RESPONSE_BYTES", 20_000);
+    let load_user_plugins = std::env::var("DIRGE_STRESS_USER_PLUGINS")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+
+    let mut mgr = PluginManager::try_new().unwrap();
+
+    // The crashing sessions had the user's whole plugin dir loaded
+    // (~38 entries, several of them response-capturing). Reproduce that
+    // env; per-plugin failures are not the point of the harness.
+    if load_user_plugins {
+        if let Ok(home) = std::env::var("HOME") {
+            let dir = std::path::PathBuf::from(home).join(".config/dirge/plugins");
+            if dir.is_dir() {
+                let mut entries: Vec<_> = std::fs::read_dir(&dir)
+                    .unwrap()
+                    .filter_map(|e| e.ok().map(|e| e.path()))
+                    .filter(|p| p.extension().is_some_and(|e| e == "janet") || p.is_dir())
+                    .collect();
+                entries.sort();
+                for path in entries {
+                    let _ = load_plugin(&mut mgr, &path);
+                }
+            }
+        }
+    }
+
+    // Realistic response material: markdown + code fences + quotes +
+    // backslashes + unicode, so the ctx escaper sees the same shape of
+    // text the crashing sessions carried.
+    let unit = "Some **markdown** with `code` and \"quotes\" and \\\\ paths — ünïcødé ✓\n```rust\nfn main() { println!(\"line\"); }\n```\n";
+    let big_response = unit.repeat(response_bytes / unit.len() + 1);
+
+    for turn in 0..turns {
+        mgr.dispatch("on-prompt", "@{:prompt \"stress turn\"}").unwrap();
+        mgr.dispatch("on-turn-start", "@{}").unwrap();
+        for u in 0..updates {
+            let partial_len = turn * 100 + u * 50;
+            let mut pend = partial_len.min(big_response.len());
+            while pend > 0 && !big_response.is_char_boundary(pend) {
+                pend -= 1;
+            }
+            let partial = &big_response[..pend];
+            let ctx = format!(
+                "@{{:index {} :partial \"{}\"}}",
+                u,
+                escape_janet_string(partial)
+            );
+            mgr.dispatch("on-message-update", &ctx).unwrap();
+        }
+        let mut rend = (response_bytes + turn * 10).min(big_response.len());
+        while rend > 0 && !big_response.is_char_boundary(rend) {
+            rend -= 1;
+        }
+        let response = &big_response[..rend];
+        let ctx = format!("@{{:response \"{}\"}}", escape_janet_string(response));
+        mgr.dispatch("on-response", &ctx).unwrap();
+        // Force collection every turn so freed slots get reused — the
+        // dirge-eona window. No-op turns: a normal, collected GC cycle.
+        mgr.eval("(gccollect)").unwrap();
+        let r = mgr.invoke_command("resp-clipboard-handler", "").unwrap();
+        if turn % 50 == 0 {
+            println!("turn {turn}: {:?}", r.map(|s| s.chars().take(60).collect::<String>()));
+        }
+    }
+    println!("stress completed without crashing: {turns} turns");
+}

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -2190,6 +2190,24 @@ fn run_command_loop(
     }
 }
 
+/// dirge-eona: `janet_vm` is `__thread` in evil-janet's janet.c (that is
+/// how the plugin and notebook VMs coexist on separate threads), and its
+/// layout is file-local to janet.c so the bindings cannot expose it. Only
+/// the first two fields are needed; `top_dyns` sits at offset 8 in
+/// `struct JanetVM`. Access goes through `janet_local_vm`, which returns
+/// the calling thread's copy of the VM.
+#[cfg(feature = "plugin")]
+#[repr(C)]
+struct JanetVMPrefix {
+    user: *mut core::ffi::c_void,
+    top_dyns: *mut janetrs::lowlevel::JanetTable,
+}
+
+#[cfg(feature = "plugin")]
+unsafe extern "C" {
+    fn janet_local_vm() -> *mut JanetVMPrefix;
+}
+
 /// Point Janet's TOP-LEVEL dyn table at the same `:out`/`:err` buffers the
 /// harness prelude installed in the root env (dirge-c8lh).
 ///
@@ -2221,6 +2239,18 @@ fn mirror_capture_buffers_into_top_dyns(client: &JanetClient) {
         unsafe {
             janetrs::lowlevel::janet_gcroot(raw);
             janetrs::lowlevel::janet_setdyn(c_name.as_ptr(), raw);
+        }
+    }
+    // dirge-eona: `janet_setdyn` above created `janet_vm.top_dyns` (no
+    // fiber is live here), and Janet's collector never marks that table —
+    // it appears nowhere in the mark phase of janet.c. The first full
+    // collection frees it, and the next no-fiber `janet_dyn` (the stack
+    // trace printer's `:err-color` lookup) reads the freed table and
+    // segfaults the VM. Root the table itself, not just the buffers in it.
+    unsafe {
+        let top = (*janet_local_vm()).top_dyns;
+        if !top.is_null() {
+            janetrs::lowlevel::janet_gcroot(janetrs::lowlevel::janet_wrap_table(top));
         }
     }
 }

--- a/src/plugin/worker.rs
+++ b/src/plugin/worker.rs
@@ -2192,20 +2192,38 @@ fn run_command_loop(
 
 /// dirge-eona: `janet_vm` is `__thread` in evil-janet's janet.c (that is
 /// how the plugin and notebook VMs coexist on separate threads), and its
-/// layout is file-local to janet.c so the bindings cannot expose it. Only
-/// the first two fields are needed; `top_dyns` sits at offset 8 in
-/// `struct JanetVM`. Access goes through `janet_local_vm`, which returns
-/// the calling thread's copy of the VM.
+/// layout is file-local to janet.c — `janet.h` only forward-declares
+/// `struct JanetVM`, so bindgen renders it opaque (`_unused: [u8; 0]`) and
+/// the bindings cannot reach a field. Only the first two are needed;
+/// `top_dyns` sits at offset 8, right after the `void *user` slot
+/// (janet.c:172).
+///
+/// That offset is an assumption about a private C layout, and it has to hold
+/// across any `evil-janet` 1.x (`janetrs` depends on `"1"`, so a `cargo
+/// update` can move it). `top_dyns_offset_is_stable` in the plugin test
+/// module pins it, so an upstream field insertion fails a test rather than
+/// silently rooting whatever now sits at offset 8.
 #[cfg(feature = "plugin")]
 #[repr(C)]
 struct JanetVMPrefix {
+    #[allow(dead_code)]
     user: *mut core::ffi::c_void,
     top_dyns: *mut janetrs::lowlevel::JanetTable,
 }
 
+/// The calling thread's `janet_vm.top_dyns` — null until the first
+/// `janet_setdyn` on this thread creates it (janet.c:4657).
+///
+/// Reads through [`JanetVMPrefix`]; see there for the layout assumption.
 #[cfg(feature = "plugin")]
-unsafe extern "C" {
-    fn janet_local_vm() -> *mut JanetVMPrefix;
+pub(super) fn top_dyns_ptr() -> *mut janetrs::lowlevel::JanetTable {
+    // SAFETY: `janet_local_vm` returns `&janet_vm`, this thread's own
+    // thread-local VM, so it is never null once Janet is initialized on the
+    // thread — true for every caller, each of which holds a live
+    // `JanetClient`. The cast reinterprets the bindings' opaque `JanetVM` as
+    // its own leading fields, so reading `top_dyns` touches only bytes
+    // inside the real struct.
+    unsafe { (*(janetrs::lowlevel::janet_local_vm() as *mut JanetVMPrefix)).top_dyns }
 }
 
 /// Point Janet's TOP-LEVEL dyn table at the same `:out`/`:err` buffers the
@@ -2247,9 +2265,17 @@ fn mirror_capture_buffers_into_top_dyns(client: &JanetClient) {
     // collection frees it, and the next no-fiber `janet_dyn` (the stack
     // trace printer's `:err-color` lookup) reads the freed table and
     // segfaults the VM. Root the table itself, not just the buffers in it.
-    unsafe {
-        let top = (*janet_local_vm()).top_dyns;
-        if !top.is_null() {
+    // Janet roots `abstract_registry` the same way, for the same reason
+    // (janet.c:35577) — a VM-struct field is not a GC root on its own.
+    let top = top_dyns_ptr();
+    if !top.is_null() {
+        // SAFETY: `top` is the table `janet_setdyn` just created on this
+        // thread, so it is a live Janet object; `janet_wrap_table` only
+        // tags the pointer. Rooting is permanent by design and cannot leak
+        // past one entry per VM: both callers run once at thread init, and
+        // `top_dyns` is assigned nowhere but `janet_init`/`janet_deinit`
+        // (NULL) and this lazy create, so the root can never go stale.
+        unsafe {
             janetrs::lowlevel::janet_gcroot(janetrs::lowlevel::janet_wrap_table(top));
         }
     }


### PR DESCRIPTION
`mirror_capture_buffers_into_top_dyns` created the top-level dyn table via `janet_setdyn` but only rooted the buffers inside it. Janet's collector never marks `top_dyns` (absent from the mark phase in 1.37.2 and 1.41.3 alike), so the first full GC freed the table and the next no-fiber `janet_dyn` (the stack-trace printer's `:err-color` lookup) read freed memory, faulting in `janet_dict_find`.

- Root the table itself after the mirror; access the TLS `janet_vm` through `janet_local_vm()`.
- Add `plugin_worker_uaf_stress` regression test (env-driven, `#[ignore]`-gated) replaying the hook sequence that preceded the crash; previously SIGSEGV'd in 3 turns, now passes 3/30.

Refs: dirge-eona