### PR TITLE
Trip the repeat-loop guard on inert shell commands (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- A run that spins on no-op shell commands is now caught by the repeat-loop
+  guard. A model that had decided it needed a different tool but kept reaching
+  for `bash` anyway issued a long run of `echo "ready"` / `echo done` / `true`
+  / `echo ok`, narrating "I need to call the memory tool" between each one, and
+  every guard missed it: the storm breaker needs *identical* arguments and each
+  echoed string differed, the failure tracker needs errored results and every
+  echo succeeded, nothing was edited so the file-touch tracker saw nothing, and
+  the progress monitor only judges a turn boundary and caps itself at two
+  nudges. The run burned turns until the cap. Inert commands — ones that change
+  no state and return nothing the model did not already know — now share a
+  single storm signature, so a spin of *varied* no-ops counts as the one
+  repeated behaviour it is and trips the guard on the third. The intervention
+  it gets is its own message rather than the generic repeat one: it names the
+  emptiness and points at the tool list, because "study the earlier results"
+  is useless advice when the earlier result was `ok`. The classifier is
+  deliberately narrow (literal `echo`/`printf` and the null builtins, nothing
+  with a substitution, redirect, pipe, subshell or background), so ordinary
+  shell work is untouched. (#808)
+
 ## [0.25.3] - 2026-08-31
 
 ### Fixed

--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -125,6 +125,16 @@ The intervention is deliberately *not* a bare "don't repeat yourself". Research 
 
 This gives the model one structured shot to self-correct (`turn_self_corrected`). If it keeps producing only suppressed calls afterward, the inner loop exits rather than spinning. The outermost backstop is the `max_turns` cap (see [config.md](config.md)), which stops the run and surfaces a `<system>` notice.
 
+### Inert commands share one signature
+
+The identical-args rule has a blind spot: a model can spin without ever repeating itself exactly. The reported case ([#808](https://github.com/dirge-code/dirge/issues/808)) was a run that had decided it needed the `memory` tool, could not bring itself to emit that call, and instead issued `echo "ready"`, `echo done`, `true`, `echo ok`, `echo "switching to memory tool"` — narrating its intent between each one. Every guard missed it: the arguments all differed (storm), every command succeeded (failure tracker), nothing was edited (file-touch tracker), and the progress monitor only judges a turn boundary and caps itself at two nudges.
+
+`src/agent/agent_loop/inert.rs` classifies a shell command as **inert** when it can change no state and return no information the model did not already hold — literal `echo`/`printf`, the null builtins (`true`, `false`, `:`), and sequences of exactly those. The storm breaker keys every inert call on one shared signature, so a spin of *varied* no-ops counts as the single repeated behaviour it is and trips the guard on the third.
+
+The classifier is deliberately narrow, because a false positive costs real work: anything reaching outside the process — a substitution, a redirect, a pipe, a subshell, a backgrounded job — disqualifies the whole command, and the segment scan is quote-blind in the direction that can only turn an inert verdict into a non-inert one. An inert call also counts as non-mutating for the window, so it can't launder prior read-only entries out of the guard's reach.
+
+Suppression here carries its own intervention (`INERT_LOOP_GUARD` in `run.rs`) rather than the reflect-then-pivot text above. "Look at the earlier results" is useless advice when the earlier result was `ok`; the inert message names the emptiness and points the model at its tool list instead.
+
 ## Phased plan workflow (`/plan`)
 
 An opt-in, per-task workflow (ported from [vix](https://github.com/kirby88/vix)) that splits a complex request into separate, context-isolated phases instead of one long single-agent run. It is an **explicit command**, not a forced mode — regular chat is untouched, and the user decides which tasks warrant it. Gated by `phased_workflow_enabled` (default off; see [config.md](config.md)). The logic lives under `src/agent/plan/`: `workflow.rs` (phase prompts + verdict parsing + the shared `next_review_step` policy) and `runtime.rs` (the runner-drain glue + reviewer fork); the entry is `src/ui/slash/cmd_plan.rs` and the reviewer loop runs in `src/ui/run_handlers/plan_review.rs`.

--- a/src/agent/agent_loop/inert.rs
+++ b/src/agent/agent_loop/inert.rs
@@ -1,0 +1,266 @@
+//! Inert-command classification — the "spinning on no-ops" signal (#808).
+//!
+//! Every existing loop guard keys on something the model *does*: the storm
+//! breaker needs a call repeated with IDENTICAL args
+//! ([`super::storm`]), the failure tracker needs errored results
+//! ([`super::failure_tracker`]), the file-touch tracker needs the same
+//! file edited over and over ([`super::context_depth`]), and the progress
+//! monitor only judges a turn BOUNDARY and is capped at two nudges
+//! ([`super::progress`]).
+//!
+//! A model that has lost the thread slips between all of them. The
+//! reported case (#808): the model decided it needed the `memory` tool,
+//! could not bring itself to emit that call, and instead issued a run of
+//! shell commands that did nothing at all —
+//!
+//! ```text
+//! echo "ready"          →  ready
+//! echo done             →  done
+//! echo ok               →  ok
+//! true                  →  (no output)
+//! echo "switching to memory tool"
+//! echo "final check before memory call"
+//! ```
+//!
+//! — narrating "I keep calling bash, I need to call the memory tool"
+//! between each one. Storm never fired because the echoed strings all
+//! differed. The failure tracker never fired because every command
+//! *succeeded*. Nothing was edited, so context-depth saw nothing. The run
+//! burned turns until the cap.
+//!
+//! What ties those calls together is not their arguments but their
+//! *effect*: none. An inert command changes no state and returns no
+//! information the model did not already hold — it echoes back a literal
+//! the model itself just wrote. Collapsing them all onto ONE storm
+//! signature ([`INERT_ARGS`]) is what lets the existing repeat-loop guard
+//! see a spin of varied no-ops as the single repeated call it actually is.
+//!
+//! ## Conservative by construction
+//!
+//! A false positive here costs real work, so the classifier only says
+//! "inert" for shapes it can prove: literal `echo`/`printf`, the null
+//! builtins (`true`, `false`, `:`), and sequences of exactly those. The
+//! segment scan is deliberately naive about quoting — splitting on `;`,
+//! `&&`, `||` and newlines without tracking quotes can only ever *break*
+//! a segment into pieces that fail the exact-token match below, so
+//! misparsing a quoted separator turns an inert verdict into a
+//! non-inert one and never the reverse. Anything reaching outside the
+//! process — a substitution, a redirect, a pipe, a subshell, a
+//! backgrounded job — disqualifies the whole command.
+
+use super::tools::ToolCall;
+
+/// The synthetic storm signature every inert command collapses onto.
+/// Not valid JSON, so it can never collide with a real
+/// [`super::message::canonical_json`] argument blob.
+pub const INERT_ARGS: &str = "<inert-command>";
+
+/// Shell metacharacters that take a command outside "prints a literal I
+/// already knew". `$` and a backtick substitute in state we can't see;
+/// `<`, `>` redirect; `|` pipes the output somewhere it can matter; `&`
+/// backgrounds; parens and braces open a subshell or group whose contents
+/// this scanner does not read.
+const OUTWARD_CHARS: &[char] = &['$', '`', '<', '>', '|', '&', '(', ')', '{', '}'];
+
+/// Builtins that do nothing and say nothing.
+const NULL_BUILTINS: &[&str] = &["true", "false", ":"];
+
+/// Verbs whose only effect is to print their (literal) arguments back.
+const ECHO_VERBS: &[&str] = &["echo", "printf"];
+
+/// True when `command` cannot change any state or surface any information
+/// the caller did not already have.
+///
+/// See the module docs for why this is deliberately narrow. An empty or
+/// whitespace-only command is NOT inert: it is a malformed call, which is
+/// the tool-input-repair path's business, not this one's.
+pub fn is_inert_command(command: &str) -> bool {
+    let mut saw_segment = false;
+    for segment in split_segments(command) {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            // A trailing `;` or a blank line between statements.
+            continue;
+        }
+        if !is_inert_segment(segment) {
+            return false;
+        }
+        saw_segment = true;
+    }
+    saw_segment
+}
+
+/// True when `call` is a `bash` invocation whose command is inert.
+///
+/// Keyed on the tool NAME rather than a permission operation: this is a
+/// shell-syntax judgement, and applying it to some future `Execute` tool
+/// with different argument semantics would be reading a `command` field
+/// that means something else.
+pub fn is_inert_call(call: &ToolCall) -> bool {
+    if call.name != "bash" {
+        return false;
+    }
+    // A backgrounded shell is never inert regardless of its command: it
+    // returns a shell id the model can poll, which is state.
+    let background = call.arguments.get("background").and_then(|v| v.as_bool());
+    if background == Some(true) {
+        return false;
+    }
+    let command = call.arguments.get("command").and_then(|v| v.as_str());
+    command.is_some_and(is_inert_command)
+}
+
+/// Split on the statement separators `;`, `&&`, `||` and newlines.
+///
+/// Quote-blind on purpose — see the module docs. `&&` and `||` are
+/// matched before the single `&`/`|` they contain so a legitimate
+/// separator isn't left behind as a disqualifying [`OUTWARD_CHARS`]
+/// character in the segment.
+fn split_segments(command: &str) -> Vec<&str> {
+    let bytes = command.as_bytes();
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (is_sep, width) = match bytes[i] {
+            b'&' if bytes.get(i + 1) == Some(&b'&') => (true, 2),
+            b'|' if bytes.get(i + 1) == Some(&b'|') => (true, 2),
+            b';' | b'\n' => (true, 1),
+            _ => (false, 1),
+        };
+        if is_sep {
+            out.push(&command[start..i]);
+            i += width;
+            start = i;
+        } else {
+            i += width;
+        }
+    }
+    out.push(&command[start..]);
+    out
+}
+
+/// True when one already-trimmed, non-empty statement is inert.
+fn is_inert_segment(segment: &str) -> bool {
+    if segment.contains(OUTWARD_CHARS) {
+        return false;
+    }
+    if NULL_BUILTINS.contains(&segment) {
+        return true;
+    }
+    let verb = segment.split_whitespace().next().unwrap_or("");
+    // `echo` alone prints a newline; `echo <literals>` prints them back.
+    // Either way the model learns nothing, and OUTWARD_CHARS above has
+    // already ruled out substitutions and redirects in the arguments.
+    ECHO_VERBS.contains(&verb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn bash(command: &str) -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({ "command": command }),
+        }
+    }
+
+    #[test]
+    fn the_commands_from_the_report_are_all_inert() {
+        // Verbatim from #808 — the run that no guard could see.
+        for cmd in [
+            "echo \"ready\"",
+            "echo done",
+            "echo ok",
+            "true",
+            "echo \"switching to memory tool\"",
+            "echo \"final check before memory call\"",
+        ] {
+            assert!(is_inert_command(cmd), "{cmd}");
+        }
+    }
+
+    #[test]
+    fn null_builtins_and_sequences_of_them_are_inert() {
+        assert!(is_inert_command(":"));
+        assert!(is_inert_command("false"));
+        assert!(is_inert_command("true; true"));
+        assert!(is_inert_command("echo a && true"));
+        assert!(is_inert_command("echo a\necho b\n"));
+        assert!(is_inert_command("  echo spaced  ;  "));
+        assert!(is_inert_command("printf 'hello'"));
+    }
+
+    #[test]
+    fn real_work_is_never_inert() {
+        for cmd in [
+            "cargo test",
+            "git status",
+            "ls",
+            "pwd",
+            "date",
+            "cat src/main.rs",
+            // Anything reaching outward, even wrapped around an echo.
+            "echo hi > file.txt",
+            "echo $HOME",
+            "echo `hostname`",
+            "echo hi | wc -l",
+            "echo hi &",
+            "(echo hi)",
+            "python3 - << 'PYEOF'\nprint(\"x\")\nPYEOF",
+            // From #808: this one genuinely attempted something.
+            "cd /home/x && memory_replace 2>/dev/null || echo \"no shell memory tool\"",
+            // A real command anywhere in the sequence disqualifies it.
+            "echo starting && cargo build",
+            "true; rm -rf build",
+        ] {
+            assert!(!is_inert_command(cmd), "{cmd}");
+        }
+    }
+
+    #[test]
+    fn quote_blind_splitting_only_ever_errs_toward_not_inert() {
+        // A separator inside quotes splits a segment into pieces that
+        // fail the exact-token match, so the verdict is "not inert".
+        // Wrong, but wrong in the safe direction.
+        assert!(!is_inert_command("echo \"a; true\""));
+        assert!(!is_inert_command("echo 'x && true'"));
+    }
+
+    #[test]
+    fn an_empty_command_is_not_inert() {
+        assert!(!is_inert_command(""));
+        assert!(!is_inert_command("   \n  "));
+        assert!(!is_inert_command(";;"));
+    }
+
+    #[test]
+    fn only_bash_calls_are_classified() {
+        assert!(is_inert_call(&bash("echo ok")));
+        assert!(!is_inert_call(&bash("cargo test")));
+
+        // Same argument shape, different tool: not our judgement to make.
+        let mut other = bash("echo ok");
+        other.name = "shell_plugin".to_string();
+        assert!(!is_inert_call(&other));
+
+        // Missing or non-string `command`.
+        let mut malformed = bash("echo ok");
+        malformed.arguments = json!({});
+        assert!(!is_inert_call(&malformed));
+    }
+
+    #[test]
+    fn a_backgrounded_shell_is_never_inert() {
+        // It returns a pollable shell id, which is state the model gains.
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({ "command": "echo ok", "background": true }),
+        };
+        assert!(!is_inert_call(&call));
+    }
+}

--- a/src/agent/agent_loop/mod.rs
+++ b/src/agent/agent_loop/mod.rs
@@ -41,6 +41,7 @@ pub mod goal;
 mod h7_smoke;
 pub mod heal;
 pub mod hooks;
+pub mod inert;
 pub mod inflight;
 pub mod integration;
 #[cfg(test)]

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -3374,6 +3374,10 @@ pub async fn run_loop(
             // are backfilled (below). None unless the terminal-stuck
             // branch fires.
             let mut storm_give_up_tools: Option<Vec<String>> = None;
+            // Whether that give-up was a spin of inert shell commands
+            // (#808) rather than an identical repeat, so the explanation
+            // the user reads matches what actually happened.
+            let mut storm_give_up_inert = false;
             if !tool_calls.is_empty() {
                 let original_count = tool_calls.len();
                 let (mut surviving_calls, storm_report) = guards.inspect_calls(&tool_calls);
@@ -3402,6 +3406,24 @@ pub async fn run_loop(
                         3. Propose 2-3 FUNDAMENTALLY different approaches — a different tool, a different entry point, or a different interpretation of the problem — and pick the most promising one.\n\
                         4. Proceed with that approach.\n\
                         If none of them can work with the tools available, say so plainly and report what you found instead of trying again.";
+                    // #808: the same reflect-then-pivot shape, but for a
+                    // spin of no-op shell commands the diagnosis has to
+                    // differ. The repeat message tells the model to study
+                    // "the earlier results" — for `echo ok` there are none
+                    // worth studying, and the observed failure was a model
+                    // that already KNEW it wanted a different tool and kept
+                    // reaching for the shell anyway. So this one names the
+                    // emptiness directly and points at the tool list.
+                    const INERT_LOOP_GUARD: &str = "[inert-loop guard] Your last several shell commands did nothing — they changed no state and told you nothing you didn't already know (`echo`, `true`, and the like). You're spinning. Do NOT run another one. Before doing anything else, work through these steps:\n\
+                        1. State plainly what you are actually trying to do right now.\n\
+                        2. If it needs a tool other than `bash`, call that tool directly — a shell command cannot invoke another tool, and narrating that you intend to call one does not call it. Check the tool list you were given for its exact name and argument schema.\n\
+                        3. If the tool you want does not exist, say so plainly and either do the job with the tools you have or stop and report what is blocking you.\n\
+                        4. Proceed. Your next action must be either a real tool call that does work or a message to the user — not another placeholder command.";
+                    let guard_head = if storm_report.all_inert() {
+                        INERT_LOOP_GUARD
+                    } else {
+                        REPEAT_LOOP_GUARD
+                    };
                     // F4: record each looped call as an abandoned approach,
                     // then append the running list so the model sees every
                     // dead end it has hit this run, not just this repeat.
@@ -3414,10 +3436,8 @@ pub async fn run_loop(
                         let sig = super::reflexion::approach_signature(&call.name, &args);
                         reflections.record(sig);
                     }
-                    let guard_text = format!(
-                        "{REPEAT_LOOP_GUARD}{}",
-                        reflections.block().unwrap_or_default()
-                    );
+                    let guard_text =
+                        format!("{guard_head}{}", reflections.block().unwrap_or_default());
                     let guard_blocks = vec![ContentBlock::Text {
                         text: guard_text.clone(),
                     }];
@@ -3448,6 +3468,7 @@ pub async fn run_loop(
                     // stop, synthesize a coherent assistant explanation
                     // (built after backfill, below).
                     storm_give_up_tools = Some(tool_calls.iter().map(|c| c.name.clone()).collect());
+                    storm_give_up_inert = storm_report.all_inert();
                 }
 
                 // dirge-1elu.1: publish-state guard — pre-dispatch, after the
@@ -3655,7 +3676,11 @@ pub async fn run_loop(
                 // the user sees a coherent reply instead of an empty turn
                 // and the model carries its own failure account forward.
                 if let Some(tools) = storm_give_up_tools.take() {
-                    let text = super::storm::failure_narrative(&tools);
+                    let text = if storm_give_up_inert {
+                        super::storm::inert_narrative()
+                    } else {
+                        super::storm::failure_narrative(&tools)
+                    };
                     let msg =
                         AssistantMessage::new(vec![ContentBlock::Text { text }], StopReason::Stop);
                     // Render it to the user (text flows via MessageUpdate).

--- a/src/agent/agent_loop/storm.rs
+++ b/src/agent/agent_loop/storm.rs
@@ -6,6 +6,14 @@
 //! call appears `threshold` times within `window_size` entries, the
 //! call is suppressed (the model is stuck in a loop).
 //!
+//! **Inert shell commands share one signature** (#808). A model spinning
+//! on `echo ok` / `true` / `echo done` is repeating one behaviour, not
+//! three calls, but the raw arguments differ every time so the identical-
+//! args rule never sees it. [`super::inert`] classifies those calls and
+//! this module keys them all on [`inert::INERT_ARGS`], which is what puts
+//! them back inside the window's reach. See that module for why the
+//! classifier is narrow.
+//!
 //! Mutating calls (write, edit, bash) clear prior read-only entries
 //! from the window so a post-edit verify-read isn't flagged as a
 //! repeat. Mutators still count amongst themselves — three identical
@@ -15,6 +23,7 @@
 //! the guard regardless of repetition count.
 
 use super::activity::Outcome;
+use super::inert;
 use super::tools::ToolCall;
 use std::collections::HashSet;
 
@@ -23,6 +32,13 @@ use std::collections::HashSet;
 pub struct StormVerdict {
     pub suppress: bool,
     pub reason: Option<String>,
+    /// The suppressed call was an inert shell command (#808) rather than
+    /// an identical repeat. Carried through to [`StormReport`] so the
+    /// loop can name the actual problem — "these commands did nothing" is
+    /// a different diagnosis from "you ran this twice", and the generic
+    /// repeat message would send the model looking for a result its
+    /// `echo` never produced.
+    pub inert: bool,
 }
 
 impl StormVerdict {
@@ -30,6 +46,7 @@ impl StormVerdict {
         Self {
             suppress: false,
             reason: None,
+            inert: false,
         }
     }
 
@@ -39,6 +56,18 @@ impl StormVerdict {
             reason: Some(format!(
                 "{name} called with identical args {count} times — repeat-loop guard tripped"
             )),
+            inert: false,
+        }
+    }
+
+    fn suppress_inert(name: &str, count: usize) -> Self {
+        Self {
+            suppress: true,
+            reason: Some(format!(
+                "{name} ran {count} commands with no effect (no state change, no new \
+                 information) — inert-loop guard tripped"
+            )),
+            inert: true,
         }
     }
 }
@@ -48,6 +77,9 @@ impl StormVerdict {
 pub struct StormReport {
     /// How many calls were suppressed.
     pub storms_broken: usize,
+    /// How many of `storms_broken` were inert shell commands (#808)
+    /// rather than identical repeats.
+    pub inert_broken: usize,
     /// Per-suppression reasons for diagnostics.
     pub notes: Vec<String>,
 }
@@ -56,6 +88,13 @@ impl StormReport {
     /// True when every call was suppressed and there was at least one.
     pub fn all_suppressed(&self, original_count: usize) -> bool {
         self.storms_broken > 0 && self.storms_broken == original_count && original_count > 0
+    }
+
+    /// True when every suppression this batch was an inert command — the
+    /// cue for the loop to use the inert diagnosis instead of the generic
+    /// repeat one.
+    pub fn all_inert(&self) -> bool {
+        self.storms_broken > 0 && self.inert_broken == self.storms_broken
     }
 }
 
@@ -121,6 +160,20 @@ impl StormBreaker {
         format!("{name}\u{0}{args}")
     }
 
+    /// The args half of a call's signature.
+    ///
+    /// Normally the canonical (key-sorted) JSON blob. An inert shell
+    /// command instead collapses onto [`inert::INERT_ARGS`] so a spin of
+    /// varied no-ops counts as the one repeated behaviour it is (#808).
+    /// Used by both `inspect` and `note_outcome` so the two can never
+    /// disagree about what "the same call" means.
+    fn args_key(call: &ToolCall) -> String {
+        if inert::is_inert_call(call) {
+            return inert::INERT_ARGS.to_string();
+        }
+        super::message::canonical_json(&call.arguments)
+    }
+
     /// Record the [`Outcome`] of a dispatched call. A `Timeout` marks the
     /// call's signature expensive so the next identical retry trips the
     /// breaker one occurrence sooner. Ok/Error are no-ops — ordinary
@@ -129,7 +182,7 @@ impl StormBreaker {
         if outcome != Outcome::Timeout {
             return;
         }
-        let args = super::message::canonical_json(&call.arguments);
+        let args = Self::args_key(call);
         self.expensive.insert(Self::signature(&call.name, &args));
     }
 
@@ -148,10 +201,16 @@ impl StormBreaker {
         // reprs (`1` ≡ `1.0`), so the repeat detector isn't silently dependent
         // on `serde_json`'s `preserve_order` feature staying off (dirge-ark9,
         // closing dirge-7bwx review-fix #6) and matches the scavenger's
-        // dedup exactly.
-        let args = super::message::canonical_json(&call.arguments);
+        // dedup exactly. Inert shell commands short-circuit to one shared
+        // key — see [`Self::args_key`].
+        let args = Self::args_key(call);
+        let is_inert = args == inert::INERT_ARGS;
 
-        let mutating = self.is_mutating.as_ref().map(|f| f(call)).unwrap_or(false);
+        // An inert command is `Execute` by permission operation but by
+        // definition changes nothing, so it must not clear the window's
+        // read-only entries — otherwise a read/echo/read/echo spin would
+        // launder the reads out of the guard's reach on every echo.
+        let mutating = !is_inert && self.is_mutating.as_ref().map(|f| f(call)).unwrap_or(false);
         let read_only = !mutating;
 
         if mutating {
@@ -187,7 +246,11 @@ impl StormBreaker {
         };
 
         if count >= effective.saturating_sub(1) {
-            return StormVerdict::suppress(name, count + 1);
+            return if is_inert {
+                StormVerdict::suppress_inert(name, count + 1)
+            } else {
+                StormVerdict::suppress(name, count + 1)
+            };
         }
 
         self.recent.push(RecentEntry {
@@ -219,6 +282,9 @@ impl StormBreaker {
             let verdict = self.inspect(call);
             if verdict.suppress {
                 report.storms_broken += 1;
+                if verdict.inert {
+                    report.inert_broken += 1;
+                }
                 if let Some(reason) = verdict.reason {
                     tracing::warn!("storm breaker: {reason}");
                     report.notes.push(reason);
@@ -278,6 +344,22 @@ pub fn failure_narrative(looped_tools: &[String]) -> String {
     )
 }
 
+/// The [`failure_narrative`] counterpart for a run that gave up on a spin
+/// of inert shell commands (#808).
+///
+/// Kept separate because the honest account differs: nothing was retried
+/// and nothing came back the same, so "I kept making the same call and
+/// getting the same result" would misdescribe what the user watched
+/// happen. Takes no tool list — by construction the loop was `bash`.
+pub fn inert_narrative() -> String {
+    "I've stopped here because I was spinning. I kept running shell commands that did \
+     nothing — `echo`, `true`, and the like — instead of taking a real next step, and \
+     running more of them wasn't going to get me any further.\n\n\
+     I wasn't able to finish what you asked. If you can confirm the goal or point me at \
+     the next concrete step, I'll pick it back up from there."
+        .to_string()
+}
+
 /// Built-in mutating tools: calls that change filesystem state or run
 /// external code. Derived from the canonical tool→[`Operation`] mapping
 /// (`Edit` = file mutation, `Execute` = shell) rather than a hand-kept
@@ -319,6 +401,10 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The `is_mutating` predicate slot, spelled once so the inert-window
+    /// test can name it without repeating the full boxed-closure type.
+    type MutPred = Box<dyn Fn(&ToolCall) -> bool + Send + Sync>;
+
     fn call(name: &str, args: serde_json::Value) -> ToolCall {
         ToolCall {
             id: "call_1".to_string(),
@@ -332,6 +418,10 @@ mod tests {
             name,
             serde_json::from_str::<serde_json::Value>(args_json).unwrap_or(json!({})),
         )
+    }
+
+    fn bash(command: &str) -> ToolCall {
+        call("bash", json!({ "command": command }))
     }
 
     #[test]
@@ -390,6 +480,72 @@ mod tests {
         assert!(!sb.inspect(&c).suppress);
         assert!(!sb.inspect(&c).suppress);
         assert!(sb.inspect(&c).suppress, "back to threshold 3 after reset");
+    }
+
+    #[test]
+    fn varied_inert_shell_commands_trip_the_guard() {
+        // #808: the exact spin no guard could see. Three DIFFERENT no-op
+        // commands share one signature, so the third is suppressed.
+        let mut sb = StormBreaker::default();
+        assert!(!sb.inspect(&bash("echo done")).suppress);
+        assert!(!sb.inspect(&bash("echo ok")).suppress);
+        let verdict = sb.inspect(&bash("true"));
+        assert!(verdict.suppress, "3rd inert command should be suppressed");
+        assert!(verdict.inert, "and be reported as inert, not a repeat");
+        let reason = verdict.reason.unwrap_or_default();
+        assert!(
+            reason.contains("inert-loop guard"),
+            "reason must name the inert guard, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn varied_real_commands_still_pass() {
+        // The counterpart guarantee: folding inert commands together must
+        // not fold ordinary shell work together.
+        let mut sb = StormBreaker::default();
+        for cmd in ["cargo build", "cargo test", "git status", "ls -la"] {
+            assert!(!sb.inspect(&bash(cmd)).suppress, "{cmd}");
+        }
+    }
+
+    #[test]
+    fn an_inert_command_does_not_clear_read_only_window_entries() {
+        // An inert command is `Execute` by permission operation but
+        // mutates nothing, so it must not launder prior read-only entries
+        // out of the window the way a real mutator does. No exemption
+        // predicate here, so the read-only tool is actually tracked.
+        let mutating: MutPred = Box::new(default_mutating);
+        let mut sb = StormBreaker::new(6, 3, Some(mutating), None);
+        let r = call_json("read", r#"{"path":"a.rs"}"#);
+        assert!(!sb.inspect(&r).suppress);
+        assert!(!sb.inspect(&bash("echo a")).suppress);
+        assert!(!sb.inspect(&r).suppress);
+        assert!(sb.inspect(&r).suppress, "the reads must still add up");
+    }
+
+    #[test]
+    fn report_flags_an_all_inert_batch() {
+        let mut sb = StormBreaker::default();
+        sb.inspect(&bash("echo a"));
+        sb.inspect(&bash("echo b"));
+        let (surviving, report) = sb.filter_calls(&[bash("echo c")]);
+        assert!(surviving.is_empty());
+        assert_eq!(report.storms_broken, 1);
+        assert_eq!(report.inert_broken, 1);
+        assert!(report.all_inert());
+    }
+
+    #[test]
+    fn an_identical_repeat_is_not_reported_as_inert() {
+        let mut sb = StormBreaker::default();
+        let c = bash("cargo test");
+        sb.inspect(&c);
+        sb.inspect(&c);
+        let (_, report) = sb.filter_calls(&[c]);
+        assert_eq!(report.storms_broken, 1);
+        assert_eq!(report.inert_broken, 0);
+        assert!(!report.all_inert(), "must keep the generic repeat message");
     }
 
     #[test]
@@ -591,6 +747,16 @@ mod tests {
         ]);
         assert!(n.contains("`edit` and `bash`"), "got: {n}");
         assert_eq!(n.matches("`edit`").count(), 1, "edit listed once: {n}");
+    }
+
+    #[test]
+    fn inert_narrative_describes_the_spin_not_a_repeat() {
+        let n = inert_narrative();
+        assert!(n.starts_with("I've stopped"), "first-person: {n}");
+        // It must not claim the run repeated a call and got the same
+        // result — that is the other guard's story, and untrue here.
+        assert!(!n.contains("the same"), "must not read as a repeat: {n}");
+        assert!(n.contains("nothing"), "names the emptiness: {n}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #808.

## The failure

A run decided it needed the `memory` tool, could not bring itself to emit that call, and kept reaching for the shell anyway — `echo "ready"`, `echo done`, `true`, `echo ok`, `echo "switching to memory tool"` — narrating "I need to call the memory tool" between each one. Every loop guard missed it:

| guard | why it missed |
|---|---|
| storm breaker | needs **identical** args; each echoed string differed |
| failure tracker | needs errored results; every echo **succeeded** |
| context-depth | needs the same file touched; nothing was edited |
| progress monitor | only judges a turn boundary, and caps itself at two nudges |

The run burned turns until `max_turns`.

## The fix

What ties those calls together is not their arguments but their *effect*: none. A new `src/agent/agent_loop/inert.rs` classifies a shell command as **inert** when it can change no state and return no information the model did not already hold, and the storm breaker keys every inert call on one shared signature — so a spin of *varied* no-ops counts as the single repeated behaviour it is and trips on the third.

Three things beyond the plumbing:

- **The classifier is narrow on purpose** — a false positive costs real work. Literal `echo`/`printf` and the null builtins (`true`, `false`, `:`) only; anything reaching outside the process (substitution, redirect, pipe, subshell, background) disqualifies the whole command. The segment scan is quote-blind *in the direction that can only turn an inert verdict into a non-inert one*, never the reverse.
- **Inert counts as non-mutating for the window**, so a read/echo/read/echo spin cannot launder the reads out of the guard's reach on every echo.
- **Its own messages.** "Look at the earlier results" is useless advice when the earlier result was `ok`, so the intervention (`INERT_LOOP_GUARD` in `run.rs`) names the emptiness and points at the tool list. The give-up narrative the user reads is separate too, since nothing was retried and nothing came back the same.

Plus a CHANGELOG entry and a new `docs/agent-loop.md` section.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` all pass — **5454 passed, 0 failed**, including 11 new tests covering the exact command sequence from the report.

Caveat: that ran under `--no-default-features --features no-plugin`, because `evil-janet` needs libclang and the dev box lacks it, so the Janet plugin paths were not compiled locally. Nothing here touches them; CI is the first build that covers them.