### PR TITLE
Report a provider usage cap as one in the TUI (#818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- A provider usage cap now reads as one in the TUI instead of arriving as a raw
+  provider blob. `classify_error` already routed GLM's `429` code `1308` to the
+  non-retryable `UsageCap`, and `--print` already reported it in a sentence, but
+  the interactive surface printed `error:` followed by whatever the provider
+  sent — for z.ai that is an `HttpError: Invalid status code 429` wrapper around
+  a Chinese sentence and an error code, so the two things the user needs (when
+  the quota lifts, and that `/model` works right now) were the two things the
+  line did not carry. Both surfaces now share one headline, which names the
+  reset instant when the provider gave one, and the provider's own text is kept
+  verbatim as the cause. Nothing about the retry behaviour changes — a cap was
+  already non-retryable. (#818)
 - A run that spins on no-op shell commands is now caught by the repeat-loop
   guard. A model that had decided it needed a different tool but kept reaching
   for `bash` anyway issued a long run of `echo "ready"` / `echo done` / `true`

--- a/src/agent/recovery.rs
+++ b/src/agent/recovery.rs
@@ -529,6 +529,24 @@ pub fn usage_cap_reset_hint(msg: &str) -> Option<String> {
     })
 }
 
+/// The one-line headline a usage cap deserves, with the reset time when the
+/// provider named one.
+///
+/// A usage cap is not a failure to debug: the request was well-formed and the
+/// provider simply refused it until a quota rolls over. The raw text says none
+/// of that — Zhipu/GLM's is an `HttpError: Invalid status code 429` wrapper
+/// around a Chinese sentence and an error code (#818) — so every surface that
+/// reports one starts from this sentence and appends the cause verbatim, which
+/// keeps the provider's own wording available for bug reports.
+pub fn usage_cap_headline(msg: &str) -> String {
+    match usage_cap_reset_hint(msg) {
+        Some(reset) => format!("Provider usage cap reached — quota resets at {reset}"),
+        None => {
+            "Provider usage cap reached — quota won't reset within a retryable window".to_string()
+        }
+    }
+}
+
 /// Scan `msg` for a `Retry-After:` header whose value parses as an
 /// RFC 7231 HTTP-date (IMF-fixdate, RFC 850, or asctime form). Returns
 /// the time from now until that date, clamped to 0 if in the past.
@@ -1255,6 +1273,36 @@ mod tests {
         assert_eq!(
             usage_cap_reset_hint("plain error, no reset").as_deref(),
             None
+        );
+    }
+
+    /// #818: the GLM cap the interactive surface used to dump raw. The
+    /// headline names the wall and the reset instant; the caller appends the
+    /// provider's own text as the cause.
+    #[test]
+    fn usage_cap_headline_names_the_reset_when_the_provider_gave_one() {
+        let glm = "HttpError: Invalid status code 429 Too Many Requests with message: \
+                   {\"error\":{\"code\":\"1308\",\"message\":\"已达到 5 小时的使用上限。\
+                   您的限额将在 2026-08-25 07:41:44 重置。\"}}";
+        assert_eq!(
+            classify_error(glm),
+            ErrorKind::UsageCap,
+            "the 1308 cap must not be mistaken for a retryable throttle",
+        );
+        assert_eq!(
+            usage_cap_headline(glm),
+            "Provider usage cap reached — quota resets at 2026-08-25 07:41:44",
+        );
+    }
+
+    /// No parseable reset — the headline still has to say what happened, and
+    /// must not invent a time.
+    #[test]
+    fn usage_cap_headline_without_a_reset_says_so() {
+        let msg = "429 too many requests: usage limit reached";
+        assert_eq!(
+            usage_cap_headline(msg),
+            "Provider usage cap reached — quota won't reset within a retryable window",
         );
     }
 

--- a/src/provider/run.rs
+++ b/src/provider/run.rs
@@ -513,14 +513,10 @@ impl AnyAgent {
                         let resume = format!(
                             "Session {session_id} saved; re-run (e.g. `dirge --continue`) once the quota resets to resume."
                         );
-                        match crate::agent::recovery::usage_cap_reset_hint(&err) {
-                            Some(reset) => eprintln!(
-                                "Provider usage cap reached — quota resets at {reset}. {resume}\n  ↳ cause: {err}"
-                            ),
-                            None => eprintln!(
-                                "Provider usage cap reached — quota won't reset within a retryable window. {resume}\n  ↳ cause: {err}"
-                            ),
-                        }
+                        // Same headline the interactive surface writes (#818),
+                        // so a cap reads identically wherever it is reported.
+                        let headline = crate::agent::recovery::usage_cap_headline(&err);
+                        eprintln!("{headline}. {resume}\n  ↳ cause: {err}");
                         break;
                     }
                     // No `eprintln!` here: the error is returned, and both

--- a/src/ui/run_handlers/error.rs
+++ b/src/ui/run_handlers/error.rs
@@ -57,8 +57,34 @@ pub(crate) async fn handle_error(
         *last_token_render = None;
     }
     let safe = sanitize_output(&error);
-    ctx.renderer
-        .write_line(&format!("error: {}", safe), c_error())?;
+    // #818: a provider usage cap is not a failure to debug — the request was
+    // well-formed and the provider refused it until a quota rolls over. The raw
+    // text says none of that: GLM's is an `HttpError: Invalid status code 429`
+    // wrapper around a Chinese sentence and an error code, so the one thing the
+    // user needs (when it lifts, and that switching providers works now) is the
+    // one thing the line did not carry. Retries were already suppressed —
+    // `classify_error` routes a cap to the non-retryable `UsageCap` — so this
+    // changes what is SAID, not what is done. The cause is kept verbatim
+    // underneath for bug reports. `--print` reports the same headline
+    // (`provider::run`).
+    if matches!(
+        crate::agent::recovery::classify_error(&error),
+        crate::agent::recovery::ErrorKind::UsageCap
+    ) {
+        ctx.renderer.write_line(
+            &crate::agent::recovery::usage_cap_headline(&error),
+            c_error(),
+        )?;
+        ctx.renderer.write_line(
+            "  ↳ hint: wait for the reset, or /model to a provider that still has quota",
+            c_error(),
+        )?;
+        ctx.renderer
+            .write_line(&format!("  ↳ cause: {safe}"), c_error())?;
+    } else {
+        ctx.renderer
+            .write_line(&format!("error: {}", safe), c_error())?;
+    }
 
     // Persist the partial turn (whatever streamed before the error) so it's
     // searchable and the session records what went wrong.


### PR DESCRIPTION
Closes #818.

## What was wrong

`classify_error` has understood z.ai's cap since #718: HTTP 429 with code `1308`
matches the `使用上限` / `code":"1308"` arm and comes back `UsageCap`, which the
retry policy treats as non-retryable. So the *behaviour* was already right — the
run stopped instead of burning its budget against a quota hours out.

What was wrong is what the user was told. `--print` reports a cap in a sentence
(dirge-u6zc), but the interactive handler had one path for every error:

```
error: HttpError: Invalid status code 429 Too Many Requests with message: {"error":{"code":"1308","message":"已达到 5\n小时的使用上限。您的限额将在 2026-08-25 07:41:44 重置。"}}
```

The two things the user needs — when the quota lifts, and that `/model` works
right now — are in there, one of them in Chinese, inside a transport wrapper.

## What this does

Adds `recovery::usage_cap_headline`, which pairs the existing
`usage_cap_reset_hint` with a sentence, and routes both surfaces through it:

```
Provider usage cap reached — quota resets at 2026-08-25 07:41:44
  ↳ hint: wait for the reset, or /model to a provider that still has quota
  ↳ cause: HttpError: Invalid status code 429 …
```

The provider's own text is kept verbatim as the cause, so nothing is lost for a
bug report. `--print`'s output is byte-identical to before — it already built
the same two sentences inline, and now shares them.

No behaviour change: a cap was already non-retryable, and nothing here touches
classification, the rate-limit gate, or session persistence.

## Tests

Two unit tests in `recovery.rs` covering the reported GLM payload (classifies as
`UsageCap`; headline names the reset instant) and a cap with no parseable reset
(says so rather than inventing a time).
