### PR TITLE
Say when /model does not recognise the id (#831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reset instant when the provider gave one, and the provider's own text is kept
   verbatim as the cause. Nothing about the retry behaviour changes — a cap was
   already non-retryable. (#818)
+- `/model <id>` says when it does not recognise the id, instead of reporting a
+  clean switch onto a string no endpoint serves. `resolve_model_switch` ends in a
+  deliberate permissive fallthrough — an id matching no configured alias and no
+  known model family still applies, which is what lets `/model claude-opus-6`
+  work on release day — and that stays. But it is also what `/model off` got, and
+  reaching for `off` is a natural slip: it is a valid argument to both `/effort`
+  and `/agent`, and `/model` has no "go back". The switch now carries one clause,
+  `(unrecognised — your provider may not serve it)`, which never fires on a
+  configured alias, an exact pin, the gateway dialect, or an id whose family
+  dirge knows. It asserts recognition rather than validity: only the provider
+  knows whether an id is servable, and the two come apart for a new-but-valid
+  id. Same clause on the ACP `/model` path. (#831)
 - A run that spins on no-op shell commands is now caught by the repeat-loop
   guard. A model that had decided it needed a different tool but kept reaching
   for `bash` anyway issued a long run of `echo "ready"` / `echo done` / `true`

--- a/src/extras/acp/mod.rs
+++ b/src/extras/acp/mod.rs
@@ -939,7 +939,17 @@ async fn acp_model(
             let refusal = RouteRefusal::NoProviderForFamily { model, family };
             return format!("{refusal} Keeping model '{current_model}' on '{current_provider}'.",);
         }
-        ModelRoute::Active(_) => (None, String::new()),
+        // GH #831: an id matching no configured alias and no known model family
+        // still applies (see `ModelSwitch::KeepUnrecognized`), but say so — the
+        // alternative is reporting a clean switch onto a string like `off`.
+        ModelRoute::Active { recognized, .. } => (
+            None,
+            if recognized {
+                String::new()
+            } else {
+                "  (unrecognised — your provider may not serve it)".to_string()
+            },
+        ),
     };
 
     let mut map = sessions.lock().await;
@@ -1693,9 +1703,11 @@ mod tests {
         assert!(list.contains("current model: current-x"), "got {list}");
 
         // `llama-3.1` has no recognized family → ModelRoute::Active → override
-        // set, provider left alone.
+        // set, provider left alone. GH #831: it still applies, and now says the
+        // id is one dirge does not recognise.
         let set = acp_model(&sessions, &cfg, id, "llama-3.1", "openrouter", "current-x").await;
         assert!(set.contains("switched to model: llama-3.1"), "got {set}");
+        assert!(set.contains("unrecognised"), "got {set}");
         let (model_ovr, provider_ovr, _) = session_overrides(&sessions, id).await;
         assert_eq!(model_ovr.as_deref(), Some("llama-3.1"));
         assert!(

--- a/src/provider/build.rs
+++ b/src/provider/build.rs
@@ -1052,7 +1052,7 @@ pub fn resolve_profile_model(
     };
 
     match resolve_model_route(cfg, active_provider, &model) {
-        ModelRoute::Active(model) => Some(active_client.completion_model(model)),
+        ModelRoute::Active { model, .. } => Some(active_client.completion_model(model)),
         ModelRoute::Provider { alias, model } => {
             if !clients.contains_key(&alias) {
                 match build_route_client(cfg, &alias, &model) {

--- a/src/provider/resolve.rs
+++ b/src/provider/resolve.rs
@@ -173,6 +173,16 @@ pub(super) enum ModelSwitch {
     /// Keep the current client — the id belongs to the active provider (or
     /// carries no cross-provider signal). Just rename the model.
     Keep,
+    /// GH #831: keep the current client, exactly like [`ModelSwitch::Keep`],
+    /// but the id matched no configured provider alias and no model family
+    /// [`model_family`] knows.
+    ///
+    /// It still applies. The permissive fallthrough is deliberate — it is what
+    /// lets `/model claude-opus-6` work on release day, before dirge has heard
+    /// of the id — and a whitelist would be the wrong fix. The distinction
+    /// exists so the caller can SAY the id is unrecognised rather than report a
+    /// clean switch onto a string like `off`.
+    KeepUnrecognized,
     /// Rebuild the client against this configured provider alias, then rename.
     Switch(String),
     /// GH #825: the id named a configured provider ALIAS that pins a `model`.
@@ -273,7 +283,10 @@ pub(super) fn resolve_model_switch(
     }
 
     let Some(family) = model_family(model) else {
-        return ModelSwitch::Keep;
+        // GH #831: nothing recognised this id — not a pin, not a gateway
+        // dialect, not an alias, not a family. Still `Keep` (see the variant's
+        // doc), but flagged so `/model` can say so.
+        return ModelSwitch::KeepUnrecognized;
     };
     if active_kind == Some(family) {
         return ModelSwitch::Keep;
@@ -1094,14 +1107,45 @@ mod resolve_model_switch_tests {
         );
     }
 
+    /// GH #831: no family signal → still keep the current client (unchanged
+    /// pre-fix behavior, so a local / alt same-provider id isn't disturbed),
+    /// but flagged as unrecognised so `/model` can say so rather than report a
+    /// clean switch onto a string no endpoint serves.
     #[test]
-    fn unclassifiable_id_keeps_current_client() {
+    fn unclassifiable_id_keeps_current_client_and_is_flagged() {
         let providers = user_like_providers();
-        // No family signal → keep current client (unchanged pre-fix behavior),
-        // so a local / alt same-provider id isn't disturbed.
         assert_eq!(
             resolve_model_switch(&providers, "deepseek", "some-local-model"),
-            ModelSwitch::Keep
+            ModelSwitch::KeepUnrecognized
+        );
+        // The reported slip: `off` is a valid argument to `/effort` and
+        // `/agent`, so reaching for `/model off` is natural.
+        assert_eq!(
+            resolve_model_switch(&providers, "deepseek", "off"),
+            ModelSwitch::KeepUnrecognized
+        );
+    }
+
+    /// The flag must NOT fire on the paths that DO recognise the id: a
+    /// same-family free-form id, an exact pin, a configured alias, or the
+    /// gateway dialect. Those all stay plain `Keep`/`Switch`.
+    #[test]
+    fn recognised_ids_are_not_flagged() {
+        let providers = user_like_providers();
+        assert_eq!(
+            resolve_model_switch(&providers, "glm", "glm-4.6"),
+            ModelSwitch::Keep,
+            "same family as the active provider",
+        );
+        assert_eq!(
+            resolve_model_switch(&providers, "deepseek", "deepseek-v4-pro"),
+            ModelSwitch::Keep,
+            "the active provider's own pin",
+        );
+        assert_eq!(
+            resolve_model_switch(&providers, "deepseek", "glm-5.2"),
+            ModelSwitch::Switch("glm".to_string()),
+            "an exact pin elsewhere",
         );
     }
 
@@ -1267,11 +1311,15 @@ mod resolve_model_switch_tests {
         );
     }
 
+    /// `gpt-oss-*` is deliberately unclassified (OpenAI authorship does not
+    /// imply an OpenAI endpoint), so it keeps the active client — flagged
+    /// unrecognised since GH #831, which changes what `/model` SAYS, not where
+    /// the id runs.
     #[test]
     fn cerebras_zero_config_gpt_oss_keeps_the_active_client() {
         assert_eq!(
             resolve_model_switch(&HashMap::new(), "cerebras", "gpt-oss-120b"),
-            ModelSwitch::Keep,
+            ModelSwitch::KeepUnrecognized,
         );
     }
 
@@ -1282,7 +1330,7 @@ mod resolve_model_switch_tests {
 
         assert_eq!(
             resolve_model_switch(&providers, "fast-cerebras", "gpt-oss-120b"),
-            ModelSwitch::Keep,
+            ModelSwitch::KeepUnrecognized,
         );
     }
 
@@ -1297,7 +1345,7 @@ mod resolve_model_switch_tests {
         }
         assert_eq!(
             resolve_model_switch(&HashMap::new(), "deepseek", "gpt-oss-120b"),
-            ModelSwitch::Keep,
+            ModelSwitch::KeepUnrecognized,
         );
     }
 
@@ -1415,18 +1463,19 @@ mod resolve_model_switch_tests {
         ]);
         assert_eq!(
             resolve_model_switch(&providers, "high", "local"),
-            ModelSwitch::Keep,
+            ModelSwitch::KeepUnrecognized,
         );
     }
 
     /// GH #825 must not narrow the deliberate permissiveness: an id that is
     /// neither an alias nor classifiable still keeps the active client, which
-    /// is what lets a brand-new model id work before dirge knows it.
+    /// is what lets a brand-new model id work before dirge knows it. GH #831
+    /// flags it so `/model` can say so — the routing is unchanged.
     #[test]
     fn unknown_non_alias_id_still_keeps_the_active_client() {
         assert_eq!(
             resolve_model_switch(&tiered_providers(), "high", "banana"),
-            ModelSwitch::Keep,
+            ModelSwitch::KeepUnrecognized,
         );
     }
 

--- a/src/provider/route.rs
+++ b/src/provider/route.rs
@@ -33,7 +33,17 @@ use super::AnyClient;
 pub enum ModelRoute {
     /// Build on the ACTIVE client — the id belongs to the active provider's
     /// family, or carries no cross-provider signal.
-    Active(String),
+    Active {
+        model: String,
+        /// GH #831: false when the id matched no configured provider alias and
+        /// no model family dirge knows.
+        ///
+        /// The route still applies — dirge cannot know whether an id is valid,
+        /// only whether it RECOGNISES it, and those come apart for a
+        /// new-but-valid id — but a caller holding this can say so instead of
+        /// reporting a clean switch onto a string no endpoint serves.
+        recognized: bool,
+    },
     /// Build on `alias`'s client: the id's family differs from the active
     /// client's and a provider of that family is configured.
     Provider { alias: String, model: String },
@@ -47,7 +57,7 @@ impl ModelRoute {
     /// The model id this route carries, whatever the variant.
     pub fn model(&self) -> &str {
         match self {
-            ModelRoute::Active(model)
+            ModelRoute::Active { model, .. }
             | ModelRoute::Provider { model, .. }
             | ModelRoute::Unroutable { model, .. } => model,
         }
@@ -107,7 +117,16 @@ pub fn resolve_model_route(cfg: &Config, active_provider: &str, model: &str) -> 
     use super::ModelSwitch;
     let model = model.to_string();
     match super::resolve_model_switch(&cfg.providers_map(), active_provider, &model) {
-        ModelSwitch::Keep => ModelRoute::Active(model),
+        ModelSwitch::Keep => ModelRoute::Active {
+            model,
+            recognized: true,
+        },
+        // GH #831: applied like any other `Keep`, but the caller is told the id
+        // is one dirge does not recognise.
+        ModelSwitch::KeepUnrecognized => ModelRoute::Active {
+            model,
+            recognized: false,
+        },
         ModelSwitch::Switch(alias) => ModelRoute::Provider { alias, model },
         // GH #825: the id named a provider alias — the route must carry the
         // alias's pinned model, NOT the alias string the user typed, or the
@@ -145,7 +164,7 @@ pub fn swap_client_for_route(
     route: &ModelRoute,
 ) -> Result<Option<String>, RouteRefusal> {
     match route {
-        ModelRoute::Active(_) => Ok(None),
+        ModelRoute::Active { .. } => Ok(None),
         // Already on that provider — this is a rename, not a swap. Rebuilding
         // would be wasted work and can fail outright: the rebuild re-resolves
         // credentials from config/env, so a session launched with `--api-key`
@@ -249,7 +268,19 @@ mod tests {
         );
         assert_eq!(
             resolve_model_route(&cfg, "gpt-sol", "gpt-5.5-mini"),
-            ModelRoute::Active("gpt-5.5-mini".into()),
+            ModelRoute::Active {
+                model: "gpt-5.5-mini".into(),
+                recognized: true,
+            },
+        );
+        // GH #831: an id nothing classifies still routes to the active client,
+        // but carries the flag `/model` uses to say so.
+        assert_eq!(
+            resolve_model_route(&cfg, "gpt-sol", "off"),
+            ModelRoute::Active {
+                model: "off".into(),
+                recognized: false,
+            },
         );
         assert_eq!(
             resolve_model_route(&cfg, "gpt-sol", "claude-opus-4"),

--- a/src/ui/slash/cmd/model.rs
+++ b/src/ui/slash/cmd/model.rs
@@ -66,6 +66,18 @@ pub(crate) async fn cmd_model(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow:
         // Same-provider and unclassifiable ids keep the current client.
         let old_ctx = ctx.session.context_window;
         let route = resolve_model_route(ctx.cfg, ctx.session.provider.as_str(), new_model.as_str());
+        // GH #831: read before the route is consumed. An id matching no
+        // configured alias and no known model family still applies — that
+        // permissive fallthrough is what lets a brand-new model id work before
+        // dirge knows it — but `/model off` reporting a clean switch onto a
+        // string no endpoint serves is what the report is about.
+        let unrecognized = matches!(
+            route,
+            crate::provider::ModelRoute::Active {
+                recognized: false,
+                ..
+            }
+        );
         // A refusal leaves the session untouched: renaming onto a client that
         // can't serve the id would just point the session at a model that can't
         // work. Keep it functional and say how to make the id routable.
@@ -93,8 +105,20 @@ pub(crate) async fn cmd_model(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow:
         // raw argument — `/model <provider-alias>` resolves to the alias's
         // pinned model, so echoing the argument would print the alias string
         // as if it were a model id. Identical on every non-alias path.
+        // The clause asserts RECOGNITION, not validity: only the provider
+        // knows whether an id is servable, and the two come apart for a
+        // new-but-valid id (`claude-opus-6` on release day). So it says what
+        // dirge knows and leaves the consequence conditional.
+        let unknown_note = if unrecognized {
+            "  (unrecognised — your provider may not serve it)"
+        } else {
+            ""
+        };
         ctx.renderer.write_line(
-            &format!("switched to model: {}{provider_note}", ctx.session.model),
+            &format!(
+                "switched to model: {}{provider_note}{unknown_note}",
+                ctx.session.model
+            ),
             c_agent(),
         )?;
         let reserve = ctx.cfg.resolve_reserve_tokens();


### PR DESCRIPTION
Closes #831. Sequel to #825/#826.

## What was wrong

`resolve_model_switch` ends in a deliberate permissive fallthrough: an id that
matches no configured alias and no known model family returns `Keep`, which is
what lets `/model claude-opus-6` work on release day, before dirge knows the id.
#826 narrowed the trap to genuinely unknown strings rather than closing it, on
purpose — and that is worth keeping.

But `Keep` is also what `/model off` gets, and the report is a real slip: `off`
is a valid argument to both `/effort off` and `/agent off`, and there is no
`/model` equivalent of "go back", so reaching for it is natural. It reports
success and leaves `session.model = "off"`, with nothing said until the next
request 400s.

## What this does

Keeps applying it, and says so. The unrecognised case now returns its own
`ModelSwitch::KeepUnrecognized`, carried through to `ModelRoute::Active { model,
recognized }`, and `/model` appends one clause:

```
switched to model: off  (unrecognised — your provider may not serve it)
```

The clause never fires on the common paths — a configured alias, an exact pin,
the gateway-dialect rule, or an id whose family `model_family` knows — so in
practice it fires on typos and on genuinely new models, where "dirge does not
recognise this" is simply true.

**On what the note claims.** dirge cannot know whether an id is valid; only the
provider can. It knows whether it *recognises* it. Those come apart for a
new-but-valid id, so the clause asserts recognition and leaves the consequence
conditional ("may not serve it") rather than predicting a failure.

The rejected alternative from the issue — suppressing the note when the id
"looks like" a model — is not implemented, for the reasons given there: it would
pass `claude-opuss-5` silently, which is the case most worth catching.

Same clause on the ACP `/model` path, which shares the routing decision.
