### PR TITLE
Make /effort off actually disable thinking (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- `/effort off` actually disables reasoning. The 0.24.1 changelog promised that
+  `off` is a real level that disables thinking; on current Anthropic models it
+  did not. Anthropic's profile carried `DisableWire::None` — "omit the
+  parameter" — which was a correct disable through Claude 4.6 and stopped being
+  one on the current generation: Sonnet 5 and Opus 5 think adaptively when
+  `thinking` is absent, so a user who explicitly opted out still paid the
+  latency and the reasoning tokens. The wire shape did not change; what omitting
+  it means did. `off` now routes through the provider's disable wire — five
+  providers had carried a real one all along for tool-less one-shots and `off`
+  simply never reached it — and Anthropic's is chosen per model: the documented
+  `{"thinking":{"type":"disabled"}}` on Claude 5, the omit on 4.6 and earlier
+  (where it is still correct and the toggle would be a 400), and nothing plus a
+  one-time note on Fable, whose reasoning is unconditional. The major version is
+  parsed rather than substring-matched, so `claude-haiku-4-5` is not mistaken
+  for a 5. `off` remains "not a reasoning turn" for #816's `max_tokens`
+  fallback. (#827)
 - Reasoning effort now seeds from the provider the session is actually on, and
   Gemini's reasoning payload goes where Gemini can read it. `build_agent`'s
   comment claimed the active provider's `effort`, but `cli.resolution_entry`

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -1099,6 +1099,21 @@ pub fn build_provider_additional_params(
     // ----- reasoning per provider -----
     if let Some(m) = reasoning_params(provider_name, model_name, opts) {
         additional.extend(m);
+    } else if opts.reasoning == Some(super::types::ThinkingLevel::Off)
+        && let Some(serde_json::Value::Object(m)) =
+            crate::provider::adapter::reasoning_profile(provider_name, model_name).disable_params()
+    {
+        // GH #827: `off` is a level, not an absence. It used to send nothing —
+        // even for the providers that have carried a real disable wire all
+        // along for tool-less one-shots — and on a model that thinks
+        // adaptively when the parameter is missing (Sonnet 5, Opus 5) that
+        // left reasoning fully on.
+        //
+        // Deliberately NOT folded into `reasoning_params`: that function
+        // answers "does this turn REQUEST reasoning", which `turn_reasoning_
+        // enabled` and #816's `max_tokens` fallback both read, and `off` must
+        // stay `false` there.
+        additional.extend(m);
     }
 
     // ----- headers -----
@@ -2657,12 +2672,24 @@ mod tests {
         assert!(v.is_none());
     }
 
-    /// DeepSeek Off → no reasoning_effort key.
+    /// DeepSeek Off → no `reasoning_effort` key. GH #827: it now sends the
+    /// disable toggle instead of nothing at all — DeepSeek has carried that
+    /// shape all along for tool-less one-shots, and omitting the effort string
+    /// only means "provider default", which is not off.
     #[test]
-    fn deepseek_off_omits_reasoning_effort() {
+    fn deepseek_off_disables_rather_than_omitting_everything() {
         let opts = opts_with_reasoning(ThinkingLevel::Off);
-        let v = build_provider_additional_params(Some("deepseek"), None, &opts);
-        assert!(v.is_none());
+        let v = build_provider_additional_params(Some("deepseek"), None, &opts).unwrap();
+        assert!(v.get("reasoning_effort").is_none());
+        assert_eq!(v["thinking"]["type"], "disabled");
+    }
+
+    /// OpenAI has no safe disable knob, so `off` still sends nothing — the
+    /// routing added in #827 only reaches providers that have one.
+    #[test]
+    fn openai_off_still_sends_nothing() {
+        let opts = opts_with_reasoning(ThinkingLevel::Off);
+        assert!(build_provider_additional_params(Some("openai"), None, &opts).is_none());
     }
 
     /// OpenAI with High reasoning still returns the nested
@@ -2709,6 +2736,47 @@ mod tests {
                 .get("thinkingBudget")
                 .is_none(),
             "budget and level must never ship together: {v}",
+        );
+    }
+
+    /// GH #827: `off` is a level, not an absence. It used to send nothing, and
+    /// on a model that thinks adaptively when `thinking` is missing (Sonnet 5,
+    /// Opus 5) that left reasoning fully on — silently, on the one setting
+    /// whose whole purpose is opting out.
+    #[test]
+    fn effort_off_sends_the_providers_disable_wire() {
+        let opts = opts_with_reasoning(ThinkingLevel::Off);
+        let v = build_provider_additional_params(Some("anthropic"), Some("claude-sonnet-5"), &opts)
+            .expect("off must put the disable shape on the wire");
+        assert_eq!(v["thinking"]["type"], "disabled");
+        // Claude 4.6 keeps the omit — there, absence still means off, and the
+        // toggle would be a 400.
+        assert!(
+            build_provider_additional_params(Some("anthropic"), Some("claude-opus-4-6"), &opts)
+                .is_none(),
+        );
+        // GLM has carried this exact shape all along for tool-less one-shots;
+        // `off` simply reaches it now.
+        let glm = build_provider_additional_params(Some("glm"), None, &opts).unwrap();
+        assert_eq!(glm["thinking"]["type"], "disabled");
+    }
+
+    /// ...and `off` is still NOT a reasoning turn. #816's `max_tokens`
+    /// fallback on Anthropic reads `turn_reasoning_enabled`, so folding the
+    /// disable shape into `reasoning_params` would have flipped it true and
+    /// dropped the ceiling rig hard-errors without.
+    #[test]
+    fn effort_off_is_still_not_a_reasoning_turn() {
+        let mut opts = opts_with_reasoning(ThinkingLevel::Off);
+        opts.max_tokens = Some(8192);
+        assert!(!turn_reasoning_enabled(
+            Some("anthropic"),
+            Some("claude-sonnet-5"),
+            &opts
+        ));
+        assert_eq!(
+            request_max_tokens(Some("anthropic"), Some("claude-sonnet-5"), &opts),
+            Some(8192),
         );
     }
 

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -76,7 +76,19 @@ pub enum DisableWire {
     /// no equivalent (Google documents that 3 Pro / Flash / Flash-Lite cannot
     /// be fully turned off), so it carries [`DisableWire::None`] instead.
     GeminiZeroBudget,
-    /// No safe disable knob — request left untouched (OpenAI, Anthropic, unknown).
+    /// `{"thinking":{"type":"disabled"}}` — Anthropic models that think
+    /// ADAPTIVELY when the parameter is absent (Sonnet 5, Opus 5).
+    ///
+    /// Anthropic's own documented shape, and the one dirge already sends to
+    /// GLM. It is a separate variant from [`DisableWire::ThinkingToggle`] only
+    /// because reaching it is model-dependent — see
+    /// [`anthropic_disable_wire`].
+    AnthropicToggle,
+    /// Nothing works: thinking is unconditional on this model and the toggle
+    /// above is rejected outright (Fable). Sends no key and says so once,
+    /// rather than accepting an `off` it cannot deliver.
+    AnthropicUnconditional,
+    /// No safe disable knob — request left untouched (OpenAI, unknown).
     None,
 }
 
@@ -103,7 +115,7 @@ pub fn reasoning_profile(provider: Option<&str>, model: Option<&str>) -> Reasoni
     match provider {
         Some("anthropic") => ReasoningProfile {
             effort: EffortWire::AnthropicBudget,
-            disable: DisableWire::None,
+            disable: anthropic_disable_wire(model),
         },
         Some("deepseek") => ReasoningProfile {
             effort: EffortWire::TopLevelEffort,
@@ -220,6 +232,67 @@ fn thinking_level_to_glm_effort(level: ThinkingLevel) -> Option<&'static str> {
         ThinkingLevel::Medium | ThinkingLevel::High => Some("high"),
         ThinkingLevel::Xhigh | ThinkingLevel::Max => Some("max"),
     }
+}
+
+/// How `off` reaches an Anthropic model.
+///
+/// Omitting `thinking` was a correct disable through Claude 4.6 and stopped
+/// being one on the current generation: Sonnet 5 and Opus 5 think adaptively
+/// when the parameter is absent, so `off` left thinking fully on — silently, on
+/// the one setting whose whole purpose is opting out (GH #827). The wire shape
+/// did not change; what omitting it means did.
+///
+/// - Claude 4.6 and earlier → omit. Still a correct disable there, and sending
+///   the toggle instead would trade this bug for 400s.
+/// - Claude 5 → `{"thinking":{"type":"disabled"}}`.
+/// - Fable → nothing. Its thinking is unconditional and it rejects the toggle.
+/// - An id we cannot classify → omit, which is the pre-#827 behaviour and the
+///   safe answer not knowing.
+///
+/// The major version is PARSED, not substring-matched, so `claude-haiku-4-5`
+/// reads as major 4 and keeps the omit. Both naming schemes are handled: the
+/// legacy `claude-3-5-sonnet-…` puts the version first, the current
+/// `claude-<family>-<major>…` puts the family first.
+fn anthropic_disable_wire(model: Option<&str>) -> DisableWire {
+    let Some(model) = model else {
+        return DisableWire::None;
+    };
+    let id = model.trim().to_ascii_lowercase();
+    let bare = id.rsplit('/').next().unwrap_or(id.as_str());
+    let Some(rest) = bare.strip_prefix("claude-") else {
+        return DisableWire::None;
+    };
+    if rest.starts_with("fable") {
+        return DisableWire::AnthropicUnconditional;
+    }
+    let mut segments = rest.split('-');
+    let Some(first) = segments.next() else {
+        return DisableWire::None;
+    };
+    let version = if first.starts_with(|c: char| c.is_ascii_digit()) {
+        first
+    } else {
+        segments.next().unwrap_or_default()
+    };
+    let major: String = version.chars().take_while(char::is_ascii_digit).collect();
+    match major.parse::<u32>() {
+        Ok(v) if v >= 5 => DisableWire::AnthropicToggle,
+        _ => DisableWire::None,
+    }
+}
+
+/// Say once that `off` cannot be honoured on this model. Silence is what the
+/// issue is about; accepting the level and quietly ignoring it would reproduce
+/// the same bug one level down.
+fn warn_thinking_not_disablable() {
+    use std::sync::Once;
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            target: "dirge::provider",
+            "this model's reasoning cannot be disabled; `off` leaves it on",
+        );
+    });
 }
 
 /// Which thinking knob a Gemini model takes.
@@ -423,6 +496,16 @@ impl ReasoningProfile {
             DisableWire::GeminiZeroBudget => Some(gemini_generation_config(
                 serde_json::json!({ "thinkingBudget": 0 }),
             )),
+            DisableWire::AnthropicToggle => {
+                // Opus 5 accepts `disabled` only alongside effort `high` or
+                // below. That cannot arise here: the toggle is emitted only for
+                // `off`, which sends no effort at all.
+                Some(serde_json::json!({ "thinking": { "type": "disabled" } }))
+            }
+            DisableWire::AnthropicUnconditional => {
+                warn_thinking_not_disablable();
+                None
+            }
             DisableWire::None => None,
         }
     }
@@ -554,6 +637,69 @@ mod tests {
             }
             .disable_params(),
             None
+        );
+    }
+
+    /// GH #827: which shape `off` takes on Anthropic, per model. The major
+    /// version is parsed, not substring-matched — `claude-haiku-4-5` is the
+    /// trap a naive "-5" check falls into, and sending it the toggle would
+    /// trade a silent bug for a 400.
+    #[test]
+    fn anthropic_disable_wire_follows_the_model_generation() {
+        for id in [
+            "claude-sonnet-5",
+            "claude-opus-5",
+            "claude-opus-5-20260101",
+            "anthropic/claude-sonnet-5",
+            "  CLAUDE-OPUS-5  ",
+        ] {
+            assert_eq!(
+                anthropic_disable_wire(Some(id)),
+                DisableWire::AnthropicToggle,
+                "{id}",
+            );
+        }
+        for id in [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "claude-opus-4-1",
+            "claude-3-5-sonnet-20241022",
+        ] {
+            assert_eq!(
+                anthropic_disable_wire(Some(id)),
+                DisableWire::None,
+                "omitting the parameter is still a correct disable on {id}",
+            );
+        }
+        assert_eq!(
+            anthropic_disable_wire(Some("claude-fable-5-1")),
+            DisableWire::AnthropicUnconditional,
+            "Fable's thinking is unconditional and it rejects the toggle",
+        );
+        // Not knowing means keeping the pre-#827 behaviour.
+        assert_eq!(anthropic_disable_wire(None), DisableWire::None);
+        assert_eq!(
+            anthropic_disable_wire(Some("some-proxy-alias")),
+            DisableWire::None,
+        );
+    }
+
+    /// And the profile turns that into the payload. `{"type":"disabled"}` is
+    /// Anthropic's own documented shape — the one dirge already sends to GLM.
+    #[test]
+    fn anthropic_profile_emits_the_documented_disable_shape() {
+        assert_eq!(
+            reasoning_profile(Some("anthropic"), Some("claude-sonnet-5")).disable_params(),
+            Some(serde_json::json!({ "thinking": { "type": "disabled" } })),
+        );
+        assert_eq!(
+            reasoning_profile(Some("anthropic"), Some("claude-opus-4-6")).disable_params(),
+            None,
+        );
+        assert_eq!(
+            reasoning_profile(Some("anthropic"), Some("claude-fable-5-1")).disable_params(),
+            None,
         );
     }
 

--- a/src/ui/slash/cmd/model.rs
+++ b/src/ui/slash/cmd/model.rs
@@ -238,6 +238,28 @@ pub(crate) async fn cmd_effort(ctx: &mut SlashCtx<'_>, parts: &[&str]) -> anyhow
         ),
         c_agent(),
     )?;
+    // GH #827: `off` is not deliverable on every model — Fable's reasoning is
+    // unconditional and it rejects the disable toggle outright. Say so where
+    // the level was asked for. Accepting it and quietly ignoring it is the bug
+    // this issue is about, one level down.
+    if level == ThinkingLevel::Off
+        && matches!(
+            crate::provider::adapter::reasoning_profile(
+                Some(ctx.agent.provider_name()),
+                Some(ctx.session.model.as_str()),
+            )
+            .disable,
+            crate::provider::adapter::DisableWire::AnthropicUnconditional,
+        )
+    {
+        ctx.renderer.write_line(
+            &format!(
+                "note: {} always reasons — `off` cannot be honoured on it",
+                ctx.session.model
+            ),
+            c_result(),
+        )?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Closes #827. **Stacked on the #832 PR** — merge that first; this branch is based
on it and shares the model-aware `effort_params`/`disable_params` plumbing.

## What was wrong

The 0.24.1 changelog promised that `off` is a real level that disables
reasoning. On current Anthropic models it did not. `DisableWire::None` for
`anthropic` means "omit the parameter", which *was* a correct disable through
Claude 4.6 and stopped being one on the current generation: Sonnet 5 and Opus 5
think adaptively when `thinking` is absent. So `/effort off` left thinking fully
on — silently, on the one setting whose whole purpose is opting out.

The wire shape did not change; what omitting it means did.

## What this does

Two pieces.

**`off` now routes through the provider's disable wire.** `effort_params` has
always returned `None` for `Off`, and `build_provider_additional_params` sent
nothing — even for the five providers that have carried a real `DisableWire` all
along for tool-less one-shots. An explicit `off` now emits that shape. This is
kept separate from `turn_reasoning_enabled`, which still means "this turn
requests reasoning" and stays `false` for `off`, so #816's `max_tokens` fallback
on non-reasoning Anthropic requests is unaffected.

**Anthropic gets a model-aware disable.** A blanket `ThinkingToggle` would trade
this bug for 400s, so the choice is made per model:

| model | `off` |
|---|---|
| Claude 4.6 and earlier | omit the parameter — still a correct disable |
| Sonnet 5 / Opus 5 | `{"thinking":{"type":"disabled"}}` |
| Fable | omit, and warn once that `off` is unavailable |
| unrecognised id | omit — today's behaviour, the safe default |

`claude-haiku-4-5` is deliberately not caught by the "-5" rule: the major
version is parsed, not substring-matched.

Fable's thinking is unconditional and it rejects the disabled toggle outright,
so `off` can never be honoured there. Warning once that the level is unavailable
is more honest than silently accepting it — that silence is the bug this issue
is about, one level down.

Opus 5's constraint that `disabled` pairs only with effort `high` or below
cannot arise (the toggle is emitted only at `off`, which sends no effort), and
is noted in the code rather than assumed.

## Impact

There is now a way to get a fast, non-thinking turn out of Opus 5 or Sonnet 5
through dirge — which is what had been forcing a non-thinking tier to be
Haiku 4.5.
