### PR TITLE
Replay Gemini tool calls with their thought_signature (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   which takes a depth instead and rejects a request carrying both. Gemini 3 gets
   no disable knob at all, because Google documents that 3 Pro / Flash /
   Flash-Lite cannot be fully turned off. (#832)
+- Gemini tool calls replay with the `thought_signature` Gemini requires, so a
+  tool-using turn works there at all. Same defect as #821, one field over, and
+  the gap #823 disclosed when it scoped itself to Anthropic thinking blocks.
+  Gemini mints a signature on every `functionCall` part and rejects a replayed
+  call without one ("Function call is missing a thought_signature in
+  functionCall parts"), so the first `grep` in any session failed on the replay.
+  rig hands the value over on capture and sends it straight back out again —
+  dirge discarded it at capture and hardcoded `None` at replay. `ContentBlock::
+  ToolCall` now carries `signature` / `signatureModel` (both skipped when
+  absent, so saved sessions round-trip unchanged), the factory stamps the
+  minting model the way it already did for thinking blocks, and replay attaches
+  the signature when the request's model is the one that minted it. When no
+  usable signature exists — a session saved before this change, or a
+  cross-model switch — the call and its paired result are dropped together and
+  the turn is logged: a tool call cannot be dropped alone without orphaning its
+  result, so the choice is one lost step of history against a turn that cannot
+  be sent at all. Every other provider keeps today's unsigned replay,
+  byte-identical on the wire. (#833)
 - A run that spins on no-op shell commands is now caught by the repeat-loop
   guard. A model that had decided it needed a different tool but kept reaching
   for `bash` anyway issued a long run of `echo "ready"` / `echo done` / `true`

--- a/src/agent/agent_loop/call_syntax.rs
+++ b/src/agent/agent_loop/call_syntax.rs
@@ -411,6 +411,8 @@ pub fn absorb_text_calls(
         id: c.id.clone(),
         name: c.name.clone(),
         arguments: c.arguments.clone(),
+        signature: None,
+        signature_model: None,
     }));
     super::message::AssistantMessage {
         content,

--- a/src/agent/agent_loop/integration.rs
+++ b/src/agent/agent_loop/integration.rs
@@ -258,6 +258,8 @@ pub fn rig_message_to_loop_messages(m: rig::completion::Message) -> Vec<LoopMess
                             id: tc.id,
                             name: tc.function.name,
                             arguments: tc.function.arguments,
+                            signature: None,
+                            signature_model: None,
                         });
                     }
                     AssistantContent::Reasoning(r) => {
@@ -1116,6 +1118,8 @@ mod tests {
                 id: id.to_string(),
                 name: name.to_string(),
                 arguments: args,
+                signature: None,
+                signature_model: None,
             }],
             StopReason::ToolUse,
         )

--- a/src/agent/agent_loop/integration_tests.rs
+++ b/src/agent/agent_loop/integration_tests.rs
@@ -137,6 +137,8 @@ fn tool_use_response(id: &str, name: &str, args: Value) -> AssistantMessage {
             id: id.to_string(),
             name: name.to_string(),
             arguments: args,
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     )
@@ -149,6 +151,8 @@ fn multi_tool_use_response(calls: Vec<(&str, &str, Value)>) -> AssistantMessage 
             id: id.to_string(),
             name: name.to_string(),
             arguments: args,
+            signature: None,
+            signature_model: None,
         })
         .collect();
     AssistantMessage::new(content, StopReason::ToolUse)

--- a/src/agent/agent_loop/message.rs
+++ b/src/agent/agent_loop/message.rs
@@ -87,6 +87,29 @@ pub enum ContentBlock {
         id: String,
         name: String,
         arguments: Value,
+        /// Provider-issued signature over the tool call (GH #833). Gemini
+        /// mints a `thought_signature` on every `functionCall` part and
+        /// rejects a replayed call that lacks one ("Function call is missing
+        /// a thought_signature in functionCall parts"), so a tool-using turn
+        /// cannot be replayed without it. `None` for providers that do not
+        /// sign tool calls and for calls captured before this field existed;
+        /// both serde attributes keep the serialized shape byte-identical to
+        /// the legacy `{type, id, name, arguments}` form in that case, so
+        /// existing saved sessions round-trip unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+        /// The model that minted `signature` (GH #833, mirroring the same
+        /// field on [`ContentBlock::Thinking`] from #821). A signature is
+        /// only valid for the model that produced it, and dirge can switch
+        /// models mid-session (`/model`, escalation, subagents), so the
+        /// replay path attaches it only when this matches the request's
+        /// model.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "signatureModel"
+        )]
+        signature_model: Option<String>,
     },
 }
 
@@ -143,6 +166,7 @@ impl AssistantMessage {
                 id,
                 name,
                 arguments,
+                ..
             } => Some((id.as_str(), name.as_str(), arguments)),
             _ => None,
         })
@@ -1000,11 +1024,54 @@ mod tests {
             id: "call_1".to_string(),
             name: "read".to_string(),
             arguments: serde_json::json!({"path": "/tmp/x"}),
+            signature: None,
+            signature_model: None,
         };
         let encoded = serde_json::to_string(&tool).unwrap();
         assert!(encoded.contains("\"type\":\"toolCall\""), "got: {encoded}");
         assert!(encoded.contains("\"id\":\"call_1\""));
         assert!(encoded.contains("\"name\":\"read\""));
+    }
+
+    /// GH #833: the two added fields must not change the serialized shape of
+    /// a call that carries neither — saved sessions have to round-trip
+    /// unchanged, in both directions.
+    #[test]
+    fn an_unsigned_tool_call_keeps_the_legacy_wire_shape() {
+        let legacy_json = serde_json::json!({
+            "type": "toolCall",
+            "id": "call_1",
+            "name": "read",
+            "arguments": {"path": "/tmp/x"},
+        });
+        let block = ContentBlock::ToolCall {
+            id: "call_1".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({"path": "/tmp/x"}),
+            signature: None,
+            signature_model: None,
+        };
+        assert_eq!(serde_json::to_value(&block).unwrap(), legacy_json);
+        let round_tripped: ContentBlock = serde_json::from_value(legacy_json).unwrap();
+        assert_eq!(round_tripped, block);
+    }
+
+    /// And a signed one carries both, under the camelCase key the thinking
+    /// block already uses for the same purpose.
+    #[test]
+    fn a_signed_tool_call_serializes_both_fields() {
+        let block = ContentBlock::ToolCall {
+            id: "call_1".to_string(),
+            name: "grep".to_string(),
+            arguments: serde_json::json!({}),
+            signature: Some("thought-sig-833".to_string()),
+            signature_model: Some("gemini-3.6-flash".to_string()),
+        };
+        let encoded = serde_json::to_value(&block).unwrap();
+        assert_eq!(encoded["signature"], "thought-sig-833");
+        assert_eq!(encoded["signatureModel"], "gemini-3.6-flash");
+        let round_tripped: ContentBlock = serde_json::from_value(encoded).unwrap();
+        assert_eq!(round_tripped, block);
     }
 
     /// `AssistantMessage::tool_calls()` filters the toolCall
@@ -1022,6 +1089,8 @@ mod tests {
                     id: "c1".to_string(),
                     name: "read".to_string(),
                     arguments: serde_json::json!({}),
+                    signature: None,
+                    signature_model: None,
                 },
                 ContentBlock::Text {
                     text: "more text".to_string(),
@@ -1030,6 +1099,8 @@ mod tests {
                     id: "c2".to_string(),
                     name: "write".to_string(),
                     arguments: serde_json::json!({"path": "x"}),
+                    signature: None,
+                    signature_model: None,
                 },
             ],
             StopReason::ToolUse,

--- a/src/agent/agent_loop/plugin_hooks.rs
+++ b/src/agent/agent_loop/plugin_hooks.rs
@@ -645,6 +645,8 @@ mod tests {
                     id: "call-1".to_string(),
                     name: "echo".to_string(),
                     arguments: args.clone(),
+                    signature: None,
+                    signature_model: None,
                 }],
                 StopReason::ToolUse,
             ),

--- a/src/agent/agent_loop/plugin_hooks_tests.rs
+++ b/src/agent/agent_loop/plugin_hooks_tests.rs
@@ -151,6 +151,8 @@ fn tool_use_response(id: &str, name: &str, args: Value) -> AssistantMessage {
             id: id.to_string(),
             name: name.to_string(),
             arguments: args,
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     )

--- a/src/agent/agent_loop/rig_stream.rs
+++ b/src/agent/agent_loop/rig_stream.rs
@@ -521,6 +521,15 @@ where
                         id: tool_call.id.clone(),
                         name: tool_call.function.name.clone(),
                         arguments: tool_call.function.arguments.clone(),
+                        // GH #833: rig hands us Gemini's `thought_signature`
+                        // here and sends it back out as one on replay. This
+                        // used to be discarded, which is the whole bug: the
+                        // replayed call had no signature and Gemini rejected
+                        // the turn. The minting model is stamped by the
+                        // factory, which knows it; this layer sees only the
+                        // stream.
+                        signature: tool_call.signature.clone(),
+                        signature_model: None,
                     };
                     let was_existing =
                         tool_indices.contains_key(&internal_call_id);
@@ -574,6 +583,11 @@ where
                             id: id.clone(),
                             name: String::new(),
                             arguments: serde_json::Value::String(String::new()),
+                            // Deltas carry no signature; the authoritative
+                            // `Complete` event that closes the call replaces
+                            // this block wholesale and brings one with it.
+                            signature: None,
+                            signature_model: None,
                         });
                         tool_indices.insert(internal_call_id.clone(), i);
                         // Phase-1 #4: mark this call open so the
@@ -590,6 +604,7 @@ where
                         id: existing_id,
                         name,
                         arguments,
+                        ..
                     }) = partial.content.get_mut(idx)
                     {
                         apply_tool_call_delta(existing_id, name, arguments, &id, content);
@@ -885,6 +900,7 @@ mod tests {
                     id,
                     name,
                     arguments,
+                    ..
                 } = &message.content[0]
                 {
                     assert_eq!(id, "call_1");
@@ -936,6 +952,7 @@ mod tests {
                     id,
                     name,
                     arguments,
+                    ..
                 } = &message.content[0]
                 {
                     assert_eq!(id, "call_2");
@@ -1105,6 +1122,7 @@ mod tests {
             id,
             name,
             arguments,
+            ..
         } = &final_msg.content[0]
         {
             assert_eq!(id, "call_x");
@@ -1844,6 +1862,7 @@ mod tests {
                     id,
                     name,
                     arguments,
+                    ..
                 } => Some(crate::agent::agent_loop::tools::ToolCall {
                     id: id.clone(),
                     name: name.clone(),

--- a/src/agent/agent_loop/rig_stream_factory.rs
+++ b/src/agent/agent_loop/rig_stream_factory.rs
@@ -227,10 +227,23 @@ where
             model_id,
             turn_reasoning_enabled(provider, model_id, &opts),
         );
+        // GH #833: decided over the WHOLE history first, because a tool call
+        // that cannot be replayed takes its paired result with it — a decision
+        // no per-message pass can make.
+        let tool_call_replay = tool_call_replay_for(provider, model_name.as_ref().as_deref());
+        let dropped_tool_calls = unreplayable_tool_calls(&ctx.messages, tool_call_replay);
+        if !dropped_tool_calls.is_empty() {
+            tracing::warn!(
+                target: "dirge::provider",
+                model = %model_name.as_ref().as_deref().unwrap_or("default"),
+                pairs = dropped_tool_calls.len(),
+                "dropping tool calls (with their results) that carry no signature this model can replay",
+            );
+        }
         let rig_messages: Vec<Message> = ctx
             .messages
             .iter()
-            .filter_map(|message| value_to_rig_message_with_thinking_replay(message, provider, thinking_replay, ctx.asset_dir.as_deref()))
+            .filter_map(|message| value_to_rig_message_with_replay(message, provider, thinking_replay, tool_call_replay, &dropped_tool_calls, ctx.asset_dir.as_deref()))
             .collect();
 
         // 2. Split: last is prompt; rest is chat_history.
@@ -357,7 +370,7 @@ where
                     // from. Stamp it here — the one place that knows — so
                     // the replay path can tell a same-model echo (attach)
                     // from a cross-model one (drop).
-                    let evt = stamp_thinking_signature_model(evt, model_name.as_ref().as_deref());
+                    let evt = stamp_signature_models(evt, model_name.as_ref().as_deref());
                     yield evt;
                 }
             }
@@ -644,7 +657,7 @@ pub(crate) const EMPTY_TOOL_RESULT_PLACEHOLDER: &str = "(no output)";
 /// Legacy 2-knob entry point, kept so the existing tests (and
 /// `value_to_rig_message`) stay untouched: replays thinking blocks the way
 /// every provider other than Anthropic gets them — unsigned. Production goes
-/// through `value_to_rig_message_with_thinking_replay`, which the factory
+/// through `value_to_rig_message_with_replay`, which the factory
 /// calls with the request's model + reasoning state (GH #821).
 #[cfg(test)]
 fn value_to_rig_message_for_provider(
@@ -652,18 +665,22 @@ fn value_to_rig_message_for_provider(
     provider_name: Option<&str>,
     asset_dir: Option<&std::path::Path>,
 ) -> Option<Message> {
-    value_to_rig_message_with_thinking_replay(
+    value_to_rig_message_with_replay(
         value,
         provider_name,
         thinking_replay_for(provider_name, None, false),
+        tool_call_replay_for(provider_name, None),
+        &std::collections::HashSet::new(),
         asset_dir,
     )
 }
 
-fn value_to_rig_message_with_thinking_replay(
+fn value_to_rig_message_with_replay(
     value: &Value,
     provider_name: Option<&str>,
     thinking_replay: ThinkingReplay<'_>,
+    tool_call_replay: ToolCallReplay<'_>,
+    dropped_tool_calls: &std::collections::HashSet<String>,
     asset_dir: Option<&std::path::Path>,
 ) -> Option<Message> {
     let role = value.get("role").and_then(|r| r.as_str())?;
@@ -719,6 +736,7 @@ fn value_to_rig_message_with_thinking_replay(
                         include_reasoning,
                         synthesize_call_id,
                         thinking_replay,
+                        tool_call_replay,
                     )
                 })
                 .collect();
@@ -736,6 +754,12 @@ fn value_to_rig_message_with_thinking_replay(
                 .get("toolCallId")
                 .or_else(|| value.get("tool_call_id"))
                 .and_then(|c| c.as_str())?;
+            // GH #833: the call this result belongs to could not be replayed,
+            // so the result goes with it. Keeping it alone would orphan it —
+            // every backend rejects a result with no matching call.
+            if dropped_tool_calls.contains(tool_call_id) {
+                return None;
+            }
             // Content may be a plain string (legacy `tool` shape)
             // or an array of content blocks (loop `toolResult` shape).
             let text = value
@@ -876,13 +900,113 @@ fn thinking_replay_for<'a>(
     }
 }
 
+/// GH #833: how a stored tool call replays to the current request.
+///
+/// Gemini mints a `thought_signature` on every `functionCall` part and rejects
+/// a replayed call that lacks one ("Function call is missing a
+/// thought_signature in functionCall parts"), so for that backend the choice is
+/// attach-or-drop. A signature is only valid for the model that minted it, so
+/// attaching is gated on the recorded `signatureModel` matching the request's
+/// model — the same gate #821 built for thinking blocks, which stops being a
+/// single-provider guard here and becomes the cross-provider one it was for.
+///
+/// Every other provider keeps today's unsigned replay, byte-identical on the
+/// wire.
+#[derive(Clone, Copy)]
+enum ToolCallReplay<'a> {
+    /// Replay with no signature — the pre-#833 behavior, unchanged for every
+    /// provider that does not sign tool calls.
+    Unsigned,
+    /// Gemini: attach the stored signature when it was minted by `model`;
+    /// otherwise the call cannot be replayed at all.
+    SignedOrDrop { model: Option<&'a str> },
+}
+
+/// Pick the [`ToolCallReplay`] policy for one request.
+fn tool_call_replay_for<'a>(
+    provider_name: Option<&str>,
+    model: Option<&'a str>,
+) -> ToolCallReplay<'a> {
+    if matches!(provider_name, Some(provider) if provider.eq_ignore_ascii_case("gemini")) {
+        ToolCallReplay::SignedOrDrop { model }
+    } else {
+        ToolCallReplay::Unsigned
+    }
+}
+
+/// The signature a stored `toolCall` block replays with, or `None` when it
+/// cannot be replayed to this request at all.
+///
+/// `Some(None)` and `None` are different answers: the first is "replay it,
+/// unsigned", the second is "this call has to go".
+fn tool_call_replay_signature(
+    obj: &serde_json::Map<String, Value>,
+    replay: ToolCallReplay<'_>,
+) -> Option<Option<String>> {
+    match replay {
+        ToolCallReplay::Unsigned => Some(None),
+        ToolCallReplay::SignedOrDrop { model } => {
+            let signature = obj.get("signature").and_then(|s| s.as_str());
+            let minted_by = obj.get("signatureModel").and_then(|s| s.as_str());
+            match (signature, minted_by, model) {
+                (Some(signature), Some(minted_by), Some(current)) if minted_by == current => {
+                    Some(Some(signature.to_string()))
+                }
+                // No signature (a session saved before #833, or a provider that
+                // mints none), a foreign model's signature, or no model id to
+                // compare against. Sending it unsigned is the 400 this fixes.
+                _ => None,
+            }
+        }
+    }
+}
+
+/// GH #833: the ids of tool calls this request cannot replay.
+///
+/// A tool call cannot be dropped on its own — its paired `tool_result` would be
+/// orphaned, which Anthropic and OpenAI reject outright and which leaves the
+/// conversation malformed for Gemini too — so the pair goes together. That
+/// costs one step of history, against a turn that otherwise cannot be sent at
+/// all. Callers use the set to drop both halves in the same pass.
+fn unreplayable_tool_calls(
+    messages: &[Value],
+    replay: ToolCallReplay<'_>,
+) -> std::collections::HashSet<String> {
+    let mut dropped = std::collections::HashSet::new();
+    if matches!(replay, ToolCallReplay::Unsigned) {
+        return dropped;
+    }
+    for message in messages {
+        if message.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(blocks) = message.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        for block in blocks {
+            let Some(obj) = block.as_object() else {
+                continue;
+            };
+            if obj.get("type").and_then(|t| t.as_str()) != Some("toolCall") {
+                continue;
+            }
+            if tool_call_replay_signature(obj, replay).is_none()
+                && let Some(id) = obj.get("id").and_then(|i| i.as_str())
+            {
+                dropped.insert(id.to_string());
+            }
+        }
+    }
+    dropped
+}
+
 /// GH #821: record which model minted each captured thinking-block
 /// signature. The capture layer (`rig_stream`) sees only the provider's
 /// stream, not the model identity, so the factory — which knows the model
 /// it was built for — stamps it on every event it forwards. Only blocks
 /// that carry a signature and haven't been stamped yet are touched, so
 /// everything else in the message is byte-identical.
-fn stamp_thinking_signature_model(mut evt: StreamEvent, model_name: Option<&str>) -> StreamEvent {
+fn stamp_signature_models(mut evt: StreamEvent, model_name: Option<&str>) -> StreamEvent {
     let Some(model) = model_name else {
         return evt;
     };
@@ -892,11 +1016,23 @@ fn stamp_thinking_signature_model(mut evt: StreamEvent, model_name: Option<&str>
         StreamEvent::Error { .. } | StreamEvent::Retry { .. } => return evt,
     };
     for block in &mut message.content {
-        if let ContentBlock::Thinking {
-            signature,
-            signature_model,
-            ..
-        } = block
+        // GH #833: tool calls carry a signature too (Gemini's
+        // `thought_signature`), and it needs the same stamp for the same
+        // reason — a signature is only valid for the model that minted it.
+        let stamp = match block {
+            ContentBlock::Thinking {
+                signature,
+                signature_model,
+                ..
+            }
+            | ContentBlock::ToolCall {
+                signature,
+                signature_model,
+                ..
+            } => Some((signature, signature_model)),
+            _ => None,
+        };
+        if let Some((signature, signature_model)) = stamp
             && signature.is_some()
             && signature_model.is_none()
         {
@@ -913,6 +1049,7 @@ fn value_to_assistant_content(
     include_reasoning: bool,
     synthesize_call_id: bool,
     thinking_replay: ThinkingReplay<'_>,
+    tool_call_replay: ToolCallReplay<'_>,
 ) -> Option<AssistantContent> {
     let obj = block.as_object()?;
     let kind = obj.get("type").and_then(|t| t.as_str())?;
@@ -973,11 +1110,17 @@ fn value_to_assistant_content(
             let id = obj.get("id").and_then(|t| t.as_str())?.to_string();
             let name = obj.get("name").and_then(|t| t.as_str())?.to_string();
             let arguments = obj.get("arguments").cloned().unwrap_or(Value::Null);
+            // GH #833: rig sends this straight back out as the `functionCall`
+            // part's `thought_signature`, which Gemini requires. `None` from
+            // the helper means the call cannot be replayed to this model at
+            // all; the caller has already put its id in the drop set, so its
+            // paired result goes too and the conversation stays well-formed.
+            let signature = tool_call_replay_signature(obj, tool_call_replay)?;
             Some(AssistantContent::ToolCall(ToolCall {
                 call_id: synthesize_call_id.then(|| id.clone()),
                 id,
                 function: ToolFunction { name, arguments },
-                signature: None,
+                signature,
                 additional_params: None,
             }))
         }
@@ -1628,6 +1771,130 @@ mod tests {
         }
     }
 
+    /// GH #833: an assistant turn carrying one tool call, and the result it
+    /// is paired with. `signature_model` is what the factory stamps at
+    /// capture; `None` reproduces a block that was never stamped.
+    fn tool_call_history(signature: Option<&str>, signature_model: Option<&str>) -> Vec<Value> {
+        let mut call = serde_json::json!({
+            "type": "toolCall",
+            "id": "call-1",
+            "name": "grep",
+            "arguments": {"pattern": "x"},
+        });
+        if let Some(signature) = signature {
+            call["signature"] = serde_json::json!(signature);
+        }
+        if let Some(model) = signature_model {
+            call["signatureModel"] = serde_json::json!(model);
+        }
+        vec![
+            serde_json::json!({"role": "user", "content": "find x"}),
+            serde_json::json!({"role": "assistant", "content": [call]}),
+            serde_json::json!({"role": "toolResult", "toolCallId": "call-1", "content": "found"}),
+        ]
+    }
+
+    fn tool_call_signature(msg: &Message) -> Option<Option<String>> {
+        match msg {
+            Message::Assistant { content, .. } => content.iter().find_map(|c| match c {
+                AssistantContent::ToolCall(call) => Some(call.signature.clone()),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
+    fn convert_all(
+        history: &[Value],
+        provider: Option<&str>,
+        replay: ToolCallReplay<'_>,
+        dropped: &std::collections::HashSet<String>,
+    ) -> Vec<Message> {
+        history
+            .iter()
+            .filter_map(|m| {
+                value_to_rig_message_with_replay(
+                    m,
+                    provider,
+                    ThinkingReplay::Unsigned,
+                    replay,
+                    dropped,
+                    None,
+                )
+            })
+            .collect()
+    }
+
+    /// GH #833: Gemini requires a `thought_signature` on every `functionCall`
+    /// part and rejects a replayed call without one, so the model that minted
+    /// it must get it back verbatim. rig sends it straight out again as the
+    /// part's `thought_signature`.
+    #[test]
+    fn gemini_same_model_replay_attaches_the_tool_call_signature() {
+        let history = tool_call_history(Some("thought-sig-833"), Some("gemini-3.6-flash"));
+        let replay = tool_call_replay_for(Some("gemini"), Some("gemini-3.6-flash"));
+        let dropped = unreplayable_tool_calls(&history, replay);
+        assert!(dropped.is_empty(), "a same-model signature is replayable");
+        let converted = convert_all(&history, Some("gemini"), replay, &dropped);
+        assert_eq!(converted.len(), 3, "nothing is dropped");
+        assert_eq!(
+            tool_call_signature(&converted[1]),
+            Some(Some("thought-sig-833".to_string())),
+        );
+    }
+
+    /// GH #833: with no usable signature the call cannot go out — and it
+    /// cannot go alone either, because its paired result would be orphaned,
+    /// which every backend rejects. The pair is dropped together: one lost
+    /// step of history against a turn that could not be sent at all.
+    #[test]
+    fn an_unreplayable_gemini_tool_call_takes_its_result_with_it() {
+        let cases = [
+            (
+                tool_call_history(Some("thought-sig-833"), Some("gemini-2.5-flash")),
+                "a signature minted by a different model",
+            ),
+            (
+                tool_call_history(Some("thought-sig-833"), None),
+                "a signature that was never stamped",
+            ),
+            (
+                tool_call_history(None, None),
+                "no signature at all — a session saved before #833",
+            ),
+        ];
+        for (history, why) in cases {
+            let replay = tool_call_replay_for(Some("gemini"), Some("gemini-3.6-flash"));
+            let dropped = unreplayable_tool_calls(&history, replay);
+            assert_eq!(dropped.len(), 1, "{why}");
+            let converted = convert_all(&history, Some("gemini"), replay, &dropped);
+            assert_eq!(
+                converted.len(),
+                1,
+                "only the user turn survives ({why}); an orphaned result is not an option",
+            );
+        }
+    }
+
+    /// GH #833: every other provider keeps today's unsigned replay,
+    /// byte-identical on the wire — and never drops anything.
+    #[test]
+    fn non_gemini_tool_calls_replay_unsigned_and_are_never_dropped() {
+        let history = tool_call_history(None, None);
+        for provider in [Some("anthropic"), Some("openai"), Some("glm"), None] {
+            let replay = tool_call_replay_for(provider, Some("some-model"));
+            let dropped = unreplayable_tool_calls(&history, replay);
+            assert!(dropped.is_empty(), "{provider:?}");
+            let converted = convert_all(&history, provider, replay, &dropped);
+            assert_eq!(converted.len(), 3, "{provider:?}");
+            assert_eq!(
+                tool_call_signature(&converted[1]),
+                Some(None),
+                "{provider:?}"
+            );
+        }
+    }
+
     /// GH #821: replaying a signed thinking block to Anthropic with the
     /// SAME model that minted the signature (reasoning on) must attach
     /// the signature verbatim — Anthropic schema-rejects the block
@@ -1636,8 +1903,15 @@ mod tests {
     fn anthropic_same_model_replay_attaches_the_signature() {
         let v = signed_thinking_assistant();
         let replay = thinking_replay_for(Some("anthropic"), Some("claude-opus-4-6"), true);
-        let msg = value_to_rig_message_with_thinking_replay(&v, Some("anthropic"), replay, None)
-            .expect("must convert");
+        let msg = value_to_rig_message_with_replay(
+            &v,
+            Some("anthropic"),
+            replay,
+            ToolCallReplay::Unsigned,
+            &Default::default(),
+            None,
+        )
+        .expect("must convert");
         assert_eq!(
             reasoning_signature(&msg),
             Some(Some("sig-821".to_string())),
@@ -1684,8 +1958,15 @@ mod tests {
             ),
         ];
         for (v, replay, case) in cases {
-            let msg = value_to_rig_message_with_thinking_replay(v, Some("anthropic"), replay, None)
-                .unwrap_or_else(|| panic!("{case}: message with text must survive"));
+            let msg = value_to_rig_message_with_replay(
+                v,
+                Some("anthropic"),
+                replay,
+                ToolCallReplay::Unsigned,
+                &Default::default(),
+                None,
+            )
+            .unwrap_or_else(|| panic!("{case}: message with text must survive"));
             match msg {
                 Message::Assistant { content, .. } => {
                     assert!(
@@ -1715,8 +1996,15 @@ mod tests {
         for provider in [Some("cerebras"), Some("deepseek"), Some("custom"), None] {
             let replay = thinking_replay_for(provider, Some("claude-opus-4-6"), true);
             assert!(matches!(replay, ThinkingReplay::Unsigned));
-            let msg = value_to_rig_message_with_thinking_replay(&v, provider, replay, None)
-                .unwrap_or_else(|| panic!("{provider:?} must keep the message"));
+            let msg = value_to_rig_message_with_replay(
+                &v,
+                provider,
+                replay,
+                ToolCallReplay::Unsigned,
+                &Default::default(),
+                None,
+            )
+            .unwrap_or_else(|| panic!("{provider:?} must keep the message"));
             assert_eq!(
                 reasoning_signature(&msg),
                 Some(None),
@@ -1759,7 +2047,7 @@ mod tests {
             message,
             usage: None,
         };
-        let stamped = stamp_thinking_signature_model(evt, Some("claude-opus-4-6"));
+        let stamped = stamp_signature_models(evt, Some("claude-opus-4-6"));
         let StreamEvent::Done { message, .. } = stamped else {
             panic!("expected Done back");
         };

--- a/src/agent/agent_loop/run_tests.rs
+++ b/src/agent/agent_loop/run_tests.rs
@@ -1670,6 +1670,8 @@ fn tool_use_response(id: &str, name: &str, args: Value) -> AssistantMessage {
             id: id.to_string(),
             name: name.to_string(),
             arguments: args,
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     )
@@ -3029,6 +3031,8 @@ fn build_critic_transcript_pins_the_exact_critic_facing_format() {
                     id: "c1".to_string(),
                     name: "read".to_string(),
                     arguments: serde_json::json!({"path": "/x"}),
+                    signature: None,
+                    signature_model: None,
                 },
             ],
             StopReason::Stop,
@@ -3239,6 +3243,8 @@ fn scavenge_source_skips_non_text_blocks() {
             id: "call_1".to_string(),
             name: "noop".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         },
     ];
     let source = super::build_scavenge_source(&blocks);
@@ -3400,16 +3406,22 @@ async fn dirge_7bwx_end_to_end_storm_dedupes_after_truncation_repair() {
                 id: "tool-1".to_string(),
                 name: "echo".to_string(),
                 arguments: truncated(r#"{"v":1"#), // tight
+                signature: None,
+                signature_model: None,
             },
             ContentBlock::ToolCall {
                 id: "tool-2".to_string(),
                 name: "echo".to_string(),
                 arguments: truncated(r#"{"v": 1"#), // single space
+                signature: None,
+                signature_model: None,
             },
             ContentBlock::ToolCall {
                 id: "tool-3".to_string(),
                 name: "echo".to_string(),
                 arguments: truncated(r#"{"v":  1"#), // double space
+                signature: None,
+                signature_model: None,
             },
         ],
         StopReason::ToolUse,
@@ -3484,6 +3496,8 @@ async fn storm_terminal_emits_failure_narrative() {
                 id: format!("call-{i}"),
                 name: "echo".to_string(),
                 arguments: serde_json::json!({"v": 1}),
+                signature: None,
+                signature_model: None,
             }],
             StopReason::ToolUse,
         )
@@ -3780,6 +3794,8 @@ async fn native_call_invalid_args_still_errors() {
             id: "call_native_1".to_string(),
             name: "typed_path_tool".to_string(),
             arguments: serde_json::json!({"wrong_param": 1}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -6898,6 +6914,8 @@ fn assistant_calling(tool: &str) -> LoopMessage {
             id: "tc1".into(),
             name: tool.into(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     ))
@@ -6989,6 +7007,8 @@ fn awaiting_user_response_question_but_made_tool_calls_is_false() {
             id: "tc1".into(),
             name: "edit".into(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         },
         ContentBlock::Text {
             text: "Which file should I edit next?".into(),
@@ -7348,6 +7368,8 @@ fn asst_with_tool(id: &str, name: &str, args: serde_json::Value) -> LoopMessage 
             id: id.to_string(),
             name: name.to_string(),
             arguments: args,
+            signature: None,
+            signature_model: None,
         }],
         crate::agent::agent_loop::message::StopReason::ToolUse,
     ))
@@ -7855,6 +7877,8 @@ fn boundary_emits_at_most_one_nudge() {
             id: "c1".into(),
             name: "edit".into(),
             arguments: serde_json::json!({"path": "src/f0.rs"}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::Stop,
     ))];
@@ -10138,6 +10162,8 @@ async fn a_native_call_is_not_recorded_twice_alongside_a_lifted_one() {
                     id: "native_1".to_string(),
                     name: "typed_path_tool".to_string(),
                     arguments: serde_json::json!({"path": "/tmp/a"}),
+                    signature: None,
+                    signature_model: None,
                 },
                 ContentBlock::Text {
                     text: lifted.to_string(),

--- a/src/agent/agent_loop/steering.rs
+++ b/src/agent/agent_loop/steering.rs
@@ -318,6 +318,8 @@ mod tests {
                         id: "call-1".to_string(),
                         name: "echo".to_string(),
                         arguments: serde_json::json!({}),
+                        signature: None,
+                        signature_model: None,
                     }],
                     StopReason::ToolUse,
                 )

--- a/src/agent/agent_loop/stream.rs
+++ b/src/agent/agent_loop/stream.rs
@@ -1184,6 +1184,8 @@ mod tests {
                         id: "call-1".to_string(),
                         name: "read".to_string(),
                         arguments: serde_json::json!({"path": "x.rs"}),
+                        signature: None,
+                        signature_model: None,
                     },
                 ],
                 StopReason::ToolUse,

--- a/src/agent/agent_loop/tools.rs
+++ b/src/agent/agent_loop/tools.rs
@@ -1240,6 +1240,7 @@ pub fn extract_tool_calls(msg: &AssistantMessage) -> Vec<ToolCall> {
                 id,
                 name,
                 arguments,
+                ..
             } => Some(ToolCall {
                 id: id.clone(),
                 name: name.clone(),

--- a/src/agent/agent_loop/tools_tests.rs
+++ b/src/agent/agent_loop/tools_tests.rs
@@ -283,6 +283,8 @@ async fn test_handle_tool_calls_and_results() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::json!({"value": "hello"}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -347,6 +349,8 @@ async fn test_before_tool_call_mutates_args() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::json!({"value": "hello"}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -415,6 +419,8 @@ async fn test_prepare_arguments_shim() {
             id: "tool-1".to_string(),
             name: "edit".to_string(),
             arguments: serde_json::json!({"oldText": "before", "newText": "after"}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -460,6 +466,8 @@ async fn test_dispatcher_terminate_when_all_results_terminate() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -497,6 +505,8 @@ async fn test_after_tool_call_can_set_terminate() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -545,6 +555,8 @@ async fn test_tool_not_found_immediate_error() {
             id: "tool-1".to_string(),
             name: "nonexistent".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -586,6 +598,8 @@ async fn test_tool_not_found_suggests_closest() {
             id: "tool-1".to_string(),
             name: "ehco".to_string(), // typo of "echo"
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -623,6 +637,8 @@ async fn test_before_tool_call_block_with_reason() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -730,6 +746,8 @@ fn assistant_with_calls(calls: &[ToolCall]) -> AssistantMessage {
             id: c.id.clone(),
             name: c.name.clone(),
             arguments: c.arguments.clone(),
+            signature: None,
+            signature_model: None,
         })
         .collect();
     AssistantMessage::new(content, StopReason::ToolUse)
@@ -1155,6 +1173,8 @@ async fn aborted_tool_returns_aborted_error_promptly() {
                 id: c.id.clone(),
                 name: c.name.clone(),
                 arguments: c.arguments.clone(),
+                signature: None,
+                signature_model: None,
             })
             .collect(),
         StopReason::ToolUse,
@@ -1274,6 +1294,8 @@ async fn cancelled_tool_future_is_dropped_not_detached() {
                 id: c.id.clone(),
                 name: c.name.clone(),
                 arguments: c.arguments.clone(),
+                signature: None,
+                signature_model: None,
             })
             .collect(),
         StopReason::ToolUse,
@@ -1349,6 +1371,8 @@ async fn truncation_repair_end_to_end_through_dispatch() {
             id: "tool-1".to_string(),
             name: "echo".to_string(),
             arguments: serde_json::Value::String(truncated.to_string()),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -1523,6 +1547,8 @@ async fn truncation_hard_fallback_does_not_fabricate_args() {
             id: "tool-1".to_string(),
             name: "strict".to_string(),
             arguments: serde_json::Value::String("}}}}}".to_string()),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -1752,6 +1778,8 @@ async fn dispatch_one(tool: Arc<dyn LoopTool>, name: &str, config: &LoopConfig) 
             id: "tool-1".to_string(),
             name: name.to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -1871,6 +1899,8 @@ async fn a_cancelled_call_is_not_retried() {
             id: "tool-1".to_string(),
             name: "read".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -1910,6 +1940,8 @@ async fn a_cancel_during_execution_stops_the_retry() {
             id: "tool-1".to_string(),
             name: "read".to_string(),
             arguments: serde_json::json!({}),
+            signature: None,
+            signature_model: None,
         }],
         StopReason::ToolUse,
     );
@@ -2134,6 +2166,8 @@ async fn a_budget_stopped_call_yields_a_result_and_the_batch_continues() {
                 id: c.id.clone(),
                 name: c.name.clone(),
                 arguments: c.arguments.clone(),
+                signature: None,
+                signature_model: None,
             })
             .collect(),
         StopReason::ToolUse,


### PR DESCRIPTION
Closes #833. Same defect as #821, one field over; #823's disclosed gap arriving.

## What was wrong

Gemini requires a `thought_signature` on `functionCall` parts. rig hands it to us
on capture (`gemini/completion.rs:489`, `ToolCall::new(..).with_signature(..)`)
and sends it back out again as `Part.thought_signature`
(`impl From<message::ToolCall> for Part`), so the round trip is entirely
available — dirge just dropped the value at capture and hardcoded `signature:
None` at replay. Result: any tool-using turn on Gemini fails on the replay.

## What this does

Mirrors #823's mechanism, which was built for exactly this:

1. `ContentBlock::ToolCall` gains `signature` / `signatureModel`, both
   `#[serde(default, skip_serializing_if = "Option::is_none")]`, so saved
   sessions still deserialize and a call without one serializes byte-identically
   to the old shape.
2. Capture keeps `ToolCall.signature` instead of discarding it, and the factory
   stamps the minting model — the same stamp pass #821 added for thinking
   blocks, now covering both block kinds.
3. Replay attaches the signature when the request's model is the one that minted
   it. The attach gate widens beyond Anthropic: `signature_model` stops being a
   single-provider guard and becomes the cross-provider one it was built to be.

## The missing-signature case

A tool call cannot be dropped on its own — its paired `tool_result` would be
orphaned and the conversation malformed — so when no usable signature exists (a
session saved before this change, or a cross-model switch) **the call and its
result are dropped together**, and the turn is logged with how many pairs went.

The alternatives were to send it unsigned and take the 400 (which is the bug) or
to refuse the turn outright (which hard-blocks every pre-existing Gemini
session). Dropping loses one step of history and keeps the session working,
which matches how #823 treated an unsigned thinking block.

Every other provider is untouched: the replay policy is `Unsigned` for them,
byte-identical on the wire.

## Verified against rig, not assumed

Checked in the rig-core 0.41.0 source rather than inferred: capture is
`gemini/completion.rs:489` (`ToolCall::new(..).with_signature(thought_signature)`)
and the return trip is `impl From<message::ToolCall> for Part`, which sets
`thought_signature: tool_call.signature` on the `functionCall` part. So the
round trip exists end to end and this is entirely dirge-side, as the issue said.

## One adjacent limit, deliberately not touched

Gemini reasoning blocks still replay unsigned — `ThinkingReplay::SignedOrDrop`
stays Anthropic-only. rig does carry a signature there too, so the same
treatment is available, but nothing has reported Gemini rejecting an unsigned
`thought: true` part, and widening the thinking gate would start dropping
reasoning blocks on a provider where they are currently kept. Worth its own
issue if a repro turns up.
