### PR TITLE
Count reasoning, images and fixed overhead in the context estimate (dirge-qobx.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- Auto-compaction now measures what it actually sends. The fold trigger reads
+  the provider's prompt count — system prompt, every tool schema, replayed
+  reasoning, images, the lot — while the fold's own accounting was `chars / 4`
+  over `messages`, counting only text and tool-call arguments. A live run
+  printed `context compacted: 63800 → 63479 tokens` against a request the
+  provider charged 204,320 for and then stopped mid-task, because nothing the
+  fold could see explained the ratio it was reacting to. Three terms were
+  invisible: a `thinking` block counted zero chars although reasoning is
+  echoed back to every provider but OpenAI and nothing strips a stale one; an
+  image counted zero because the transcript holds a reference rather than
+  bytes; and the system prompt plus tool schemas — ~16k tokens for the
+  built-in surface, ~33k with MCP servers — are not in `messages` at all, so
+  the pre-send tiers read 25% of the window on a request that filled 82% of
+  it and the turn-start fold never fired. Reasoning and images are now priced,
+  and the fixed overhead is re-derived after every response as what the
+  provider charged minus what the estimator made of the messages sent, then
+  added back at the two pre-send tiers. Separately, on Anthropic the ratio was
+  reading `input_tokens`, which there is only the UNCACHED remainder: with a
+  warm prompt cache the whole ladder under-read the prompt by the entire
+  cached prefix, so no tier fired and the first sign of trouble was the
+  provider refusing the request. Every decision site now reads a normalized
+  prompt total, and the context gauge reads the same number. (dirge-qobx.1,
+  dirge-qobx.6)
 - A provider usage cap now reads as one in the TUI instead of arriving as a raw
   provider blob. `classify_error` already routed GLM's `429` code `1308` to the
   non-retryable `UsageCap`, and `--print` already reported it in a sentence, but

--- a/src/agent/agent_loop/context_manager.rs
+++ b/src/agent/agent_loop/context_manager.rs
@@ -49,12 +49,29 @@
 //!
 //!   - **pre-send** (turn-start fold, the per-result cap tier): the local
 //!     estimate, since the API hasn't been called yet;
-//!   - **post-response** ([`decide_after_usage`]): the API's exact
-//!     `prompt_tokens` from the usage response.
+//!   - **post-response** ([`decide_after_usage`]): the provider's own prompt
+//!     count from the usage response, normalized across the two usage
+//!     conventions by [`TokenUsage::prompt_total`] (on Anthropic the three
+//!     lanes are disjoint and `input_tokens` alone is just the uncached
+//!     remainder — dirge-qobx.6).
 //!
-//! These two numbers can legitimately disagree (the estimate is approximate);
-//! that's inherent to measuring before vs. after the call, not a duplicated
-//! estimator.
+//! These two numbers are approximations of the same quantity and will
+//! disagree at the margin; that is inherent to measuring before vs. after the
+//! call. What is NOT inherent — and was the bug in dirge-qobx.1 — is a
+//! disagreement about what is being measured. The estimator accounts
+//! `messages`; the provider charges for the system prompt and every tool
+//! schema too, ~16k tokens for the built-in surface and ~33k with MCP servers
+//! (see [`crate::agent::agent_loop::compact_schema`]). So the pre-send sites
+//! add a **fixed-overhead** term, re-derived after every response as
+//! `prompt_total − estimate(messages we sent)` and carried on the loop. Before
+//! that, a request the provider charged 82% of the window for read as 25% at
+//! the turn-start tier, and the 0.90 fold never fired on anything.
+//!
+//! The estimator also has to count everything that ships. Reasoning blocks
+//! are replayed to every provider but OpenAI and images are billed by area;
+//! both used to account as zero chars (dirge-qobx.1).
+//!
+//! [`TokenUsage::prompt_total`]: crate::agent::agent_loop::message::TokenUsage::prompt_total
 //!
 //! # The snip override
 //!

--- a/src/agent/agent_loop/message.rs
+++ b/src/agent/agent_loop/message.rs
@@ -231,6 +231,35 @@ pub struct TokenUsage {
     pub cache_creation_input_tokens: u64,
 }
 
+impl TokenUsage {
+    /// What this request's prompt actually cost, normalized across the two
+    /// provider conventions (dirge-qobx.6).
+    ///
+    /// `input_tokens` is not the prompt size on every backend, and the whole
+    /// context-budget ladder reads it as if it were. DeepSeek, OpenAI and
+    /// Gemini report `cached_input_tokens` as a SUBSET of `input_tokens`, so
+    /// `input_tokens` IS the prompt. Anthropic reports them DISJOINT:
+    /// `input_tokens` is the uncached remainder, so a warm prompt cache — the
+    /// normal case — leaves it a small fraction of what was sent. Read
+    /// directly there it under-reads the prompt by the entire cached prefix,
+    /// which is most of it: no fold at 0.75, none at 0.78, no exit-with-summary
+    /// at 0.80, and the first sign of trouble is the provider refusing the
+    /// request.
+    ///
+    /// The raw fields stay exactly as the provider reported them —
+    /// `Session::cache_hit_ratio` deliberately handles both conventions and
+    /// must keep seeing what came back.
+    pub fn prompt_total(&self, provider: Option<&str>) -> u64 {
+        if matches!(provider, Some(p) if p.eq_ignore_ascii_case("anthropic")) {
+            self.input_tokens
+                .saturating_add(self.cached_input_tokens)
+                .saturating_add(self.cache_creation_input_tokens)
+        } else {
+            self.input_tokens
+        }
+    }
+}
+
 /// Sub-discriminator for `StreamEvent::Delta`. Mirrors pi's nine
 /// individual variants in a compact form. The pi-faithful order
 /// (text → thinking → toolcall, each in start/delta/end order)
@@ -801,6 +830,38 @@ impl LoopEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// dirge-qobx.6: the two provider conventions, and why reading
+    /// `input_tokens` directly is not the prompt size.
+    #[test]
+    fn prompt_total_normalizes_both_usage_conventions() {
+        // Anthropic on a warm cache: the three counts are DISJOINT, and
+        // `input_tokens` alone is 2% of a request that nearly fills a 200k
+        // window. Read directly, the fold ladder sees 5k and does nothing.
+        let anthropic = TokenUsage {
+            input_tokens: 5_000,
+            output_tokens: 900,
+            cached_input_tokens: 190_000,
+            cache_creation_input_tokens: 1_000,
+        };
+        assert_eq!(anthropic.prompt_total(Some("anthropic")), 196_000);
+        assert_eq!(anthropic.prompt_total(Some("Anthropic")), 196_000);
+
+        // DeepSeek/OpenAI/Gemini report cached as a SUBSET, so the same sum
+        // would bill the cached prefix twice.
+        let deepseek = TokenUsage {
+            input_tokens: 196_000,
+            output_tokens: 900,
+            cached_input_tokens: 190_000,
+            cache_creation_input_tokens: 0,
+        };
+        assert_eq!(deepseek.prompt_total(Some("deepseek")), 196_000);
+        // Unknown or absent provider: assume the subset convention, which is
+        // what every backend but Anthropic uses.
+        assert_eq!(deepseek.prompt_total(None), 196_000);
+        // OpenRouter serving a Claude model still reports OpenAI-style.
+        assert_eq!(deepseek.prompt_total(Some("openrouter")), 196_000);
+    }
 
     /// GH #821 back-compat pin: `ContentBlock` is serde-serialized into
     /// session storage, so the `Thinking` variant's new optional

--- a/src/agent/agent_loop/run.rs
+++ b/src/agent/agent_loop/run.rs
@@ -2679,6 +2679,23 @@ pub async fn run_loop(
     // (IMPROVEMENTS_PLAN #4). Reset after each post-usage decision.
     let mut snip_tokens_freed: u64 = 0;
 
+    // dirge-qobx.1: tokens the request carries that are NOT in
+    // `current_context.messages` — the system prompt and every tool schema,
+    // measured at ~16k for the built-in surface and ~33k with MCP servers
+    // (see `compact_schema`). Nothing local can count them, so they are
+    // derived after each response as (what the provider charged for the
+    // prompt) − (what the estimator made of the messages we sent), and added
+    // back at the two PRE-SEND tiers that compare an estimate against
+    // `ctx_max`. Without this the turn-start fold read 25% of the window on a
+    // request the provider charged 82% for, and never fired.
+    //
+    // Last observed, not a running maximum: the tool surface changes with
+    // `/model`, an MCP server connecting, or a prompt-layer swap, and the most
+    // recent request is the one that describes the next one. Zero until the
+    // first response, which is the same "no usage yet" fallback the panel
+    // gauge uses.
+    let mut fixed_overhead: u64 = 0;
+
     // dirge-5mtx.1: per-run gate/capability tally. Declared before the
     // initial steering poll so both steering-poll sites can record into it.
     let mut tally = GateTally::new();
@@ -2882,7 +2899,12 @@ pub async fn run_loop(
             if !folded_this_turn {
                 let rough_estimate =
                     crate::agent::compression::estimate_messages_tokens(&current_context.messages);
-                let estimate = context_manager::estimate_turn_start(rough_estimate, ctx_max);
+                // dirge-qobx.1: + the system prompt and tool schemas, which are
+                // in the request and not in `messages`.
+                let estimate = context_manager::estimate_turn_start(
+                    rough_estimate.saturating_add(fixed_overhead),
+                    ctx_max,
+                );
                 if estimate.ratio > context_manager::TURN_START_FOLD_THRESHOLD {
                     tracing::info!(
                         target: "dirge::agent_loop",
@@ -2992,7 +3014,13 @@ pub async fn run_loop(
             // the (reactive) post-response fold fires.
             let cap_estimate =
                 crate::agent::compression::estimate_messages_tokens(&current_context.messages);
-            let result_cap = crate::agent::compression::tiered_result_cap(cap_estimate, ctx_max);
+            // dirge-qobx.1: same correction as the turn-start tier — this cap
+            // tightens at 60% of the window, and 60% of the window is not 60%
+            // of the messages.
+            let result_cap = crate::agent::compression::tiered_result_cap(
+                cap_estimate.saturating_add(fixed_overhead),
+                ctx_max,
+            );
             // Counted variant (IMPROVEMENTS_PLAN #4): track how much the
             // snip freed so the post-response fold can be skipped if it
             // bought enough headroom.
@@ -3002,6 +3030,14 @@ pub async fn run_loop(
             );
             current_context.messages = capped;
             snip_tokens_freed = snip_tokens_freed.saturating_add(freed);
+
+            // dirge-qobx.1: the estimator's account of exactly what this
+            // request carries in `messages`, taken after every pre-send
+            // rewrite and before the call. Paired with the provider's own
+            // prompt count below, it is the only way to see the system prompt
+            // and tool schemas at all.
+            let sent_estimate =
+                crate::agent::compression::estimate_messages_tokens(&current_context.messages);
 
             // Pi lines 192-194: LLM call.
             // dirge-e31n.6: the permission checkpoint tells the model that
@@ -3024,6 +3060,24 @@ pub async fn run_loop(
                 turn_tool_choice,
             )
             .await;
+            // dirge-qobx.1: re-derive the fixed overhead from this response.
+            // `saturating_sub` is the whole error handling this needs: the
+            // estimator overshoots on prose as often as it undershoots on
+            // JSON, and an overshoot means "no visible overhead", not a
+            // negative one.
+            if let Some(prompt_tokens) =
+                token_usage.map(|u| u.prompt_total(config.provider_name.as_deref()))
+            {
+                fixed_overhead = prompt_tokens.saturating_sub(sent_estimate);
+                tracing::debug!(
+                    target: "dirge::agent_loop",
+                    prompt_tokens,
+                    sent_estimate,
+                    fixed_overhead,
+                    "context: prompt accounting for this request",
+                );
+            }
+
             // Where this turn's assistant message sits in each transcript, so
             // a call scavenged out of its text can be recorded ON it further
             // down (dirge-n00z). Both are appended to below, so neither index
@@ -3851,7 +3905,9 @@ pub async fn run_loop(
             // defaults to None (carry on).
             {
                 let decision = context_manager::decide_after_usage(
-                    token_usage.map(|u| u.input_tokens),
+                    // dirge-qobx.6: the prompt total, not Anthropic's uncached
+                    // remainder.
+                    token_usage.map(|u| u.prompt_total(config.provider_name.as_deref())),
                     ctx_max,
                     folded_this_turn,
                 );
@@ -3911,7 +3967,8 @@ pub async fn run_loop(
                             // Context compaction: prune old tool results and
                             // compress the middle section of the conversation.
                             // Port of Hermes's compression pass.
-                            if let Some(prompt_tokens) = token_usage.map(|u| u.input_tokens)
+                            if let Some(prompt_tokens) =
+                                token_usage.map(|u| u.prompt_total(config.provider_name.as_deref()))
                                 && crate::agent::compression::should_compress(
                                     prompt_tokens,
                                     ctx_max,

--- a/src/agent/compression.rs
+++ b/src/agent/compression.rs
@@ -266,11 +266,26 @@ pub(crate) fn content_chars(content: Option<&Value>) -> usize {
     }
 }
 
+/// Rough token cost of one image block (dirge-qobx.1).
+///
+/// An image is a handful of bytes in the transcript (an asset id and a media
+/// type — the base64 is reified at the provider boundary) and between several
+/// hundred and a couple of thousand tokens in the request. Anthropic bills a
+/// full-window screenshot at roughly `(w × h) / 750`, which for the 1456×816
+/// shape dirge's own screenshots come out at is ~1.6k; OpenAI and Gemini land
+/// in the same order of magnitude.
+///
+/// The transcript records no dimensions, so this is one flat number rather than
+/// a computed one. It is deliberately a round 1.5k: the alternative in force
+/// until now was zero, and zero is wrong by 1.5k per image on a session that
+/// reads screenshots all day.
+pub(crate) const IMAGE_TOKENS_ESTIMATE: u64 = 1_500;
+
 /// Characters a single content block contributes to the request (dirge-tmex).
 ///
 /// Not the same question as [`text_of_block`], which asks "what text would the
 /// model READ". This asks "how much of the request does this block occupy",
-/// and a tool call answers differently to an image:
+/// and the block types answer differently:
 ///
 ///   * `text` — its text, obviously.
 ///   * `toolCall` — its ARGUMENTS, in full. Every byte is serialized into the
@@ -279,20 +294,29 @@ pub(crate) fn content_chars(content: Option<&Value>) -> usize {
 ///     blind to what is routinely the largest thing in the turn, which matters
 ///     because that estimate gates the turn-start fold and the tiered
 ///     result cap.
-///   * anything else — zero. An image really does reach the model as an opaque
-///     reference, and inflating every turn that carries one would be the
-///     opposite error.
+///   * `thinking` — its text (dirge-qobx.1). Reasoning is not a local artifact:
+///     it is echoed back in the assistant turn for every provider except
+///     OpenAI (`rig_stream_factory::provider_rejects_reasoning_echo`), nothing
+///     ever strips a stale block, and on a long reasoning-heavy run it is the
+///     largest single thing in the request. Counting it as zero is how a fold
+///     comes to report `63800 → 63479` against a request the provider charged
+///     204,320 for.
+///   * `image` — [`IMAGE_TOKENS_ESTIMATE`] worth of chars. The block itself is
+///     an opaque reference, which is why this was zero; what reaches the model
+///     is not.
+///   * anything else — zero.
 fn block_chars(block: &Value) -> usize {
     let Some(obj) = block.as_object() else {
         return 0;
     };
     match obj.get("type").and_then(|t| t.as_str()) {
-        Some("text") => obj.get("text").and_then(|t| t.as_str()).map_or(0, str::len),
+        Some("text" | "thinking") => obj.get("text").and_then(|t| t.as_str()).map_or(0, str::len),
         Some("toolCall") => {
             let args = obj.get("arguments").map_or(0, |a| a.to_string().len());
             let name = obj.get("name").and_then(|n| n.as_str()).map_or(0, str::len);
             args + name
         }
+        Some("image") => (IMAGE_TOKENS_ESTIMATE * CHARS_PER_TOKEN) as usize,
         _ => 0,
     }
 }
@@ -2567,21 +2591,36 @@ mod tests {
         assert_eq!(estimate_messages_tokens(&msgs), 10);
     }
 
-    /// Multi-block content sums across all text blocks; non-text
-    /// blocks (image, tool_use) contribute zero.
+    /// Multi-block content sums across all text blocks. A block type nobody
+    /// prices contributes zero; an image contributes its flat rate
+    /// (dirge-qobx.1 — it used to be zero, and a screenshot is not free).
     #[test]
-    fn estimate_tokens_sums_multi_block_skipping_non_text() {
+    fn estimate_tokens_sums_multi_block_content() {
         let msgs = vec![serde_json::json!({
             "role": "toolResult",
             "content": [
                 {"type": "text", "text": "a".repeat(20)},
-                {"type": "image", "source": "ignored"},
+                {"type": "video", "source": "unpriced"},
                 {"type": "text", "text": "b".repeat(20)},
             ],
             "toolName": "bash",
         })];
         // 40 chars / 4 = 10 tokens.
         assert_eq!(estimate_messages_tokens(&msgs), 10);
+
+        let with_image = vec![serde_json::json!({
+            "role": "toolResult",
+            "content": [
+                {"type": "text", "text": "a".repeat(20)},
+                {"type": "image", "assetId": "ignored"},
+                {"type": "text", "text": "b".repeat(20)},
+            ],
+            "toolName": "bash",
+        })];
+        assert_eq!(
+            estimate_messages_tokens(&with_image),
+            10 + IMAGE_TOKENS_ESTIMATE
+        );
     }
 
     /// Mix of string-content + block-content messages — both
@@ -2799,19 +2838,59 @@ mod tests {
         );
     }
 
-    /// The other side: a block that really IS an opaque reference must stay
-    /// uncounted, or the fix would inflate every turn carrying an image.
+    /// dirge-qobx.1: an image block is a few bytes in the transcript and
+    /// ~1.5k tokens in the request, and this test used to assert the former.
+    ///
+    /// The reversal is deliberate. "Opaque reference" describes the block,
+    /// not the cost: the reference is reified to base64 at the provider
+    /// boundary and billed by area. Counting it as zero was defensible when
+    /// an image was a rarity and indefensible for a session that reads
+    /// screenshots all day — twenty of them are 30k tokens of window that the
+    /// pre-send tiers could not see.
     #[test]
-    fn the_estimator_still_ignores_an_opaque_block() {
+    fn the_estimator_prices_an_image_block() {
         let msgs = vec![serde_json::json!({
             "role": "user",
             "content": [
                 {"type": "text", "text": "look at this"},
-                {"type": "image", "sha256": "a".repeat(64), "mime": "image/png"},
+                {"type": "image", "assetId": "a".repeat(36), "mediaType": "image/png"},
             ],
         })];
-        // Only "look at this" (12 chars) counts.
-        assert_eq!(estimate_messages_tokens(&msgs), 3);
+        // "look at this" is 12 chars → 3 tokens, plus the image's flat rate.
+        assert_eq!(estimate_messages_tokens(&msgs), 3 + IMAGE_TOKENS_ESTIMATE);
+        // A block type nobody prices still contributes nothing.
+        let unknown = vec![serde_json::json!({
+            "role": "assistant",
+            "content": [{"type": "audio", "assetId": "b".repeat(36)}],
+        })];
+        assert_eq!(estimate_messages_tokens(&unknown), 0);
+    }
+
+    /// dirge-qobx.1: the estimator must count reasoning, because the request
+    /// carries it.
+    ///
+    /// A `thinking` block is echoed back inside the assistant turn for every
+    /// provider except OpenAI, and nothing strips a stale one, so on a long
+    /// reasoning-heavy run it is the largest single term in the prompt. While
+    /// it counted zero, a fold could report `63800 → 63479` on a request the
+    /// provider charged 204,320 for — and the tiers that read the estimate
+    /// (turn-start fold, tiered result cap) never fired at all.
+    #[test]
+    fn the_estimator_counts_replayed_reasoning() {
+        let reasoning = "let me think about this step by step. ".repeat(1_000);
+        let msgs = vec![serde_json::json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "text": reasoning},
+                {"type": "text", "text": "done"},
+            ],
+        })];
+
+        let got = estimate_messages_tokens(&msgs);
+        assert!(
+            got > 9_000,
+            "estimated {got} tokens for a turn carrying 38 KB of replayed              reasoning — the pre-send tiers read this number, and reasoning              is on the wire for every provider but OpenAI"
+        );
     }
 
     /// `SUMMARY_SECTIONS` is a hand-written copy of the template's headers,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -519,15 +519,31 @@ impl Session {
         // dirge-hwk9.2: the context gauge needs the LAST request's prompt
         // size, which the cumulative counters cannot answer.
         //
-        // `input_tokens` ALONE, deliberately: this must be the same number
-        // `context_manager::decide_after_usage` divides by, and that reads
-        // `usage.input_tokens` and nothing else. Summing the cached and
-        // creation figures would be closer to the true prompt on Anthropic
-        // (which reports cached DISJOINT from input) and would double-count on
-        // DeepSeek/OpenAI (which report it as a SUBSET) — and either way it
-        // would put the gauge back to describing a fold that does not happen,
-        // which is the bug being fixed.
-        self.last_prompt_tokens = Some(input_tokens);
+        // It must stay the same number `context_manager::decide_after_usage`
+        // divides by, or the gauge describes a fold that does not happen. That
+        // number used to be `input_tokens` alone; as of dirge-qobx.6 it is
+        // `TokenUsage::prompt_total`, which sums input + cached + creation on
+        // Anthropic (where the three are DISJOINT and `input_tokens` is only
+        // the uncached remainder) and keeps `input_tokens` everywhere else
+        // (where cached is a SUBSET and summing would double-count). Same
+        // convention here, so the two stay in lockstep.
+        //
+        // Keyed off `self.provider`, which is the resolved provider name — the
+        // canonical `"anthropic"` for the built-in and for OAuth. A user's own
+        // config alias pointing at Anthropic reads as the subset convention
+        // and under-reads the gauge; the LOOP gets it right regardless,
+        // because it keys off `AnyAgent::provider_name`. Erring toward the
+        // smaller number keeps a wrong alias from inventing headroom
+        // pressure that isn't there.
+        self.last_prompt_tokens = Some(
+            crate::agent::agent_loop::message::TokenUsage {
+                input_tokens,
+                output_tokens,
+                cached_input_tokens,
+                cache_creation_input_tokens,
+            }
+            .prompt_total(Some(self.provider.as_str())),
+        );
         self.cumulative_output_tokens = self.cumulative_output_tokens.saturating_add(output_tokens);
         self.cumulative_input_tokens = self.cumulative_input_tokens.saturating_add(input_tokens);
         self.cumulative_cached_input_tokens = self


### PR DESCRIPTION
The fold trigger reads the provider's prompt count. The fold's own accounting read `chars / 4` over `messages`, counting only text blocks and tool-call arguments. Three things that ship with every request counted zero:

- **replayed reasoning** — a `thinking` block is echoed back inside the assistant turn for every provider except OpenAI (`provider_rejects_reasoning_echo`), and nothing ever strips a stale one. On a long reasoning-heavy run it is the largest single term in the prompt.
- **images** — the transcript holds an asset id, the request carries ~1.5k tokens of billed area.
- **the system prompt and every tool schema** — ~16k tokens for the built-in surface, ~33k with MCP servers (measured in `compact_schema`), and not in `messages` at all.

So a request the provider charged 82% of the window for read as 25% at the turn-start tier: the 0.90 fold never fired on anything, the 0.60 result-cap tier tightened late, and a fold could report `context compacted: 63800 → 63479` against a 204,320-token request — which is what a live run did, one turn before stopping mid-task.

- `block_chars` prices `thinking` text and `image` blocks (`IMAGE_TOKENS_ESTIMATE`, a flat 1.5k — the transcript records no dimensions).
- The fixed overhead is re-derived after each response as `prompt_total − estimate(messages we sent)` and added back at the two pre-send tiers. Last observed, not a running maximum: the tool surface changes with `/model`, an MCP server connecting, or a prompt-layer swap.

Also **dirge-qobx.6**, because the derivation above depends on it: on Anthropic `input_tokens` is the *uncached remainder*, not the prompt (`TokenUsage`'s own doc says so). With a warm prompt cache every tier under-read the prompt by the entire cached prefix — no fold at 0.75, none at 0.78, no exit-with-summary at 0.80, and the first sign of trouble was the provider refusing the request. `TokenUsage::prompt_total` normalizes the two conventions, every decision site reads it, and `Session::record_token_usage` follows the same convention so the gauge keeps describing the fold it warns about.

Follow-ups in the epic (dirge-qobx): strip stale reasoning at the provider boundary (qobx.2), stop ending the run on a prune-only fold (qobx.3), fold when an autonomous stretch has no user turn (qobx.4), log the silent skip (qobx.5).